### PR TITLE
Update documentation for new endpoint naming

### DIFF
--- a/SEQUENCE.md
+++ b/SEQUENCE.md
@@ -1,4 +1,4 @@
-# 🛡️ Trusted Server — First-Party Proxying Flow
+# 🛡️ Trusted Server — Proxying Flow
 
 ## 🔄 System Flow Diagram
 
@@ -80,7 +80,7 @@ sequenceDiagram
     activate TS
     activate PBS
     activate DSP
-    JS->>TS: GET /first-party/ad<br/>(with signals)
+    JS->>TS: GET /ad/render<br/>(with signals)
     TS->>PBS: POST /openrtb2/auction<br/>(OpenRTB 2.x)
     PBS->>DSP: POST bid request
     DSP-->>PBS: 200 bid response

--- a/crates/common/README.md
+++ b/crates/common/README.md
@@ -1,6 +1,6 @@
 # trusted-server-common
 
-Utilities shared by Trusted Server components. This crate contains HTML/CSS rewriting helpers used to normalize ad creative assets to first‑party proxy endpoints.
+Utilities shared by Trusted Server components. This crate contains HTML/CSS rewriting helpers used to normalize ad creative assets to proxy endpoints.
 
 ## Creative Rewriting
 

--- a/docs/guide/error-reference.md
+++ b/docs/guide/error-reference.md
@@ -659,7 +659,7 @@ fastly log-tail
 fastly compute serve
 
 # Test endpoint
-curl http://localhost:7676/first-party/ad?slot=test&w=300&h=250
+curl http://localhost:7676/ad/render?slot=test&w=300&h=250
 ```
 
 ---

--- a/docs/guide/what-is-trusted-server.md
+++ b/docs/guide/what-is-trusted-server.md
@@ -1,6 +1,6 @@
 # What is Trusted Server?
 
-Trusted Server is an open-source, cloud based orchestration framework and runtime for publishers. It moves code execution and operations that traditionally occurs in browsers (via 3rd party JS) to secure, zero-cold-start WASM binaries running in WASI supported environments.
+Trusted Server is an open-source, cloud based orchestration framework and runtime for publishers. It moves code execution and operations that traditionally occurs in browsers (via external JS) to secure, zero-cold-start WASM binaries running in WASI supported environments.
 
 Trusted Server is the new execution layer for the open-web, returning control of 1st party data, security, and overall user-experience back to publishers.
 


### PR DESCRIPTION
## Summary

Minor documentation updates to align with new endpoint naming conventions:

- **SEQUENCE.md**: Update flow diagram endpoint `/first-party/ad` → `/ad/render`
- **crates/common/README.md**: Change "first-party proxy" → "proxy" for clarity
- **docs/guide/error-reference.md**: Update example curl command to use `/ad/render`
- **docs/guide/what-is-trusted-server.md**: Change "3rd party JS" → "external JS"

## Test plan

- [ ] Review documentation changes for accuracy
- [ ] Verify no broken links

## Dependencies

None - this PR is independent and can be merged at any time.

Closes #253
Related to #179