### PR TITLE
Return generic error messages to clients for server-side errors

### DIFF
--- a/crates/trusted-server-core/src/error.rs
+++ b/crates/trusted-server-core/src/error.rs
@@ -151,11 +151,8 @@ mod tests {
             TrustedServerError::Proxy {
                 message: "upstream 10.0.0.1 refused".into(),
             },
-            TrustedServerError::SyntheticId {
+            TrustedServerError::Ec {
                 message: "seed file missing".into(),
-            },
-            TrustedServerError::Template {
-                message: "render failed".into(),
             },
             TrustedServerError::Auction {
                 message: "bid timeout".into(),
@@ -172,9 +169,6 @@ mod tests {
             },
             TrustedServerError::Settings {
                 message: "parse failed".into(),
-            },
-            TrustedServerError::InsecureDefault {
-                field: "api_key".into(),
             },
             TrustedServerError::InvalidUtf8 {
                 message: "byte 0xff".into(),


### PR DESCRIPTION
## Summary

- Prevent server-side error details (store names, config paths, proxy addresses) from leaking to clients by replacing the `user_message()` passthrough with categorized responses
- Client errors (4xx) retain brief, safe descriptions; server/integration errors (5xx/502/503) return a generic "An internal error occurred"
- Add unit tests asserting the security boundary: all server-error variants must return only the generic message

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/error.rs` | Replace `self.to_string()` in `user_message()` with a `match` that surfaces safe messages for client errors and a generic message for server errors. Add doc comments on `BadRequest` (user-visible message warning), `GdprConsent` (why detail is suppressed), and `user_message` trait method (updated semantics). Add two unit tests covering all variants. |

## Closes

Closes #437

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/js/lib && npx vitest run`
- [x] JS format: `cd crates/js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [x] WASM build: `cargo build --bin trusted-server-fastly --release --target wasm32-wasip1`
- [x] Manual testing via `fastly compute serve`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `log` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed