### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: "Run Tests"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/IABTechLab/trusted-server/security/code-scanning/4](https://github.com/IABTechLab/trusted-server/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions` block limiting the default `GITHUB_TOKEN` permissions to the least privilege needed. For this workflow, both jobs simply check out code and run tests; they do not need to write to repository contents, issues, or pull requests. The recommended minimal safe setting is `permissions: contents: read` at the workflow level so it applies to all jobs, unless a specific job needs more.

The best fix here is to add a top-level `permissions` block right after the `name` (or before `jobs`) in `.github/workflows/test.yml`, setting `contents: read`. This documents the intended use and ensures both `test-rust` and `test-typescript` inherit read-only repo access. No other functionality needs to change, and no imports or extra methods are required because this is purely a YAML configuration change for GitHub Actions.

Concretely:
- Edit `.github/workflows/test.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 2 and line 3 (after `name: "Run Tests"` and the blank line), keeping indentation consistent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
