### PR TITLE
Removes the custom response header config from trusted-server.toml

### DIFF
--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -22,8 +22,9 @@ secret_key = "trusted-server"
 template = "{{ client_ip }}:{{ user_agent }}:{{ accept_language }}:{{ accept_encoding }}"
 
 # Custom headers to be included in every response
-[response_headers]
-X-Custom-Header = "custom header value"
+# Allows publishers to include tags such as X-Robots-Tag: noindex
+# [response_headers]
+# X-Custom-Header = "custom header value"
 
 # Request Signing Configuration
 # Enable signing of OpenRTB requests and other API calls


### PR DESCRIPTION
Also adds a more descriptive comment when a publisher would use the
config.

closes #234 