### PR TITLE
Move secret validation to compile-time for release builds

### DIFF
--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -38,13 +38,24 @@ fn main() {
 
     // Merge base TOML with environment variable overrides and write output.
     // Panics if admin endpoints are not covered by a handler.
-    // Note: placeholder secret rejection is intentionally NOT done here.
-    // The base trusted-server.toml ships with placeholder secrets that
-    // production deployments override via TRUSTED_SERVER__* env vars at
-    // build time. Runtime startup (get_settings) rejects any remaining
-    // placeholders so a misconfigured deployment fails fast.
     let settings = settings::Settings::from_toml_and_env(&toml_content)
         .expect("Failed to parse settings at build time");
+
+    // Reject placeholder secrets in release builds so a misconfigured
+    // production deployment fails at compile time rather than at runtime.
+    // Debug builds (cargo test, cargo build) allow placeholders so that
+    // the base trusted-server.toml works without env var overrides.
+    //
+    // The runtime code uses `cfg(not(debug_assertions))` for the same
+    // purpose; both align under standard debug/release profiles.
+    let profile = std::env::var("PROFILE").expect("should have PROFILE set by Cargo");
+    if profile == "release" {
+        settings.reject_placeholder_secrets().expect(
+            "Release build must not contain placeholder secrets. \
+             Override them with TRUSTED_SERVER__PUBLISHER__PROXY_SECRET \
+             and TRUSTED_SERVER__SYNTHETIC__SECRET_KEY environment variables.",
+        );
+    }
 
     let merged_toml =
         toml::to_string_pretty(&settings).expect("Failed to serialize settings to TOML");

--- a/crates/common/src/settings.rs
+++ b/crates/common/src/settings.rs
@@ -219,8 +219,9 @@ impl Synthetic {
     ///
     /// Placeholder detection is intentionally **not** performed here because
     /// this validator runs at build time (via `from_toml_and_env`) when the
-    /// config legitimately contains placeholder values. Placeholder rejection
-    /// happens at runtime via [`Settings::reject_placeholder_secrets`].
+    /// config may legitimately contain placeholder values (e.g. debug builds).
+    /// Placeholder rejection happens in release builds at both compile time
+    /// (`build.rs`) and runtime ([`Settings::reject_placeholder_secrets`]).
     ///
     /// # Errors
     ///

--- a/crates/common/src/settings_data.rs
+++ b/crates/common/src/settings_data.rs
@@ -34,7 +34,11 @@ pub fn get_settings() -> Result<Settings, Report<TrustedServerError>> {
             message: "Failed to validate configuration".to_string(),
         })?;
 
-    // Reject known placeholder values for secrets that feed into cryptographic operations.
+    // Reject known placeholder values for secrets that feed into cryptographic
+    // operations. Release builds also enforce this at compile time (build.rs),
+    // so this is a runtime safety net. Debug builds skip the check so the
+    // default trusted-server.toml works without env var overrides.
+    #[cfg(not(debug_assertions))]
     settings.reject_placeholder_secrets()?;
 
     if !settings.proxy.certificate_check {
@@ -140,18 +144,12 @@ mod tests {
     }
 
     /// Smoke-test the full `get_settings()` pipeline (embedded bytes → UTF-8 →
-    /// parse → validate → placeholder check).  The build-time TOML ships with
-    /// placeholder secrets, so the expected outcome is an [`InsecureDefault`]
-    /// error — but reaching that error proves every earlier stage succeeded.
+    /// parse → validate).  Debug builds skip the placeholder-secret check so
+    /// the default `trusted-server.toml` works without env var overrides.
+    /// Release builds enforce placeholders at both compile time (`build.rs`)
+    /// and runtime, but tests run in debug mode.
     #[test]
-    fn get_settings_rejects_embedded_placeholder_secrets() {
-        let err = super::get_settings().expect_err("should reject embedded placeholder secrets");
-        assert!(
-            matches!(
-                err.current_context(),
-                TrustedServerError::InsecureDefault { .. }
-            ),
-            "should fail with InsecureDefault, got: {err}"
-        );
+    fn get_settings_allows_placeholders_in_debug_builds() {
+        super::get_settings().expect("debug builds should allow placeholder secrets");
     }
 }


### PR DESCRIPTION
## Summary

- Move placeholder secret rejection from an unconditional runtime gate to a compile-time check in `build.rs` that only fires for release builds, so `cargo build --release` fails fast if secrets have not been overridden.
- Guard the runtime `reject_placeholder_secrets()` call with `#[cfg(not(debug_assertions))]` so debug/test builds work with the default `trusted-server.toml` placeholders without needing env var overrides.
- Keep a runtime safety net for release builds while eliminating the DX friction of setting secrets for local development.

## Changes

| File | Change |
| ---- | ------ |
| `crates/common/build.rs` | Add release-only `reject_placeholder_secrets()` call after merging settings (checks `PROFILE == "release"`) |
| `crates/common/src/settings_data.rs` | Guard runtime `reject_placeholder_secrets()` with `#[cfg(not(debug_assertions))]`; update test to expect success in debug mode |
| `crates/common/src/settings.rs` | Update doc comment on `validate_secret_key` to describe new compile-time + runtime behavior |

## Closes

Closes #524

## Test plan

- [x] `cargo test --workspace` — 669 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/js/lib && npx vitest run` — 272 passed
- [x] JS format: `cd crates/js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [x] WASM build: `cargo build --bin trusted-server-fastly --release --target wasm32-wasip1` (with secret env vars set)

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed