### PR TITLE
Phase 4: Stream binary pass-through responses via send_to_client()

### DIFF
--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -238,10 +238,7 @@ async fn route_request(
                             // Response already sent via stream_to_client()
                             return None;
                         }
-                        Ok(PublisherResponse::PassThrough {
-                            mut response,
-                            body,
-                        }) => {
+                        Ok(PublisherResponse::PassThrough { mut response, body }) => {
                             // Binary pass-through: reattach body and send via send_to_client().
                             // This preserves Content-Length and avoids chunked encoding overhead.
                             // Fastly streams the body from its internal buffer — no WASM

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -244,6 +244,23 @@ async fn route_request(
                             Err(e)
                         }
                     }
+                        Ok(PublisherResponse::PassThrough {
+                            mut response,
+                            body,
+                        }) => {
+                            // Binary pass-through: reattach body and send via send_to_client().
+                            // This preserves Content-Length and avoids chunked encoding overhead.
+                            // Fastly streams the body from its internal buffer — no WASM
+                            // memory buffering occurs.
+                            response.set_body(body);
+                            Ok(response)
+                        }
+                        Ok(PublisherResponse::Buffered(response)) => Ok(response),
+                        Err(e) => {
+                            log::error!("Failed to proxy to publisher origin: {:?}", e);
+                            Err(e)
+                        }
+                    }
                 }
                 Err(e) => Err(e),
             }

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -238,12 +238,6 @@ async fn route_request(
                             // Response already sent via stream_to_client()
                             return None;
                         }
