### PR TITLE
fix: Forward Origin header to Lockr API for domain validation

### DIFF
--- a/crates/common/src/integrations/lockr.rs
+++ b/crates/common/src/integrations/lockr.rs
@@ -281,10 +281,13 @@ impl LockrIntegration {
         }
 
         // Handle Origin header - use override if configured, otherwise forward original
-        if let Some(ref origin_override) = self.config.origin_override {
-            to.set_header(header::ORIGIN, origin_override.as_str());
-        } else if let Some(value) = from.get_header(header::ORIGIN) {
-            to.set_header(header::ORIGIN, value);
+        let origin = self
+            .config
+            .origin_override
+            .as_deref()
+            .or_else(|| from.get_header_str(header::ORIGIN));
+        if let Some(origin) = origin {
+            to.set_header(header::ORIGIN, origin);
         }
 
         // Copy any X-* custom headers


### PR DESCRIPTION
Closes #201 

## Summary
- Lockr's API validates the `Origin` header to verify requests come from authorized domains
- Without forwarding this header, proxied requests fail with `{"success":false}`
- Added `origin_override` config option for local development when using domains not registered with Lockr

## Changes
- Add `origin_override` config option to `LockrConfig`
- Forward `Origin` header from original request (or use override if configured)
- Update all test configs to include the new field

## Test plan
- [x] Unit tests pass
- [x] Manual test: Verify Lockr API proxy works with `origin_override` set
- [x] Manual test: Verify Lockr API proxy works in production without `origin_override`

## Configuration
For local development with a domain not registered with Lockr:
```toml
[integrations.lockr]
origin_override = "https://www.example.com"
```

Or via environment variable:
```
TRUSTED_SERVER__INTEGRATIONS__LOCKR__ORIGIN_OVERRIDE=https://www.example.com
```

