### PR TITLE
Enforce auction timeout in orchestrator wait logic

### DIFF
--- a/crates/common/src/auction/orchestrator.rs
+++ b/crates/common/src/auction/orchestrator.rs
@@ -18,7 +18,8 @@ use super::types::{AuctionContext, AuctionRequest, AuctionResponse, Bid, BidStat
 /// measured from `start`. Returns `0` when the deadline has already passed.
 #[inline]
 fn remaining_budget_ms(start: Instant, timeout_ms: u32) -> u32 {
-    timeout_ms.saturating_sub(start.elapsed().as_millis() as u32)
+    let elapsed = u32::try_from(start.elapsed().as_millis()).unwrap_or(u32::MAX);
+    timeout_ms.saturating_sub(elapsed)
 }
 
 /// Manages auction execution across multiple providers.
@@ -266,8 +267,26 @@ impl AuctionOrchestrator {
                 continue;
             }
 
-            // Get the backend name for this provider to map responses back
-            let backend_name = match provider.backend_name() {
+            // Give each provider only the remaining time from the auction
+            // deadline so that its backend first_byte_timeout doesn't extend
+            // past the overall budget. Also respect the provider's own
+            // configured timeout when it is tighter than the remaining budget.
+            let remaining_ms = remaining_budget_ms(auction_start, context.timeout_ms);
+            let effective_timeout = remaining_ms.min(provider.timeout_ms());
+
+            if effective_timeout == 0 {
+                log::warn!(
+                    "Auction timeout ({}ms) exhausted before launching '{}' — skipping",
+                    context.timeout_ms,
+                    provider.provider_name()
+                );
+                continue;
+            }
+
+            // Get the backend name for this provider to map responses back.
+            // Must be computed after effective_timeout since the timeout is
+            // part of the backend name.
+            let backend_name = match provider.backend_name(effective_timeout) {
                 Some(name) => name,
                 None => {
                     log::warn!(
@@ -278,14 +297,10 @@ impl AuctionOrchestrator {
                 }
             };
 
-            // Give each provider only the remaining time from the auction
-            // deadline so that its backend first_byte_timeout doesn't extend
-            // past the overall budget.
-            let remaining_ms = remaining_budget_ms(auction_start, context.timeout_ms);
             let provider_context = AuctionContext {
                 settings: context.settings,
                 request: context.request,
-                timeout_ms: remaining_ms,
+                timeout_ms: effective_timeout,
                 provider_responses: context.provider_responses,
             };
 
@@ -293,7 +308,7 @@ impl AuctionOrchestrator {
                 "Launching bid request to: {} (backend: {}, budget: {}ms)",
                 provider.provider_name(),
                 backend_name,
-                remaining_ms
+                effective_timeout
             );
 
             let start_time = Instant::now();
@@ -329,6 +344,11 @@ impl AuctionOrchestrator {
         // Phase 2: Wait for responses using select() to process as they become ready.
         // Enforce the auction deadline: after each select() returns, check
         // elapsed time and drop remaining requests if the timeout is exceeded.
+        //
+        // NOTE: `select()` blocks until at least one backend responds (or its
+        // transport timeout fires). Hard deadline enforcement therefore depends
+        // on every backend's `first_byte_timeout` being set to at most the
+        // remaining auction budget — which Phase 1 above guarantees.
         let mut responses = Vec::new();
         let mut remaining = pending_requests;
 
@@ -695,7 +715,13 @@ mod tests {
     // Untested timeout enforcement paths (require real backends):
     // - Deadline check in select() loop (drops remaining requests)
     // - Mediator skip when remaining_ms == 0 (bidding exhausts budget)
+    // - Provider skip when effective_timeout == 0 (budget exhausted before launch)
     // - Provider context receives reduced timeout_ms per remaining budget
+    //
+    // Follow-up: introduce a thin abstraction over `select()` (e.g. a trait)
+    // so the deadline/drop logic can be unit-tested with mock futures instead
+    // of requiring real Fastly backends.  An `#[ignore]` integration test
+    // exercising the full path via Viceroy would also catch regressions.
 
     #[tokio::test]
     async fn test_no_providers_configured() {

--- a/crates/common/src/auction/provider.rs
+++ b/crates/common/src/auction/provider.rs
@@ -60,12 +60,11 @@ pub trait AuctionProvider: Send + Sync {
 
     /// Return the backend name used by this provider for request routing.
     ///
-    /// This is used by the orchestrator to correlate responses with providers
-    /// when using `select()` to wait for multiple concurrent requests.
-    /// Implementations should use [`BackendConfig::backend_name_for_url()`] to
-    /// compute the name without registering a backend — the actual registration
-    /// happens in [`request_bids`](Self::request_bids).
-    fn backend_name(&self) -> Option<String> {
+    /// `timeout_ms` is the effective timeout that will be used when the backend
+    /// is registered in [`request_bids`](Self::request_bids).  It must be
+    /// forwarded to [`BackendConfig::backend_name_for_url()`] so the predicted
+    /// name matches the actual registration (the timeout is part of the name).
+    fn backend_name(&self, _timeout_ms: u32) -> Option<String> {
         None
     }
 }

--- a/crates/common/src/backend.rs
+++ b/crates/common/src/backend.rs
@@ -92,8 +92,11 @@ impl<'a> BackendConfig<'a> {
 
     /// Compute the deterministic backend name without registering anything.
     ///
-    /// The name encodes scheme, host, port, and certificate setting so that
-    /// backends with different configurations never collide.
+    /// The name encodes scheme, host, port, certificate setting, and
+    /// first-byte timeout so that backends with different configurations
+    /// never collide.  Including the timeout prevents "first-registration-wins"
+    /// poisoning where a later request for the same origin with a tighter
+    /// timeout would silently inherit the original registration's value.
     fn compute_name(&self) -> Result<(String, u16), Report<TrustedServerError>> {
         if self.host.is_empty() {
             return Err(Report::new(TrustedServerError::Proxy {
@@ -111,10 +114,12 @@ impl<'a> BackendConfig<'a> {
         } else {
             "_nocert"
         };
+        let timeout_ms = self.first_byte_timeout.as_millis();
         let backend_name = format!(
-            "backend_{}{}",
+            "backend_{}{}_t{}",
             name_base.replace(['.', ':'], "_"),
-            cert_suffix
+            cert_suffix,
+            timeout_ms
         );
 
         Ok((backend_name, target_port))
@@ -122,10 +127,10 @@ impl<'a> BackendConfig<'a> {
 
     /// Ensure a dynamic backend exists for this configuration and return its name.
     ///
-    /// The backend name is derived from the scheme, host, port, and certificate
-    /// setting to avoid collisions. **Note:** `first_byte_timeout` is *not*
-    /// part of the name, so backends for the same origin share a single
-    /// registration (first-registration-wins for timeout and other settings).
+    /// The backend name is derived from the scheme, host, port, certificate
+    /// setting, and `first_byte_timeout` to avoid collisions.  Different
+    /// timeout values produce different backend registrations so that a
+    /// tight deadline cannot be silently widened by an earlier registration.
     ///
     /// # Errors
     ///
@@ -186,6 +191,33 @@ impl<'a> BackendConfig<'a> {
         }
     }
 
+    /// Parse an origin URL into its (scheme, host, port) components.
+    ///
+    /// Centralises URL parsing so that [`from_url`](Self::from_url),
+    /// [`from_url_with_first_byte_timeout`](Self::from_url_with_first_byte_timeout),
+    /// and [`backend_name_for_url`](Self::backend_name_for_url) share one
+    /// code-path.
+    fn parse_origin(
+        origin_url: &str,
+    ) -> Result<(String, String, Option<u16>), Report<TrustedServerError>> {
+        let parsed_url = Url::parse(origin_url).change_context(TrustedServerError::Proxy {
+            message: format!("Invalid origin_url: {}", origin_url),
+        })?;
+
+        let scheme = parsed_url.scheme().to_owned();
+        let host = parsed_url
+            .host_str()
+            .ok_or_else(|| {
+                Report::new(TrustedServerError::Proxy {
+                    message: "Missing host in origin_url".to_string(),
+                })
+            })?
+            .to_owned();
+        let port = parsed_url.port();
+
+        Ok((scheme, host, port))
+    }
+
     /// Parse an origin URL and ensure a dynamic backend exists for it.
     ///
     /// This is a convenience constructor that parses the URL, extracts scheme,
@@ -223,31 +255,26 @@ impl<'a> BackendConfig<'a> {
         certificate_check: bool,
         first_byte_timeout: Duration,
     ) -> Result<String, Report<TrustedServerError>> {
-        let parsed_url = Url::parse(origin_url).change_context(TrustedServerError::Proxy {
-            message: format!("Invalid origin_url: {}", origin_url),
-        })?;
+        let (scheme, host, port) = Self::parse_origin(origin_url)?;
 
-        let scheme = parsed_url.scheme();
-        let host = parsed_url.host_str().ok_or_else(|| {
-            Report::new(TrustedServerError::Proxy {
-                message: "Missing host in origin_url".to_string(),
-            })
-        })?;
-        let port = parsed_url.port();
-
-        BackendConfig::new(scheme, host)
+        BackendConfig::new(&scheme, &host)
             .port(port)
             .certificate_check(certificate_check)
             .first_byte_timeout(first_byte_timeout)
             .ensure()
     }
 
-    /// Compute the backend name that [`from_url`](Self::from_url) would produce
-    /// for the given URL, **without** registering a backend.
+    /// Compute the backend name that
+    /// [`from_url_with_first_byte_timeout`](Self::from_url_with_first_byte_timeout)
+    /// would produce for the given URL and timeout, **without** registering a
+    /// backend.
     ///
     /// This is useful when callers need the name for mapping purposes (e.g. the
     /// auction orchestrator correlating responses to providers) but want the
     /// actual registration to happen later with specific settings.
+    ///
+    /// The `first_byte_timeout` must match the value that will be used at
+    /// registration time so that the predicted name is correct.
     ///
     /// # Errors
     ///
@@ -255,22 +282,14 @@ impl<'a> BackendConfig<'a> {
     pub fn backend_name_for_url(
         origin_url: &str,
         certificate_check: bool,
+        first_byte_timeout: Duration,
     ) -> Result<String, Report<TrustedServerError>> {
-        let parsed_url = Url::parse(origin_url).change_context(TrustedServerError::Proxy {
-            message: format!("Invalid origin_url: {}", origin_url),
-        })?;
+        let (scheme, host, port) = Self::parse_origin(origin_url)?;
 
-        let scheme = parsed_url.scheme();
-        let host = parsed_url.host_str().ok_or_else(|| {
-            Report::new(TrustedServerError::Proxy {
-                message: "Missing host in origin_url".to_string(),
-            })
-        })?;
-        let port = parsed_url.port();
-
-        let (name, _) = BackendConfig::new(scheme, host)
+        let (name, _) = BackendConfig::new(&scheme, &host)
             .port(port)
             .certificate_check(certificate_check)
+            .first_byte_timeout(first_byte_timeout)
             .compute_name()?;
 
         Ok(name)
@@ -328,7 +347,7 @@ mod tests {
         let name = BackendConfig::new("https", "origin.example.com")
             .ensure()
             .expect("should create backend for valid HTTPS origin");
-        assert_eq!(name, "backend_https_origin_example_com_443");
+        assert_eq!(name, "backend_https_origin_example_com_443_t15000");
     }
 
     #[test]
@@ -337,7 +356,7 @@ mod tests {
             .certificate_check(false)
             .ensure()
             .expect("should create backend with cert check disabled");
-        assert_eq!(name, "backend_https_origin_example_com_443_nocert");
+        assert_eq!(name, "backend_https_origin_example_com_443_nocert_t15000");
     }
 
     #[test]
@@ -346,11 +365,7 @@ mod tests {
             .port(Some(8080))
             .ensure()
             .expect("should create backend for HTTP origin with explicit port");
-        assert_eq!(name, "backend_http_api_test-site_org_8080");
-        assert!(
-            name.ends_with("_8080"),
-            "should sanitize ':' to '_' in backend name"
-        );
+        assert_eq!(name, "backend_http_api_test-site_org_8080_t15000");
     }
 
     #[test]
@@ -358,7 +373,7 @@ mod tests {
         let name = BackendConfig::new("http", "example.org")
             .ensure()
             .expect("should create backend defaulting to port 80 for HTTP");
-        assert_eq!(name, "backend_http_example_org_80");
+        assert_eq!(name, "backend_http_example_org_80_t15000");
     }
 
     #[test]
@@ -384,6 +399,32 @@ mod tests {
         assert_eq!(
             first, second,
             "should return same backend name on repeat call"
+        );
+    }
+
+    #[test]
+    fn different_timeouts_produce_different_names() {
+        use std::time::Duration;
+
+        let (name_a, _) = BackendConfig::new("https", "origin.example.com")
+            .first_byte_timeout(Duration::from_millis(2000))
+            .compute_name()
+            .expect("should compute name with 2000ms timeout");
+        let (name_b, _) = BackendConfig::new("https", "origin.example.com")
+            .first_byte_timeout(Duration::from_millis(500))
+            .compute_name()
+            .expect("should compute name with 500ms timeout");
+        assert_ne!(
+            name_a, name_b,
+            "backends with different timeouts should have different names"
+        );
+        assert!(
+            name_a.ends_with("_t2000"),
+            "name should include timeout suffix"
+        );
+        assert!(
+            name_b.ends_with("_t500"),
+            "name should include timeout suffix"
         );
     }
 }

--- a/crates/common/src/integrations/adserver_mock.rs
+++ b/crates/common/src/integrations/adserver_mock.rs
@@ -373,15 +373,19 @@ impl AuctionProvider for AdServerMockProvider {
         self.config.enabled
     }
 
-    fn backend_name(&self) -> Option<String> {
-        BackendConfig::backend_name_for_url(&self.config.endpoint, true)
-            .inspect_err(|e| {
-                log::error!(
-                    "Failed to create backend for AdServer Mock endpoint '{}': {e:?}",
-                    self.config.endpoint
-                );
-            })
-            .ok()
+    fn backend_name(&self, timeout_ms: u32) -> Option<String> {
+        BackendConfig::backend_name_for_url(
+            &self.config.endpoint,
+            true,
+            Duration::from_millis(u64::from(timeout_ms)),
+        )
+        .inspect_err(|e| {
+            log::error!(
+                "Failed to create backend for AdServer Mock endpoint '{}': {e:?}",
+                self.config.endpoint
+            );
+        })
+        .ok()
     }
 }
 

--- a/crates/common/src/integrations/aps.rs
+++ b/crates/common/src/integrations/aps.rs
@@ -521,15 +521,19 @@ impl AuctionProvider for ApsAuctionProvider {
         self.config.enabled
     }
 
-    fn backend_name(&self) -> Option<String> {
-        BackendConfig::backend_name_for_url(&self.config.endpoint, true)
-            .inspect_err(|e| {
-                log::error!(
-                    "Failed to create backend for APS endpoint '{}': {e:?}",
-                    self.config.endpoint
-                );
-            })
-            .ok()
+    fn backend_name(&self, timeout_ms: u32) -> Option<String> {
+        BackendConfig::backend_name_for_url(
+            &self.config.endpoint,
+            true,
+            Duration::from_millis(u64::from(timeout_ms)),
+        )
+        .inspect_err(|e| {
+            log::error!(
+                "Failed to create backend for APS endpoint '{}': {e:?}",
+                self.config.endpoint
+            );
+        })
+        .ok()
     }
 }
 

--- a/crates/common/src/integrations/prebid.rs
+++ b/crates/common/src/integrations/prebid.rs
@@ -985,15 +985,19 @@ impl AuctionProvider for PrebidAuctionProvider {
         self.config.enabled
     }
 
-    fn backend_name(&self) -> Option<String> {
-        BackendConfig::backend_name_for_url(&self.config.server_url, true)
-            .inspect_err(|e| {
-                log::error!(
-                    "Failed to create backend for Prebid server URL '{}': {e:?}",
-                    self.config.server_url
-                );
-            })
-            .ok()
+    fn backend_name(&self, timeout_ms: u32) -> Option<String> {
+        BackendConfig::backend_name_for_url(
+            &self.config.server_url,
+            true,
+            Duration::from_millis(u64::from(timeout_ms)),
+        )
+        .inspect_err(|e| {
+            log::error!(
+                "Failed to create backend for Prebid server URL '{}': {e:?}",
+                self.config.server_url
+            );
+        })
+        .ok()
     }
 }
 


### PR DESCRIPTION
## Summary

- **Enforce the configured auction timeout** (`settings.auction.timeout_ms`) in the orchestrator's `select()` loop — previously, waits could extend to the backend's hardcoded 15s `first_byte_timeout`, ignoring the auction deadline.
- **Two complementary mechanisms**: (1) each auction provider's backend `first_byte_timeout` is set to `timeout_ms` instead of 15s, and (2) the orchestrator checks elapsed time after each `select()` return, dropping remaining requests when the deadline is exceeded.
- **Mediator receives remaining time budget** after the bidding phase, preventing mediation from extending the auction past the configured deadline.

## Changes

| File | Change |
| ---- | ------ |
| `crates/common/src/backend.rs` | Add configurable `first_byte_timeout` field to `BackendConfig` (default 15s), builder method, timeout-aware backend naming, and `from_url_with_first_byte_timeout()` convenience method |
| `crates/common/src/auction/orchestrator.rs` | Add deadline enforcement in `select()` loop — track `auction_start`, drop remaining requests when timeout exceeded, pass only remaining time to mediator |
| `crates/common/src/integrations/prebid.rs` | Use `from_url_with_first_byte_timeout()` with `context.timeout_ms` for bid requests |
| `crates/common/src/integrations/aps.rs` | Use `from_url_with_first_byte_timeout()` with `context.timeout_ms` for bid requests; rename `_context` → `context` |
| `crates/common/src/integrations/adserver_mock.rs` | Use `from_url_with_first_byte_timeout()` with `context.timeout_ms` for mediation requests |

## Closes

Closes #405

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/js/lib && npx vitest run`
- [x] JS format: `cd crates/js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [x] WASM build: `cargo build --bin trusted-server-fastly --release --target wasm32-wasip1`
- [x] Manual testing via `fastly compute serve`
- [ ] Other:

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed