### PR TITLE
Add IntegrationHeadInjector trait for head script injection

### DIFF
--- a/crates/common/src/html_processor.rs
+++ b/crates/common/src/html_processor.rs
@@ -111,7 +111,7 @@ impl HtmlProcessorConfig {
     }
 }
 
-/// Create an HTML processor with URL replacement and optional Prebid injection
+/// Create an HTML processor with URL replacement and integration hooks
 #[must_use]
 pub fn create_html_processor(config: HtmlProcessorConfig) -> impl StreamProcessor {
     let post_processors = config.integrations.html_post_processors();
@@ -474,6 +474,7 @@ mod tests {
     use super::*;
     use crate::integrations::{
         AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
+        IntegrationHeadInjector, IntegrationHtmlContext,
     };
     use crate::streaming_processor::{Compression, PipelineConfig, StreamingPipeline};
     use crate::test_support::tests::create_test_settings;
@@ -542,6 +543,77 @@ mod tests {
 
         assert!(processed.contains("keep-me"));
         assert!(!processed.contains("remove-me"));
+    }
+
+    #[test]
+    fn integration_head_injector_prepends_after_tsjs_once() {
+        struct TestHeadInjector;
+
+        impl IntegrationHeadInjector for TestHeadInjector {
+            fn integration_id(&self) -> &'static str {
+                "test"
+            }
+
+            fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+                vec![r#"<script>window.__testHeadInjector=true;</script>"#.to_string()]
+            }
+        }
+
+        let html = r#"<html><head><title>Test</title></head><body></body></html>"#;
+
+        let mut config = create_test_config();
+        config.integrations = IntegrationRegistry::from_rewriters_with_head_injectors(
+            Vec::new(),
+            Vec::new(),
+            vec![Arc::new(TestHeadInjector)],
+        );
+
+        let processor = create_html_processor(config);
+        let pipeline_config = PipelineConfig {
+            input_compression: Compression::None,
+            output_compression: Compression::None,
+            chunk_size: 8192,
+        };
+        let mut pipeline = StreamingPipeline::new(pipeline_config, processor);
+
+        let mut output = Vec::new();
+        pipeline
+            .process(Cursor::new(html.as_bytes()), &mut output)
+            .expect("pipeline should process HTML");
+        let processed = String::from_utf8(output).expect("output should be valid UTF-8");
+
+        let tsjs_marker = "id=\"trustedserver-js\"";
+        let head_marker = "window.__testHeadInjector=true";
+
+        assert_eq!(
+            processed.matches(tsjs_marker).count(),
+            1,
+            "should inject unified tsjs tag once"
+        );
+        assert_eq!(
+            processed.matches(head_marker).count(),
+            1,
+            "should inject head snippet once"
+        );
+
+        let tsjs_index = processed
+            .find(tsjs_marker)
+            .expect("should include unified tsjs tag");
+        let head_index = processed
+            .find(head_marker)
+            .expect("should include head snippet");
+        let title_index = processed
+            .find("<title>")
+            .expect("should keep existing head content");
+
+        assert!(
+            tsjs_index < head_index,
+            "should inject head snippet after tsjs tag"
+        );
+        assert!(
+            head_index < title_index,
+            "should prepend head snippet before existing head content"
+        );
     }
 
     #[test]

--- a/crates/common/src/integrations/mod.rs
+++ b/crates/common/src/integrations/mod.rs
@@ -15,9 +15,9 @@ pub mod testlight;
 pub use registry::{
     AttributeRewriteAction, AttributeRewriteOutcome, IntegrationAttributeContext,
     IntegrationAttributeRewriter, IntegrationDocumentState, IntegrationEndpoint,
-    IntegrationHtmlContext, IntegrationHtmlPostProcessor, IntegrationMetadata, IntegrationProxy,
-    IntegrationRegistration, IntegrationRegistrationBuilder, IntegrationRegistry,
-    IntegrationScriptContext, IntegrationScriptRewriter, ScriptRewriteAction,
+    IntegrationHeadInjector, IntegrationHtmlContext, IntegrationHtmlPostProcessor,
+    IntegrationMetadata, IntegrationProxy, IntegrationRegistration, IntegrationRegistrationBuilder,
+    IntegrationRegistry, IntegrationScriptContext, IntegrationScriptRewriter, ScriptRewriteAction,
 };
 
 type IntegrationBuilder = fn(&Settings) -> Option<IntegrationRegistration>;

--- a/crates/common/src/integrations/registry.rs
+++ b/crates/common/src/integrations/registry.rs
@@ -503,6 +503,7 @@ pub struct IntegrationMetadata {
     pub routes: Vec<IntegrationEndpoint>,
     pub attribute_rewriters: usize,
     pub script_selectors: Vec<&'static str>,
+    pub head_injectors: usize,
 }
 
 impl IntegrationMetadata {
@@ -512,6 +513,7 @@ impl IntegrationMetadata {
             routes: Vec::new(),
             attribute_rewriters: 0,
             script_selectors: Vec::new(),
+            head_injectors: 0,
         }
     }
 }
