### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: "Run Tests"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/IABTechLab/trusted-server/security/code-scanning/1](https://github.com/IABTechLab/trusted-server/security/code-scanning/1)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions to the minimum needed by this workflow. These jobs only need to read repository contents and possibly read packages; they do not perform any write operations to GitHub resources. The simplest and safest fix is to add a `permissions:` block at the top level of the workflow (alongside `name` and `on`) so it applies to all jobs that don't override it, setting `contents: read`. If you know the workflow never needs to access packages, you can omit `packages: read`; otherwise you can include it for clarity.

Concretely, edit `.github/workflows/test.yml` and insert a `permissions:` section after the `name:` (line 1) and before the `on:` key (line 3). For example:

```yaml
name: "Run Tests"

permissions:
  contents: read

on:
  push:
    branches: [main]
  ...
```

No additional methods, imports, or definitions are required; this is purely a YAML workflow configuration change. This will ensure the `GITHUB_TOKEN` has only read access to repository contents for all jobs in this workflow, satisfying the CodeQL rule and adhering to least privilege without changing the behavior of any existing steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