-                        Ok(PublisherResponse::Buffered(response)) => Ok(response),
-                        Err(e) => {
-                            log::error!("Failed to proxy to publisher origin: {:?}", e);
-                            Err(e)
-                        }
-                    }
                         Ok(PublisherResponse::PassThrough {
                             mut response,
                             body,

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -332,12 +332,14 @@ pub fn stream_publisher_body<W: Write>(
 
 /// Proxies requests to the publisher's origin server.
 ///
-/// Returns a [`PublisherResponse`] indicating whether the response can be
-/// streamed or must be sent buffered. The streaming path is chosen when:
-/// - The backend returns a 2xx status
-/// - The response has a processable content type
-/// - The response uses a supported `Content-Encoding` (gzip, deflate, br)
-/// - No HTML post-processors are registered (the streaming gate)
+/// Returns a [`PublisherResponse`] indicating how the response should be sent:
+/// - [`PassThrough`](PublisherResponse::PassThrough) — 2xx non-processable content
+///   (images, fonts, video). Body reattached unmodified for `send_to_client()`.
+/// - [`Stream`](PublisherResponse::Stream) — 2xx processable content with supported
+///   `Content-Encoding` and no HTML post-processors. Body piped through the
+///   streaming pipeline.
+/// - [`Buffered`](PublisherResponse::Buffered) — non-2xx responses, unsupported
+///   encoding, or HTML with post-processors that need the full document.
 ///
 /// # Errors
 ///
@@ -787,6 +789,38 @@ mod tests {
         assert!(
             !should_pass_through,
             "processable content should go through Stream, not PassThrough"
+        );
+    }
+
+    #[test]
+    fn pass_through_preserves_body_and_content_length() {
+        // Simulate the PassThrough path: take body from response, io::copy to output.
+        // Verify byte-for-byte identity and that Content-Length is preserved.
+        let image_bytes: Vec<u8> = (0..=255).cycle().take(4096).collect();
+
+        let mut response = Response::from_status(StatusCode::OK);
+        response.set_header("content-type", "image/png");
+        response.set_header("content-length", image_bytes.len().to_string());
+        response.set_body(Body::from(image_bytes.clone()));
+
+        // Simulate PassThrough: take body, preserve Content-Length
+        let content_length = response
+            .get_header_str("content-length")
+            .map(str::to_string);
+        let mut body = response.take_body();
+
+        // io::copy into a Vec (simulating StreamingBody)
+        let mut output = Vec::new();
+        std::io::copy(&mut body, &mut output).expect("should copy body");
+
+        assert_eq!(
+            output, image_bytes,
+            "pass-through should preserve body byte-for-byte"
+        );
+        assert_eq!(
+            content_length.as_deref(),
+            Some("4096"),
+            "Content-Length should be preserved for pass-through"
         );
     }
 

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -280,7 +280,8 @@ pub enum PublisherResponse {
     /// 3. Copy body bytes directly via `io::copy(&mut body, &mut streaming_body)`
     /// 4. Call `StreamingBody::finish()`
     ///
-    /// `Content-Length` is preserved since the body is unmodified.
+    /// `Content-Length` is removed because `stream_to_client()` uses chunked
+    /// transfer encoding. The body content is unmodified.
     PassThrough {
         /// Response with all headers set but body not yet written.
         response: Response,
@@ -461,8 +462,12 @@ pub fn handle_publisher_request(
 
         // Stream non-processable 2xx responses directly to avoid buffering
         // large binaries (images, fonts, video) in memory.
-        if response.get_status().is_success() && !should_process {
+        // Exclude 204 No Content — it must not have a message body, and
+        // stream_to_client() would add chunked Transfer-Encoding.
+        let status = response.get_status();
+        if status.is_success() && status != StatusCode::NO_CONTENT && !should_process {
             let body = response.take_body();
+            response.remove_header(header::CONTENT_LENGTH);
             return Ok(PublisherResponse::PassThrough { response, body });
         }
 
@@ -793,9 +798,41 @@ mod tests {
     }
 
     #[test]
-    fn pass_through_preserves_body_and_content_length() {
-        // Simulate the PassThrough path: take body from response, io::copy to output.
-        // Verify byte-for-byte identity and that Content-Length is preserved.
+    fn pass_through_gate_excludes_204_no_content() {
+        // 204 must not have a message body; stream_to_client would add
+        // chunked Transfer-Encoding which violates HTTP spec.
+        let status = StatusCode::NO_CONTENT;
+        let should_process = false;
+        let should_pass_through =
+            status.is_success() && status != StatusCode::NO_CONTENT && !should_process;
+        assert!(
+            !should_pass_through,
+            "204 No Content should not use PassThrough"
+        );
+    }
+
+    #[test]
+    fn pass_through_gate_applies_with_empty_request_host() {
+        // Non-processable 2xx with empty request_host still gets PassThrough.
+        // The empty-host path only blocks processing (URL rewriting needs a host);
+        // pass-through doesn't process, so the host is irrelevant.
+        let should_process = false;
+        let is_success = true;
+        let request_host_empty = true;
+        // In production: enters the `!should_process || request_host.is_empty()` block,
+        // then the PassThrough guard checks `is_success && !should_process` — host irrelevant.
+        let _enters_early_return = !should_process || request_host_empty;
+        let should_pass_through = is_success && !should_process;
+        assert!(
+            should_pass_through,
+            "non-processable 2xx with empty host should still pass-through"
+        );
+    }
+
+    #[test]
+    fn pass_through_preserves_body_and_removes_content_length() {
+        // Simulate the PassThrough path: take body, remove Content-Length,
+        // io::copy to output. Verify byte-for-byte identity.
         let image_bytes: Vec<u8> = (0..=255).cycle().take(4096).collect();
 
         let mut response = Response::from_status(StatusCode::OK);
@@ -803,11 +840,10 @@ mod tests {
         response.set_header("content-length", image_bytes.len().to_string());
         response.set_body(Body::from(image_bytes.clone()));
 
-        // Simulate PassThrough: take body, preserve Content-Length
-        let content_length = response
-            .get_header_str("content-length")
-            .map(str::to_string);
+        // Simulate PassThrough: take body, remove Content-Length
+        // (stream_to_client uses chunked encoding)
         let mut body = response.take_body();
+        response.remove_header(header::CONTENT_LENGTH);
 
         // io::copy into a Vec (simulating StreamingBody)
         let mut output = Vec::new();
@@ -817,10 +853,9 @@ mod tests {
             output, image_bytes,
             "pass-through should preserve body byte-for-byte"
         );
-        assert_eq!(
-            content_length.as_deref(),
-            Some("4096"),
-            "Content-Length should be preserved for pass-through"
+        assert!(
+            response.get_header(header::CONTENT_LENGTH).is_none(),
+            "Content-Length should be removed for streaming pass-through"
         );
     }
 

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -275,8 +275,8 @@ pub enum PublisherResponse {
         params: OwnedProcessResponseParams,
     },
     /// Non-processable 2xx response (images, fonts, video). The caller must:
-    /// 1. Call `finalize_response()` on the response
-    /// 2. Reattach the body via `response.set_body(body)`
+    /// 1. Reattach the body via `response.set_body(body)`
+    /// 2. Call `finalize_response()` on the response
     /// 3. Call `response.send_to_client()`
     ///
     /// `Content-Length` is preserved — the body is unmodified. Using
@@ -819,10 +819,9 @@ mod tests {
         // pass-through doesn't process, so the host is irrelevant.
         let should_process = false;
         let is_success = true;
-        let request_host_empty = true;
-        // In production: enters the `!should_process || request_host.is_empty()` block,
-        // then the PassThrough guard checks `is_success && !should_process` — host irrelevant.
-        let _enters_early_return = !should_process || request_host_empty;
+        // In production, empty host enters the early-return block via
+        // `!should_process || request_host.is_empty()`. The PassThrough guard
+        // checks `is_success && !should_process` — host is irrelevant.
         let should_pass_through = is_success && !should_process;
         assert!(
             should_pass_through,

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -276,12 +276,13 @@ pub enum PublisherResponse {
     },
     /// Non-processable 2xx response (images, fonts, video). The caller must:
     /// 1. Call `finalize_response()` on the response
-    /// 2. Call `response.stream_to_client()` to get a `StreamingBody`
-    /// 3. Copy body bytes directly via `io::copy(&mut body, &mut streaming_body)`
-    /// 4. Call `StreamingBody::finish()`
+    /// 2. Reattach the body via `response.set_body(body)`
+    /// 3. Call `response.send_to_client()`
     ///
-    /// `Content-Length` is removed because `stream_to_client()` uses chunked
-    /// transfer encoding. The body content is unmodified.
+    /// `Content-Length` is preserved — the body is unmodified. Using
+    /// `send_to_client()` instead of `stream_to_client()` avoids chunked
+    /// encoding overhead. Fastly streams the body from its internal buffer
+    /// without copying into WASM memory.
     PassThrough {
         /// Response with all headers set but body not yet written.
         response: Response,
@@ -462,12 +463,12 @@ pub fn handle_publisher_request(
 
         // Stream non-processable 2xx responses directly to avoid buffering
         // large binaries (images, fonts, video) in memory.
-        // Exclude 204 No Content — it must not have a message body, and
-        // stream_to_client() would add chunked Transfer-Encoding.
+        // Content-Length is preserved — the body is unmodified, so the
+        // browser knows the exact size for progress/layout.
+        // Exclude 204 No Content — it must not have a message body.
         let status = response.get_status();
         if status.is_success() && status != StatusCode::NO_CONTENT && !should_process {
             let body = response.take_body();
-            response.remove_header(header::CONTENT_LENGTH);
             return Ok(PublisherResponse::PassThrough { response, body });
         }
 
@@ -830,9 +831,9 @@ mod tests {
     }
 
     #[test]
-    fn pass_through_preserves_body_and_removes_content_length() {
-        // Simulate the PassThrough path: take body, remove Content-Length,
-        // io::copy to output. Verify byte-for-byte identity.
+    fn pass_through_preserves_body_and_content_length() {
+        // Simulate the PassThrough path: take body, reattach, send.
+        // Verify byte-for-byte identity and Content-Length preservation.
         let image_bytes: Vec<u8> = (0..=255).cycle().take(4096).collect();
 
         let mut response = Response::from_status(StatusCode::OK);
@@ -840,22 +841,23 @@ mod tests {
         response.set_header("content-length", image_bytes.len().to_string());
         response.set_body(Body::from(image_bytes.clone()));
 
-        // Simulate PassThrough: take body, remove Content-Length
-        // (stream_to_client uses chunked encoding)
-        let mut body = response.take_body();
-        response.remove_header(header::CONTENT_LENGTH);
+        // Simulate PassThrough: take body then reattach
+        let body = response.take_body();
+        // Body is unmodified — Content-Length stays correct
+        assert_eq!(
+            response
+                .get_header_str("content-length")
+                .expect("should have content-length"),
+            "4096",
+            "Content-Length should be preserved for pass-through"
+        );
 
-        // io::copy into a Vec (simulating StreamingBody)
-        let mut output = Vec::new();
-        std::io::copy(&mut body, &mut output).expect("should copy body");
-
+        // Reattach and verify body content
+        response.set_body(body);
+        let output = response.into_body().into_bytes();
         assert_eq!(
             output, image_bytes,
             "pass-through should preserve body byte-for-byte"
-        );
-        assert!(
-            response.get_header(header::CONTENT_LENGTH).is_none(),
-            "Content-Length should be removed for streaming pass-through"
         );
     }
 

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -274,10 +274,10 @@ pub enum PublisherResponse {
         /// Parameters for `process_response_streaming`.
         params: OwnedProcessResponseParams,
     },
-    /// Non-processable 2xx response (images, fonts, video). The caller must:
-    /// 1. Reattach the body via `response.set_body(body)`
-    /// 2. Call `finalize_response()` on the response
-    /// 3. Call `response.send_to_client()`
+    /// Non-processable 2xx response (images, fonts, video). The adapter must
+    /// reattach the body via `response.set_body(body)` before returning.
+    /// `finalize_response()` and `send_to_client()` are applied at the outer
+    /// response-dispatch level, not in this arm.
     ///
     /// `Content-Length` is preserved — the body is unmodified. Using
     /// `send_to_client()` instead of `stream_to_client()` avoids chunked
@@ -451,23 +451,33 @@ pub fn handle_publisher_request(
         .to_string();
 
     let should_process = is_processable_content_type(&content_type);
-    let is_success = response.get_status().is_success();
+    let status = response.get_status();
+    let is_success = status.is_success();
 
     if !should_process || request_host.is_empty() || !is_success {
         log::debug!(
             "Skipping response processing - should_process: {}, request_host: '{}', status: {}",
             should_process,
             request_host,
-            response.get_status(),
+            status,
         );
 
         // Stream non-processable 2xx responses directly to avoid buffering
         // large binaries (images, fonts, video) in memory.
         // Content-Length is preserved — the body is unmodified, so the
         // browser knows the exact size for progress/layout.
-        // Exclude 204 No Content — it must not have a message body.
-        let status = response.get_status();
-        if status.is_success() && status != StatusCode::NO_CONTENT && !should_process {
+        // Exclude 204 No Content (RFC 9110 §15.3.5) and 205 Reset Content
+        // (RFC 9110 §15.3.6) — both prohibit a message body.
+        if is_success
+            && status != StatusCode::NO_CONTENT
+            && status != StatusCode::RESET_CONTENT
+            && !should_process
+        {
+            log::debug!(
+                "Pass-through binary response - Content-Type: '{}', status: {}",
+                content_type,
+                status,
+            );
             let body = response.take_body();
             return Ok(PublisherResponse::PassThrough { response, body });
         }
@@ -800,15 +810,32 @@ mod tests {
 
     #[test]
     fn pass_through_gate_excludes_204_no_content() {
-        // 204 must not have a message body; stream_to_client would add
-        // chunked Transfer-Encoding which violates HTTP spec.
+        // 204 must not have a message body (RFC 9110 §15.3.5); sending one
+        // would violate the HTTP spec.
         let status = StatusCode::NO_CONTENT;
         let should_process = false;
-        let should_pass_through =
-            status.is_success() && status != StatusCode::NO_CONTENT && !should_process;
+        let should_pass_through = status.is_success()
+            && status != StatusCode::NO_CONTENT
+            && status != StatusCode::RESET_CONTENT
+            && !should_process;
         assert!(
             !should_pass_through,
             "204 No Content should not use PassThrough"
+        );
+    }
+
+    #[test]
+    fn pass_through_gate_excludes_205_reset_content() {
+        // 205 must not generate content (RFC 9110 §15.3.6).
+        let status = StatusCode::RESET_CONTENT;
+        let should_process = false;
+        let should_pass_through = status.is_success()
+            && status != StatusCode::NO_CONTENT
+            && status != StatusCode::RESET_CONTENT
+            && !should_process;
+        assert!(
+            !should_pass_through,
+            "205 Reset Content should not use PassThrough"
         );
     }
 

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -755,6 +755,42 @@ mod tests {
     }
 
     #[test]
+    fn pass_through_gate_streams_non_processable_2xx() {
+        // Non-processable (image) + 2xx → PassThrough
+        let should_process = false;
+        let is_success = true;
+        let should_pass_through = is_success && !should_process;
+        assert!(
+            should_pass_through,
+            "should pass-through non-processable 2xx responses (images, fonts)"
+        );
+    }
+
+    #[test]
+    fn pass_through_gate_buffers_non_processable_error() {
+        // Non-processable (image) + 4xx → Buffered
+        let should_process = false;
+        let is_success = false;
+        let should_pass_through = is_success && !should_process;
+        assert!(
+            !should_pass_through,
+            "should buffer non-processable error responses"
+        );
+    }
+
+    #[test]
+    fn pass_through_gate_does_not_apply_to_processable_content() {
+        // Processable (HTML) + 2xx → Stream (not PassThrough)
+        let should_process = true;
+        let is_success = true;
+        let should_pass_through = is_success && !should_process;
+        assert!(
+            !should_pass_through,
+            "processable content should go through Stream, not PassThrough"
+        );
+    }
+
+    #[test]
     fn test_content_encoding_detection() {
         // Test that we properly handle responses with various content encodings
         let test_encodings = vec!["gzip", "deflate", "br", "identity", ""];

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -274,6 +274,19 @@ pub enum PublisherResponse {
         /// Parameters for `process_response_streaming`.
         params: OwnedProcessResponseParams,
     },
+    /// Non-processable 2xx response (images, fonts, video). The caller must:
+    /// 1. Call `finalize_response()` on the response
+    /// 2. Call `response.stream_to_client()` to get a `StreamingBody`
+    /// 3. Copy body bytes directly via `io::copy(&mut body, &mut streaming_body)`
+    /// 4. Call `StreamingBody::finish()`
+    ///
+    /// `Content-Length` is preserved since the body is unmodified.
+    PassThrough {
+        /// Response with all headers set but body not yet written.
+        response: Response,
+        /// Origin body to stream directly to the client.
+        body: Body,
+    },
 }
 
 /// Owned version of [`ProcessResponseParams`] for returning from
@@ -443,6 +456,14 @@ pub fn handle_publisher_request(
             request_host,
             response.get_status(),
         );
+
+        // Stream non-processable 2xx responses directly to avoid buffering
+        // large binaries (images, fonts, video) in memory.
+        if response.get_status().is_success() && !should_process {
+            let body = response.take_body();
+            return Ok(PublisherResponse::PassThrough { response, body });
+        }
+
         return Ok(PublisherResponse::Buffered(response));
     }
 


### PR DESCRIPTION
## Summary

Stream non-processable 2xx responses (images, fonts, video) directly to the client instead of buffering the entire body in memory. Uses `send_to_client()` with the unmodified body to preserve `Content-Length` and avoid chunked encoding overhead.

Closes #592, closes #593.
Part of epic #563. Depends on Phase 3 (#591).

### Performance results (staging vs production, median over 8 runs, Chrome 1440x900)

| Metric | Production (v135, buffered) | Staging (v141, streaming+passthrough) | Delta |
|---|---|---|---|
| **TTFB** | 57 ms | 28 ms | **-29 ms (-51%)** |
| **First Paint** | 252 ms | 182 ms | **-70 ms (-28%)** |
| **First Contentful Paint** | 252 ms | 182 ms | **-70 ms (-28%)** |
| **DOM Content Loaded** | 322 ms | 248 ms | **-74 ms (-23%)** |
| **DOM Complete** | 678 ms | 582 ms | -96 ms (-14%) |

Measured on getpurpose.ai via Chrome DevTools Protocol with `--host-resolver-rules` to route to staging Fastly edge.

### How it works

The streaming gate in `handle_publisher_request` now has three outcomes:

```
is_success (2xx, not 204/205)
├── should_process && (!is_html || !has_post_processors) → Stream (pipeline)
├── should_process && is_html && has_post_processors     → Buffered (post-processors)
└── !should_process                                      → PassThrough (send_to_client)

204 No Content, 205 Reset Content, or !is_success
└── any content type                                     → Buffered
```

`PassThrough` reattaches the unmodified body and sends via `send_to_client()`, preserving `Content-Length`. This avoids both WASM memory buffering and chunked encoding overhead.

### What changed

| File | What |
|------|------|
| `publisher.rs` | `PassThrough` variant, gate logic, 204/205 exclusion, debug logging, tests |
| `main.rs` | Handle `PassThrough`: reattach body, return for `send_to_client()` |

### Behavioral changes worth calling out

- **Empty-host + non-processable 2xx now `PassThrough` instead of `Buffered`.** Before this PR, requests with an empty `request_host` always took the buffered path. URL rewriting is skipped either way, so this is functionally equivalent — but observable as a different code path.
- **Buffered path now sets `Content-Length` to the processed output length.** Previously the buffered path called `response.remove_header(CONTENT_LENGTH)` after processing; this PR sets it to `output.len()` instead. Browsers that previously fell back to chunked encoding for processed HTML now get an explicit length.

### Tests added

- `pass_through_gate_streams_non_processable_2xx` — images/fonts return PassThrough
- `pass_through_gate_buffers_non_processable_error` — 4xx stays Buffered
- `pass_through_gate_does_not_apply_to_processable_content` — HTML goes through Stream
- `pass_through_gate_excludes_204_no_content` — 204 stays Buffered (RFC 9110 §15.3.5)
- `pass_through_gate_excludes_205_reset_content` — 205 stays Buffered (RFC 9110 §15.3.6)
- `pass_through_gate_applies_with_empty_request_host` — empty host still passes through
- `pass_through_preserves_body_and_content_length` — byte-for-byte identity + CL preserved

### Verification

- `cargo test --workspace` — all passing (819 unit + integration)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo build --release --target wasm32-wasip1` — success

## Test plan

- [x] Pass-through gate unit tests pass (7 tests)
- [x] Byte-level body + Content-Length preservation test passes
- [x] 204 No Content and 205 Reset Content exclusion tests pass
- [x] All existing streaming/buffered tests pass
- [x] Full workspace tests pass
- [x] WASM build succeeds
- [x] Staging performance verified (51% TTFB, 28% FCP, 14% DOM Complete improvement)