### PR TITLE
Set x-synthetic-id header on integration routes for response from Trusted Server

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -39,6 +39,7 @@ pub const INTERNAL_HEADERS: &[&str] = &[
     "x-pub-user-id",
     "x-subject-id",
     "x-consent-advertising",
+    "x-forwarded-for",
     "x-geo-city",
     "x-geo-continent",
     "x-geo-coordinates",

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -25,3 +25,28 @@ pub const HEADER_ACCEPT: HeaderName = HeaderName::from_static("accept");
 pub const HEADER_ACCEPT_LANGUAGE: HeaderName = HeaderName::from_static("accept-language");
 pub const HEADER_ACCEPT_ENCODING: HeaderName = HeaderName::from_static("accept-encoding");
 pub const HEADER_REFERER: HeaderName = HeaderName::from_static("referer");
+
+/// TS-internal header names that must NOT be forwarded to downstream third-party services.
+///
+/// These headers are used internally by Trusted Server for identity, geo-enrichment,
+/// debugging, and compression hints. Leaking them to external origins could expose
+/// user tracking data and internal implementation details.
+///
+/// Uses `&str` slices because `HeaderName` has interior mutability and cannot appear
+/// in `const` context.
+pub const INTERNAL_HEADERS: &[&str] = &[
+    "x-synthetic-id",
+    "x-pub-user-id",
+    "x-subject-id",
+    "x-consent-advertising",
+    "x-geo-city",
+    "x-geo-continent",
+    "x-geo-coordinates",
+    "x-geo-country",
+    "x-geo-info-available",
+    "x-geo-metro-code",
+    "x-geo-region",
+    "x-request-id",
+    "x-compress-hint",
+    "x-debug-fastly-pop",
+];

--- a/crates/common/src/cookies.rs
+++ b/crates/common/src/cookies.rs
@@ -179,4 +179,24 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    fn test_set_synthetic_cookie() {
+        let settings = create_test_settings();
+        let mut response = fastly::Response::new();
+        set_synthetic_cookie(&settings, &mut response, "test-id-123");
+
+        let cookie_header = response
+            .get_header(header::SET_COOKIE)
+            .expect("Set-Cookie header should be present");
+        let cookie_str = cookie_header
+            .to_str()
+            .expect("header should be valid UTF-8");
+
+        let expected = create_synthetic_cookie(&settings, "test-id-123");
+        assert_eq!(
+            cookie_str, expected,
+            "Set-Cookie header should match create_synthetic_cookie output"
+        );
+    }
 }

--- a/crates/common/src/cookies.rs
+++ b/crates/common/src/cookies.rs
@@ -71,6 +71,21 @@ pub fn create_synthetic_cookie(settings: &Settings, synthetic_id: &str) -> Strin
     )
 }
 
