### PR TITLE
send permutive segments to adserver

### DIFF
--- a/crates/common/src/auction/context.rs
+++ b/crates/common/src/auction/context.rs
@@ -1,0 +1,205 @@
+//! Context query-parameter forwarding for auction providers.
+//!
+//! Provides a config-driven mechanism for ad-server / mediator providers to
+//! forward integration-supplied data (e.g. audience segments) as URL query
+//! parameters without hard-coding integration-specific knowledge.
+
+use std::collections::HashMap;
+
+/// Mapping from auction-request context keys to query-parameter names.
+///
+/// Used by ad-server / mediator providers to forward integration-supplied data
+/// (e.g. audience segments) as URL query parameters without hard-coding
+/// integration-specific knowledge.
+///
+/// ```toml
+/// [integrations.adserver_mock.context_query_params]
+/// permutive_segments = "permutive"
+/// lockr_ids          = "lockr"
+/// ```
+pub type ContextQueryParams = HashMap<String, String>;
+
+/// Build a URL by appending context values as query parameters according to the
+/// provided mapping.
+///
+/// For each entry in `mapping`, if the corresponding key exists in `context`:
+/// - **Arrays** are serialised as a comma-separated string.
+/// - **Strings / numbers** are serialised as-is.
+/// - Other JSON types are skipped.
+///
+/// The [`url::Url`] crate is used for construction so all values are
+/// percent-encoded, preventing query-parameter injection.
+///
+/// Returns the original `base_url` unchanged when no parameters are appended.
+#[must_use]
+pub fn build_url_with_context_params(
+    base_url: &str,
+    context: &HashMap<String, serde_json::Value>,
+    mapping: &ContextQueryParams,
+) -> String {
+    let Ok(mut url) = url::Url::parse(base_url) else {
+        log::warn!("build_url_with_context_params: failed to parse base URL, returning as-is");
+        return base_url.to_string();
+    };
+
+    let mut appended = 0usize;
+
+    for (context_key, param_name) in mapping {
+        if let Some(value) = context.get(context_key) {
+            let serialized = serialize_context_value(value);
+            if !serialized.is_empty() {
+                url.query_pairs_mut().append_pair(param_name, &serialized);
+                appended += 1;
+            }
+        }
+    }
+
+    if appended > 0 {
+        log::info!(
+            "build_url_with_context_params: appended {} context query params",
+            appended
+        );
+    }
+
+    url.to_string()
+}
+
+/// Serialise a single [`serde_json::Value`] into a string suitable for a query
+/// parameter value.  Arrays are joined with commas; strings and numbers are
+/// returned directly; anything else yields an empty string (skipped).
+fn serialize_context_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| match v {
+                serde_json::Value::String(s) => Some(s.clone()),
+                serde_json::Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_build_url_with_context_params_appends_array() {
+        let context = HashMap::from([(
+            "permutive_segments".to_string(),
+            json!(["10000001", "10000003", "adv"]),
+        )]);
+        let mapping = HashMap::from([("permutive_segments".to_string(), "permutive".to_string())]);
+
+        let url = build_url_with_context_params(
+            "http://localhost:6767/adserver/mediate",
+            &context,
+            &mapping,
+        );
+        assert_eq!(
+            url,
+            "http://localhost:6767/adserver/mediate?permutive=10000001%2C10000003%2Cadv"
+        );
+    }
+
+    #[test]
+    fn test_build_url_with_context_params_preserves_existing_query() {
+        let context = HashMap::from([("permutive_segments".to_string(), json!(["123", "adv"]))]);
+        let mapping = HashMap::from([("permutive_segments".to_string(), "permutive".to_string())]);
+
+        let url = build_url_with_context_params(
+            "http://localhost:6767/adserver/mediate?debug=true",
+            &context,
+            &mapping,
+        );
+        assert_eq!(
+            url,
+            "http://localhost:6767/adserver/mediate?debug=true&permutive=123%2Cadv"
+        );
+    }
+
+    #[test]
+    fn test_build_url_with_context_params_no_matching_keys() {
+        let context = HashMap::new();
+        let mapping = HashMap::from([("permutive_segments".to_string(), "permutive".to_string())]);
+
+        let url = build_url_with_context_params(
+            "http://localhost:6767/adserver/mediate",
+            &context,
+            &mapping,
+        );
+        assert_eq!(url, "http://localhost:6767/adserver/mediate");
+    }
+
+    #[test]
+    fn test_build_url_with_context_params_empty_array_skipped() {
+        let context = HashMap::from([("permutive_segments".to_string(), json!([]))]);
+        let mapping = HashMap::from([("permutive_segments".to_string(), "permutive".to_string())]);
+
+        let url = build_url_with_context_params(
+            "http://localhost:6767/adserver/mediate",
+            &context,
+            &mapping,
+        );
+        assert!(!url.contains("permutive="));
+    }
+
+    #[test]
+    fn test_build_url_with_context_params_multiple_mappings() {
+        let context = HashMap::from([
+            ("permutive_segments".to_string(), json!(["seg1"])),
+            ("lockr_ids".to_string(), json!("lockr-abc-123")),
+        ]);
+        let mapping = HashMap::from([
+            ("permutive_segments".to_string(), "permutive".to_string()),
+            ("lockr_ids".to_string(), "lockr".to_string()),
+        ]);
+
+        let url = build_url_with_context_params(
+            "http://localhost:6767/adserver/mediate",
+            &context,
+            &mapping,
+        );
+        assert!(url.contains("permutive=seg1"));
+        assert!(url.contains("lockr=lockr-abc-123"));
+    }
+
+    #[test]
+    fn test_build_url_with_context_params_scalar_number() {
+        let context = HashMap::from([("count".to_string(), json!(42))]);
+        let mapping = HashMap::from([("count".to_string(), "n".to_string())]);
+
+        let url = build_url_with_context_params(
+            "http://localhost:6767/adserver/mediate",
+            &context,
+            &mapping,
+        );
+        assert_eq!(url, "http://localhost:6767/adserver/mediate?n=42");
+    }
+
+    #[test]
+    fn test_serialize_context_value_array() {
+        assert_eq!(serialize_context_value(&json!(["a", "b", 3])), "a,b,3");
+    }
+
+    #[test]
+    fn test_serialize_context_value_string() {
+        assert_eq!(serialize_context_value(&json!("hello")), "hello");
+    }
+
+    #[test]
+    fn test_serialize_context_value_number() {
+        assert_eq!(serialize_context_value(&json!(99)), "99");
+    }
+
+    #[test]
+    fn test_serialize_context_value_object_returns_empty() {
+        assert_eq!(serialize_context_value(&json!({"a": 1})), "");
+    }
+}

