### PR TITLE
Enhanced request signing with domain verification (v1.1)

### DIFF
--- a/crates/common/src/integrations/prebid.rs
+++ b/crates/common/src/integrations/prebid.rs
@@ -26,7 +26,7 @@ use crate::openrtb::{
     Banner, Device, Format, Geo, Imp, ImpExt, OpenRtbRequest, PrebidExt, PrebidImpExt, Regs,
     RegsExt, RequestExt, Site, TrustedServerExt, User, UserExt,
 };
-use crate::request_signing::RequestSigner;
+use crate::request_signing::{RequestSigner, SigningParams, SIGNING_VERSION};
 use crate::settings::{IntegrationConfig, Settings};
 
 const PREBID_INTEGRATION_ID: &str = "prebid";
@@ -466,7 +466,7 @@ impl PrebidAuctionProvider {
         &self,
         request: &AuctionRequest,
         context: &AuctionContext<'_>,
-        signer: Option<(&RequestSigner, String)>,
+        signer: Option<(&RequestSigner, String, &SigningParams)>,
     ) -> OpenRtbRequest {
         let imps: Vec<Imp> = request
             .slots
@@ -553,19 +553,28 @@ impl PrebidAuctionProvider {
 
         // Build ext object
         let request_info = RequestInfo::from_request(context.request);
-        let (signature, kid) = signer
-            .map(|(s, sig)| (Some(sig), Some(s.kid.clone())))
-            .unwrap_or((None, None));
+        let (version, signature, kid, ts) = signer
+            .map(|(s, sig, params)| {
+                (
+                    Some(SIGNING_VERSION.to_string()),
+                    Some(sig),
+                    Some(s.kid.clone()),
+                    Some(params.timestamp),
+                )
+            })
+            .unwrap_or((None, None, None, None));
 
         let ext = Some(RequestExt {
             prebid: Some(PrebidExt {
                 debug: if self.config.debug { Some(true) } else { None },
             }),
             trusted_server: Some(TrustedServerExt {
+                version,
                 signature,
                 kid,
                 request_host: Some(request_info.host),
                 request_scheme: Some(request_info.scheme),
+                ts,
             }),
         });
 
@@ -689,9 +698,15 @@ impl AuctionProvider for PrebidAuctionProvider {
         let signer_with_signature =
             if let Some(request_signing_config) = &context.settings.request_signing {
                 if request_signing_config.enabled {
+                    let request_info = RequestInfo::from_request(context.request);
                     let signer = RequestSigner::from_config()?;
-                    let signature = signer.sign(request.id.as_bytes())?;
-                    Some((signer, signature))
+                    let params = SigningParams::new(
+                        request.id.clone(),
+                        request_info.host,
+                        request_info.scheme,
+                    );
+                    let signature = signer.sign_request(&params)?;
+                    Some((signer, signature, params))
                 } else {
                     None
                 }
@@ -705,7 +720,7 @@ impl AuctionProvider for PrebidAuctionProvider {
             context,
             signer_with_signature
                 .as_ref()
-                .map(|(s, sig)| (s, sig.clone())),
+                .map(|(s, sig, params)| (s, sig.clone(), params)),
         );
 
         // Log the outgoing OpenRTB request for debugging

--- a/crates/common/src/integrations/prebid.rs
+++ b/crates/common/src/integrations/prebid.rs
@@ -333,7 +333,6 @@ fn expand_trusted_server_bidders(
         })
         .collect()
 }
-
 fn transform_prebid_response(
     response: &mut Json,
     request_host: &str,
@@ -695,24 +694,22 @@ impl AuctionProvider for PrebidAuctionProvider {
         log::info!("Prebid: requesting bids for {} slots", request.slots.len());
 
         // Create signer and compute signature if request signing is enabled
-        let signer_with_signature =
-            if let Some(request_signing_config) = &context.settings.request_signing {
-                if request_signing_config.enabled {
-                    let request_info = RequestInfo::from_request(context.request);
-                    let signer = RequestSigner::from_config()?;
-                    let params = SigningParams::new(
-                        request.id.clone(),
-                        request_info.host,
-                        request_info.scheme,
-                    );
-                    let signature = signer.sign_request(&params)?;
-                    Some((signer, signature, params))
-                } else {
-                    None
-                }
+        let signer_with_signature = if let Some(request_signing_config) =
+            &context.settings.request_signing
+        {
+            if request_signing_config.enabled {
+                let request_info = RequestInfo::from_request(context.request);
+                let signer = RequestSigner::from_config()?;
+                let params =
+                    SigningParams::new(request.id.clone(), request_info.host, request_info.scheme);
+                let signature = signer.sign_request(&params)?;
+                Some((signer, signature, params))
             } else {
                 None
-            };
+            }
+        } else {
+            None
+        };
 
         // Convert to OpenRTB with all enrichments
         let openrtb = self.to_openrtb(

--- a/crates/common/src/openrtb.rs
+++ b/crates/common/src/openrtb.rs
@@ -124,7 +124,7 @@ pub struct TrustedServerExt {
     pub request_host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_scheme: Option<String>,
-    /// Unix timestamp for replay protection
+    /// Unix timestamp in milliseconds for replay protection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ts: Option<u64>,
 }

--- a/crates/common/src/openrtb.rs
+++ b/crates/common/src/openrtb.rs
@@ -113,6 +113,9 @@ pub struct PrebidExt {
 
 #[derive(Debug, Serialize, Default)]
 pub struct TrustedServerExt {
+    /// Version of the signing protocol (e.g., "1.1")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -121,6 +124,9 @@ pub struct TrustedServerExt {
     pub request_host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_scheme: Option<String>,
+    /// Unix timestamp for replay protection
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ts: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/common/src/request_signing/signing.rs
+++ b/crates/common/src/request_signing/signing.rs
@@ -6,6 +6,7 @@
 use base64::{engine::general_purpose, Engine};
 use ed25519_dalek::{Signature, Signer as Ed25519Signer, SigningKey, Verifier, VerifyingKey};
 use error_stack::{Report, ResultExt};
+use serde::Serialize;
 
 use crate::error::TrustedServerError;
 use crate::fastly_storage::{FastlyConfigStore, FastlySecretStore};
@@ -48,6 +49,20 @@ pub struct RequestSigner {
 /// Current version of the signing protocol
 pub const SIGNING_VERSION: &str = "1.1";
 
+/// Canonical payload structure for request signing.
+///
+/// Serialized as JSON to prevent signature confusion attacks that could
+/// exploit delimiter-based formats.
+#[derive(Serialize)]
+struct SigningPayload<'a> {
+    version: &'a str,
+    kid: &'a str,
+    host: &'a str,
+    scheme: &'a str,
+    id: &'a str,
+    ts: u64,
+}
+
 /// Parameters for enhanced request signing
 #[derive(Debug, Clone)]
 pub struct SigningParams {
@@ -74,13 +89,26 @@ impl SigningParams {
 
     /// Builds the canonical payload string for signing.
     ///
-    /// Format: `kid:request_host:request_scheme:id:ts`
-    #[must_use]
-    pub fn build_payload(&self, kid: &str) -> String {
-        format!(
-            "{}:{}:{}:{}:{}",
-            kid, self.request_host, self.request_scheme, self.request_id, self.timestamp
-        )
+    /// The payload is a JSON-serialized [`SigningPayload`] to prevent signature
+    /// confusion attacks that could exploit delimiter-based formats.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload cannot be serialized to JSON.
+    pub fn build_payload(&self, kid: &str) -> Result<String, Report<TrustedServerError>> {
+        let payload = SigningPayload {
+            version: SIGNING_VERSION,
+            kid,
+            host: &self.request_host,
+            scheme: &self.request_scheme,
+            id: &self.request_id,
+            ts: self.timestamp,
+        };
+        serde_json::to_string(&payload).map_err(|e| {
+            Report::new(TrustedServerError::Configuration {
+                message: format!("Failed to serialize signing payload: {}", e),
+            })
+        })
     }
 }
 
@@ -124,7 +152,8 @@ impl RequestSigner {
 
     /// Signs a request using the enhanced v1.1 signing protocol.
     ///
-    /// The signed payload format is: `kid:request_host:request_scheme:id:ts`
+    /// The signed payload is a JSON object containing version, kid, host,
+    /// scheme, id, and ts fields.
     ///
     /// # Errors
     ///
@@ -133,7 +162,7 @@ impl RequestSigner {
         &self,
         params: &SigningParams,
     ) -> Result<String, Report<TrustedServerError>> {
-        let payload = params.build_payload(&self.kid);
+        let payload = params.build_payload(&self.kid)?;
         self.sign(payload.as_bytes())
     }
 }
@@ -298,8 +327,17 @@ mod tests {
             timestamp: 1706900000,
         };
 
-        let payload = params.build_payload("kid-abc");
-        assert_eq!(payload, "kid-abc:example.com:https:req-123:1706900000");
+        let payload = params
+            .build_payload("kid-abc")
+            .expect("should build payload");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload).expect("should be valid JSON");
+        assert_eq!(parsed["version"], SIGNING_VERSION);
+        assert_eq!(parsed["kid"], "kid-abc");
+        assert_eq!(parsed["host"], "example.com");
+        assert_eq!(parsed["scheme"], "https");
+        assert_eq!(parsed["id"], "req-123");
+        assert_eq!(parsed["ts"], 1706900000);
     }
 
     #[test]
@@ -335,7 +373,7 @@ mod tests {
         assert!(!signature.is_empty());
 
         // Verify the signature is valid by reconstructing the payload
-        let payload = params.build_payload(&signer.kid);
+        let payload = params.build_payload(&signer.kid).unwrap();
         let result = verify_signature(payload.as_bytes(), &signature, &signer.kid).unwrap();
         assert!(result, "Enhanced signature should be valid");
     }
@@ -365,10 +403,5 @@ mod tests {
             sig1, sig2,
             "Different hosts should produce different signatures"
         );
-    }
-
-    #[test]
-    fn test_signing_version_constant() {
-        assert_eq!(SIGNING_VERSION, "1.1");
     }
 }


### PR DESCRIPTION
## Summary

- Implements cryptographic signing of OpenRTB requests that includes publisher domain verification and replay protection
- The signed payload format is: `kid:request_host:request_scheme:id:ts`
- Adds `version` ("1.1") and `ts` (Unix timestamp) fields to `ext.trusted_server`

This prevents request tampering and domain spoofing by ensuring the signature is cryptographically bound to the originating publisher domain.

## Changes

- **openrtb.rs**: Add `version` and `ts` fields to `TrustedServerExt`
- **signing.rs**: Add `SigningParams` struct, `SIGNING_VERSION` constant, and `sign_request()` method
- **prebid.rs**: Update both `PrebidAuctionProvider` and `enhance_openrtb_request` to use enhanced signing

## Output Format

```json
{
  "ext": {
    "trusted_server": {
      "version": "1.1",
      "kid": "ts-2026-01-A",
      "request_host": "publisher.com",
      "request_scheme": "https",
      "ts": 1738527600,
      "signature": "base64-encoded-ed25519-signature"
    }
  }
}
```

Closes #274 
Closes #216 

## Test plan

- [ ] Verify build passes (`cargo build --release`)
- [ ] Verify clippy passes (`cargo clippy`)
- [ ] Deploy to test environment and verify signature verification works on Mocktioneer
- [ ] Test with different hosts to confirm signatures differ