### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   format-rust:
     name: cargo fmt


### PR DESCRIPTION
Potential fix for [https://github.com/IABTechLab/trusted-server/security/code-scanning/5](https://github.com/IABTechLab/trusted-server/security/code-scanning/5)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for this workflow instead of relying on repository/organization defaults. Since all three jobs only need to read the repository contents and do local formatting/linting, the minimal required permission is `contents: read`.

The best way to do this without changing existing functionality is to add a single top‑level `permissions` block in `.github/workflows/format.yml`, right after the `on:` section and before `jobs:`. This will apply to all jobs in the workflow because none of them currently define their own `permissions`. Concretely, insert:

```yaml
permissions:
  contents: read
```

at the root level (same indentation as `on:` and `jobs:`). No additional imports, methods, or other definitions are needed; this is a pure YAML configuration change that does not affect how the steps run, only the scope of the `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
