### PR TITLE
Add robots_tag configuration to control X-Robots-Tag header in responses

### DIFF
--- a/crates/common/src/settings.rs
+++ b/crates/common/src/settings.rs
@@ -20,6 +20,18 @@ pub struct Publisher {
     /// Secret used to encrypt/decrypt proxied URLs in `/first-party/proxy`.
     /// Keep this secret stable to allow existing links to decode.
     pub proxy_secret: String,
+    /// X-Robots-Tag header value to add to publisher content responses.
+    /// Common values:
+    ///   - "noindex, nofollow" (default) - blocks indexing and following links
+    ///   - "noindex" - blocks indexing but allows following links
+    ///   - "nofollow" - allows indexing but blocks following links
+    ///   - "" or omit - no header, allows full indexing (for production)
+    #[serde(default = "default_robots_tag")]
+    pub robots_tag: Option<String>,
+}
+
+fn default_robots_tag() -> Option<String> {
+    Some("noindex, nofollow".to_string())
 }
 
 impl Publisher {

--- a/crates/fastly/src/main.rs
+++ b/crates/fastly/src/main.rs
@@ -79,8 +79,12 @@ async fn route_request(settings: Settings, req: Request) -> Result<Response, Err
     // Convert any errors to HTTP error responses
     let mut response = result.unwrap_or_else(to_error_response);
 
-    // Add X-Robots-Tag header to prevent crawlers and indexers
-    response.set_header("X-Robots-Tag", "noindex, nofollow");
+    // Add X-Robots-Tag header to all responses if configured
+    if let Some(robots_tag) = &settings.publisher.robots_tag {
+        if !robots_tag.is_empty() {
+            response.set_header("X-Robots-Tag", robots_tag);
+        }
+    }
 
     Ok(response)
 }

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -3,6 +3,14 @@ domain = "test-publisher.com"
 cookie_domain = ".test-publisher.com"
 origin_url = "https://origin.test-publisher.com"
 proxy_secret = "change-me-proxy-secret"
+# X-Robots-Tag header value to add to publisher content responses.
+# Common values:
+#   - "noindex, nofollow" (default) - blocks indexing and following links
+#   - "noindex" - blocks indexing but allows following links  
+#   - "nofollow" - allows indexing but blocks following links
+#   - "" (empty string) or omit - no header, allows full indexing (for production)
+# Set to empty string "" to allow search engines and crawlers to index the site.
+robots_tag = "noindex, nofollow"
 
 [prebid]
 server_url = "http://68.183.113.79:8000"


### PR DESCRIPTION
Updated trusted-server.toml and settings.rs to include a new robots_tag option for controlling the X-Robots-Tag header in publisher content responses. The default value is set to "noindex, nofollow". Modified main.rs to conditionally add the X-Robots-Tag header based on the configured value.