### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,5 +1,8 @@
 name: "Run Format"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/IABTechLab/trusted-server/security/code-scanning/3](https://github.com/IABTechLab/trusted-server/security/code-scanning/3)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` in this workflow to the minimal permissions required. Since all the jobs only need to read the repository contents (for checkout, dependency resolution, and running tools) and do not write back to GitHub, we can safely declare `contents: read` at the top level of the workflow. Defining `permissions` at the workflow root applies to all jobs that don't have their own `permissions` block, which matches this file.

Concretely, edit `.github/workflows/format.yml` to add a `permissions` block near the top, alongside `name` and `on`. For example, add:

```yml
permissions:
  contents: read
```

between the `name` and `on` keys. No additional methods, imports, or steps are required; this only changes the token scope that GitHub automatically injects, without altering the existing job behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
