### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,6 @@
 name: "Run Format"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/IABTechLab/trusted-server/security/code-scanning/2](https://github.com/IABTechLab/trusted-server/security/code-scanning/2)

In general, the fix is to explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow YAML, either globally (at the root) or per job, instead of relying on repository defaults. For this workflow, all jobs only need to read the repository contents and do not interact with PRs, issues, or write back to the repo, so `contents: read` is sufficient.

The best fix without changing behavior is to add a `permissions` block at the root level (just under `name:` and before `on:`). This ensures every job in this workflow uses the same restricted permissions and avoids having to repeat the block for each job. No additional imports or external actions are needed. Concretely, edit `.github/workflows/format.yml` and insert:

```yaml
permissions:
  contents: read
```

after line 1 (the `name:` line). All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