@@ -725,6 +727,13 @@ impl IntegrationRegistry {
             entry.script_selectors.push(rewriter.selector());
         }
 
+        for injector in &self.inner.head_injectors {
+            let entry = map
+                .entry(injector.integration_id())
+                .or_insert_with(|| IntegrationMetadata::new(injector.integration_id()));
+            entry.head_injectors += 1;
+        }
+
         map.into_values().collect()
     }
 
@@ -751,7 +760,7 @@ impl IntegrationRegistry {
     }
 
     #[cfg(test)]
-    #[must_use] 
+    #[must_use]
     pub fn from_rewriters_with_head_injectors(
         attribute_rewriters: Vec<Arc<dyn IntegrationAttributeRewriter>>,
         script_rewriters: Vec<Arc<dyn IntegrationScriptRewriter>>,

--- a/docs/guide/creative-processing.md
+++ b/docs/guide/creative-processing.md
@@ -666,6 +666,32 @@ impl IntegrationScriptRewriter for NextJsIntegration {
 - `replace(content)` - Replace script content
 - `remove_node()` - Delete script element
 
+### Head Injectors
+
+Integrations can inject HTML snippets at the start of `<head>`, immediately after the unified TSJS bundle:
+
+**Example**: An integration injects configuration that runs after the TSJS API is available
+
+```rust
+impl IntegrationHeadInjector for MyIntegration {
+    fn integration_id(&self) -> &'static str { "my_integration" }
+
+    fn head_inserts(&self, ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+        vec![format!(
+            r#"<script>tsjs.setConfig({{ host: "{}" }});</script>"#,
+            ctx.request_host
+        )]
+    }
+}
+```
+
+**Behavior**:
+
+- Snippets are prepended into `<head>` after the TSJS bundle tag
+- Called once per HTML response
+- Multiple integrations can each contribute snippets
+- If no snippets are returned, no extra markup is added
+
 See [Integration Guide](/guide/integration-guide) for creating custom rewriters.
 
 ## TSJS Injection

--- a/docs/guide/integrations-overview.md
+++ b/docs/guide/integrations-overview.md
@@ -174,11 +174,12 @@ All integrations support:
 
 ### Rewriting System
 
-Integrations can implement three types of rewriting:
+Integrations can implement four types of rewriting:
 
 1. **HTTP Proxying** - Route requests through first-party domain
 2. **HTML Attribute Rewriting** - Modify element attributes during streaming
 3. **Script Content Rewriting** - Transform inline script content
+4. **Head Injection** - Insert HTML snippets at the start of `<head>`
 
 ## Choosing an Integration
 
@@ -242,6 +243,7 @@ You can create your own integrations by implementing the integration traits:
 - `IntegrationProxy` - For HTTP endpoint proxying
 - `IntegrationAttributeRewriter` - For HTML attribute rewriting
 - `IntegrationScriptRewriter` - For script content transformation
+- `IntegrationHeadInjector` - For injecting HTML snippets into `<head>`
 
 See the [Integration Guide](./integration-guide.md) for details on building custom integrations.
 


### PR DESCRIPTION
## Summary

- Adds `IntegrationHeadInjector` trait allowing integrations to inject HTML snippets into `<head>`
- Adds `with_head_injector()` builder method to `IntegrationRegistrationBuilder`
- Adds `head_inserts()` method to `IntegrationRegistry` to collect all injector snippets
- Updates `html_processor` to inject integration head inserts after the TSJS bundle

This enables integrations (like the upcoming GAM interceptor) to inject configuration scripts into the document head without modifying the main TSJS bundle.

## Test plan

- [x] Verify `cargo check` passes
- [x] Verify `cargo test -p trusted-server-common` passes
- [x] Verify HTML processing still injects TSJS bundle correctly
- [x] Integration head inserts appear after TSJS bundle in `<head>`
- [x] Update documentation

## Dependencies

- Depends on #238 (cert verification & port handling)

Closes #247
Related to #179