--- a/crates/common/src/auction/context.rs
+++ b/crates/common/src/auction/context.rs
@@ -230,19 +230,20 @@ mod tests {
 
     #[test]
     fn test_context_value_deserialize_array() {
-        let v: ContextValue = serde_json::from_str(r#"["a","b"]"#).unwrap();
+        let v: ContextValue =
+            serde_json::from_str(r#"["a","b"]"#).expect("should deserialize string list");
         assert_eq!(v, ContextValue::StringList(vec!["a".into(), "b".into()]));
     }
 
     #[test]
     fn test_context_value_deserialize_string() {
-        let v: ContextValue = serde_json::from_str(r#""hello""#).unwrap();
+        let v: ContextValue = serde_json::from_str(r#""hello""#).expect("should deserialize text");
         assert_eq!(v, ContextValue::Text("hello".into()));
     }
 
     #[test]
     fn test_context_value_deserialize_number() {
-        let v: ContextValue = serde_json::from_str("42").unwrap();
+        let v: ContextValue = serde_json::from_str("42").expect("should deserialize number");
         assert_eq!(v, ContextValue::Number(42.0));
     }
 }

--- a/crates/common/src/auction/formats.rs
+++ b/crates/common/src/auction/formats.rs
@@ -135,6 +135,20 @@ pub fn convert_tsjs_to_auction_request(
         geo: GeoInfo::from_request(req),
     });
 
+    // Extract optional Permutive segments from the request config
+    let mut context = HashMap::new();
+    if let Some(ref config) = body.config {
+        if let Some(segments) = config.get("permutive_segments") {
+            if segments.is_array() {
+                log::info!(
+                    "Auction request includes {} Permutive segments",
+                    segments.as_array().map_or(0, Vec::len)
+                );
+                context.insert("permutive_segments".to_string(), segments.clone());
+            }
+        }
+    }
+
     Ok(AuctionRequest {
         id: Uuid::new_v4().to_string(),
         slots,
@@ -152,7 +166,7 @@ pub fn convert_tsjs_to_auction_request(
             domain: settings.publisher.domain.clone(),
             page: format!("https://{}", settings.publisher.domain),
         }),
-        context: HashMap::new(),
+        context,
     })
 }
 

--- a/crates/common/src/auction/formats.rs
+++ b/crates/common/src/auction/formats.rs
@@ -9,7 +9,7 @@ use fastly::http::{header, StatusCode};
 use fastly::{Request, Response};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::auction::context::ContextValue;
@@ -139,17 +139,11 @@ pub fn convert_tsjs_to_auction_request(
     // Only keys listed in `auction.allowed_context_keys` are accepted;
     // unrecognised keys are silently dropped to prevent injection of
     // arbitrary data by a malicious client payload.
-    let allowed: HashSet<&str> = settings
-        .auction
-        .allowed_context_keys
-        .iter()
-        .map(String::as_str)
-        .collect();
     let mut context = HashMap::new();
     if let Some(ref config) = body.config {
         if let Some(obj) = config.as_object() {
             for (key, value) in obj {
-                if allowed.contains(key.as_str()) {
+                if settings.auction.allowed_context_keys.contains(key) {
                     match serde_json::from_value::<ContextValue>(value.clone()) {
                         Ok(cv) => {
                             context.insert(key.clone(), cv);

--- a/crates/common/src/auction/formats.rs
+++ b/crates/common/src/auction/formats.rs
@@ -9,9 +9,10 @@ use fastly::http::{header, StatusCode};
 use fastly::{Request, Response};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
+use crate::auction::context::ContextValue;
 use crate::creative;
 use crate::error::TrustedServerError;
 use crate::geo::GeoInfo;
@@ -138,13 +139,28 @@ pub fn convert_tsjs_to_auction_request(
     // Only keys listed in `auction.allowed_context_keys` are accepted;
     // unrecognised keys are silently dropped to prevent injection of
     // arbitrary data by a malicious client payload.
-    let allowed = &settings.auction.allowed_context_keys;
+    let allowed: HashSet<&str> = settings
+        .auction
+        .allowed_context_keys
+        .iter()
+        .map(String::as_str)
+        .collect();
     let mut context = HashMap::new();
     if let Some(ref config) = body.config {
         if let Some(obj) = config.as_object() {
             for (key, value) in obj {
-                if allowed.iter().any(|k| k == key) {
-                    context.insert(key.clone(), value.clone());
+                if allowed.contains(key.as_str()) {
+                    match serde_json::from_value::<ContextValue>(value.clone()) {
+                        Ok(cv) => {
+                            context.insert(key.clone(), cv);
+                        }
+                        Err(_) => {
+                            log::debug!(
+                                "Auction context: dropping key '{}' with unsupported type",
+                                key
+                            );
+                        }
+                    }
                 } else {
                     log::debug!("Auction context: dropping disallowed key '{}'", key);
                 }

--- a/crates/common/src/auction/mod.rs
+++ b/crates/common/src/auction/mod.rs
@@ -19,7 +19,7 @@ pub mod provider;
 pub mod types;
 
 pub use config::AuctionConfig;
-pub use context::{build_url_with_context_params, ContextQueryParams};
+pub use context::{build_url_with_context_params, ContextQueryParams, ContextValue};
 pub use orchestrator::AuctionOrchestrator;
 pub use provider::AuctionProvider;
 pub use types::{

--- a/crates/common/src/auction/mod.rs
+++ b/crates/common/src/auction/mod.rs
@@ -11,6 +11,7 @@ use crate::settings::Settings;
 use std::sync::Arc;
 
 pub mod config;
+pub mod context;
 pub mod endpoints;
 pub mod formats;
 pub mod orchestrator;
@@ -18,6 +19,7 @@ pub mod provider;
 pub mod types;
 
 pub use config::AuctionConfig;
+pub use context::{build_url_with_context_params, ContextQueryParams};
 pub use orchestrator::AuctionOrchestrator;
 pub use provider::AuctionProvider;
 pub use types::{

--- a/crates/common/src/auction/orchestrator.rs
+++ b/crates/common/src/auction/orchestrator.rs
@@ -645,6 +645,7 @@ mod tests {
             mediator: None,
             timeout_ms: 2000,
             creative_store: "creative_store".to_string(),
+            allowed_context_keys: vec!["permutive_segments".to_string()],
         };
 
         let orchestrator = AuctionOrchestrator::new(config);

--- a/crates/common/src/auction/orchestrator.rs
+++ b/crates/common/src/auction/orchestrator.rs
@@ -509,7 +509,7 @@ mod tests {
     };
     use crate::test_support::tests::crate_test_settings_str;
     use fastly::Request;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     use super::AuctionOrchestrator;
 
@@ -645,7 +645,7 @@ mod tests {
             mediator: None,
             timeout_ms: 2000,
             creative_store: "creative_store".to_string(),
-            allowed_context_keys: vec!["permutive_segments".to_string()],
+            allowed_context_keys: HashSet::from(["permutive_segments".to_string()]),
         };
 
         let orchestrator = AuctionOrchestrator::new(config);

--- a/crates/common/src/auction/types.rs
+++ b/crates/common/src/auction/types.rs
@@ -4,6 +4,7 @@ use fastly::Request;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::auction::context::ContextValue;
 use crate::geo::GeoInfo;
 use crate::settings::Settings;
 
@@ -22,8 +23,8 @@ pub struct AuctionRequest {
     pub device: Option<DeviceInfo>,
     /// Site information
     pub site: Option<SiteInfo>,
-    /// Additional context
-    pub context: HashMap<String, serde_json::Value>,
+    /// Additional context forwarded from the JS client payload.
+    pub context: HashMap<String, ContextValue>,
 }
 
 /// Represents a single ad slot/impression.

--- a/crates/common/src/auction_config_types.rs
+++ b/crates/common/src/auction_config_types.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Auction orchestration configuration.
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AuctionConfig {
     /// Enable the auction orchestrator
     #[serde(default)]
@@ -26,6 +26,26 @@ pub struct AuctionConfig {
     /// KV store name for creative storage (deprecated: creatives are now delivered inline)
     #[serde(default = "default_creative_store")]
     pub creative_store: String,
+
+    /// Keys allowed in the auction request context map.
+    /// Only config entries from the JS payload whose key appears in this list
+    /// are forwarded into the `AuctionRequest.context`. Unrecognised keys are
+    /// silently dropped. An empty list blocks all context keys.
+    #[serde(default = "default_allowed_context_keys")]
+    pub allowed_context_keys: Vec<String>,
+}
+
+impl Default for AuctionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            providers: Vec::new(),
+            mediator: None,
+            timeout_ms: default_timeout(),
+            creative_store: default_creative_store(),
+            allowed_context_keys: default_allowed_context_keys(),
+        }
+    }
 }
 
 fn default_timeout() -> u32 {
@@ -34,6 +54,10 @@ fn default_timeout() -> u32 {
 
 fn default_creative_store() -> String {
     "creative_store".to_string()
+}
+
+fn default_allowed_context_keys() -> Vec<String> {
+    vec!["permutive_segments".to_string()]
 }
 
 #[allow(dead_code)] // Methods used in runtime but not in build script

--- a/crates/common/src/auction_config_types.rs
+++ b/crates/common/src/auction_config_types.rs
@@ -57,7 +57,7 @@ fn default_creative_store() -> String {
 }
 
 fn default_allowed_context_keys() -> Vec<String> {
-    vec!["permutive_segments".to_string()]
+    vec![]
 }
 
 #[allow(dead_code)] // Methods used in runtime but not in build script

--- a/crates/common/src/auction_config_types.rs
+++ b/crates/common/src/auction_config_types.rs
@@ -1,6 +1,7 @@
 //! Auction configuration types (separated to avoid circular deps in build.rs).
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 /// Auction orchestration configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -32,7 +33,7 @@ pub struct AuctionConfig {
     /// are forwarded into the `AuctionRequest.context`. Unrecognised keys are
     /// silently dropped. An empty list blocks all context keys.
     #[serde(default = "default_allowed_context_keys")]
-    pub allowed_context_keys: Vec<String>,
+    pub allowed_context_keys: HashSet<String>,
 }
 
 impl Default for AuctionConfig {
@@ -43,7 +44,7 @@ impl Default for AuctionConfig {
             mediator: None,
             timeout_ms: default_timeout(),
             creative_store: default_creative_store(),
-            allowed_context_keys: default_allowed_context_keys(),
+            allowed_context_keys: HashSet::new(),
         }
     }
 }
@@ -56,8 +57,8 @@ fn default_creative_store() -> String {
     "creative_store".to_string()
 }
 
-fn default_allowed_context_keys() -> Vec<String> {
-    vec![]
+fn default_allowed_context_keys() -> HashSet<String> {
+    HashSet::new()
 }
 
 #[allow(dead_code)] // Methods used in runtime but not in build script

--- a/crates/common/src/integrations/adserver_mock.rs
+++ b/crates/common/src/integrations/adserver_mock.rs
@@ -95,8 +95,11 @@ impl AdServerMockProvider {
             if let Some(segments) = segments_val.as_array() {
                 let csv: String = segments
                     .iter()
-                    .filter_map(|v| v.as_u64().or_else(|| v.as_f64().map(|f| f as u64)))
-                    .map(|n| n.to_string())
+                    .filter_map(|v| {
+                        v.as_str()
+                            .map(String::from)
+                            .or_else(|| v.as_u64().map(|n| n.to_string()))
+                    })
                     .collect::<Vec<_>>()
                     .join(",");
 
@@ -764,13 +767,13 @@ mod tests {
         let mut request = create_test_auction_request();
         request.context.insert(
             "permutive_segments".to_string(),
-            json!([10000001, 10000003, 10000008]),
+            json!(["10000001", "10000003", "adv", "bhgp"]),
         );
 
         let url = provider.build_endpoint_url(&request);
         assert_eq!(
             url,
-            "http://localhost:6767/adserver/mediate?permutive=10000001,10000003,10000008"
+            "http://localhost:6767/adserver/mediate?permutive=10000001,10000003,adv,bhgp"
         );
     }
 
@@ -820,12 +823,12 @@ mod tests {
         let mut request = create_test_auction_request();
         request
             .context
-            .insert("permutive_segments".to_string(), json!([123, 456]));
+            .insert("permutive_segments".to_string(), json!(["123", "adv"]));
 
         let url = provider.build_endpoint_url(&request);
         assert_eq!(
             url,
-            "http://localhost:6767/adserver/mediate?debug=true&permutive=123,456"
+            "http://localhost:6767/adserver/mediate?debug=true&permutive=123,adv"
         );
     }
 }

--- a/crates/common/src/integrations/adserver_mock.rs
+++ b/crates/common/src/integrations/adserver_mock.rs
@@ -283,7 +283,7 @@ impl AuctionProvider for AdServerMockProvider {
 
         log::debug!("AdServer Mock: mediation request: {:?}", mediation_req);
 
-        // Build endpoint URL with optional Permutive segments query string
+        // Build endpoint URL with context-driven query parameters
         let endpoint_url = self.build_endpoint_url(request);
 
         // Create HTTP POST request

--- a/crates/common/src/settings.rs
+++ b/crates/common/src/settings.rs
@@ -540,6 +540,7 @@ mod tests {
     use super::*;
     use regex::Regex;
     use serde_json::json;
+    use std::collections::HashSet;
 
     use crate::integrations::{
         nextjs::NextJsIntegrationConfig, prebid::PrebidIntegrationConfig,
@@ -1149,7 +1150,7 @@ mod tests {
         let settings = Settings::from_toml(&toml_str).expect("should parse valid TOML");
         assert_eq!(
             settings.auction.allowed_context_keys,
-            vec!["permutive_segments", "lockr_ids"]
+            HashSet::from(["permutive_segments".to_string(), "lockr_ids".to_string()])
         );
     }
 

--- a/crates/common/src/settings.rs
+++ b/crates/common/src/settings.rs
@@ -1129,12 +1129,11 @@ mod tests {
     }
 
     #[test]
-    fn test_auction_allowed_context_keys_defaults_to_permutive_segments() {
+    fn test_auction_allowed_context_keys_defaults_to_empty() {
         let settings = create_test_settings();
-        assert_eq!(
-            settings.auction.allowed_context_keys,
-            vec!["permutive_segments"],
-            "Default allowed_context_keys should contain permutive_segments"
+        assert!(
+            settings.auction.allowed_context_keys.is_empty(),
+            "Default allowed_context_keys should be empty (secure-by-default)"
         );
     }
 

--- a/crates/common/src/settings.rs
+++ b/crates/common/src/settings.rs
@@ -1127,4 +1127,46 @@ mod tests {
         assert!(!rewrite.is_excluded("not a url"));
         assert!(!rewrite.is_excluded(""));
     }
+
+    #[test]
+    fn test_auction_allowed_context_keys_defaults_to_permutive_segments() {
+        let settings = create_test_settings();
+        assert_eq!(
+            settings.auction.allowed_context_keys,
+            vec!["permutive_segments"],
+            "Default allowed_context_keys should contain permutive_segments"
+        );
+    }
+
+    #[test]
+    fn test_auction_allowed_context_keys_from_toml() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [auction]
+            enabled = true
+            providers = []
+            allowed_context_keys = ["permutive_segments", "lockr_ids"]
+            "#;
+        let settings = Settings::from_toml(&toml_str).expect("should parse valid TOML");
+        assert_eq!(
+            settings.auction.allowed_context_keys,
+            vec!["permutive_segments", "lockr_ids"]
+        );
+    }
+
+    #[test]
+    fn test_auction_empty_allowed_context_keys_blocks_all() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [auction]
+            enabled = true
+            providers = []
+            allowed_context_keys = []
+            "#;
+        let settings = Settings::from_toml(&toml_str).expect("should parse valid TOML");
+        assert!(
+            settings.auction.allowed_context_keys.is_empty(),
+            "Empty allowed_context_keys should be respected (blocks all keys)"
+        );
+    }
 }

--- a/crates/js/lib/src/core/context.ts
+++ b/crates/js/lib/src/core/context.ts
@@ -1,0 +1,41 @@
+// Context provider registry: lets integrations contribute data to auction requests
+// without core needing integration-specific knowledge.
+import { log } from './log';
+
+/**
+ * A context provider returns key-value pairs to merge into the auction
+ * request's `config` payload, or `undefined` to contribute nothing.
+ */
+export type ContextProvider = () => Record<string, unknown> | undefined;
+
+const providers: ContextProvider[] = [];
+
+/**
+ * Register a context provider that will be called before every auction request.
+ * Integrations call this at import time to inject their data (e.g. segments,
+ * identifiers) into the auction payload without core needing to know about them.
+ */
+export function registerContextProvider(provider: ContextProvider): void {
+  providers.push(provider);
+  log.debug('context: registered provider', { total: providers.length });
+}
+
+/**
+ * Collect context from all registered providers. Called by core's `requestAds`
+ * to build the `config` object sent to `/auction`.
+ *
+ * Each provider's returned keys are merged (later providers win on collision).
+ * Providers that throw or return `undefined` are silently skipped.
+ */
+export function collectContext(): Record<string, unknown> {
+  const context: Record<string, unknown> = {};
+  for (const provider of providers) {
+    try {
+      const data = provider();
+      if (data) Object.assign(context, data);
+    } catch {
+      log.debug('context: provider threw, skipping');
+    }
+  }
+  return context;
+}

--- a/crates/js/lib/src/core/request.ts
+++ b/crates/js/lib/src/core/request.ts
@@ -11,7 +11,6 @@ export interface RequestAdsOptions {
   timeout?: number;
 }
 
-
 // Entry point matching Prebid's requestBids signature; uses unified /auction endpoint.
 export function requestAds(
   callbackOrOpts?: RequestAdsCallback | RequestAdsOptions,

--- a/crates/js/lib/src/core/request.ts
+++ b/crates/js/lib/src/core/request.ts
@@ -10,6 +10,42 @@ export interface RequestAdsOptions {
   timeout?: number;
 }
 
+/**
+ * Read Permutive segment IDs from localStorage.
+ *
+ * Permutive stores event data in the `permutive-app` key. Each event entry in
+ * `eventPublication.eventUpload` is a tuple of [eventKey, eventObject]. We
+ * iterate in reverse (most recent first) looking for any event whose
+ * `properties.segments` is a non-empty array.
+ *
+ * Returns an array of segment ID numbers, or an empty array if unavailable.
+ */
+function getPermutiveSegments(): number[] {
+  try {
+    const raw = localStorage.getItem('permutive-app');
+    if (!raw) return [];
+
+    const data = JSON.parse(raw);
+    const uploads: unknown[] = data?.eventPublication?.eventUpload;
+    if (!Array.isArray(uploads) || uploads.length === 0) return [];
+
+    // Iterate most-recent-first to get the freshest segments
+    for (let i = uploads.length - 1; i >= 0; i--) {
+      const entry = uploads[i];
+      if (!Array.isArray(entry) || entry.length < 2) continue;
+
+      const segments = entry[1]?.event?.properties?.segments;
+      if (Array.isArray(segments) && segments.length > 0) {
+        log.debug('getPermutiveSegments: found segments', { count: segments.length });
+        return segments.filter((s: unknown) => typeof s === 'number') as number[];
+      }
+    }
+  } catch {
+    log.debug('getPermutiveSegments: failed to read from localStorage');
+  }
+  return [];
+}
+
 // Entry point matching Prebid's requestBids signature; uses unified /auction endpoint.
 export function requestAds(
   callbackOrOpts?: RequestAdsCallback | RequestAdsOptions,
@@ -28,8 +64,13 @@ export function requestAds(
   log.info('requestAds: called', { hasCallback: typeof callback === 'function' });
   try {
     const adUnits = getAllUnits();
-    const payload = buildAdRequest(adUnits);
-    log.debug('requestAds: payload', { units: adUnits.length });
+    const permutiveSegments = getPermutiveSegments();
+    const config: Record<string, unknown> = {};
+    if (permutiveSegments.length > 0) {
+      config.permutive_segments = permutiveSegments;
+    }
+    const payload = { ...buildAdRequest(adUnits), config };
+    log.debug('requestAds: payload', { units: adUnits.length, permutiveSegments: permutiveSegments.length });
 
     // Use unified auction endpoint
     void sendAuction('/auction', payload)

--- a/crates/js/lib/src/integrations/permutive/index.ts
+++ b/crates/js/lib/src/integrations/permutive/index.ts
@@ -1,6 +1,8 @@
 import { log } from '../../core/log';
+import { registerContextProvider } from '../../core/context';
 
 import { installPermutiveGuard } from './script_guard';
+import { getPermutiveSegments } from './segments';
 
 declare const permutive: {
   config: {
@@ -99,6 +101,14 @@ function waitForPermutiveSDK(callback: () => void, maxAttempts = 50) {
 
 if (typeof window !== 'undefined') {
   installPermutiveGuard();
+
+  // Register a context provider so Permutive segments are included in auction
+  // requests. Core calls collectContext() before every /auction POST — this
+  // keeps all Permutive localStorage knowledge inside this integration.
+  registerContextProvider(() => {
+    const segments = getPermutiveSegments();
+    return segments.length > 0 ? { permutive_segments: segments } : undefined;
+  });
 
   waitForPermutiveSDK(() => installPermutiveShim());
 }

--- a/crates/js/lib/src/integrations/permutive/index.ts
+++ b/crates/js/lib/src/integrations/permutive/index.ts
@@ -105,7 +105,7 @@ if (typeof window !== 'undefined') {
   // Register a context provider so Permutive segments are included in auction
   // requests. Core calls collectContext() before every /auction POST — this
   // keeps all Permutive localStorage knowledge inside this integration.
-  registerContextProvider(() => {
+  registerContextProvider('permutive', () => {
     const segments = getPermutiveSegments();
     return segments.length > 0 ? { permutive_segments: segments } : undefined;
   });

--- a/crates/js/lib/src/integrations/permutive/segments.ts
+++ b/crates/js/lib/src/integrations/permutive/segments.ts
@@ -3,6 +3,9 @@
 // integration-specific data-reading code.
 import { log } from '../../core/log';
 
+/** Upper bound on the number of segments we forward to avoid oversized URLs. */
+const MAX_SEGMENTS = 100;
+
 /**
  * Read Permutive segment IDs from localStorage.
  *
@@ -27,7 +30,7 @@ export function getPermutiveSegments(): string[] {
     const all = data?.core?.cohorts?.all;
     if (Array.isArray(all) && all.length > 0) {
       log.debug('getPermutiveSegments: found segments in core.cohorts.all', { count: all.length });
-      return all.filter((s: unknown) => typeof s === 'string' || typeof s === 'number').map(String);
+      return all.filter((s: unknown) => typeof s === 'string' || typeof s === 'number').map(String).slice(0, MAX_SEGMENTS);
     }
 
     // Fallback: eventUpload entries (transient event data)
@@ -44,7 +47,8 @@ export function getPermutiveSegments(): string[] {
           });
           return segments
             .filter((s: unknown) => typeof s === 'string' || typeof s === 'number')
-            .map(String);
+            .map(String)
+            .slice(0, MAX_SEGMENTS);
         }
       }
     }

--- a/crates/js/lib/src/integrations/permutive/segments.ts
+++ b/crates/js/lib/src/integrations/permutive/segments.ts
@@ -27,9 +27,7 @@ export function getPermutiveSegments(): string[] {
     const all = data?.core?.cohorts?.all;
     if (Array.isArray(all) && all.length > 0) {
       log.debug('getPermutiveSegments: found segments in core.cohorts.all', { count: all.length });
-      return all
-        .filter((s: unknown) => typeof s === 'string' || typeof s === 'number')
-        .map(String);
+      return all.filter((s: unknown) => typeof s === 'string' || typeof s === 'number').map(String);
     }
 
     // Fallback: eventUpload entries (transient event data)

--- a/crates/js/lib/src/integrations/permutive/segments.ts
+++ b/crates/js/lib/src/integrations/permutive/segments.ts
@@ -30,7 +30,10 @@ export function getPermutiveSegments(): string[] {
     const all = data?.core?.cohorts?.all;
     if (Array.isArray(all) && all.length > 0) {
       log.debug('getPermutiveSegments: found segments in core.cohorts.all', { count: all.length });
-      return all.filter((s: unknown) => typeof s === 'string' || typeof s === 'number').map(String).slice(0, MAX_SEGMENTS);
+      return all
+        .filter((s: unknown) => typeof s === 'string' || typeof s === 'number')
+        .map(String)
+        .slice(0, MAX_SEGMENTS);
     }
 
     // Fallback: eventUpload entries (transient event data)

--- a/crates/js/lib/src/integrations/permutive/segments.ts
+++ b/crates/js/lib/src/integrations/permutive/segments.ts
@@ -1,0 +1,57 @@
+// Permutive segment extraction from localStorage.
+// This logic is owned by the Permutive integration, keeping core free of
+// integration-specific data-reading code.
+import { log } from '../../core/log';
+
+/**
+ * Read Permutive segment IDs from localStorage.
+ *
+ * Permutive stores cohort data in the `permutive-app` key. We check two
+ * locations (most reliable first):
+ *
+ * 1. `core.cohorts.all` — full cohort membership (numeric IDs + activation keys).
+ * 2. `eventPublication.eventUpload` — transient event data; we iterate
+ *    most-recent-first looking for any event whose `properties.segments` is a
+ *    non-empty array.
+ *
+ * Returns an array of segment ID strings, or an empty array if unavailable.
+ */
+export function getPermutiveSegments(): string[] {
+  try {
+    const raw = localStorage.getItem('permutive-app');
+    if (!raw) return [];
+
+    const data = JSON.parse(raw);
+
+    // Primary: core.cohorts.all (full cohort membership — numeric IDs + activation keys)
+    const all = data?.core?.cohorts?.all;
+    if (Array.isArray(all) && all.length > 0) {
+      log.debug('getPermutiveSegments: found segments in core.cohorts.all', { count: all.length });
+      return all
+        .filter((s: unknown) => typeof s === 'string' || typeof s === 'number')
+        .map(String);
+    }
+
+    // Fallback: eventUpload entries (transient event data)
+    const uploads: unknown[] = data?.eventPublication?.eventUpload;
+    if (Array.isArray(uploads)) {
+      for (let i = uploads.length - 1; i >= 0; i--) {
+        const entry = uploads[i];
+        if (!Array.isArray(entry) || entry.length < 2) continue;
+
+        const segments = entry[1]?.event?.properties?.segments;
+        if (Array.isArray(segments) && segments.length > 0) {
+          log.debug('getPermutiveSegments: found segments in eventUpload', {
+            count: segments.length,
+          });
+          return segments
+            .filter((s: unknown) => typeof s === 'string' || typeof s === 'number')
+            .map(String);
+        }
+      }
+    }
+  } catch {
+    log.debug('getPermutiveSegments: failed to read from localStorage');
+  }
+  return [];
+}

--- a/crates/js/lib/src/integrations/permutive/segments.ts
+++ b/crates/js/lib/src/integrations/permutive/segments.ts
@@ -55,8 +55,8 @@ export function getPermutiveSegments(): string[] {
         }
       }
     }
-  } catch {
-    log.debug('getPermutiveSegments: failed to read from localStorage');
+  } catch (err) {
+    log.debug('getPermutiveSegments: failed to read segments', err);
   }
   return [];
 }

--- a/crates/js/lib/test/core/context.test.ts
+++ b/crates/js/lib/test/core/context.test.ts
@@ -12,37 +12,44 @@ describe('context provider registry', () => {
 
   it('collects data from a single provider', async () => {
     const { registerContextProvider, collectContext } = await import('../../src/core/context');
-    registerContextProvider(() => ({ foo: 'bar' }));
+    registerContextProvider('test', () => ({ foo: 'bar' }));
     expect(collectContext()).toEqual({ foo: 'bar' });
   });
 
   it('merges data from multiple providers', async () => {
     const { registerContextProvider, collectContext } = await import('../../src/core/context');
-    registerContextProvider(() => ({ a: 1 }));
-    registerContextProvider(() => ({ b: 2 }));
+    registerContextProvider('a', () => ({ a: 1 }));
+    registerContextProvider('b', () => ({ b: 2 }));
     expect(collectContext()).toEqual({ a: 1, b: 2 });
   });
 
   it('later providers overwrite earlier ones on key collision', async () => {
     const { registerContextProvider, collectContext } = await import('../../src/core/context');
-    registerContextProvider(() => ({ key: 'first' }));
-    registerContextProvider(() => ({ key: 'second' }));
+    registerContextProvider('first', () => ({ key: 'first' }));
+    registerContextProvider('second', () => ({ key: 'second' }));
     expect(collectContext()).toEqual({ key: 'second' });
   });
 
   it('skips providers that return undefined', async () => {
     const { registerContextProvider, collectContext } = await import('../../src/core/context');
-    registerContextProvider(() => undefined);
-    registerContextProvider(() => ({ kept: true }));
+    registerContextProvider('noop', () => undefined);
+    registerContextProvider('kept', () => ({ kept: true }));
     expect(collectContext()).toEqual({ kept: true });
   });
 
   it('skips providers that throw', async () => {
     const { registerContextProvider, collectContext } = await import('../../src/core/context');
-    registerContextProvider(() => {
+    registerContextProvider('boom', () => {
       throw new Error('boom');
     });
-    registerContextProvider(() => ({ survived: true }));
+    registerContextProvider('survivor', () => ({ survived: true }));
     expect(collectContext()).toEqual({ survived: true });
+  });
+
+  it('re-registration with same id replaces previous provider', async () => {
+    const { registerContextProvider, collectContext } = await import('../../src/core/context');
+    registerContextProvider('dup', () => ({ v: 1 }));
+    registerContextProvider('dup', () => ({ v: 2 }));
+    expect(collectContext()).toEqual({ v: 2 });
   });
 });

--- a/crates/js/lib/test/core/context.test.ts
+++ b/crates/js/lib/test/core/context.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('context provider registry', () => {
+  beforeEach(async () => {
+    await vi.resetModules();
+  });
+
+  it('returns empty context when no providers registered', async () => {
+    const { collectContext } = await import('../../src/core/context');
+    expect(collectContext()).toEqual({});
+  });
+
+  it('collects data from a single provider', async () => {
+    const { registerContextProvider, collectContext } = await import('../../src/core/context');
+    registerContextProvider(() => ({ foo: 'bar' }));
+    expect(collectContext()).toEqual({ foo: 'bar' });
+  });
+
+  it('merges data from multiple providers', async () => {
+    const { registerContextProvider, collectContext } = await import('../../src/core/context');
+    registerContextProvider(() => ({ a: 1 }));
+    registerContextProvider(() => ({ b: 2 }));
+    expect(collectContext()).toEqual({ a: 1, b: 2 });
+  });
+
+  it('later providers overwrite earlier ones on key collision', async () => {
+    const { registerContextProvider, collectContext } = await import('../../src/core/context');
+    registerContextProvider(() => ({ key: 'first' }));
+    registerContextProvider(() => ({ key: 'second' }));
+    expect(collectContext()).toEqual({ key: 'second' });
+  });
+
+  it('skips providers that return undefined', async () => {
+    const { registerContextProvider, collectContext } = await import('../../src/core/context');
+    registerContextProvider(() => undefined);
+    registerContextProvider(() => ({ kept: true }));
+    expect(collectContext()).toEqual({ kept: true });
+  });
+
+  it('skips providers that throw', async () => {
+    const { registerContextProvider, collectContext } = await import('../../src/core/context');
+    registerContextProvider(() => {
+      throw new Error('boom');
+    });
+    registerContextProvider(() => ({ survived: true }));
+    expect(collectContext()).toEqual({ survived: true });
+  });
+});

--- a/crates/js/lib/test/integrations/permutive/segments.test.ts
+++ b/crates/js/lib/test/integrations/permutive/segments.test.ts
@@ -81,6 +81,18 @@ describe('getPermutiveSegments', () => {
     expect(getPermutiveSegments()).toEqual([]);
   });
 
+  it('caps segments at 100', () => {
+    const ids = Array.from({ length: 150 }, (_, i) => `seg-${i}`);
+    localStorage.setItem(
+      'permutive-app',
+      JSON.stringify({ core: { cohorts: { all: ids } } })
+    );
+    const result = getPermutiveSegments();
+    expect(result).toHaveLength(100);
+    expect(result[0]).toBe('seg-0');
+    expect(result[99]).toBe('seg-99');
+  });
+
   it('filters out non-string non-number values', () => {
     localStorage.setItem(
       'permutive-app',

--- a/crates/js/lib/test/integrations/permutive/segments.test.ts
+++ b/crates/js/lib/test/integrations/permutive/segments.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+describe('getPermutiveSegments', () => {
+  let getPermutiveSegments: () => string[];
+
+  beforeEach(async () => {
+    await vi.resetModules();
+    localStorage.clear();
+    const mod = await import('../../../src/integrations/permutive/segments');
+    getPermutiveSegments = mod.getPermutiveSegments;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns empty array when no permutive-app in localStorage', () => {
+    expect(getPermutiveSegments()).toEqual([]);
+  });
+
+  it('returns empty array when permutive-app is invalid JSON', () => {
+    localStorage.setItem('permutive-app', 'not-json');
+    expect(getPermutiveSegments()).toEqual([]);
+  });
+
+  it('reads segments from core.cohorts.all (primary path)', () => {
+    localStorage.setItem(
+      'permutive-app',
+      JSON.stringify({
+        core: { cohorts: { all: ['10000001', '10000003', 'adv', 'bhgp'] } },
+      }),
+    );
+    expect(getPermutiveSegments()).toEqual(['10000001', '10000003', 'adv', 'bhgp']);
+  });
+
+  it('converts numeric cohort IDs to strings', () => {
+    localStorage.setItem(
+      'permutive-app',
+      JSON.stringify({
+        core: { cohorts: { all: [123, 456] } },
+      }),
+    );
+    expect(getPermutiveSegments()).toEqual(['123', '456']);
+  });
+
+  it('falls back to eventUpload when cohorts.all is missing', () => {
+    localStorage.setItem(
+      'permutive-app',
+      JSON.stringify({
+        eventPublication: {
+          eventUpload: [
+            ['key1', { event: { properties: { segments: ['seg1', 'seg2'] } } }],
+          ],
+        },
+      }),
+    );
+    expect(getPermutiveSegments()).toEqual(['seg1', 'seg2']);
+  });
+
+  it('reads most recent eventUpload entry first', () => {
+    localStorage.setItem(
+      'permutive-app',
+      JSON.stringify({
+        eventPublication: {
+          eventUpload: [
+            ['old', { event: { properties: { segments: ['old1'] } } }],
+            ['new', { event: { properties: { segments: ['new1', 'new2'] } } }],
+          ],
+        },
+      }),
+    );
+    // Should return the last (most recent) entry
+    expect(getPermutiveSegments()).toEqual(['new1', 'new2']);
+  });
+
+  it('returns empty array when cohorts.all is empty and no eventUpload', () => {
+    localStorage.setItem(
+      'permutive-app',
+      JSON.stringify({
+        core: { cohorts: { all: [] } },
+      }),
+    );
+    expect(getPermutiveSegments()).toEqual([]);
+  });
+
+  it('filters out non-string non-number values', () => {
+    localStorage.setItem(
+      'permutive-app',
+      JSON.stringify({
+        core: { cohorts: { all: ['valid', 123, null, undefined, true, { obj: 1 }] } },
+      }),
+    );
+    expect(getPermutiveSegments()).toEqual(['valid', '123']);
+  });
+});

--- a/crates/js/lib/test/integrations/permutive/segments.test.ts
+++ b/crates/js/lib/test/integrations/permutive/segments.test.ts
@@ -28,7 +28,7 @@ describe('getPermutiveSegments', () => {
       'permutive-app',
       JSON.stringify({
         core: { cohorts: { all: ['10000001', '10000003', 'adv', 'bhgp'] } },
-      }),
+      })
     );
     expect(getPermutiveSegments()).toEqual(['10000001', '10000003', 'adv', 'bhgp']);
   });
@@ -38,7 +38,7 @@ describe('getPermutiveSegments', () => {
       'permutive-app',
       JSON.stringify({
         core: { cohorts: { all: [123, 456] } },
-      }),
+      })
     );
     expect(getPermutiveSegments()).toEqual(['123', '456']);
   });
@@ -48,11 +48,9 @@ describe('getPermutiveSegments', () => {
       'permutive-app',
       JSON.stringify({
         eventPublication: {
-          eventUpload: [
-            ['key1', { event: { properties: { segments: ['seg1', 'seg2'] } } }],
-          ],
+          eventUpload: [['key1', { event: { properties: { segments: ['seg1', 'seg2'] } } }]],
         },
-      }),
+      })
     );
     expect(getPermutiveSegments()).toEqual(['seg1', 'seg2']);
   });
@@ -67,7 +65,7 @@ describe('getPermutiveSegments', () => {
             ['new', { event: { properties: { segments: ['new1', 'new2'] } } }],
           ],
         },
-      }),
+      })
     );
     // Should return the last (most recent) entry
     expect(getPermutiveSegments()).toEqual(['new1', 'new2']);
@@ -78,7 +76,7 @@ describe('getPermutiveSegments', () => {
       'permutive-app',
       JSON.stringify({
         core: { cohorts: { all: [] } },
-      }),
+      })
     );
     expect(getPermutiveSegments()).toEqual([]);
   });
@@ -88,7 +86,7 @@ describe('getPermutiveSegments', () => {
       'permutive-app',
       JSON.stringify({
         core: { cohorts: { all: ['valid', 123, null, undefined, true, { obj: 1 }] } },
-      }),
+      })
     );
     expect(getPermutiveSegments()).toEqual(['valid', '123']);
   });

--- a/crates/js/lib/test/integrations/permutive/segments.test.ts
+++ b/crates/js/lib/test/integrations/permutive/segments.test.ts
@@ -83,10 +83,7 @@ describe('getPermutiveSegments', () => {
 
   it('caps segments at 100', () => {
     const ids = Array.from({ length: 150 }, (_, i) => `seg-${i}`);
-    localStorage.setItem(
-      'permutive-app',
-      JSON.stringify({ core: { cohorts: { all: ids } } })
-    );
+    localStorage.setItem('permutive-app', JSON.stringify({ core: { cohorts: { all: ids } } }));
     const result = getPermutiveSegments();
     expect(result).toHaveLength(100);
     expect(result[0]).toBe('seg-0');

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -135,4 +135,10 @@ enabled = false
 endpoint = "https://origin-mocktioneer.cdintel.com/adserver/mediate"
 timeout_ms = 1000
 
+# Map auction-request context keys to mediation URL query parameters.
+# Each key is a context key from the JS client; the value becomes the
+# query parameter name. Arrays are joined with commas.
+[integrations.adserver_mock.context_query_params]
+permutive_segments = "permutive"
+
 

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -115,6 +115,9 @@ enabled = true
 providers = ["prebid"]
 # mediator = "adserver_mock"  # will use mediator when set
 timeout_ms = 2000
+# Context keys the JS client is allowed to forward into auction requests.
+# Keys not in this list are silently dropped. An empty list blocks all keys.
+allowed_context_keys = ["permutive_segments"]
 
 [integrations.aps]
 enabled = false


### PR DESCRIPTION
Passes Permutive audience segments from the browser through to the ad server mediation endpoint, enabling segment-targeted ad decisioning.
- Introduces a context provider registry on the JS side (context.ts) — a generic mechanism for integrations to contribute data to auction requests without core needing integration-specific knowledge.
- The Permutive integration registers a context provider that reads cohort segments from localStorage (permutive-app key) and injects them as permutive_segments in the request config.
- On the Rust side, convert_tsjs_to_auction_request now forwards all config entries into the AuctionRequest.context map instead of discarding them.
- The AdServer Mock provider reads permutive_segments from the context and appends them as a ?permutive=seg1,seg2,... query parameter on the mediation endpoint URL.
Changes

| Layer | File | What |
|-------|------|------|
| JS core | core/context.ts (new) | Context provider registry (registerContextProvider, collectContext) |
| JS core | core/request.ts | Calls collectContext() to build config payload |
| JS integration | integrations/permutive/segments.ts (new) | Reads segments from localStorage (core.cohorts.all primary, eventUpload fallback) |
| JS integration | integrations/permutive/index.ts | Registers context provider with Permutive segments |
| Rust common | auction/formats.rs | Forwards config entries into AuctionRequest.context |
| Rust common | integrations/adserver_mock.rs | build_endpoint_url() appends ?permutive= query param |
| Tests | context.test.ts, segments.test.ts, Rust unit tests | Full coverage for new functionality |

Closes #132

---

How to Manually Test
1. Verify Permutive segment extraction (JS)
1. Open a publisher page that has Permutive active (or any page where you can set localStorage manually).
2. Open DevTools Console and confirm localStorage.getItem('permutive-app') has data — look for core.cohorts.all containing segment IDs.
3. If testing without a real Permutive install, seed it manually:
```
      localStorage.setItem('permutive-app', JSON.stringify({
     core: { cohorts: { all: ['10000001', '10000003', 'adv', 'bhgp'] } }
   }));
```
   5. Load the page with the tsjs tag. In the DevTools Console, filter for context — you should see a log like:
      requestAds: payload { units: N, contextKeys: ["permutive_segments"] }
   
2. Verify segments are sent to the server
1. Open DevTools Network tab and filter for /auction.
2. Trigger an ad request.
3. Inspect the /auction POST request body — the config object should contain:
```
      {
     config: {
       permutive_segments: [10000001, 10000003, adv, bhgp]
     }
   }
```