+/// Sets the synthetic ID cookie on the given response.
+///
+/// This helper abstracts the logic of creating the cookie string and appending
+/// the Set-Cookie header to the response.
+pub fn set_synthetic_cookie(
+    settings: &Settings,
+    response: &mut fastly::Response,
+    synthetic_id: &str,
+) {
+    response.append_header(
+        header::SET_COOKIE,
+        create_synthetic_cookie(settings, synthetic_id),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test_support::tests::create_test_settings;

--- a/crates/common/src/http_util.rs
+++ b/crates/common/src/http_util.rs
@@ -481,7 +481,7 @@ mod tests {
         assert_eq!(
             target.get_header("x-custom-2").unwrap().to_str().unwrap(),
             "value2",
-            "Should copy arbitary X-header (case insensitive)"
+            "Should copy arbitrary X-header (case insensitive)"
         );
         assert!(
             target.get_header("x-synthetic-id").is_none(),

--- a/crates/common/src/http_util.rs
+++ b/crates/common/src/http_util.rs
@@ -4,7 +4,27 @@ use fastly::http::{header, StatusCode};
 use fastly::{Request, Response};
 use sha2::{Digest, Sha256};
 
+use crate::constants::INTERNAL_HEADERS;
 use crate::settings::Settings;
+
+/// Copy `X-*` custom headers from one request to another, skipping TS-internal headers.
+///
+/// This filters out all headers listed in [`INTERNAL_HEADERS`] to prevent leaking
+/// internal identity, geo-enrichment, and debugging data to downstream third-party
+/// services. Integrations that forward custom headers should use this utility
+/// instead of manually iterating over header names.
+pub fn copy_custom_headers(from: &Request, to: &mut Request) {
+    for header_name in from.get_header_names() {
+        let name_str = header_name.as_str();
+        if (name_str.starts_with("x-") || name_str.starts_with("X-"))
+            && !INTERNAL_HEADERS.contains(&name_str)
+        {
+            if let Some(value) = from.get_header(header_name) {
+                to.set_header(header_name, value);
+            }
+        }
+    }
+}
 
 /// Extracted request information for host rewriting.
 ///
@@ -438,6 +458,38 @@ mod tests {
         assert_eq!(
             info.scheme, "https",
             "Scheme should use X-Forwarded-Proto in chained proxy scenarios"
+        );
+    }
+
+    #[test]
+    fn test_copy_custom_headers_filters_internal() {
+        let mut req = Request::new(fastly::http::Method::GET, "https://example.com");
+        req.set_header("x-custom-1", "value1");
+        // HeaderName is case-insensitive and always lowercase, but set_header accepts strings
+        req.set_header("X-Custom-2", "value2");
+        req.set_header("x-synthetic-id", "should not copy");
+        req.set_header("x-geo-country", "US");
+
+        let mut target = Request::new(fastly::http::Method::GET, "https://target.com");
+        copy_custom_headers(&req, &mut target);
+
+        assert_eq!(
+            target.get_header("x-custom-1").unwrap().to_str().unwrap(),
+            "value1",
+            "Should copy arbitrary x-header"
+        );
+        assert_eq!(
+            target.get_header("x-custom-2").unwrap().to_str().unwrap(),
+            "value2",
+            "Should copy arbitary X-header (case insensitive)"
+        );
+        assert!(
+            target.get_header("x-synthetic-id").is_none(),
+            "Should filter x-synthetic-id"
+        );
+        assert!(
+            target.get_header("x-geo-country").is_none(),
+            "Should filter x-geo-country"
         );
     }
 }

--- a/crates/common/src/integrations/lockr.rs
+++ b/crates/common/src/integrations/lockr.rs
@@ -25,6 +25,7 @@ use validator::Validate;
 
 use crate::backend::ensure_backend_from_url;
 use crate::error::TrustedServerError;
+use crate::http_util::copy_custom_headers;
 use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
@@ -290,15 +291,8 @@ impl LockrIntegration {
             to.set_header(header::ORIGIN, origin);
         }
 
-        // Copy any X-* custom headers
-        for header_name in from.get_header_names() {
-            let name_str = header_name.as_str();
-            if name_str.starts_with("x-") || name_str.starts_with("X-") {
-                if let Some(value) = from.get_header(header_name) {
-                    to.set_header(header_name, value);
-                }
-            }
-        }
+        // Copy any X-* custom headers, skipping TS-internal headers
+        copy_custom_headers(from, to);
     }
 }
 

--- a/crates/common/src/integrations/permutive.rs
+++ b/crates/common/src/integrations/permutive.rs
@@ -14,6 +14,7 @@ use validator::Validate;
 
 use crate::backend::ensure_backend_from_url;
 use crate::error::TrustedServerError;
+use crate::http_util::copy_custom_headers;
 use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
@@ -495,15 +496,8 @@ impl PermutiveIntegration {
             }
         }
 
-        // Copy any X-* custom headers
-        for header_name in from.get_header_names() {
-            let name_str = header_name.as_str();
-            if name_str.starts_with("x-") || name_str.starts_with("X-") {
-                if let Some(value) = from.get_header(header_name) {
-                    to.set_header(header_name, value);
-                }
-            }
-        }
+        // Copy any X-* custom headers, skipping TS-internal headers
+        copy_custom_headers(from, to);
     }
 }
 

