### PR TITLE
Add cargo and npm updates to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'cargo' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: 'crates/js/lib/' # Location of package manifests
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: 'docs/' # Location of package manifests
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Closes #289

Adds a `.github/dependabot.yml` configuration to enable weekly automated dependency update checks for:

- **Cargo** — root workspace
- **npm** — `crates/js/lib/`
- **npm** — `docs/`