### PR TITLE
Migrate utility layer to http::Request/Response and add compat adapter (PR 11)

### DIFF
--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -5,14 +5,13 @@ use log_fastly::Logger;
 
 use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{build_orchestrator, AuctionOrchestrator};
-use trusted_server_core::auth::enforce_basic_auth;
+use trusted_server_core::compat;
 use trusted_server_core::constants::{
     ENV_FASTLY_IS_STAGING, ENV_FASTLY_SERVICE_VERSION, HEADER_X_GEO_INFO_AVAILABLE,
     HEADER_X_TS_ENV, HEADER_X_TS_VERSION,
 };
 use trusted_server_core::error::TrustedServerError;
 use trusted_server_core::geo::GeoInfo;
-use trusted_server_core::http_util::sanitize_forwarded_headers;
 use trusted_server_core::integrations::IntegrationRegistry;
 use trusted_server_core::platform::RuntimeServices;
 use trusted_server_core::proxy::{
@@ -97,7 +96,7 @@ async fn route_request(
     // Strip client-spoofable forwarded headers at the edge.
     // On Fastly this service IS the first proxy — these headers from
     // clients are untrusted and can hijack URL rewriting (see #409).
-    sanitize_forwarded_headers(&mut req);
+    compat::sanitize_forwarded_headers_fastly(&mut req);
 
     // Look up geo info via the platform abstraction using the client IP
     // already captured in RuntimeServices at the entry point.
@@ -112,7 +111,7 @@ async fn route_request(
     // `get_settings()` should already have rejected invalid handler regexes.
     // Keep this fallback so manually-constructed or otherwise unprepared
     // settings still become an error response instead of panicking.
-    match enforce_basic_auth(settings, &req) {
+    match compat::enforce_basic_auth_fastly(settings, &req) {
         Ok(Some(mut response)) => {
             finalize_response(settings, geo_info.as_ref(), &mut response);
             return Ok(response);

--- a/crates/trusted-server-core/src/auction/endpoints.rs
+++ b/crates/trusted-server-core/src/auction/endpoints.rs
@@ -4,9 +4,8 @@ use error_stack::{Report, ResultExt};
 use fastly::{Request, Response};
 
 use crate::auction::formats::AdRequest;
+use crate::compat;
 use crate::consent;
-use crate::cookies::handle_request_cookies;
-use crate::edge_cookie::get_or_generate_ec_id;
 use crate::error::TrustedServerError;
 use crate::geo::GeoInfo;
 use crate::platform::RuntimeServices;
@@ -49,13 +48,14 @@ pub async fn handle_auction(
 
     // Generate EC ID early so the consent pipeline can use it for
     // KV Store fallback/write operations.
-    let ec_id =
-        get_or_generate_ec_id(settings, &req).change_context(TrustedServerError::Auction {
+    let ec_id = compat::get_or_generate_ec_id_fastly(settings, &req).change_context(
+        TrustedServerError::Auction {
             message: "Failed to generate EC ID".to_string(),
-        })?;
+        },
+    )?;
 
     // Extract consent from request cookies, headers, and geo.
-    let cookie_jar = handle_request_cookies(&req)?;
+    let cookie_jar = compat::handle_request_cookies_fastly(&req)?;
     #[allow(deprecated)]
     let geo = GeoInfo::from_request(&req);
     let consent_context = consent::build_consent_context(&consent::ConsentPipelineInput {

--- a/crates/trusted-server-core/src/auction/formats.rs
+++ b/crates/trusted-server-core/src/auction/formats.rs
@@ -13,10 +13,10 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::auction::context::ContextValue;
+use crate::compat;
 use crate::consent::ConsentContext;
 use crate::constants::{HEADER_X_TS_EC, HEADER_X_TS_EC_FRESH};
 use crate::creative;
-use crate::edge_cookie::generate_ec_id;
 use crate::error::TrustedServerError;
 use crate::geo::GeoInfo;
 use crate::openrtb::{to_openrtb_i32, OpenRtbBid, OpenRtbResponse, ResponseExt, SeatBid, ToExt};
@@ -88,9 +88,11 @@ pub fn convert_tsjs_to_auction_request(
     ec_id: &str,
 ) -> Result<AuctionRequest, Report<TrustedServerError>> {
     let ec_id = ec_id.to_owned();
-    let fresh_id = generate_ec_id(settings, req).change_context(TrustedServerError::Auction {
-        message: "Failed to generate fresh EC ID".to_string(),
-    })?;
+    let fresh_id = compat::generate_ec_id_fastly(settings, req).change_context(
+        TrustedServerError::Auction {
+            message: "Failed to generate fresh EC ID".to_string(),
+        },
+    )?;
 
     // Convert ad units to slots
     let mut slots = Vec::new();

--- a/crates/trusted-server-core/src/auth.rs
+++ b/crates/trusted-server-core/src/auth.rs
@@ -1,7 +1,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
+use edgezero_core::body::Body;
 use error_stack::Report;
-use fastly::http::{header, StatusCode};
-use fastly::{Request, Response};
+use http::{header, StatusCode};
 use sha2::{Digest as _, Sha256};
 use subtle::ConstantTimeEq as _;
 
@@ -27,9 +27,10 @@ const BASIC_AUTH_REALM: &str = r#"Basic realm="Trusted Server""#;
 /// un-compilable path regex.
 pub fn enforce_basic_auth(
     settings: &Settings,
-    req: &Request,
-) -> Result<Option<Response>, Report<TrustedServerError>> {
-    let Some(handler) = settings.handler_for_path(req.get_path())? else {
+    req: &http::Request<Body>,
+) -> Result<Option<http::Response<Body>>, Report<TrustedServerError>> {
+    let path = req.uri().path();
+    let Some(handler) = settings.handler_for_path(path)? else {
         return Ok(None);
     };
 
@@ -53,14 +54,15 @@ pub fn enforce_basic_auth(
     if bool::from(username_match & password_match) {
         Ok(None)
     } else {
-        log::warn!("Basic auth failed for path: {}", req.get_path());
+        log::warn!("Basic auth failed for path: {}", path);
         Ok(Some(unauthorized_response()))
     }
 }
 
-fn extract_credentials(req: &Request) -> Option<(String, String)> {
+fn extract_credentials(req: &http::Request<Body>) -> Option<(String, String)> {
     let header_value = req
-        .get_header(header::AUTHORIZATION)
+        .headers()
+        .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())?;
 
     let mut parts = header_value.splitn(2, ' ');
@@ -84,25 +86,43 @@ fn extract_credentials(req: &Request) -> Option<(String, String)> {
     Some((username, password))
 }
 
-fn unauthorized_response() -> Response {
-    Response::from_status(StatusCode::UNAUTHORIZED)
-        .with_header(header::WWW_AUTHENTICATE, BASIC_AUTH_REALM)
-        .with_header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .with_body_text_plain("Unauthorized")
+fn unauthorized_response() -> http::Response<Body> {
+    http::Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .header(header::WWW_AUTHENTICATE, BASIC_AUTH_REALM)
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(Body::from("Unauthorized"))
+        .expect("should build unauthorized response")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use base64::engine::general_purpose::STANDARD;
-    use fastly::http::{header, Method};
 
     use crate::test_support::tests::{crate_test_settings_str, create_test_settings};
+
+    fn make_request(method: &str, uri: &str) -> http::Request<Body> {
+        http::Request::builder()
+            .method(method)
+            .uri(uri)
+            .body(Body::empty())
+            .expect("should build test request")
+    }
+
+    fn make_request_with_auth(method: &str, uri: &str, token: &str) -> http::Request<Body> {
+        http::Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(header::AUTHORIZATION, format!("Basic {token}"))
+            .body(Body::empty())
+            .expect("should build test request with auth header")
+    }
 
     #[test]
     fn no_challenge_for_non_protected_path() {
         let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://example.com/open");
+        let req = make_request("GET", "https://example.com/open");
 
         assert!(enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
@@ -112,14 +132,15 @@ mod tests {
     #[test]
     fn challenge_when_missing_credentials() {
         let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://example.com/secure");
+        let req = make_request("GET", "https://example.com/secure");
 
         let response = enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
             .expect("should challenge");
-        assert_eq!(response.get_status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         let realm = response
-            .get_header(header::WWW_AUTHENTICATE)
+            .headers()
+            .get(header::WWW_AUTHENTICATE)
             .expect("should have WWW-Authenticate header");
         assert_eq!(realm, BASIC_AUTH_REALM);
     }
@@ -127,9 +148,8 @@ mod tests {
     #[test]
     fn allow_when_credentials_match() {
         let settings = create_test_settings();
-        let mut req = Request::new(Method::GET, "https://example.com/secure/data");
         let token = STANDARD.encode("user:pass");
-        req.set_header(header::AUTHORIZATION, format!("Basic {token}"));
+        let req = make_request_with_auth("GET", "https://example.com/secure/data", &token);
 
         assert!(enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
@@ -139,29 +159,27 @@ mod tests {
     #[test]
     fn challenge_when_both_credentials_wrong() {
         let settings = create_test_settings();
-        let mut req = Request::new(Method::GET, "https://example.com/secure/data");
         let token = STANDARD.encode("wrong:wrong");
-        req.set_header(header::AUTHORIZATION, format!("Basic {token}"));
+        let req = make_request_with_auth("GET", "https://example.com/secure/data", &token);
 
         let response = enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
             .expect("should challenge");
-        assert_eq!(response.get_status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[test]
     fn challenge_when_username_wrong_password_correct() {
         // Validates that both fields are always evaluated — no short-circuit username oracle.
         let settings = create_test_settings();
-        let mut req = Request::new(Method::GET, "https://example.com/secure/data");
         let token = STANDARD.encode("wrong-user:pass");
-        req.set_header(header::AUTHORIZATION, format!("Basic {token}"));
+        let req = make_request_with_auth("GET", "https://example.com/secure/data", &token);
 
         let response = enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
             .expect("should challenge");
         assert_eq!(
-            response.get_status(),
+            response.status(),
             StatusCode::UNAUTHORIZED,
             "should reject wrong username even with correct password"
         );
@@ -170,15 +188,14 @@ mod tests {
     #[test]
     fn challenge_when_username_correct_password_wrong() {
         let settings = create_test_settings();
-        let mut req = Request::new(Method::GET, "https://example.com/secure/data");
         let token = STANDARD.encode("user:wrong-pass");
-        req.set_header(header::AUTHORIZATION, format!("Basic {token}"));
+        let req = make_request_with_auth("GET", "https://example.com/secure/data", &token);
 
         let response = enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
             .expect("should challenge");
         assert_eq!(
-            response.get_status(),
+            response.status(),
             StatusCode::UNAUTHORIZED,
             "should reject correct username with wrong password"
         );
@@ -187,13 +204,17 @@ mod tests {
     #[test]
     fn challenge_when_scheme_is_not_basic() {
         let settings = create_test_settings();
-        let mut req = Request::new(Method::GET, "https://example.com/secure");
-        req.set_header(header::AUTHORIZATION, "Bearer token");
+        let req = http::Request::builder()
+            .method("GET")
+            .uri("https://example.com/secure")
+            .header(header::AUTHORIZATION, "Bearer token")
+            .body(Body::empty())
+            .expect("should build test request");
 
         let response = enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
             .expect("should challenge");
-        assert_eq!(response.get_status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[test]
@@ -210,9 +231,8 @@ mod tests {
     #[test]
     fn allow_admin_path_with_valid_credentials() {
         let settings = create_test_settings();
-        let mut req = Request::new(Method::POST, "https://example.com/admin/keys/rotate");
         let token = STANDARD.encode("admin:admin-pass");
-        req.set_header(header::AUTHORIZATION, format!("Basic {token}"));
+        let req = make_request_with_auth("POST", "https://example.com/admin/keys/rotate", &token);
 
         assert!(
             enforce_basic_auth(&settings, &req)
@@ -225,24 +245,23 @@ mod tests {
     #[test]
     fn challenge_admin_path_with_wrong_credentials() {
         let settings = create_test_settings();
-        let mut req = Request::new(Method::POST, "https://example.com/admin/keys/rotate");
         let token = STANDARD.encode("admin:wrong");
-        req.set_header(header::AUTHORIZATION, format!("Basic {token}"));
+        let req = make_request_with_auth("POST", "https://example.com/admin/keys/rotate", &token);
 
         let response = enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
             .expect("should challenge admin path with wrong credentials");
-        assert_eq!(response.get_status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[test]
     fn challenge_admin_path_with_missing_credentials() {
         let settings = create_test_settings();
-        let req = Request::new(Method::POST, "https://example.com/admin/keys/rotate");
+        let req = make_request("POST", "https://example.com/admin/keys/rotate");
 
         let response = enforce_basic_auth(&settings, &req)
             .expect("should evaluate auth")
             .expect("should challenge admin path with missing credentials");
-        assert_eq!(response.get_status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/crates/trusted-server-core/src/compat.rs
+++ b/crates/trusted-server-core/src/compat.rs
@@ -1,0 +1,640 @@
+//! Compatibility adapter bridging `fastly::Request/Response` with `http::Request/Response`.
+//!
+//! This module provides type conversion functions and request extension types used during the
+//! Phase 2 of the platform migration. All items here are temporary bridges scheduled for removal
+//! once the full type migration is complete.
+//!
+//! ## Usage pattern
+//!
+//! Handler-layer functions that still accept `fastly::Request` call these helpers at each
+//! utility-function boundary:
+//!
+//! ```ignore
+//! // read-only: borrow-based — no body copy
+//! let http_req = compat::from_fastly_request_ref(&req);
+//! let info = http_util::RequestInfo::from_request(&http_req);
+//!
+//! // mutable: build an http outgoing request, then convert back
+//! let mut http_out = http::Request::builder().method(...).uri(...).body(Body::empty())...;
+//! cookies::forward_cookie_header(&http_req, &mut http_out, true);
+//! let fastly_out = compat::to_fastly_request(http_out);
+//! ```
+//!
+//! # TODO(PR15)
+//!
+//! Remove this entire module after handler-layer type migration is complete.
+
+use std::net::IpAddr;
+
+use edgezero_core::body::Body;
+use http::{HeaderName, HeaderValue, StatusCode};
+
+// ── Request extension types ────────────────────────────────────────────────
+
+/// TLS protocol string detected by the Fastly SDK.
+///
+/// Stored as a [`http::Request`] extension by [`from_fastly_request_ref`] so that
+/// `http_util::detect_request_scheme` can check it without Fastly SDK access.
+///
+/// # TODO(PR15): Remove once handler-layer migration is complete.
+#[derive(Debug, Clone)]
+pub struct TlsProtocol(pub Option<&'static str>);
+
+/// TLS cipher string detected by the Fastly SDK.
+///
+/// Stored as a [`http::Request`] extension by [`from_fastly_request_ref`] so that
+/// `http_util::detect_request_scheme` can check it without Fastly SDK access.
+///
+/// # TODO(PR15): Remove once handler-layer migration is complete.
+#[derive(Debug, Clone)]
+pub struct TlsCipher(pub Option<&'static str>);
+
+/// Client IP address captured from the Fastly SDK.
+///
+/// Stored as a [`http::Request`] extension by [`from_fastly_request_ref`] so that
+/// `edge_cookie::generate_ec_id` can read the client IP without Fastly SDK access.
+///
+/// # TODO(PR15): Remove once handler-layer migration is complete.
+#[derive(Debug, Clone)]
+pub struct ClientIpExt(pub Option<IpAddr>);
+
+// ── Request conversions ────────────────────────────────────────────────────
+
+/// Create an `http::Request<Body>` from a `&fastly::Request` reference.
+///
+/// Copies all headers and the URI from the Fastly request. The body is **not** copied —
+/// the returned request carries an empty body. Fastly-specific TLS and client IP
+/// information is preserved in the request's extensions.
+///
+/// Prefer this over [`from_fastly_request`] for utility calls that only read
+/// headers or the request path, so that the original `fastly::Request` body is
+/// not consumed.
+///
+/// # Panics
+///
+/// Panics if the Fastly request URL cannot be parsed as an `http::Uri`.
+///
+/// # TODO(PR15): Remove after handler-layer migration is complete.
+pub fn from_fastly_request_ref(req: &fastly::Request) -> http::Request<Body> {
+    let uri: http::Uri = req
+        .get_url_str()
+        .parse()
+        .expect("should parse fastly request URL as URI");
+
+    let mut builder = http::Request::builder()
+        .method(req.get_method().clone())
+        .uri(uri);
+
+    for (name, value) in req.get_headers() {
+        builder = builder.header(name.clone(), value.clone());
+    }
+
+    let mut http_req = builder
+        .body(Body::empty())
+        .expect("should build http request from fastly request reference");
+
+    http_req
+        .extensions_mut()
+        .insert(TlsProtocol(req.get_tls_protocol()));
+    http_req
+        .extensions_mut()
+        .insert(TlsCipher(req.get_tls_cipher_openssl_name()));
+    http_req
+        .extensions_mut()
+        .insert(ClientIpExt(req.get_client_ip_addr()));
+
+    http_req
+}
+
+/// Consume a `fastly::Request` and produce an `http::Request<Body>`.
+///
+/// Moves the request body out of the Fastly request. Use this when the utility layer
+/// needs to read or process the request body. Fastly-specific TLS and client IP
+/// information is preserved in the request's extensions.
+///
+/// # Panics
+///
+/// Panics if the Fastly request URL cannot be parsed as an `http::Uri`.
+///
+/// # TODO(PR15): Remove after handler-layer migration is complete.
+pub fn from_fastly_request(mut req: fastly::Request) -> http::Request<Body> {
+    let uri: http::Uri = req
+        .get_url_str()
+        .parse()
+        .expect("should parse fastly request URL as URI");
+
+    let tls_protocol = req.get_tls_protocol();
+    let tls_cipher = req.get_tls_cipher_openssl_name();
+    let client_ip = req.get_client_ip_addr();
+
+    let mut builder = http::Request::builder()
+        .method(req.get_method().clone())
+        .uri(uri);
+
+    for (name, value) in req.get_headers() {
+        builder = builder.header(name.clone(), value.clone());
+    }
+
+    let body = Body::from_bytes(req.take_body_bytes());
+
+    let mut http_req = builder
+        .body(body)
+        .expect("should build http request from fastly request");
+
+    http_req.extensions_mut().insert(TlsProtocol(tls_protocol));
+    http_req.extensions_mut().insert(TlsCipher(tls_cipher));
+    http_req.extensions_mut().insert(ClientIpExt(client_ip));
+
+    http_req
+}
+
+/// Convert an `http::Request<Body>` back to a `fastly::Request`.
+///
+/// Used at integration layer boundaries where the utility layer produces an
+/// `http::Request<Body>` (e.g. after header manipulation) but the downstream
+/// operation still requires a `fastly::Request` for sending via the Fastly SDK.
+///
+/// Body streaming is not supported — the body is materialised into bytes before
+/// conversion. Avoid this function for large bodies until streaming support is added.
+///
+/// # TODO(PR15): Remove after handler-layer migration is complete.
+pub fn to_fastly_request(req: http::Request<Body>) -> fastly::Request {
+    let (parts, body) = req.into_parts();
+
+    let mut fastly_req = fastly::Request::new(parts.method, parts.uri.to_string());
+
+    for (name, value) in &parts.headers {
+        fastly_req.set_header(name, value);
+    }
+
+    let body_bytes = body.into_bytes();
+    if !body_bytes.is_empty() {
+        fastly_req.set_body_octet_stream(&body_bytes);
+    }
+
+    fastly_req
+}
+
+// ── Response conversions ───────────────────────────────────────────────────
+
+/// Convert a `fastly::Response` to an `http::Response<Body>`.
+///
+/// Body streaming is not supported — the body is materialised into bytes.
+///
+/// # Panics
+///
+/// Panics if the `http::Response` builder fails (unreachable in practice).
+///
+/// # TODO(PR15): Remove after handler-layer migration is complete.
+pub fn from_fastly_response(mut res: fastly::Response) -> http::Response<Body> {
+    let mut builder = http::Response::builder().status(res.get_status());
+
+    for (name, value) in res.get_headers() {
+        builder = builder.header(name.clone(), value.clone());
+    }
+
+    let body = Body::from_bytes(res.take_body_bytes());
+
+    builder
+        .body(body)
+        .expect("should build http response from fastly response")
+}
+
+/// Convert an `http::Response<Body>` to a `fastly::Response`.
+///
+/// Body streaming is not supported — the body is materialised into bytes.
+///
+/// # TODO(PR15): Remove after handler-layer migration is complete.
+pub fn to_fastly_response(res: http::Response<Body>) -> fastly::Response {
+    let (parts, body) = res.into_parts();
+
+    let mut fastly_res = fastly::Response::from_status(parts.status);
+
+    for (name, value) in &parts.headers {
+        fastly_res.set_header(name, value);
+    }
+
+    let body_bytes = body.into_bytes();
+    if !body_bytes.is_empty() {
+        fastly_res.set_body_octet_stream(&body_bytes);
+    }
+
+    fastly_res
+}
+
+// ── Response builder helpers ───────────────────────────────────────────────
+
+/// Build an `http::Response<Body>` with a given status and no body.
+///
+/// # Panics
+///
+/// Panics if the `http::Response` builder fails (unreachable in practice).
+///
+/// # TODO(PR15): Remove — callers should use `http::Response::builder()` directly.
+#[must_use]
+pub fn response_from_status(status: StatusCode) -> http::Response<Body> {
+    http::Response::builder()
+        .status(status)
+        .body(Body::empty())
+        .expect("should build response from status")
+}
+
+/// Append a header to an `http::Response<Body>`, returning the response.
+///
+/// Unlike [`http::Response::headers_mut().append()`], this is chainable.
+///
+/// # TODO(PR15): Remove — callers should use `response.headers_mut().append()` directly.
+pub fn append_header_to_response(
+    mut res: http::Response<Body>,
+    name: HeaderName,
+    value: HeaderValue,
+) -> http::Response<Body> {
+    res.headers_mut().append(name, value);
+    res
+}
+
+// ── Fastly-boundary bridge functions ──────────────────────────────────────
+//
+// These are handler/integration-layer shims that let code still holding
+// `fastly::Request` / `fastly::Response` call into the migrated utility
+// functions without converting the entire call stack in PR 11. They are
+// removed in PR 15 once the handler and integration layers are fully migrated.
+
+/// Apply `http_util::sanitize_forwarded_headers` to a `fastly::Request`.
+///
+/// Removes client-spoofable forwarded headers in place.
+///
+/// # TODO(PR15): Remove once the handler layer migrates to `http` types.
+pub fn sanitize_forwarded_headers_fastly(req: &mut fastly::Request) {
+    use crate::http_util::SPOOFABLE_FORWARDED_HEADERS;
+    for header in SPOOFABLE_FORWARDED_HEADERS {
+        if req.get_header(*header).is_some() {
+            log::debug!("Stripped spoofable header: {}", header);
+            req.remove_header(*header);
+        }
+    }
+}
+
+/// Apply `auth::enforce_basic_auth` with a `fastly::Request`, returning a `fastly::Response`.
+///
+/// Converts the request to `http::Request<Body>` and the returned response to
+/// `fastly::Response` for the adapter entry point.
+///
+/// # Errors
+///
+/// Returns an error when handler configuration is invalid.
+///
+/// # TODO(PR15): Remove once the adapter entry point migrates to `http` types.
+pub fn enforce_basic_auth_fastly(
+    settings: &crate::settings::Settings,
+    req: &fastly::Request,
+) -> Result<Option<fastly::Response>, error_stack::Report<crate::error::TrustedServerError>> {
+    use crate::auth;
+    let http_req = from_fastly_request_ref(req);
+    auth::enforce_basic_auth(settings, &http_req).map(|opt| opt.map(to_fastly_response))
+}
+
+/// Apply `http_util::serve_static_with_etag` with a `fastly::Request`, returning a
+/// `fastly::Response`.
+///
+/// # TODO(PR15): Remove once the handler layer migrates to `http` types.
+pub fn serve_static_with_etag_fastly(
+    body: &str,
+    req: &fastly::Request,
+    content_type: &str,
+) -> fastly::Response {
+    use crate::http_util;
+    let http_req = from_fastly_request_ref(req);
+    let http_resp = http_util::serve_static_with_etag(body, &http_req, content_type);
+    to_fastly_response(http_resp)
+}
+
+/// Apply `cookies::set_ec_cookie` to a `fastly::Response`.
+///
+/// Creates a temporary `http::Response<Body>` to collect the Set-Cookie header,
+/// then appends it to the Fastly response.
+///
+/// # Panics
+///
+/// Panics if the temporary `http::Response` builder fails (unreachable in practice).
+///
+/// # TODO(PR15): Remove once publisher/registry migrate to `http` types.
+pub fn set_ec_cookie_fastly(
+    settings: &crate::settings::Settings,
+    response: &mut fastly::Response,
+    ec_id: &str,
+) {
+    use crate::cookies;
+    let mut temp = http::Response::builder()
+        .status(200u16)
+        .body(Body::empty())
+        .expect("should build temp response for cookie collection");
+    cookies::set_ec_cookie(settings, &mut temp, ec_id);
+    for value in temp.headers().get_all(http::header::SET_COOKIE) {
+        response.append_header(http::header::SET_COOKIE, value);
+    }
+}
+
+/// Apply `cookies::expire_ec_cookie` to a `fastly::Response`.
+///
+/// # Panics
+///
+/// Panics if the temporary `http::Response` builder fails (unreachable in practice).
+///
+/// # TODO(PR15): Remove once publisher/registry migrate to `http` types.
+pub fn expire_ec_cookie_fastly(
+    settings: &crate::settings::Settings,
+    response: &mut fastly::Response,
+) {
+    use crate::cookies;
+    let mut temp = http::Response::builder()
+        .status(200u16)
+        .body(Body::empty())
+        .expect("should build temp response for cookie collection");
+    cookies::expire_ec_cookie(settings, &mut temp);
+    for value in temp.headers().get_all(http::header::SET_COOKIE) {
+        response.append_header(http::header::SET_COOKIE, value);
+    }
+}
+
+/// Apply `cookies::forward_cookie_header` with `fastly::Request` types.
+///
+/// Converts `from` to `http::Request<Body>`, runs the migrated utility, then
+/// applies any Cookie header changes back to `to`.
+///
+/// # Panics
+///
+/// Panics if the temporary `http::Request` builder fails (unreachable in practice).
+///
+/// # TODO(PR15): Remove once integration layer migrates to `http` types.
+pub fn forward_cookie_header_fastly(
+    from: &fastly::Request,
+    to: &mut fastly::Request,
+    strip_consent: bool,
+) {
+    use crate::cookies;
+    let http_from = from_fastly_request_ref(from);
+    let mut http_to = http::Request::builder()
+        .method("GET")
+        .uri("/")
+        .body(Body::empty())
+        .expect("should build temp request for cookie forwarding");
+    cookies::forward_cookie_header(&http_from, &mut http_to, strip_consent);
+    match http_to.headers().get(http::header::COOKIE) {
+        Some(cookie) => to.set_header(http::header::COOKIE, cookie),
+        None => {
+            to.remove_header(http::header::COOKIE);
+        }
+    }
+}
+
+/// Apply `http_util::copy_custom_headers` with `fastly::Request` types.
+///
+/// Converts `from` to `http::Request<Body>`, runs the migrated utility, then
+/// copies all resulting X-* headers to `to`.
+///
+/// # Panics
+///
+/// Panics if the temporary `http::Request` builder fails (unreachable in practice).
+///
+/// # TODO(PR15): Remove once integration layer migrates to `http` types.
+pub fn copy_custom_headers_fastly(from: &fastly::Request, to: &mut fastly::Request) {
+    use crate::http_util;
+    let http_from = from_fastly_request_ref(from);
+    let mut http_to = http::Request::builder()
+        .method("GET")
+        .uri("/")
+        .body(Body::empty())
+        .expect("should build temp request for custom header copying");
+    http_util::copy_custom_headers(&http_from, &mut http_to);
+    for (name, value) in http_to.headers() {
+        to.set_header(name, value);
+    }
+}
+
+/// Apply `http_util::RequestInfo::from_request` with a `fastly::Request`.
+///
+/// # TODO(PR15): Remove once the handler layer migrates to `http` types.
+pub fn request_info_from_fastly(req: &fastly::Request) -> crate::http_util::RequestInfo {
+    use crate::http_util::RequestInfo;
+    let http_req = from_fastly_request_ref(req);
+    RequestInfo::from_request(&http_req)
+}
+
+/// Apply `edge_cookie::get_ec_id` with a `fastly::Request`.
+///
+/// # Errors
+///
+/// Returns an error if cookie parsing fails.
+///
+/// # TODO(PR15): Remove once the handler layer migrates to `http` types.
+pub fn get_ec_id_fastly(
+    req: &fastly::Request,
+) -> Result<Option<String>, error_stack::Report<crate::error::TrustedServerError>> {
+    use crate::edge_cookie;
+    let http_req = from_fastly_request_ref(req);
+    edge_cookie::get_ec_id(&http_req)
+}
+
+/// Apply `edge_cookie::get_or_generate_ec_id` with a `fastly::Request`.
+///
+/// # Errors
+///
+/// Returns an error if EC ID generation fails.
+///
+/// # TODO(PR15): Remove once the handler layer migrates to `http` types.
+pub fn get_or_generate_ec_id_fastly(
+    settings: &crate::settings::Settings,
+    req: &fastly::Request,
+) -> Result<String, error_stack::Report<crate::error::TrustedServerError>> {
+    use crate::edge_cookie;
+    let http_req = from_fastly_request_ref(req);
+    edge_cookie::get_or_generate_ec_id(settings, &http_req)
+}
+
+/// Apply `edge_cookie::generate_ec_id` with a `fastly::Request`.
+///
+/// # Errors
+///
+/// Returns an error if EC ID generation fails.
+///
+/// # TODO(PR15): Remove once the handler layer migrates to `http` types.
+pub fn generate_ec_id_fastly(
+    settings: &crate::settings::Settings,
+    req: &fastly::Request,
+) -> Result<String, error_stack::Report<crate::error::TrustedServerError>> {
+    use crate::edge_cookie;
+    let http_req = from_fastly_request_ref(req);
+    edge_cookie::generate_ec_id(settings, &http_req)
+}
+
+/// Apply `cookies::handle_request_cookies` with a `fastly::Request`.
+///
+/// # Errors
+///
+/// Returns an error if the Cookie header contains invalid UTF-8.
+///
+/// # TODO(PR15): Remove once the handler layer migrates to `http` types.
+pub fn handle_request_cookies_fastly(
+    req: &fastly::Request,
+) -> Result<Option<cookie::CookieJar>, error_stack::Report<crate::error::TrustedServerError>> {
+    use crate::cookies;
+    let http_req = from_fastly_request_ref(req);
+    cookies::handle_request_cookies(&http_req)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::header;
+
+    fn make_fastly_req_with_headers() -> fastly::Request {
+        let mut req =
+            fastly::Request::new(fastly::http::Method::GET, "https://example.com/path?q=1");
+        req.set_header("x-custom", "value");
+        req.set_header(header::HOST, "example.com");
+        req
+    }
+
+    #[test]
+    fn from_fastly_request_ref_copies_headers_and_uri() {
+        let fastly_req = make_fastly_req_with_headers();
+        let http_req = from_fastly_request_ref(&fastly_req);
+
+        assert_eq!(
+            http_req
+                .headers()
+                .get("x-custom")
+                .map(http::HeaderValue::as_bytes),
+            Some(b"value".as_ref()),
+            "should copy x-custom header"
+        );
+        assert_eq!(
+            http_req.uri().path(),
+            "/path",
+            "should preserve request path"
+        );
+        assert_eq!(
+            http_req.uri().query(),
+            Some("q=1"),
+            "should preserve query string"
+        );
+    }
+
+    #[test]
+    fn from_fastly_request_ref_has_empty_body() {
+        let fastly_req = make_fastly_req_with_headers();
+        let http_req = from_fastly_request_ref(&fastly_req);
+
+        assert!(
+            http_req.body().as_bytes().is_empty(),
+            "should have empty body when using reference conversion"
+        );
+    }
+
+    #[test]
+    fn from_fastly_request_ref_stores_client_ip_extension() {
+        let fastly_req = make_fastly_req_with_headers();
+        let http_req = from_fastly_request_ref(&fastly_req);
+
+        assert!(
+            http_req.extensions().get::<ClientIpExt>().is_some(),
+            "should store ClientIpExt extension"
+        );
+    }
+
+    #[test]
+    fn from_fastly_request_ref_stores_tls_extensions() {
+        let fastly_req = make_fastly_req_with_headers();
+        let http_req = from_fastly_request_ref(&fastly_req);
+
+        assert!(
+            http_req.extensions().get::<TlsProtocol>().is_some(),
+            "should store TlsProtocol extension"
+        );
+        assert!(
+            http_req.extensions().get::<TlsCipher>().is_some(),
+            "should store TlsCipher extension"
+        );
+    }
+
+    #[test]
+    fn from_fastly_request_copies_body() {
+        let mut fastly_req = fastly::Request::post("https://example.com/api");
+        fastly_req.set_body_octet_stream(b"hello body");
+
+        let http_req = from_fastly_request(fastly_req);
+
+        assert_eq!(
+            http_req.body().as_bytes(),
+            b"hello body",
+            "should copy request body bytes"
+        );
+    }
+
+    #[test]
+    fn to_fastly_request_preserves_method_uri_headers() {
+        let http_req = http::Request::builder()
+            .method("POST")
+            .uri("https://api.example.com/submit")
+            .header("x-req-id", "abc-123")
+            .body(Body::empty())
+            .expect("should build http request");
+
+        let fastly_req = to_fastly_request(http_req);
+
+        assert_eq!(
+            fastly_req.get_method_str(),
+            "POST",
+            "should preserve HTTP method"
+        );
+        assert!(
+            fastly_req.get_url_str().contains("api.example.com"),
+            "should preserve URL"
+        );
+        assert!(
+            fastly_req.get_header("x-req-id").is_some(),
+            "should preserve request headers"
+        );
+    }
+
+    #[test]
+    fn response_roundtrip_preserves_status_and_headers() {
+        let mut fastly_res = fastly::Response::from_status(202);
+        fastly_res.set_header("x-resp-id", "xyz");
+
+        let http_res = from_fastly_response(fastly_res);
+        assert_eq!(
+            http_res.status().as_u16(),
+            202,
+            "should preserve status code"
+        );
+        assert_eq!(
+            http_res
+                .headers()
+                .get("x-resp-id")
+                .map(http::HeaderValue::as_bytes),
+            Some(b"xyz".as_ref()),
+            "should preserve response headers"
+        );
+
+        let fastly_res2 = to_fastly_response(http_res);
+        assert_eq!(
+            fastly_res2.get_status().as_u16(),
+            202,
+            "should round-trip status code"
+        );
+        assert!(
+            fastly_res2.get_header("x-resp-id").is_some(),
+            "should round-trip response headers"
+        );
+    }
+
+    #[test]
+    fn response_from_status_has_correct_status_and_empty_body() {
+        let res = response_from_status(StatusCode::NOT_FOUND);
+
+        assert_eq!(res.status().as_u16(), 404, "should have 404 status");
+        assert!(res.body().as_bytes().is_empty(), "should have empty body");
+    }
+}

--- a/crates/trusted-server-core/src/compat.rs
+++ b/crates/trusted-server-core/src/compat.rs
@@ -29,6 +29,12 @@ use std::net::IpAddr;
 use edgezero_core::body::Body;
 use http::{HeaderName, HeaderValue, StatusCode};
 
+use crate::auth;
+use crate::cookies;
+use crate::edge_cookie;
+use crate::http_util;
+use crate::http_util::{RequestInfo, SPOOFABLE_FORWARDED_HEADERS};
+
 // ── Request extension types ────────────────────────────────────────────────
 
 /// TLS protocol string detected by the Fastly SDK.
@@ -266,7 +272,6 @@ pub fn append_header_to_response(
 ///
 /// # TODO(PR15): Remove once the handler layer migrates to `http` types.
 pub fn sanitize_forwarded_headers_fastly(req: &mut fastly::Request) {
-    use crate::http_util::SPOOFABLE_FORWARDED_HEADERS;
     for header in SPOOFABLE_FORWARDED_HEADERS {
         if req.get_header(*header).is_some() {
             log::debug!("Stripped spoofable header: {}", header);
@@ -289,7 +294,6 @@ pub fn enforce_basic_auth_fastly(
     settings: &crate::settings::Settings,
     req: &fastly::Request,
 ) -> Result<Option<fastly::Response>, error_stack::Report<crate::error::TrustedServerError>> {
-    use crate::auth;
     let http_req = from_fastly_request_ref(req);
     auth::enforce_basic_auth(settings, &http_req).map(|opt| opt.map(to_fastly_response))
 }
@@ -303,7 +307,6 @@ pub fn serve_static_with_etag_fastly(
     req: &fastly::Request,
     content_type: &str,
 ) -> fastly::Response {
-    use crate::http_util;
     let http_req = from_fastly_request_ref(req);
     let http_resp = http_util::serve_static_with_etag(body, &http_req, content_type);
     to_fastly_response(http_resp)
@@ -324,7 +327,6 @@ pub fn set_ec_cookie_fastly(
     response: &mut fastly::Response,
     ec_id: &str,
 ) {
-    use crate::cookies;
     let mut temp = http::Response::builder()
         .status(200u16)
         .body(Body::empty())
@@ -346,7 +348,6 @@ pub fn expire_ec_cookie_fastly(
     settings: &crate::settings::Settings,
     response: &mut fastly::Response,
 ) {
-    use crate::cookies;
     let mut temp = http::Response::builder()
         .status(200u16)
         .body(Body::empty())
@@ -372,7 +373,6 @@ pub fn forward_cookie_header_fastly(
     to: &mut fastly::Request,
     strip_consent: bool,
 ) {
-    use crate::cookies;
     let http_from = from_fastly_request_ref(from);
     let mut http_to = http::Request::builder()
         .method("GET")
@@ -399,7 +399,6 @@ pub fn forward_cookie_header_fastly(
 ///
 /// # TODO(PR15): Remove once integration layer migrates to `http` types.
 pub fn copy_custom_headers_fastly(from: &fastly::Request, to: &mut fastly::Request) {
-    use crate::http_util;
     let http_from = from_fastly_request_ref(from);
     let mut http_to = http::Request::builder()
         .method("GET")
@@ -415,8 +414,7 @@ pub fn copy_custom_headers_fastly(from: &fastly::Request, to: &mut fastly::Reque
 /// Apply `http_util::RequestInfo::from_request` with a `fastly::Request`.
 ///
 /// # TODO(PR15): Remove once the handler layer migrates to `http` types.
-pub fn request_info_from_fastly(req: &fastly::Request) -> crate::http_util::RequestInfo {
-    use crate::http_util::RequestInfo;
+pub fn request_info_from_fastly(req: &fastly::Request) -> RequestInfo {
     let http_req = from_fastly_request_ref(req);
     RequestInfo::from_request(&http_req)
 }
@@ -431,7 +429,6 @@ pub fn request_info_from_fastly(req: &fastly::Request) -> crate::http_util::Requ
 pub fn get_ec_id_fastly(
     req: &fastly::Request,
 ) -> Result<Option<String>, error_stack::Report<crate::error::TrustedServerError>> {
-    use crate::edge_cookie;
     let http_req = from_fastly_request_ref(req);
     edge_cookie::get_ec_id(&http_req)
 }
@@ -447,7 +444,6 @@ pub fn get_or_generate_ec_id_fastly(
     settings: &crate::settings::Settings,
     req: &fastly::Request,
 ) -> Result<String, error_stack::Report<crate::error::TrustedServerError>> {
-    use crate::edge_cookie;
     let http_req = from_fastly_request_ref(req);
     edge_cookie::get_or_generate_ec_id(settings, &http_req)
 }
@@ -463,7 +459,6 @@ pub fn generate_ec_id_fastly(
     settings: &crate::settings::Settings,
     req: &fastly::Request,
 ) -> Result<String, error_stack::Report<crate::error::TrustedServerError>> {
-    use crate::edge_cookie;
     let http_req = from_fastly_request_ref(req);
     edge_cookie::generate_ec_id(settings, &http_req)
 }
@@ -478,7 +473,6 @@ pub fn generate_ec_id_fastly(
 pub fn handle_request_cookies_fastly(
     req: &fastly::Request,
 ) -> Result<Option<cookie::CookieJar>, error_stack::Report<crate::error::TrustedServerError>> {
-    use crate::cookies;
     let http_req = from_fastly_request_ref(req);
     cookies::handle_request_cookies(&http_req)
 }

--- a/crates/trusted-server-core/src/cookies.rs
+++ b/crates/trusted-server-core/src/cookies.rs
@@ -6,9 +6,9 @@
 use std::borrow::Cow;
 
 use cookie::{Cookie, CookieJar};
+use edgezero_core::body::Body;
 use error_stack::{Report, ResultExt};
-use fastly::http::header;
-use fastly::Request;
+use http::header;
 
 use crate::constants::{
     COOKIE_EUCONSENT_V2, COOKIE_GPP, COOKIE_GPP_SID, COOKIE_TS_EC, COOKIE_US_PRIVACY,
@@ -97,9 +97,9 @@ pub fn parse_cookies_to_jar(s: &str) -> CookieJar {
 ///
 /// - [`TrustedServerError::InvalidHeaderValue`] if the Cookie header contains invalid UTF-8
 pub fn handle_request_cookies(
-    req: &Request,
+    req: &http::Request<Body>,
 ) -> Result<Option<CookieJar>, Report<TrustedServerError>> {
-    match req.get_header(header::COOKIE) {
+    match req.headers().get(header::COOKIE) {
         Some(header_value) => {
             let header_value_str =
                 header_value
@@ -146,13 +146,18 @@ pub fn strip_cookies(cookie_header: &str, cookie_names: &[&str]) -> String {
 /// When `strip_consent` is `true`, cookies listed in [`CONSENT_COOKIE_NAMES`]
 /// are removed before forwarding. If stripping leaves no cookies, the header
 /// is omitted entirely. Non-UTF-8 cookie headers are forwarded unchanged.
-pub fn forward_cookie_header(from: &Request, to: &mut Request, strip_consent: bool) {
-    let Some(cookie_value) = from.get_header(header::COOKIE) else {
+pub fn forward_cookie_header(
+    from: &http::Request<Body>,
+    to: &mut http::Request<Body>,
+    strip_consent: bool,
+) {
+    let Some(cookie_value) = from.headers().get(header::COOKIE) else {
         return;
     };
 
     if !strip_consent {
-        to.set_header(header::COOKIE, cookie_value);
+        to.headers_mut()
+            .insert(header::COOKIE, cookie_value.clone());
         return;
     }
 
@@ -160,12 +165,15 @@ pub fn forward_cookie_header(from: &Request, to: &mut Request, strip_consent: bo
         Ok(s) => {
             let stripped = strip_cookies(s, CONSENT_COOKIE_NAMES);
             if !stripped.is_empty() {
-                to.set_header(header::COOKIE, &stripped);
+                if let Ok(val) = http::HeaderValue::from_str(&stripped) {
+                    to.headers_mut().insert(header::COOKIE, val);
+                }
             }
         }
         Err(_) => {
             // Non-UTF-8 Cookie header — forward as-is
-            to.set_header(header::COOKIE, cookie_value);
+            to.headers_mut()
+                .insert(header::COOKIE, cookie_value.clone());
         }
     }
 }
@@ -246,7 +254,7 @@ pub fn create_ec_cookie(settings: &Settings, ec_id: &str) -> String {
 /// from injecting spurious cookie attributes via a controlled ID value.
 ///
 /// `cookie_domain` comes from operator configuration and is considered trusted.
-pub fn set_ec_cookie(settings: &Settings, response: &mut fastly::Response, ec_id: &str) {
+pub fn set_ec_cookie(settings: &Settings, response: &mut http::Response<Body>, ec_id: &str) {
     if !is_safe_cookie_value(ec_id) {
         log::warn!(
             "Rejecting EC ID for Set-Cookie: value of {} bytes contains characters illegal in a cookie value",
@@ -254,16 +262,21 @@ pub fn set_ec_cookie(settings: &Settings, response: &mut fastly::Response, ec_id
         );
         return;
     }
-    response.append_header(header::SET_COOKIE, create_ec_cookie(settings, ec_id));
+    let cookie_str = create_ec_cookie(settings, ec_id);
+    if let Ok(val) = http::HeaderValue::from_str(&cookie_str) {
+        response.headers_mut().append(header::SET_COOKIE, val);
+    }
 }
 
 /// Expires the EC cookie by setting `Max-Age=0`.
 ///
 /// Used when a user revokes consent — the browser will delete the cookie
 /// on receipt of this header.
-pub fn expire_ec_cookie(settings: &Settings, response: &mut fastly::Response) {
-    let cookie = format!("{}=; {}", COOKIE_TS_EC, ec_cookie_attributes(settings, 0),);
-    response.append_header(header::SET_COOKIE, cookie);
+pub fn expire_ec_cookie(settings: &Settings, response: &mut http::Response<Body>) {
+    let cookie = format!("{}=; {}", COOKIE_TS_EC, ec_cookie_attributes(settings, 0));
+    if let Ok(val) = http::HeaderValue::from_str(&cookie) {
+        response.headers_mut().append(header::SET_COOKIE, val);
+    }
 }
 
 #[cfg(test)]
@@ -271,6 +284,22 @@ mod tests {
     use crate::test_support::tests::create_test_settings;
 
     use super::*;
+
+    fn make_request_with_cookie(cookie_value: &str) -> http::Request<Body> {
+        http::Request::builder()
+            .method("GET")
+            .uri("http://example.com")
+            .header(header::COOKIE, cookie_value)
+            .body(Body::empty())
+            .expect("should build test request with cookie")
+    }
+
+    fn make_empty_response() -> http::Response<Body> {
+        http::Response::builder()
+            .status(200)
+            .body(Body::empty())
+            .expect("should build empty response")
+    }
 
     #[test]
     fn test_parse_cookies_to_jar() {
@@ -309,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_handle_request_cookies() {
-        let req = Request::get("http://example.com").with_header(header::COOKIE, "c1=v1;c2=v2");
+        let req = make_request_with_cookie("c1=v1;c2=v2");
         let jar = handle_request_cookies(&req)
             .expect("should parse cookies")
             .expect("should have cookie jar");
@@ -321,7 +350,7 @@ mod tests {
 
     #[test]
     fn test_handle_request_cookies_with_empty_cookie() {
-        let req = Request::get("http://example.com").with_header(header::COOKIE, "");
+        let req = make_request_with_cookie("");
         let jar = handle_request_cookies(&req)
             .expect("should parse cookies")
             .expect("should have cookie jar");
@@ -331,7 +360,11 @@ mod tests {
 
     #[test]
     fn test_handle_request_cookies_no_cookie_header() {
-        let req: Request = Request::get("https://example.com");
+        let req = http::Request::builder()
+            .method("GET")
+            .uri("https://example.com")
+            .body(Body::empty())
+            .expect("should build request without cookie");
         let jar = handle_request_cookies(&req).expect("should handle missing cookie header");
 
         assert!(jar.is_none());
@@ -339,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_handle_request_cookies_invalid_cookie_header() {
-        let req = Request::get("http://example.com").with_header(header::COOKIE, "invalid");
+        let req = make_request_with_cookie("invalid");
         let jar = handle_request_cookies(&req)
             .expect("should parse cookies")
             .expect("should have cookie jar");
@@ -350,11 +383,12 @@ mod tests {
     #[test]
     fn test_set_ec_cookie() {
         let settings = create_test_settings();
-        let mut response = fastly::Response::new();
+        let mut response = make_empty_response();
         set_ec_cookie(&settings, &mut response, "abc123.XyZ789");
 
         let cookie_str = response
-            .get_header(header::SET_COOKIE)
+            .headers()
+            .get(header::SET_COOKIE)
             .expect("Set-Cookie header should be present")
             .to_str()
             .expect("header should be valid UTF-8");
@@ -403,11 +437,11 @@ mod tests {
     #[test]
     fn test_set_ec_cookie_rejects_semicolon() {
         let settings = create_test_settings();
-        let mut response = fastly::Response::new();
+        let mut response = make_empty_response();
         set_ec_cookie(&settings, &mut response, "evil; Domain=.attacker.com");
 
         assert!(
-            response.get_header(header::SET_COOKIE).is_none(),
+            response.headers().get(header::SET_COOKIE).is_none(),
             "Set-Cookie should not be set when value contains a semicolon"
         );
     }
@@ -415,11 +449,11 @@ mod tests {
     #[test]
     fn test_set_ec_cookie_rejects_crlf() {
         let settings = create_test_settings();
-        let mut response = fastly::Response::new();
+        let mut response = make_empty_response();
         set_ec_cookie(&settings, &mut response, "evil\r\nX-Injected: header");
 
         assert!(
-            response.get_header(header::SET_COOKIE).is_none(),
+            response.headers().get(header::SET_COOKIE).is_none(),
             "Set-Cookie should not be set when value contains CRLF"
         );
     }
@@ -427,11 +461,11 @@ mod tests {
     #[test]
     fn test_set_ec_cookie_rejects_space() {
         let settings = create_test_settings();
-        let mut response = fastly::Response::new();
+        let mut response = make_empty_response();
         set_ec_cookie(&settings, &mut response, "bad value");
 
         assert!(
-            response.get_header(header::SET_COOKIE).is_none(),
+            response.headers().get(header::SET_COOKIE).is_none(),
             "Set-Cookie should not be set when value contains whitespace"
         );
     }
@@ -481,12 +515,13 @@ mod tests {
     #[test]
     fn test_expire_ec_cookie_matches_security_attributes() {
         let settings = create_test_settings();
-        let mut response = fastly::Response::new();
+        let mut response = make_empty_response();
 
         expire_ec_cookie(&settings, &mut response);
 
         let cookie_header = response
-            .get_header(header::SET_COOKIE)
+            .headers()
+            .get(header::SET_COOKIE)
             .expect("Set-Cookie header should be present");
         let cookie_str = cookie_header
             .to_str()

--- a/crates/trusted-server-core/src/edge_cookie.rs
+++ b/crates/trusted-server-core/src/edge_cookie.rs
@@ -5,12 +5,13 @@
 
 use std::net::IpAddr;
 
+use edgezero_core::body::Body;
 use error_stack::{Report, ResultExt};
-use fastly::Request;
 use hmac::{Hmac, Mac};
 use rand::Rng;
 use sha2::Sha256;
 
+use crate::compat::ClientIpExt;
 use crate::constants::{COOKIE_TS_EC, HEADER_X_TS_EC};
 use crate::cookies::{ec_id_has_only_allowed_chars, handle_request_cookies};
 use crate::error::TrustedServerError;
@@ -62,17 +63,23 @@ fn generate_random_suffix(length: usize) -> String {
 /// the client IP address, then appends a random suffix for additional
 /// uniqueness. The resulting format is `{64hex}.{6alnum}`.
 ///
+/// The client IP is read from the [`ClientIpExt`] request extension, which is
+/// populated by [`crate::compat::from_fastly_request_ref`] from the Fastly SDK.
+/// Falls back to `"unknown"` when the extension is absent (e.g. in tests).
+///
 /// # Errors
 ///
 /// - [`TrustedServerError::Ec`] if HMAC generation fails
 pub fn generate_ec_id(
     settings: &Settings,
-    req: &Request,
+    req: &http::Request<Body>,
 ) -> Result<String, Report<TrustedServerError>> {
-    // Fallback to "unknown" when client IP is unavailable (e.g., local testing).
-    // All such requests share the same HMAC base; the random suffix provides uniqueness.
+    // Read client IP from the extension set by compat::from_fastly_request_ref.
+    // Falls back to "unknown" when absent (e.g. local testing or unit tests).
     let client_ip = req
-        .get_client_ip_addr()
+        .extensions()
+        .get::<ClientIpExt>()
+        .and_then(|ext| ext.0)
         .map(normalize_ip)
         .unwrap_or_else(|| "unknown".to_string());
 
@@ -105,8 +112,12 @@ pub fn generate_ec_id(
 /// # Errors
 ///
 /// - [`TrustedServerError::InvalidHeaderValue`] if cookie parsing fails
-pub fn get_ec_id(req: &Request) -> Result<Option<String>, Report<TrustedServerError>> {
-    if let Some(ec_id) = req.get_header(HEADER_X_TS_EC).and_then(|h| h.to_str().ok()) {
+pub fn get_ec_id(req: &http::Request<Body>) -> Result<Option<String>, Report<TrustedServerError>> {
+    if let Some(ec_id) = req
+        .headers()
+        .get(HEADER_X_TS_EC)
+        .and_then(|h| h.to_str().ok())
+    {
         if ec_id_has_only_allowed_chars(ec_id) {
             log::trace!("Using existing EC ID from header: {}", ec_id);
             return Ok(Some(ec_id.to_string()));
@@ -146,7 +157,7 @@ pub fn get_ec_id(req: &Request) -> Result<Option<String>, Report<TrustedServerEr
 /// Returns an error if ID generation fails.
 pub fn get_or_generate_ec_id(
     settings: &Settings,
-    req: &Request,
+    req: &http::Request<Body>,
 ) -> Result<String, Report<TrustedServerError>> {
     if let Some(id) = get_ec_id(req)? {
         return Ok(id);
@@ -161,7 +172,7 @@ pub fn get_or_generate_ec_id(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fastly::http::{HeaderName, HeaderValue};
+    use http::header;
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use crate::test_support::tests::create_test_settings;
@@ -196,16 +207,16 @@ mod tests {
         assert_eq!(normalize_ip(ipv6_a), "2001:db8:abcd:1::");
     }
 
-    fn create_test_request(headers: Vec<(HeaderName, &str)>) -> Request {
-        let mut req = Request::new("GET", "http://example.com");
-        for (key, value) in headers {
-            req.set_header(
-                key,
-                HeaderValue::from_str(value).expect("should create valid header value"),
-            );
+    fn create_test_request(headers: Vec<(&str, &str)>) -> http::Request<Body> {
+        let mut builder = http::Request::builder()
+            .method("GET")
+            .uri("http://example.com");
+        for (name, value) in headers {
+            builder = builder.header(name, value);
         }
-
-        req
+        builder
+            .body(Body::empty())
+            .expect("should build test request")
     }
 
     fn is_ec_id_format(value: &str) -> bool {
@@ -285,7 +296,7 @@ mod tests {
     #[test]
     fn test_get_ec_id_with_header() {
         let settings = create_test_settings();
-        let req = create_test_request(vec![(HEADER_X_TS_EC, "existing_ec_id")]);
+        let req = create_test_request(vec![(HEADER_X_TS_EC.as_str(), "existing_ec_id")]);
 
         let ec_id = get_ec_id(&req).expect("should get EC ID");
         assert_eq!(ec_id, Some("existing_ec_id".to_string()));
@@ -298,7 +309,7 @@ mod tests {
     fn test_get_ec_id_with_cookie() {
         let settings = create_test_settings();
         let req = create_test_request(vec![(
-            fastly::http::header::COOKIE,
+            header::COOKIE.as_str(),
             &format!("{}=existing_cookie_id", COOKIE_TS_EC),
         )]);
 
@@ -328,9 +339,9 @@ mod tests {
     #[test]
     fn test_get_ec_id_rejects_invalid_header_and_falls_back_to_cookie() {
         let req = create_test_request(vec![
-            (HEADER_X_TS_EC, "evil;injected"),
+            (HEADER_X_TS_EC.as_str(), "evil;injected"),
             (
-                fastly::http::header::COOKIE,
+                header::COOKIE.as_str(),
                 &format!("{}=valid_cookie_id", COOKIE_TS_EC),
             ),
         ]);
@@ -346,7 +357,7 @@ mod tests {
     #[test]
     fn test_get_or_generate_ec_id_replaces_invalid_header() {
         let settings = create_test_settings();
-        let req = create_test_request(vec![(HEADER_X_TS_EC, "evil;injected")]);
+        let req = create_test_request(vec![(HEADER_X_TS_EC.as_str(), "evil;injected")]);
 
         let ec_id = get_or_generate_ec_id(&settings, &req)
             .expect("should generate fresh ID on invalid header");
@@ -363,7 +374,7 @@ mod tests {
     #[test]
     fn test_get_ec_id_rejects_invalid_cookie() {
         let req = create_test_request(vec![(
-            fastly::http::header::COOKIE,
+            header::COOKIE.as_str(),
             &format!("{}=bad<script>value", COOKIE_TS_EC),
         )]);
 

--- a/crates/trusted-server-core/src/http_util.rs
+++ b/crates/trusted-server-core/src/http_util.rs
@@ -1,10 +1,11 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chacha20poly1305::{aead::Aead, aead::KeyInit, XChaCha20Poly1305, XNonce};
-use fastly::http::{header, StatusCode};
-use fastly::{Request, Response};
+use edgezero_core::body::Body;
+use http::{header, StatusCode};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq as _;
 
+use crate::compat::{TlsCipher, TlsProtocol};
 use crate::constants::INTERNAL_HEADERS;
 use crate::settings::Settings;
 
@@ -14,15 +15,13 @@ use crate::settings::Settings;
 /// internal identity, geo-enrichment, and debugging data to downstream third-party
 /// services. Integrations that forward custom headers should use this utility
 /// instead of manually iterating over header names.
-pub fn copy_custom_headers(from: &Request, to: &mut Request) {
-    for header_name in from.get_header_names() {
+pub fn copy_custom_headers(from: &http::Request<Body>, to: &mut http::Request<Body>) {
+    for (header_name, value) in from.headers() {
         let name_str = header_name.as_str();
         if (name_str.starts_with("x-") || name_str.starts_with("X-"))
             && !INTERNAL_HEADERS.contains(&name_str)
         {
-            if let Some(value) = from.get_header(header_name) {
-                to.set_header(header_name, value);
-            }
+            to.headers_mut().insert(header_name.clone(), value.clone());
         }
     }
 }
@@ -32,7 +31,7 @@ pub fn copy_custom_headers(from: &Request, to: &mut Request) {
 /// On Fastly Compute the service is the edge — there is no upstream proxy that
 /// legitimately sets these. Stripping them forces [`RequestInfo::from_request`]
 /// to fall back to the trustworthy `Host` header and Fastly SDK TLS detection.
-const SPOOFABLE_FORWARDED_HEADERS: &[&str] = &[
+pub(crate) const SPOOFABLE_FORWARDED_HEADERS: &[&str] = &[
     "forwarded",
     "x-forwarded-host",
     "x-forwarded-proto",
@@ -44,11 +43,11 @@ const SPOOFABLE_FORWARDED_HEADERS: &[&str] = &[
 /// Call this at the edge entry point (before routing) to prevent
 /// `X-Forwarded-Host: evil.com` from hijacking all URL rewriting.
 /// See <https://github.com/IABTechLab/trusted-server/issues/409>.
-pub fn sanitize_forwarded_headers(req: &mut Request) {
+pub fn sanitize_forwarded_headers(req: &mut http::Request<Body>) {
     for header in SPOOFABLE_FORWARDED_HEADERS {
-        if req.get_header(*header).is_some() {
+        if req.headers().contains_key(*header) {
             log::debug!("Stripped spoofable header: {}", header);
-            req.remove_header(*header);
+            req.headers_mut().remove(*header);
         }
     }
 }
@@ -70,7 +69,7 @@ pub struct RequestInfo {
 }
 
 impl RequestInfo {
-    /// Extract request info from a Fastly request.
+    /// Extract request info from an HTTP request.
     ///
     /// Host fallback order (first present wins):
     /// 1. `Forwarded` header (`host=...`)
@@ -78,7 +77,7 @@ impl RequestInfo {
     /// 3. `Host` header
     ///
     /// Scheme fallback order:
-    /// 1. Fastly SDK TLS detection
+    /// 1. Fastly SDK TLS detection (via [`TlsProtocol`] / [`TlsCipher`] extensions)
     /// 2. `Forwarded` header (`proto=...`)
     /// 3. `X-Forwarded-Proto`
     /// 4. `Fastly-SSL`
@@ -87,7 +86,7 @@ impl RequestInfo {
     /// In production the forwarded headers are stripped by
     /// [`sanitize_forwarded_headers`] at the edge, so `Host` and SDK TLS
     /// detection are the only sources that fire.
-    pub fn from_request(req: &Request) -> Self {
+    pub fn from_request(req: &http::Request<Body>) -> Self {
         let host = extract_request_host(req);
         let scheme = detect_request_scheme(req);
 
@@ -95,18 +94,18 @@ impl RequestInfo {
     }
 }
 
-fn extract_request_host(req: &Request) -> String {
-    req.get_header("forwarded")
-        .and_then(|h| h.to_str().ok())
+fn extract_request_host(req: &http::Request<Body>) -> String {
+    get_header_str(req, "forwarded")
         .and_then(|value| parse_forwarded_param(value, "host"))
-        .or_else(|| {
-            req.get_header("x-forwarded-host")
-                .and_then(|h| h.to_str().ok())
-                .and_then(parse_list_header_value)
-        })
-        .or_else(|| req.get_header(header::HOST).and_then(|h| h.to_str().ok()))
+        .or_else(|| get_header_str(req, "x-forwarded-host").and_then(parse_list_header_value))
+        .or_else(|| get_header_str(req, header::HOST.as_str()))
         .unwrap_or_default()
         .to_string()
+}
+
+/// Get a header value as `&str`, returning `None` if absent or non-UTF-8.
+fn get_header_str<'a>(req: &'a http::Request<Body>, name: &str) -> Option<&'a str> {
+    req.headers().get(name).and_then(|v| v.to_str().ok())
 }
 
 fn parse_forwarded_param<'a>(forwarded: &'a str, param: &str) -> Option<&'a str> {
@@ -156,55 +155,47 @@ fn normalize_scheme(value: &str) -> Option<String> {
     }
 }
 
-/// Detects the request scheme (HTTP or HTTPS) using Fastly SDK methods and headers.
+/// Detects the request scheme (HTTP or HTTPS).
 ///
-/// Tries multiple methods in order of reliability:
-/// 1. Fastly SDK TLS detection methods (most reliable)
-/// 2. Forwarded header (RFC 7239)
-/// 3. X-Forwarded-Proto header
-/// 4. Fastly-SSL header (least reliable, can be spoofed)
+/// Tries multiple sources in order of reliability:
+/// 1. Fastly SDK TLS info stored in [`TlsProtocol`] / [`TlsCipher`] request extensions
+/// 2. `Forwarded` header (RFC 7239)
+/// 3. `X-Forwarded-Proto` header
+/// 4. `Fastly-SSL` header (least reliable, can be spoofed)
 /// 5. Default to HTTP
-fn detect_request_scheme(req: &Request) -> String {
-    // 1. First try Fastly SDK's built-in TLS detection methods
-    if let Some(tls_protocol) = req.get_tls_protocol() {
-        log::debug!("TLS protocol detected: {}", tls_protocol);
+fn detect_request_scheme(req: &http::Request<Body>) -> String {
+    // 1. Check Fastly TLS extensions populated by `compat::from_fastly_request_ref`.
+    if let Some(TlsProtocol(Some(_))) = req.extensions().get::<TlsProtocol>() {
+        log::debug!("TLS protocol detected via extension");
         return "https".to_string();
     }
-
-    // Also check TLS cipher - if present, connection is HTTPS
-    if req.get_tls_cipher_openssl_name().is_some() {
-        log::debug!("TLS cipher detected, using HTTPS");
+    if let Some(TlsCipher(Some(_))) = req.extensions().get::<TlsCipher>() {
+        log::debug!("TLS cipher detected via extension, using HTTPS");
         return "https".to_string();
     }
 
     // 2. Try the Forwarded header (RFC 7239)
-    if let Some(forwarded) = req.get_header("forwarded") {
-        if let Ok(forwarded_str) = forwarded.to_str() {
-            if let Some(proto) = parse_forwarded_param(forwarded_str, "proto") {
-                if let Some(scheme) = normalize_scheme(proto) {
-                    return scheme;
-                }
+    if let Some(forwarded_str) = get_header_str(req, "forwarded") {
+        if let Some(proto) = parse_forwarded_param(forwarded_str, "proto") {
+            if let Some(scheme) = normalize_scheme(proto) {
+                return scheme;
             }
         }
     }
 
     // 3. Try X-Forwarded-Proto header
-    if let Some(proto) = req.get_header("x-forwarded-proto") {
-        if let Ok(proto_str) = proto.to_str() {
-            if let Some(value) = parse_list_header_value(proto_str) {
-                if let Some(scheme) = normalize_scheme(value) {
-                    return scheme;
-                }
+    if let Some(proto_str) = get_header_str(req, "x-forwarded-proto") {
+        if let Some(value) = parse_list_header_value(proto_str) {
+            if let Some(scheme) = normalize_scheme(value) {
+                return scheme;
             }
         }
     }
 
     // 4. Check Fastly-SSL header (can be spoofed by clients, use as last resort)
-    if let Some(ssl) = req.get_header("fastly-ssl") {
-        if let Ok(ssl_str) = ssl.to_str() {
-            if ssl_str == "1" || ssl_str.to_lowercase() == "true" {
-                return "https".to_string();
-            }
+    if let Some(ssl_str) = get_header_str(req, "fastly-ssl") {
+        if ssl_str == "1" || ssl_str.to_lowercase() == "true" {
+            return "https".to_string();
         }
     }
 
@@ -214,38 +205,48 @@ fn detect_request_scheme(req: &Request) -> String {
 
 /// Build a static text response with strong `ETag` and standard caching headers.
 /// Handles If-None-Match to return 304 when appropriate.
-pub fn serve_static_with_etag(body: &str, req: &Request, content_type: &str) -> Response {
+///
+/// # Panics
+///
+/// Panics if the `http::Response` builder fails (unreachable with valid status codes and headers).
+pub fn serve_static_with_etag(
+    body: &str,
+    req: &http::Request<Body>,
+    content_type: &str,
+) -> http::Response<Body> {
     // Compute ETag for conditional caching
     let hash = Sha256::digest(body.as_bytes());
     let etag = format!("\"sha256-{}\"", hex::encode(hash));
 
     // If-None-Match handling for 304 responses
-    if let Some(if_none_match) = req
-        .get_header(header::IF_NONE_MATCH)
-        .and_then(|h| h.to_str().ok())
-    {
+    if let Some(if_none_match) = get_header_str(req, header::IF_NONE_MATCH.as_str()) {
         if if_none_match == etag {
-            return Response::from_status(StatusCode::NOT_MODIFIED)
-                .with_header(header::ETAG, &etag)
-                .with_header(
+            return http::Response::builder()
+                .status(StatusCode::NOT_MODIFIED)
+                .header(header::ETAG, &etag)
+                .header(
                     header::CACHE_CONTROL,
                     "public, max-age=300, s-maxage=300, stale-while-revalidate=60, stale-if-error=86400",
                 )
-                .with_header("surrogate-control", "max-age=300")
-                .with_header(header::VARY, "Accept-Encoding");
+                .header("surrogate-control", "max-age=300")
+                .header(header::VARY, "Accept-Encoding")
+                .body(Body::empty())
+                .expect("should build 304 response");
         }
     }
 
-    Response::from_status(StatusCode::OK)
-        .with_header(header::CONTENT_TYPE, content_type)
-        .with_header(
+    http::Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(
             header::CACHE_CONTROL,
             "public, max-age=300, s-maxage=300, stale-while-revalidate=60, stale-if-error=86400",
         )
-        .with_header("surrogate-control", "max-age=300")
-        .with_header(header::ETAG, &etag)
-        .with_header(header::VARY, "Accept-Encoding")
-        .with_body(body)
+        .header("surrogate-control", "max-age=300")
+        .header(header::ETAG, &etag)
+        .header(header::VARY, "Accept-Encoding")
+        .body(Body::from(body.to_string()))
+        .expect("should build 200 response with body")
 }
 
 /// Encrypts a URL using XChaCha20-Poly1305 with a key derived from the publisher `proxy_secret`.
@@ -377,6 +378,20 @@ pub fn compute_encrypted_sha256_token(settings: &Settings, full_url: &str) -> St
 mod tests {
     use super::*;
 
+    fn make_request_with_header(
+        method: &str,
+        uri: &str,
+        name: &str,
+        value: &str,
+    ) -> http::Request<Body> {
+        http::Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(name, value)
+            .body(Body::empty())
+            .expect("should build test request with header")
+    }
+
     #[test]
     fn encode_decode_roundtrip() {
         let settings = crate::test_support::tests::create_test_settings();
@@ -444,26 +459,34 @@ mod tests {
 
     #[test]
     fn test_request_info_from_host_header() {
-        let mut req = Request::new(fastly::http::Method::GET, "https://test.example.com/page");
-        req.set_header("host", "test.example.com");
+        let req = make_request_with_header(
+            "GET",
+            "https://test.example.com/page",
+            "host",
+            "test.example.com",
+        );
 
         let info = RequestInfo::from_request(&req);
         assert_eq!(
             info.host, "test.example.com",
             "Host should use Host header when forwarded headers are missing"
         );
-        // No TLS or forwarded headers, defaults to http.
+        // No TLS extensions, defaults to http.
         assert_eq!(
             info.scheme, "http",
-            "Scheme should default to http without TLS or forwarded headers"
+            "Scheme should default to http without TLS extensions or forwarded headers"
         );
     }
 
     #[test]
     fn test_request_info_x_forwarded_host_precedence() {
-        let mut req = Request::new(fastly::http::Method::GET, "https://test.example.com/page");
-        req.set_header("host", "internal-proxy.local");
-        req.set_header("x-forwarded-host", "public.example.com, proxy.local");
+        let req = http::Request::builder()
+            .method("GET")
+            .uri("https://test.example.com/page")
+            .header("host", "internal-proxy.local")
+            .header("x-forwarded-host", "public.example.com, proxy.local")
+            .body(Body::empty())
+            .expect("should build test request");
 
         let info = RequestInfo::from_request(&req);
         assert_eq!(
@@ -474,9 +497,13 @@ mod tests {
 
     #[test]
     fn test_request_info_scheme_from_x_forwarded_proto() {
-        let mut req = Request::new(fastly::http::Method::GET, "https://test.example.com/page");
-        req.set_header("host", "test.example.com");
-        req.set_header("x-forwarded-proto", "https, http");
+        let req = http::Request::builder()
+            .method("GET")
+            .uri("https://test.example.com/page")
+            .header("host", "test.example.com")
+            .header("x-forwarded-proto", "https, http")
+            .body(Body::empty())
+            .expect("should build test request");
 
         let info = RequestInfo::from_request(&req);
         assert_eq!(
@@ -484,14 +511,17 @@ mod tests {
             "Scheme should prefer the first X-Forwarded-Proto value"
         );
 
-        // Test HTTP
-        let mut req = Request::new(fastly::http::Method::GET, "http://test.example.com/page");
-        req.set_header("host", "test.example.com");
-        req.set_header("x-forwarded-proto", "http");
+        let req2 = http::Request::builder()
+            .method("GET")
+            .uri("http://test.example.com/page")
+            .header("host", "test.example.com")
+            .header("x-forwarded-proto", "http")
+            .body(Body::empty())
+            .expect("should build test request");
 
-        let info = RequestInfo::from_request(&req);
+        let info2 = RequestInfo::from_request(&req2);
         assert_eq!(
-            info.scheme, "http",
+            info2.scheme, "http",
             "Scheme should use the X-Forwarded-Proto value when present"
         );
     }
@@ -499,14 +529,18 @@ mod tests {
     #[test]
     fn request_info_forwarded_header_precedence() {
         // Forwarded header takes precedence over X-Forwarded-Proto
-        let mut req = Request::new(fastly::http::Method::GET, "https://test.example.com/page");
-        req.set_header(
-            "forwarded",
-            "for=192.0.2.60;proto=\"HTTPS\";host=\"public.example.com:443\"",
-        );
-        req.set_header("host", "internal-proxy.local");
-        req.set_header("x-forwarded-host", "proxy.local");
-        req.set_header("x-forwarded-proto", "http");
+        let req = http::Request::builder()
+            .method("GET")
+            .uri("https://test.example.com/page")
+            .header(
+                "forwarded",
+                "for=192.0.2.60;proto=\"HTTPS\";host=\"public.example.com:443\"",
+            )
+            .header("host", "internal-proxy.local")
+            .header("x-forwarded-host", "proxy.local")
+            .header("x-forwarded-proto", "http")
+            .body(Body::empty())
+            .expect("should build test request");
 
         let info = RequestInfo::from_request(&req);
         assert_eq!(
@@ -521,8 +555,8 @@ mod tests {
 
     #[test]
     fn test_request_info_scheme_from_fastly_ssl() {
-        let mut req = Request::new(fastly::http::Method::GET, "https://test.example.com/page");
-        req.set_header("fastly-ssl", "1");
+        let req =
+            make_request_with_header("GET", "https://test.example.com/page", "fastly-ssl", "1");
 
         let info = RequestInfo::from_request(&req);
         assert_eq!(
@@ -534,14 +568,14 @@ mod tests {
     #[test]
     fn test_request_info_chained_proxy_scenario() {
         // Simulate: Client (HTTPS) -> Proxy A -> Trusted Server (HTTP internally)
-        // Proxy A sets X-Forwarded-Host and X-Forwarded-Proto
-        let mut req = Request::new(
-            fastly::http::Method::GET,
-            "http://trusted-server.internal/page",
-        );
-        req.set_header("host", "trusted-server.internal");
-        req.set_header("x-forwarded-host", "public.example.com");
-        req.set_header("x-forwarded-proto", "https");
+        let req = http::Request::builder()
+            .method("GET")
+            .uri("http://trusted-server.internal/page")
+            .header("host", "trusted-server.internal")
+            .header("x-forwarded-host", "public.example.com")
+            .header("x-forwarded-proto", "https")
+            .body(Body::empty())
+            .expect("should build test request");
 
         let info = RequestInfo::from_request(&req);
         assert_eq!(
@@ -558,33 +592,38 @@ mod tests {
 
     #[test]
     fn sanitize_removes_all_spoofable_headers() {
-        let mut req = Request::new(fastly::http::Method::GET, "https://example.com/page");
-        req.set_header("host", "legit.example.com");
-        req.set_header("forwarded", "host=evil.com;proto=https");
-        req.set_header("x-forwarded-host", "evil.com");
-        req.set_header("x-forwarded-proto", "https");
-        req.set_header("fastly-ssl", "1");
+        let mut req = http::Request::builder()
+            .method("GET")
+            .uri("https://example.com/page")
+            .header("host", "legit.example.com")
+            .header("forwarded", "host=evil.com;proto=https")
+            .header("x-forwarded-host", "evil.com")
+            .header("x-forwarded-proto", "https")
+            .header("fastly-ssl", "1")
+            .body(Body::empty())
+            .expect("should build test request");
 
         sanitize_forwarded_headers(&mut req);
 
         assert!(
-            req.get_header("forwarded").is_none(),
+            req.headers().get("forwarded").is_none(),
             "should strip Forwarded header"
         );
         assert!(
-            req.get_header("x-forwarded-host").is_none(),
+            req.headers().get("x-forwarded-host").is_none(),
             "should strip X-Forwarded-Host header"
         );
         assert!(
-            req.get_header("x-forwarded-proto").is_none(),
+            req.headers().get("x-forwarded-proto").is_none(),
             "should strip X-Forwarded-Proto header"
         );
         assert!(
-            req.get_header("fastly-ssl").is_none(),
+            req.headers().get("fastly-ssl").is_none(),
             "should strip Fastly-SSL header"
         );
         assert_eq!(
-            req.get_header("host")
+            req.headers()
+                .get("host")
                 .expect("should have Host header")
                 .to_str()
                 .expect("should be valid UTF-8"),
@@ -595,10 +634,14 @@ mod tests {
 
     #[test]
     fn sanitize_then_request_info_falls_back_to_host() {
-        let mut req = Request::new(fastly::http::Method::GET, "https://example.com/page");
-        req.set_header("host", "legit.example.com");
-        req.set_header("x-forwarded-host", "evil.com");
-        req.set_header("x-forwarded-proto", "http");
+        let mut req = http::Request::builder()
+            .method("GET")
+            .uri("https://example.com/page")
+            .header("host", "legit.example.com")
+            .header("x-forwarded-host", "evil.com")
+            .header("x-forwarded-proto", "http")
+            .body(Body::empty())
+            .expect("should build test request");
 
         sanitize_forwarded_headers(&mut req);
         let info = RequestInfo::from_request(&req);
@@ -633,32 +676,40 @@ mod tests {
 
     #[test]
     fn test_copy_custom_headers_filters_internal() {
-        let mut req = Request::new(fastly::http::Method::GET, "https://example.com");
-        req.set_header("x-custom-1", "value1");
-        // HeaderName is case-insensitive and always lowercase, but set_header accepts strings
-        req.set_header("X-Custom-2", "value2");
-        req.set_header("x-ts-ec", "should not copy");
-        req.set_header("x-geo-country", "US");
+        let from = http::Request::builder()
+            .method("GET")
+            .uri("https://example.com")
+            .header("x-custom-1", "value1")
+            .header("x-custom-2", "value2")
+            .header("x-ts-ec", "should not copy")
+            .header("x-geo-country", "US")
+            .body(Body::empty())
+            .expect("should build from request");
 
-        let mut target = Request::new(fastly::http::Method::GET, "https://target.com");
-        copy_custom_headers(&req, &mut target);
+        let mut to = http::Request::builder()
+            .method("GET")
+            .uri("https://target.com")
+            .body(Body::empty())
+            .expect("should build to request");
+
+        copy_custom_headers(&from, &mut to);
 
         assert_eq!(
-            target.get_header("x-custom-1").unwrap().to_str().unwrap(),
+            to.headers().get("x-custom-1").unwrap().to_str().unwrap(),
             "value1",
             "Should copy arbitrary x-header"
         );
         assert_eq!(
-            target.get_header("x-custom-2").unwrap().to_str().unwrap(),
+            to.headers().get("x-custom-2").unwrap().to_str().unwrap(),
             "value2",
-            "Should copy arbitrary X-header (case insensitive)"
+            "Should copy arbitrary x-header (case preserved in lookup)"
         );
         assert!(
-            target.get_header("x-ts-ec").is_none(),
+            to.headers().get("x-ts-ec").is_none(),
             "Should filter x-ts-ec"
         );
         assert!(
-            target.get_header("x-geo-country").is_none(),
+            to.headers().get("x-geo-country").is_none(),
             "Should filter x-geo-country"
         );
     }

--- a/crates/trusted-server-core/src/integrations/lockr.rs
+++ b/crates/trusted-server-core/src/integrations/lockr.rs
@@ -17,9 +17,8 @@ use serde::Deserialize;
 use validator::Validate;
 
 use crate::backend::BackendConfig;
-use crate::cookies::forward_cookie_header;
+use crate::compat;
 use crate::error::TrustedServerError;
-use crate::http_util::copy_custom_headers;
 use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
@@ -235,7 +234,7 @@ impl LockrIntegration {
         }
 
         // Always strip consent cookies — consent travels through the OpenRTB body
-        forward_cookie_header(from, to, true);
+        compat::forward_cookie_header_fastly(from, to, true);
 
         // Use origin override if configured, otherwise forward original
         let origin = self
@@ -247,7 +246,7 @@ impl LockrIntegration {
             to.set_header(header::ORIGIN, origin);
         }
 
-        copy_custom_headers(from, to);
+        compat::copy_custom_headers_fastly(from, to);
     }
 }
 

--- a/crates/trusted-server-core/src/integrations/permutive.rs
+++ b/crates/trusted-server-core/src/integrations/permutive.rs
@@ -13,8 +13,8 @@ use serde::Deserialize;
 use validator::Validate;
 
 use crate::backend::BackendConfig;
+use crate::compat;
 use crate::error::TrustedServerError;
-use crate::http_util::copy_custom_headers;
 use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
@@ -494,7 +494,7 @@ impl PermutiveIntegration {
         }
 
         // Copy any X-* custom headers, skipping TS-internal headers
-        copy_custom_headers(from, to);
+        compat::copy_custom_headers_fastly(from, to);
     }
 }
 

--- a/crates/trusted-server-core/src/integrations/prebid.rs
+++ b/crates/trusted-server-core/src/integrations/prebid.rs
@@ -15,10 +15,9 @@ use crate::auction::types::{
     AuctionContext, AuctionRequest, AuctionResponse, Bid as AuctionBid, MediaType,
 };
 use crate::backend::BackendConfig;
+use crate::compat;
 use crate::consent_config::ConsentForwardingMode;
-use crate::cookies::forward_cookie_header;
 use crate::error::TrustedServerError;
-use crate::http_util::RequestInfo;
 use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
@@ -441,7 +440,7 @@ fn copy_request_headers(
         }
     }
 
-    forward_cookie_header(from, to, consent_forwarding.strips_consent_cookies());
+    compat::forward_cookie_header_fastly(from, to, consent_forwarding.strips_consent_cookies());
 }
 
 /// Appends query parameters to a URL, handling both URLs with and without existing query strings.
@@ -708,7 +707,7 @@ impl PrebidAuctionProvider {
         let regs = Self::build_regs(consent_ctx);
 
         // Build ext object
-        let request_info = RequestInfo::from_request(context.request);
+        let request_info = compat::request_info_from_fastly(context.request);
         let (version, signature, kid, ts) = signer
             .map(|(s, sig, params)| {
                 (
@@ -1006,7 +1005,7 @@ impl AuctionProvider for PrebidAuctionProvider {
             &context.settings.request_signing
         {
             if request_signing_config.enabled {
-                let request_info = RequestInfo::from_request(context.request);
+                let request_info = compat::request_info_from_fastly(context.request);
                 let signer = RequestSigner::from_config()?;
                 let params =
                     SigningParams::new(request.id.clone(), request_info.host, request_info.scheme);

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -8,9 +8,8 @@ use fastly::http::Method;
 use fastly::{Request, Response};
 use matchit::Router;
 
+use crate::compat;
 use crate::constants::HEADER_X_TS_EC;
-use crate::cookies::set_ec_cookie;
-use crate::edge_cookie::get_or_generate_ec_id;
 use crate::error::TrustedServerError;
 use crate::settings::Settings;
 
@@ -656,7 +655,7 @@ impl IntegrationRegistry {
     ) -> Option<Result<Response, Report<TrustedServerError>>> {
         if let Some((proxy, _)) = self.find_route(method, path) {
             // Generate EC ID before consuming request
-            let ec_id_result = get_or_generate_ec_id(settings, &req);
+            let ec_id_result = compat::get_or_generate_ec_id_fastly(settings, &req);
 
             // Set EC ID header on the request so integrations can read it.
             // Header injection: Fastly's HeaderValue API rejects values containing \r, \n, or \0,
@@ -678,7 +677,7 @@ impl IntegrationRegistry {
                         // Cookie is intentionally not set when EC ID contains RFC 6265-illegal
                         // characters (e.g. a crafted x-ts-ec header value). The response header
                         // is still emitted; only cookie persistence is skipped.
-                        set_ec_cookie(settings, response, ec_id.as_str());
+                        compat::set_ec_cookie_fastly(settings, response, ec_id.as_str());
                     }
                     Err(ref err) => {
                         log::warn!("Failed to generate EC ID for integration response: {err:?}");

--- a/crates/trusted-server-core/src/integrations/testlight.rs
+++ b/crates/trusted-server-core/src/integrations/testlight.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use validator::Validate;
 
-use crate::edge_cookie::get_ec_id;
+use crate::compat;
 use crate::error::TrustedServerError;
 use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
@@ -149,7 +149,7 @@ impl IntegrationProxy for TestlightIntegration {
             .map_err(|err| Report::new(Self::error(format!("Invalid request payload: {err}"))))?;
 
         // Read EC ID from header (set by registry) or cookie
-        let ec_id = get_ec_id(&req)
+        let ec_id = compat::get_ec_id_fastly(&req)
             .change_context(Self::error("Failed to read EC ID"))?
             .ok_or_else(|| {
                 Report::new(Self::error(

--- a/crates/trusted-server-core/src/lib.rs
+++ b/crates/trusted-server-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod auction;
 pub mod auction_config_types;
 pub mod auth;
 pub mod backend;
+pub mod compat;
 pub mod consent;
 pub mod consent_config;
 pub mod constants;

--- a/crates/trusted-server-core/src/proxy.rs
+++ b/crates/trusted-server-core/src/proxy.rs
@@ -5,12 +5,12 @@ use fastly::{Request, Response};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::compat;
 use crate::constants::{
     HEADER_ACCEPT, HEADER_ACCEPT_ENCODING, HEADER_ACCEPT_LANGUAGE, HEADER_REFERER,
     HEADER_USER_AGENT, HEADER_X_FORWARDED_FOR,
 };
 use crate::creative::{CreativeCssProcessor, CreativeHtmlProcessor};
-use crate::edge_cookie::get_ec_id;
 use crate::error::TrustedServerError;
 use crate::settings::Settings;
 use crate::streaming_processor::{Compression, PipelineConfig, StreamProcessor, StreamingPipeline};
@@ -474,7 +474,7 @@ fn upsert_ec_query_param(url: &mut url::Url, ec_id: &str) {
 }
 
 fn append_ec_id(req: &Request, target_url_parsed: &mut url::Url) {
-    let ec_id_param = match get_ec_id(req) {
+    let ec_id_param = match compat::get_ec_id_fastly(req) {
         Ok(id) => id,
         Err(e) => {
             log::warn!("failed to extract EC ID for forwarding: {:?}", e);
@@ -737,7 +737,7 @@ pub async fn handle_first_party_click(
         had_params,
     } = reconstruct_and_validate_signed_target(settings, req.get_url_str())?;
 
-    let ec_id = match get_ec_id(&req) {
+    let ec_id = match compat::get_ec_id_fastly(&req) {
         Ok(id) => id,
         Err(e) => {
             log::warn!("failed to extract EC ID for forwarding: {:?}", e);

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -3,12 +3,10 @@ use fastly::http::{header, StatusCode};
 use fastly::{Body, Request, Response};
 
 use crate::backend::BackendConfig;
+use crate::compat;
 use crate::consent::{allows_ec_creation, build_consent_context, ConsentPipelineInput};
 use crate::constants::{COOKIE_TS_EC, HEADER_X_COMPRESS_HINT, HEADER_X_TS_EC};
-use crate::cookies::{expire_ec_cookie, handle_request_cookies, set_ec_cookie};
-use crate::edge_cookie::get_or_generate_ec_id;
 use crate::error::TrustedServerError;
-use crate::http_util::{serve_static_with_etag, RequestInfo};
 use crate::integrations::IntegrationRegistry;
 use crate::platform::RuntimeServices;
 use crate::rsc_flight::RscFlightUrlRewriter;
@@ -119,7 +117,11 @@ pub fn handle_tsjs_dynamic(
         // Serve core + immediate modules (excludes deferred like prebid)
         let module_ids = integration_registry.js_module_ids_immediate();
         let body = trusted_server_js::concatenate_modules(&module_ids);
-        let mut resp = serve_static_with_etag(&body, req, "application/javascript; charset=utf-8");
+        let mut resp = compat::serve_static_with_etag_fastly(
+            &body,
+            req,
+            "application/javascript; charset=utf-8",
+        );
         resp.set_header(HEADER_X_COMPRESS_HINT, "on");
         return Ok(resp);
     }
@@ -131,8 +133,11 @@ pub fn handle_tsjs_dynamic(
             return Ok(Response::from_status(StatusCode::NOT_FOUND).with_body("Not Found"));
         }
         if let Some(content) = trusted_server_js::module_bundle(module_id) {
-            let mut resp =
-                serve_static_with_etag(content, req, "application/javascript; charset=utf-8");
+            let mut resp = compat::serve_static_with_etag_fastly(
+                content,
+                req,
+                "application/javascript; charset=utf-8",
+            );
             resp.set_header(HEADER_X_COMPRESS_HINT, "on");
             return Ok(resp);
         }
@@ -299,7 +304,7 @@ pub fn handle_publisher_request(
     // publisher-supplied Prebid scripts; the unified TSJS bundle includes Prebid.js when enabled.
 
     // Extract request host and scheme (uses Host header and TLS detection after edge sanitization)
-    let request_info = RequestInfo::from_request(&req);
+    let request_info = compat::request_info_from_fastly(&req);
     let request_host = &request_info.host;
     let request_scheme = &request_info.scheme;
 
@@ -313,7 +318,7 @@ pub fn handle_publisher_request(
     );
 
     // Parse cookies once for reuse by both consent extraction and EC ID logic.
-    let cookie_jar = handle_request_cookies(&req)?;
+    let cookie_jar = compat::handle_request_cookies_fastly(&req)?;
 
     // Capture the current EC cookie value for revocation handling.
     // This must come from the cookie itself (not the x-ts-ec header)
@@ -326,7 +331,7 @@ pub fn handle_publisher_request(
     // Generate EC identifiers before the request body is consumed.
     // Always generated for internal use (KV lookups, logging) even when
     // consent is absent — the cookie is only *set* when consent allows it.
-    let ec_id = get_or_generate_ec_id(settings, &req)?;
+    let ec_id = compat::get_or_generate_ec_id_fastly(settings, &req)?;
 
     // Extract, decode, and log consent signals (TCF, GPP, US Privacy, GPC)
     // from the incoming request. The ConsentContext carries both raw strings
@@ -456,14 +461,14 @@ pub fn handle_publisher_request(
         response.set_header(HEADER_X_TS_EC, ec_id.as_str());
         // Cookie persistence is skipped if the EC ID contains RFC 6265-illegal
         // characters. The header is still emitted when consent allows it.
-        set_ec_cookie(settings, &mut response, ec_id.as_str());
+        compat::set_ec_cookie_fastly(settings, &mut response, ec_id.as_str());
     } else if let Some(cookie_ec_id) = existing_ec_cookie.as_deref() {
         log::info!(
             "EC revoked for '{}': consent withdrawn (jurisdiction={})",
             cookie_ec_id,
             consent_context.jurisdiction,
         );
-        expire_ec_cookie(settings, &mut response);
+        compat::expire_ec_cookie_fastly(settings, &mut response);
         if settings.consent.consent_store.is_some() {
             crate::consent::kv::delete_consent_from_kv(services.kv_store(), cookie_ec_id);
         }
@@ -673,13 +678,14 @@ mod tests {
         req.set_header("x-ts-ec", "header_id");
         req.set_header("cookie", "ts-ec=cookie_id; other=value");
 
-        let cookie_jar = handle_request_cookies(&req).expect("should parse cookies");
+        let cookie_jar = compat::handle_request_cookies_fastly(&req).expect("should parse cookies");
         let existing_ec_cookie = cookie_jar
             .as_ref()
             .and_then(|jar| jar.get(COOKIE_TS_EC))
             .map(|cookie| cookie.value().to_owned());
 
-        let resolved_ec_id = get_or_generate_ec_id(&settings, &req).expect("should resolve EC ID");
+        let resolved_ec_id =
+            compat::get_or_generate_ec_id_fastly(&settings, &req).expect("should resolve EC ID");
 
         assert_eq!(
             existing_ec_cookie.as_deref(),


### PR DESCRIPTION
## Summary

- Migrates `http_util`, `auth`, `cookies`, and `edge_cookie` from `fastly::Request/Response` to `http::Request<Body>` / `http::Response<Body>`, making these modules platform-agnostic
- Adds `compat.rs` as a temporary bridge module so handler/integration layer code (still holding `fastly::Request`) can call the migrated utilities without a full call-stack conversion in this PR — all bridge functions are marked `// TODO(PR15): Remove`
- Introduces `TlsProtocol`, `TlsCipher`, and `ClientIpExt` request extension types so the Fastly adapter can inject platform-specific TLS and client-IP data into `http::Request` extensions at the boundary, with no Fastly SDK imports in the utility layer

## Changes

| File | Change |
| ---- | ------ |
| `src/compat.rs` (new) | Compat bridge: `from_fastly_request_ref`, `from_fastly_request`, `to_fastly_request`, `from_fastly_response`, `to_fastly_response`, and `*_fastly` shims for each utility function |
| `src/http_util.rs` | Migrated to `http::Request<Body>` / `http::Response<Body>`; `SPOOFABLE_FORWARDED_HEADERS` made `pub(crate)` |
| `src/auth.rs` | Migrated `enforce_basic_auth` signature |
| `src/cookies.rs` | Migrated `handle_request_cookies`, `forward_cookie_header`, `set_ec_cookie`, `expire_ec_cookie` |
| `src/edge_cookie.rs` | Migrated `get_ec_id`, `get_or_generate_ec_id`, `generate_ec_id`; reads `ClientIpExt` from extensions |
| `src/lib.rs` | Added `pub mod compat` |
| `src/auction/endpoints.rs` | Call sites updated to `compat::*_fastly` |
| `src/auction/formats.rs` | Call site updated to `compat::generate_ec_id_fastly` |
| `src/integrations/lockr.rs` | Call sites updated to `compat::*_fastly` |
| `src/integrations/permutive.rs` | Call site updated to `compat::copy_custom_headers_fastly` |
| `src/integrations/prebid.rs` | Call sites updated to `compat::*_fastly` |
| `src/integrations/registry.rs` | Call sites updated to `compat::*_fastly` |
| `src/integrations/testlight.rs` | Call site updated to `compat::get_ec_id_fastly` |
| `src/proxy.rs` | Call sites updated to `compat::get_ec_id_fastly` |
| `src/publisher.rs` | All utility call sites updated to `compat::*_fastly` |
| `adapter-fastly/src/main.rs` | `sanitize_forwarded_headers` and `enforce_basic_auth` updated to `compat::*_fastly` |


## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/js/lib && npx vitest run`
- [x] JS format: `cd crates/js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed