### PR TITLE
fix: forward browser user-agent in OpenRTB `device.ua` field

### DIFF
--- a/crates/common/src/auction/formats.rs
+++ b/crates/common/src/auction/formats.rs
@@ -108,7 +108,7 @@ pub fn convert_tsjs_to_auction_request(
                 }
 
                 // Extract bidder params from the bids array
-                let mut bidders = std::collections::HashMap::new();
+                let mut bidders = HashMap::new();
                 if let Some(bids) = &unit.bids {
                     for bid in bids {
                         bidders.insert(bid.bidder.clone(), bid.params.clone());
@@ -119,20 +119,20 @@ pub fn convert_tsjs_to_auction_request(
                     id: unit.code.clone(),
                     formats,
                     floor_price: None,
-                    targeting: std::collections::HashMap::new(),
+                    targeting: HashMap::new(),
                     bidders,
                 });
             }
         }
     }
 
-    // Get geo info if available
-    let device = GeoInfo::from_request(req).map(|geo| DeviceInfo {
+    // Build device info with user-agent (always) and geo (if available)
+    let device = Some(DeviceInfo {
         user_agent: req
             .get_header_str("user-agent")
             .map(std::string::ToString::to_string),
         ip: req.get_client_ip_addr().map(|ip| ip.to_string()),
-        geo: Some(geo),
+        geo: GeoInfo::from_request(req),
     });
 
     Ok(AuctionRequest {

--- a/crates/common/src/integrations/prebid.rs
+++ b/crates/common/src/integrations/prebid.rs
@@ -302,7 +302,7 @@ fn transform_prebid_response(
 
 fn rewrite_ad_markup(markup: &str, request_host: &str, request_scheme: &str) -> String {
     let mut content = markup.to_string();
-    let cdn_patterns = vec![
+    let cdn_patterns = [
         ("https://cdn.adsrvr.org", "adsrvr"),
         ("https://ib.adnxs.com", "adnxs"),
         ("https://rtb.openx.net", "openx"),
@@ -451,16 +451,15 @@ impl PrebidAuctionProvider {
             }),
         });
 
-        // Build device object with geo if available
-        let device = request.device.as_ref().and_then(|d| {
-            d.geo.as_ref().map(|geo| Device {
-                geo: Some(Geo {
-                    geo_type: 2, // IP address per OpenRTB spec
-                    country: Some(geo.country.clone()),
-                    city: Some(geo.city.clone()),
-                    region: geo.region.clone(),
-                }),
-            })
+        // Build device object with user-agent and geo if available
+        let device = request.device.as_ref().map(|d| Device {
+            ua: d.user_agent.clone(),
+            geo: d.geo.as_ref().map(|geo| Geo {
+                geo_type: 2, // IP address per OpenRTB spec
+                country: Some(geo.country.clone()),
+                city: Some(geo.city.clone()),
+                region: geo.region.clone(),
+            }),
         });
 
         // Build regs object if Sec-GPC header is present

--- a/crates/common/src/openrtb.rs
+++ b/crates/common/src/openrtb.rs
@@ -67,6 +67,8 @@ pub struct UserExt {
 #[derive(Debug, Serialize, Default)]
 pub struct Device {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub ua: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub geo: Option<Geo>,
 }
 

--- a/crates/common/src/proxy.rs
+++ b/crates/common/src/proxy.rs
@@ -361,6 +361,22 @@ fn finalize_proxied_response_streaming(
     beresp
 }
 
+/// Finalize a proxied response, choosing between streaming passthrough and full
+/// content processing based on the `stream_passthrough` flag.
+fn finalize_response(
+    settings: &Settings,
+    req: &Request,
+    url: &str,
+    beresp: Response,
+    stream_passthrough: bool,
+) -> Result<Response, Report<TrustedServerError>> {
+    if stream_passthrough {
+        Ok(finalize_proxied_response_streaming(req, url, beresp))
+    } else {
+        finalize_proxied_response(settings, req, url, beresp)
+    }
+}
+
 /// Proxy a request to a clear target URL while reusing creative rewrite logic.
 ///
 /// This forwards a curated header set, follows redirects when enabled, and can append
@@ -498,15 +514,7 @@ async fn proxy_with_redirects(
             })?;
 
         if !follow_redirects {
-            return if stream_passthrough {
-                Ok(finalize_proxied_response_streaming(
-                    req,
-                    &current_url,
-                    beresp,
-                ))
-            } else {
-                finalize_proxied_response(settings, req, &current_url, beresp)
-            };
+            return finalize_response(settings, req, &current_url, beresp, stream_passthrough);
         }
 
         let status = beresp.get_status();
@@ -520,15 +528,7 @@ async fn proxy_with_redirects(
         );
 
         if !is_redirect {
-            return if stream_passthrough {
-                Ok(finalize_proxied_response_streaming(
-                    req,
-                    &current_url,
-                    beresp,
-                ))
-            } else {
-                finalize_proxied_response(settings, req, &current_url, beresp)
-            };
+            return finalize_response(settings, req, &current_url, beresp, stream_passthrough);
         }
 
         let Some(location) = beresp
@@ -536,15 +536,7 @@ async fn proxy_with_redirects(
             .and_then(|h| h.to_str().ok())
             .filter(|value| !value.is_empty())
         else {
-            return if stream_passthrough {
-                Ok(finalize_proxied_response_streaming(
-                    req,
-                    &current_url,
-                    beresp,
-                ))
-            } else {
-                finalize_proxied_response(settings, req, &current_url, beresp)
-            };
+            return finalize_response(settings, req, &current_url, beresp, stream_passthrough);
         };
 
         if redirect_attempt == MAX_REDIRECTS {
@@ -565,15 +557,7 @@ async fn proxy_with_redirects(
 
         let next_scheme = next_url.scheme().to_ascii_lowercase();
         if next_scheme != "http" && next_scheme != "https" {
-            return if stream_passthrough {
-                Ok(finalize_proxied_response_streaming(
-                    req,
-                    &current_url,
-                    beresp,
-                ))
-            } else {
-                finalize_proxied_response(settings, req, &current_url, beresp)
-            };
+            return finalize_response(settings, req, &current_url, beresp, stream_passthrough);
         }
 
         log::info!(


### PR DESCRIPTION
closes #264, #130 

### Summary

- Add `ua` field to the OpenRTB `Device` struct so user-agent is serialized into bid requests
 - Update `to_openrtb` in the Prebid integration to map `DeviceInfo.user_agent` into `device.ua`
- Fix `DeviceInfo` construction to always include user-agent and IP, not just when geo lookup succeeds

### Context

 Bidders like Kargo filter out requests with non-browser user-agents. Because `device.ua` was never set, Prebid Server would fall back to the HTTP UA of the server-to-server call (e.g. the Fastly runtime), causing bidders to return 204 No Content on every request. Verified via isolated curl testing that UA is the sole deciding factor.

 ### Changes

 | File | Change |
 |------|--------|
 | `crates/common/src/openrtb.rs` | Added `ua: Option<String>` to `Device` |
 | `crates/common/src/integrations/prebid.rs` | Map `user_agent` into `device.ua`; use `.map()` instead of `.and_then()` so device is present even without geo |
 | `crates/common/src/auction/formats.rs` | Always construct `Some(DeviceInfo { .. })` with geo as optional inside, instead of gating on geo lookup |

### Refactoring

| File | Change |
|------|--------|
| `crates/common/src/streaming_processor.rs` | Extract shared `decompress_and_process` helper to deduplicate identical decompress→process→write logic across gzip, deflate, and brotli `*_to_none` methods |
| `crates/common/src/proxy.rs` | Extract `finalize_response` helper to consolidate repeated `stream_passthrough` branching (4 call sites) |
| `crates/common/src/integrations/prebid.rs` | `vec![]` → `[]` for static `cdn_patterns` array |
| `crates/common/src/auction/formats.rs` | Use `HashMap` directly instead of `std::collections::HashMap` |