### PR TITLE
refactors .well-known/ts.jwks.json -> .well-known/trusted-server.json

### DIFF
--- a/crates/common/src/request_signing/discovery.rs
+++ b/crates/common/src/request_signing/discovery.rs
@@ -1,0 +1,88 @@
+//! Discovery endpoint for trusted-server.
+//!
+//! This module provides a standardized discovery mechanism similar to the IAB's
+//! Data Subject Rights framework. The `.well-known/trusted-server.json` endpoint
+//! allows partners to discover JWKS keys for signature verification.
+
+use serde::Serialize;
+
+/// Main discovery document returned by `.well-known/trusted-server.json`
+#[derive(Debug, Serialize)]
+pub struct TrustedServerDiscovery {
+    /// Version of the discovery document format
+    pub version: String,
+
+    /// JSON Web Key Set containing public keys for signature verification
+    pub jwks: serde_json::Value,
+}
+
+impl TrustedServerDiscovery {
+    /// Creates a new discovery document with the given JWKS
+    pub fn new(jwks_value: serde_json::Value) -> Self {
+        Self {
+            version: "1.0".to_string(),
+            jwks: jwks_value,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_discovery_document_structure() {
+        let jwks = json!({
+            "keys": [
+                {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": "test_key",
+                    "kid": "test-kid"
+                }
+            ]
+        });
+
+        let discovery = TrustedServerDiscovery::new(jwks);
+
+        assert_eq!(discovery.version, "1.0");
+        assert!(discovery.jwks.is_object());
+    }
+
+    #[test]
+    fn test_discovery_document_serialization() {
+        let jwks = json!({
+            "keys": []
+        });
+
+        let discovery = TrustedServerDiscovery::new(jwks);
+        let serialized = serde_json::to_string(&discovery).unwrap();
+
+        // Verify it's valid JSON
+        let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(parsed["version"], "1.0");
+        assert!(parsed.get("jwks").is_some());
+        assert!(parsed.get("endpoints").is_none());
+    }
+
+    #[test]
+    fn test_discovery_includes_jwks() {
+        let jwks = json!({
+            "keys": [
+                {
+                    "kty": "OKP",
+                    "kid": "test-key"
+                }
+            ]
+        });
+
+        let discovery = TrustedServerDiscovery::new(jwks);
+        let serialized = serde_json::to_string(&discovery).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+        assert!(parsed["jwks"]["keys"].is_array());
+        assert_eq!(parsed["jwks"]["keys"][0]["kid"], "test-key");
+    }
+}

--- a/crates/common/src/request_signing/mod.rs
+++ b/crates/common/src/request_signing/mod.rs
@@ -3,11 +3,13 @@
 //! This module provides cryptographic signing capabilities using Ed25519 keys,
 //! including JWKS management, key rotation, and signature verification.
 
+pub mod discovery;
 pub mod endpoints;
 pub mod jwks;
 pub mod rotation;
 pub mod signing;
 
+pub use discovery::*;
 pub use endpoints::*;
 pub use jwks::*;
 pub use rotation::*;

--- a/crates/fastly/src/main.rs
+++ b/crates/fastly/src/main.rs
@@ -12,7 +12,8 @@ use trusted_server_common::proxy::{
 };
 use trusted_server_common::publisher::{handle_publisher_request, handle_tsjs_dynamic};
 use trusted_server_common::request_signing::{
-    handle_deactivate_key, handle_jwks_endpoint, handle_rotate_key, handle_verify_signature,
+    handle_deactivate_key, handle_rotate_key, handle_trusted_server_discovery,
+    handle_verify_signature,
 };
 use trusted_server_common::settings::Settings;
 use trusted_server_common::settings_data::get_settings;
@@ -62,8 +63,10 @@ async fn route_request(
             handle_tsjs_dynamic(&settings, req)
         }
 
-        // JWKS endpoint for public key distribution
-        (Method::GET, "/.well-known/ts.jwks.json") => handle_jwks_endpoint(&settings, req),
+        // Discovery endpoint for trusted-server capabilities and JWKS
+        (Method::GET, "/.well-known/trusted-server.json") => {
+            handle_trusted_server_discovery(&settings, req)
+        }
 
         // Signature verification endpoint
         (Method::POST, "/verify-signature") => handle_verify_signature(&settings, req),


### PR DESCRIPTION
closes #105

new format for .well-known/trusted-server.json
```
{
  "version": "1.0",
  "jwks": {
    "keys": [
      {
        "crv": "Ed25519",
        "kid": "ts-2025-10-A",
        "kty": "OKP",
        "use": "sig",
        "x": "UVTi04QLrIuB7jXpVfHjUTVN5aIdcbPNr50umTtN8pw"
      },
      {
        "crv": "Ed25519",
        "kid": "ts-2025-10-B",
        "kty": "OKP",
        "use": "sig",
        "x": "HVTi04QLrIuB7jXpVfHjUTVN5aIdcbPNr50umTtN8pw"
      }
    ]
  }
}
```