--- a/crates/common/src/integrations/registry.rs
+++ b/crates/common/src/integrations/registry.rs
@@ -630,9 +630,9 @@ impl IntegrationRegistry {
             // Set synthetic ID header on successful responses
             if let Ok(ref mut response) = result {
                 if let Ok(ref synthetic_id) = synthetic_id_result {
-                    response.set_header(HEADER_X_SYNTHETIC_ID, synthetic_id.as_str());
+                    response.append_header(HEADER_X_SYNTHETIC_ID, synthetic_id.as_str());
                     if !has_synthetic_cookie {
-                        response.set_header(
+                        response.append_header(
                             header::SET_COOKIE,
                             create_synthetic_cookie(settings, synthetic_id.as_str()),
                         );

--- a/crates/common/src/integrations/registry.rs
+++ b/crates/common/src/integrations/registry.rs
@@ -630,7 +630,7 @@ impl IntegrationRegistry {
             // Set synthetic ID header on successful responses
             if let Ok(ref mut response) = result {
                 if let Ok(ref synthetic_id) = synthetic_id_result {
-                    response.append_header(HEADER_X_SYNTHETIC_ID, synthetic_id.as_str());
+                    response.set_header(HEADER_X_SYNTHETIC_ID, synthetic_id.as_str());
                     if !has_synthetic_cookie {
                         response.append_header(
                             header::SET_COOKIE,

--- a/crates/common/src/integrations/testlight.rs
+++ b/crates/common/src/integrations/testlight.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use validator::Validate;
 
-use crate::constants::HEADER_X_SYNTHETIC_ID;
 use crate::error::TrustedServerError;
 use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
@@ -175,7 +174,6 @@ impl IntegrationProxy for TestlightIntegration {
             }
         }
 
-        response.set_header(HEADER_X_SYNTHETIC_ID, &synthetic_id);
         Ok(response)
     }
 }

--- a/crates/common/src/publisher.rs
+++ b/crates/common/src/publisher.rs
@@ -199,7 +199,7 @@ pub fn handle_publisher_request(
     // Generate synthetic identifiers before the request body is consumed.
     let synthetic_id = get_or_generate_synthetic_id(settings, &req)?;
 
-    log::debug!("Proxy synthetic IDs - trusted: {}", synthetic_id,);
+    log::debug!("Proxy synthetic IDs - trusted: {}", synthetic_id);
 
     let backend_name = ensure_backend_from_url(&settings.publisher.origin_url)?;
     let origin_host = settings.publisher.origin_host();

--- a/crates/common/src/synthetic.rs
+++ b/crates/common/src/synthetic.rs
@@ -155,7 +155,7 @@ pub fn get_synthetic_id(req: &Request) -> Result<Option<String>, Report<TrustedS
 /// Gets or creates a synthetic ID from the request.
 ///
 /// Attempts to retrieve an existing synthetic ID from:
-/// 1. The `x-psid-ts` header
+/// 1. The `x-synthetic-id` header
 /// 2. The `synthetic_id` cookie
 ///
 /// If neither exists, generates a new synthetic ID.

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -21,6 +21,11 @@ secret_key = "trusted-server"
 #   - "random_uuid"
 template = "{{ client_ip }}:{{ user_agent }}:{{ accept_language }}:{{ accept_encoding }}"
 
+# Custom headers to be included in every response
+# Allows publishers to include tags such as X-Robots-Tag: noindex
+# [response_headers]
+# X-Custom-Header = "custom header value"
+
 # Request Signing Configuration
 # Enable signing of OpenRTB requests and other API calls
 [request_signing]

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -21,11 +21,6 @@ secret_key = "trusted-server"
 #   - "random_uuid"
 template = "{{ client_ip }}:{{ user_agent }}:{{ accept_language }}:{{ accept_encoding }}"
 
-# Custom headers to be included in every response
-# Allows publishers to include tags such as X-Robots-Tag: noindex
-# [response_headers]
-# X-Custom-Header = "custom header value"
-
 # Request Signing Configuration
 # Enable signing of OpenRTB requests and other API calls
 [request_signing]


### PR DESCRIPTION
Integration proxy responses were missing the `x-synthetic-id` header because `handle_proxy` dispatched to integrations without adding it. This caused identity tracking to break for first-party re-hosted integrations like Permutive's secure-signal endpoint.

Centralizing the header logic in `handle_proxy` ensures all current and future integrations automatically include the synthetic ID, rather than requiring each integration to implement it manually.

## Test Plan

Manually verified locally via `fastly compute serve` against Prospect A production config:

- `GET /integrations/permutive/secure-signals` → `x-synthetic-id` header and `Set-Cookie: synthetic_id=...` present
- `GET /integrations/lockr/api` → same
- `GET /` (publisher proxy) → same
- Confirmed `x-synthetic-id` is **not** forwarded to downstream third-party origins (filtered by `INTERNAL_HEADERS` via `copy_custom_headers`)
- All 336 tests pass

Fixes #205
