### PR TITLE
Remove immutable cache headers from integrations

### DIFF
--- a/crates/common/src/integrations/lockr.rs
+++ b/crates/common/src/integrations/lockr.rs
@@ -188,10 +188,7 @@ impl LockrIntegration {
             )
             .with_header(
                 header::CACHE_CONTROL,
-                format!(
-                    "public, max-age={}, immutable",
-                    self.config.cache_ttl_seconds
-                ),
+                format!("public, max-age={}", self.config.cache_ttl_seconds),
             )
             .with_header("X-Lockr-SDK-Proxy", "true")
             .with_header("X-SDK-Source", sdk_url)

--- a/crates/common/src/integrations/permutive.rs
+++ b/crates/common/src/integrations/permutive.rs
@@ -155,10 +155,7 @@ impl PermutiveIntegration {
             )
             .with_header(
                 header::CACHE_CONTROL,
-                format!(
-                    "public, max-age={}, immutable",
-                    self.config.cache_ttl_seconds
-                ),
+                format!("public, max-age={}", self.config.cache_ttl_seconds),
             )
             .with_header("X-Permutive-SDK-Proxy", "true")
             .with_header("X-SDK-Source", &sdk_url)

--- a/crates/common/src/integrations/prebid.rs
+++ b/crates/common/src/integrations/prebid.rs
@@ -172,7 +172,7 @@ impl PrebidIntegration {
                 header::CONTENT_TYPE,
                 "application/javascript; charset=utf-8",
             )
-            .with_header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+            .with_header(header::CACHE_CONTROL, "public, max-age=31536000")
             .with_body(body))
     }
 }
@@ -1076,7 +1076,6 @@ server_url = "https://prebid.example"
             .get_header_str(header::CACHE_CONTROL)
             .expect("should have cache-control");
         assert!(cache_control.contains("max-age=31536000"));
-        assert!(cache_control.contains("immutable"));
 
         let body = response.into_body_str();
         assert!(body.contains("// Script overridden by Trusted Server"));


### PR DESCRIPTION
Removes immutable cache headers from integrations
- Lockr
- Permutive
- Prebid

Closes #309, #310 