### PR TITLE
Remove Fingerprint Generation Capabilities

### DIFF
--- a/src/synthetic.rs
+++ b/src/synthetic.rs
@@ -108,7 +108,6 @@ mod tests {
 
     #[test]
     fn test_generate_synthetic_id() {
-        log::info!("Hello!");
         let settings: Settings = create_settings();
         let req = create_test_request(vec![
             (&header::COOKIE.to_string(), "pub_userid=12345"),
@@ -117,8 +116,6 @@ mod tests {
         ]);
 
         let synthetic_id = generate_synthetic_id(&settings, &req);
-
-        log::info!("Generated Synthetic ID: {}", synthetic_id);
 
         assert_eq!(
             synthetic_id,


### PR DESCRIPTION
This PR removes the most problematic fingerprint generation from synthetic.rs while keeping the overall workflow intact (and tests still passing). 

![image](https://github.com/user-attachments/assets/0f018d2a-bb43-4fec-8d2d-ca85194da520)

Even in a prototype, I would strongly recommend against creating a fingerprint like this. 

Why?
- In its default form, it cannot be effectively controlled or observed by an end user. In its default form, an incognito session and a standard browser session could be linked together by any platforms downstream. Does that meet user expectations? 
- Running this out of the box is likely unlawful in many regions of the world. Shipping this without a big warning label on the side (much less implementing some simple consent checks) sends a poor message about what smart defaults look like in 2025. 
- While I don't expect activists and browser makers to be enthused about this project (or much adtech does at all), the signal of integrating a super cookie fingerprint as a v.0 priority is a great way to reinforce the existing convictions of that group and spur more drastic actions. 