### PR TITLE
Ignore IDE and env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /target
 
 # env
-.env
+.env*
 
 # backup
 **/*.rs.bk
@@ -14,10 +14,7 @@ src/*.html
 # OS
 .DS_Store
 
-# IDE - VSCode
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+# IDE
+.claude
 .specstory
+.vscode


### PR DESCRIPTION
### Summary
- Broadens `.env` ignore pattern to `.env*` to catch all env file variants (e.g., `.env.local`, `.env.development`)
- Simplifies IDE ignore rules by ignoring entire `.vscode` directory instead of maintaining an allowlist
- Adds `.claude` directory to gitignore for Claude Code configuration files
- Keeps existing `.specstory` ignore

### Closes [233](https://github.com/IABTechLab/trusted-server/issues/233)

### Changes
| File | Change |
|------|--------|
| .gitignore | Updated env and IDE ignore patterns |

### Test plan
- [x] Verify `.env*` files are ignored (e.g., `.env.local`, `.env.test`)
- [x] Confirm `.vscode/` directory is fully ignored
- [x] Confirm `.claude/` directory is ignored