### PR TITLE
Standardize IntegrationConfig trait imports

### DIFF
--- a/crates/common/src/integrations/lockr.rs
+++ b/crates/common/src/integrations/lockr.rs
@@ -29,7 +29,7 @@ use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
 };
-use crate::settings::{IntegrationConfig as IntegrationConfigTrait, Settings};
+use crate::settings::{IntegrationConfig, Settings};
 
 const LOCKR_INTEGRATION_ID: &str = "lockr";
 
@@ -68,7 +68,7 @@ pub struct LockrConfig {
     pub rewrite_sdk_host: bool,
 }
 
-impl IntegrationConfigTrait for LockrConfig {
+impl IntegrationConfig for LockrConfig {
     fn is_enabled(&self) -> bool {
         self.enabled
     }

--- a/crates/common/src/integrations/permutive.rs
+++ b/crates/common/src/integrations/permutive.rs
@@ -18,7 +18,7 @@ use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
 };
-use crate::settings::{IntegrationConfig as IntegrationConfigTrait, Settings};
+use crate::settings::{IntegrationConfig, Settings};
 
 const PERMUTIVE_INTEGRATION_ID: &str = "permutive";
 
@@ -61,7 +61,7 @@ pub struct PermutiveConfig {
     pub rewrite_sdk: bool,
 }
 
-impl IntegrationConfigTrait for PermutiveConfig {
+impl IntegrationConfig for PermutiveConfig {
     fn is_enabled(&self) -> bool {
         self.enabled
     }

--- a/crates/common/src/integrations/testlight.rs
+++ b/crates/common/src/integrations/testlight.rs
@@ -15,7 +15,7 @@ use crate::integrations::{
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
 };
 use crate::proxy::{proxy_request, ProxyRequestConfig};
-use crate::settings::{IntegrationConfig as IntegrationConfigTrait, Settings};
+use crate::settings::{IntegrationConfig, Settings};
 use crate::synthetic::{generate_synthetic_id, get_or_generate_synthetic_id};
 use crate::tsjs;
 
@@ -37,7 +37,7 @@ pub struct TestlightConfig {
     pub rewrite_scripts: bool,
 }
 
-impl IntegrationConfigTrait for TestlightConfig {
+impl IntegrationConfig for TestlightConfig {
     fn is_enabled(&self) -> bool {
         self.enabled
     }


### PR DESCRIPTION
Remove the IntegrationConfigTrait alias from permutive, lockr, and testlight integration modules. Use IntegrationConfig directly without aliasing, matching the pattern in other integrations and improving code consistency and searchability.

Trait aliasing is typically reserved for avoiding name collisions, which don't exist here.

Resolves: #190