### PR TITLE
Add test coverage for error mapping and tsjs helpers

### DIFF
--- a/crates/trusted-server-core/src/cookies.rs
+++ b/crates/trusted-server-core/src/cookies.rs
@@ -268,6 +268,8 @@ pub fn expire_ec_cookie(settings: &Settings, response: &mut fastly::Response) {
 
 #[cfg(test)]
 mod tests {
+    use fastly::http::HeaderValue;
+
     use crate::test_support::tests::create_test_settings;
 
     use super::*;
@@ -345,6 +347,28 @@ mod tests {
             .expect("should have cookie jar");
 
         assert!(jar.iter().count() == 0);
+    }
+
+    #[test]
+    fn test_handle_request_cookies_invalid_utf8_header_value() {
+        let mut req = Request::get("http://example.com");
+        req.set_header(
+            header::COOKIE,
+            HeaderValue::from_bytes(b"session=\xFF")
+                .expect("should allow non-UTF-8 cookie header bytes"),
+        );
+
+        let error = handle_request_cookies(&req).expect_err("should reject invalid UTF-8");
+        let trusted_server_error = error.current_context();
+
+        assert!(
+            matches!(
+                trusted_server_error,
+                TrustedServerError::InvalidHeaderValue { message }
+                    if message == "Cookie header contains invalid UTF-8"
+            ),
+            "should return InvalidHeaderValue for invalid UTF-8 cookie headers",
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/cookies.rs
+++ b/crates/trusted-server-core/src/cookies.rs
@@ -355,7 +355,7 @@ mod tests {
         req.set_header(
             header::COOKIE,
             HeaderValue::from_bytes(b"session=\xFF")
-                .expect("should allow non-UTF-8 cookie header bytes"),
+                .expect("should construct HeaderValue from non-UTF-8 bytes"),
         );
 
         let error = handle_request_cookies(&req).expect_err("should reject invalid UTF-8");

--- a/crates/trusted-server-core/src/error.rs
+++ b/crates/trusted-server-core/src/error.rs
@@ -142,6 +142,26 @@ mod tests {
 
     #[test]
     fn status_code_maps_each_error_variant_to_expected_http_response() {
+        // Compile-time guard: adding a TrustedServerError variant without
+        // updating this test will fail to compile.
+        let _exhaustive = |error: &TrustedServerError| match error {
+            TrustedServerError::BadRequest { .. }
+            | TrustedServerError::Configuration { .. }
+            | TrustedServerError::Auction { .. }
+            | TrustedServerError::Gam { .. }
+            | TrustedServerError::GdprConsent { .. }
+            | TrustedServerError::InvalidUtf8 { .. }
+            | TrustedServerError::InvalidHeaderValue { .. }
+            | TrustedServerError::KvStore { .. }
+            | TrustedServerError::Prebid { .. }
+            | TrustedServerError::Integration { .. }
+            | TrustedServerError::Proxy { .. }
+            | TrustedServerError::Forbidden { .. }
+            | TrustedServerError::AllowlistViolation { .. }
+            | TrustedServerError::Settings { .. }
+            | TrustedServerError::Ec { .. } => (),
+        };
+
         let cases = [
             (
                 TrustedServerError::BadRequest {

--- a/crates/trusted-server-core/src/error.rs
+++ b/crates/trusted-server-core/src/error.rs
@@ -136,7 +136,115 @@ impl IntoHttpResponse for TrustedServerError {
 
 #[cfg(test)]
 mod tests {
+    use http::StatusCode;
+
     use super::*;
+
+    #[test]
+    fn status_code_maps_each_error_variant_to_expected_http_response() {
+        let cases = [
+            (
+                TrustedServerError::BadRequest {
+                    message: "missing field".into(),
+                },
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                TrustedServerError::Configuration {
+                    message: "invalid config".into(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                TrustedServerError::Auction {
+                    message: "bid timeout".into(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::Gam {
+                    message: "upstream error".into(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::GdprConsent {
+                    message: "missing consent string".into(),
+                },
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                TrustedServerError::InvalidUtf8 {
+                    message: "byte 0xff".into(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                TrustedServerError::InvalidHeaderValue {
+                    message: "non-ascii".into(),
+                },
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                TrustedServerError::KvStore {
+                    store_name: "users".into(),
+                    message: "timeout".into(),
+                },
+                StatusCode::SERVICE_UNAVAILABLE,
+            ),
+            (
+                TrustedServerError::Prebid {
+                    message: "adapter error".into(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::Integration {
+                    integration: "foo".into(),
+                    message: "connection refused".into(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::Proxy {
+                    message: "upstream refused".into(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::Forbidden {
+                    message: "missing credentials".into(),
+                },
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                TrustedServerError::AllowlistViolation {
+                    host: "blocked.example.com".into(),
+                },
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                TrustedServerError::Settings {
+                    message: "parse failed".into(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                TrustedServerError::Ec {
+                    message: "seed missing".into(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ];
+
+        for (error, expected_status) in cases {
+            assert_eq!(
+                error.status_code(),
+                expected_status,
+                "should map {error:?} to the expected HTTP status",
+            );
+        }
+    }
 
     #[test]
     fn server_errors_return_generic_message() {

--- a/crates/trusted-server-core/src/models.rs
+++ b/crates/trusted-server-core/src/models.rs
@@ -55,7 +55,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_callback_deserialization() {
+    fn test_callback_deserialization_renames_type_field() {
         let json_data = json!({
             "type": "impression",
             "url": "https://example.com/track/impression"
@@ -63,22 +63,9 @@ mod tests {
 
         let callback: Callback =
             serde_json::from_value(json_data).expect("should deserialize callback");
+
         assert_eq!(callback.callback_type, "impression");
         assert_eq!(callback.url, "https://example.com/track/impression");
-    }
-
-    #[test]
-    fn test_callback_type_field_rename() {
-        // Test that "type" is correctly renamed to callback_type
-        let json_str = r#"{
-            "type": "click",
-            "url": "https://example.com/track/click"
-        }"#;
-
-        let callback: Callback =
-            serde_json::from_str(json_str).expect("should deserialize callback from str");
-        assert_eq!(callback.callback_type, "click");
-        assert_eq!(callback.url, "https://example.com/track/click");
     }
 
     #[test]

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -67,25 +67,40 @@ pub fn tsjs_deferred_script_tags(module_ids: &[&str]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use trusted_server_js::{all_module_ids, concatenated_hash, single_module_hash};
-
     use super::*;
+
+    fn assert_sha256_hex_hash(src: &str) {
+        let hash = src
+            .rsplit_once("?v=")
+            .expect("should have cache-busting query parameter")
+            .1;
+
+        assert_eq!(hash.len(), 64, "should use a SHA-256 hex hash");
+        assert!(
+            hash.chars().all(|character| character.is_ascii_hexdigit()),
+            "should use only ASCII hex digits",
+        );
+    }
 
     #[test]
     fn tsjs_script_src_formats_unified_bundle_url_with_hash() {
-        let module_ids = ["core", "creative"];
-        let expected_hash = concatenated_hash(&module_ids);
+        let creative_src = tsjs_script_src(&["creative"]);
+        let creative_prebid_src = tsjs_script_src(&["creative", "prebid"]);
 
-        assert_eq!(
-            tsjs_script_src(&module_ids),
-            format!("/static/tsjs=tsjs-unified.min.js?v={expected_hash}"),
-            "should include the unified bundle path and cache-busting hash",
+        assert!(
+            creative_src.starts_with("/static/tsjs=tsjs-unified.min.js?v="),
+            "should include the unified bundle path and cache-busting parameter",
+        );
+        assert_sha256_hex_hash(&creative_src);
+        assert_ne!(
+            creative_src, creative_prebid_src,
+            "should generate different cache-busting URLs for different module sets",
         );
     }
 
     #[test]
     fn tsjs_script_tag_wraps_source_in_a_single_tag() {
-        let module_ids = ["core", "creative"];
+        let module_ids = ["creative"];
         let expected_src = tsjs_script_src(&module_ids);
 
         assert_eq!(
@@ -97,20 +112,16 @@ mod tests {
 
     #[test]
     fn tsjs_unified_helpers_use_all_module_ids() {
-        let all_ids = all_module_ids();
-        let expected_src = format!(
-            "/static/tsjs=tsjs-unified.min.js?v={}",
-            concatenated_hash(&all_ids)
-        );
+        let src = tsjs_unified_script_src();
 
-        assert_eq!(
-            tsjs_unified_script_src(),
-            expected_src,
-            "should hash all compiled modules for the unified bundle",
+        assert!(
+            src.starts_with("/static/tsjs=tsjs-unified.min.js?v="),
+            "should include the unified bundle path and cache-busting parameter",
         );
+        assert_sha256_hex_hash(&src);
         assert_eq!(
             tsjs_unified_script_tag(),
-            format!("<script src=\"{expected_src}\" id=\"trustedserver-js\"></script>"),
+            format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>"),
             "should wrap the unified bundle source in the standard script tag",
         );
     }
@@ -134,11 +145,11 @@ mod tests {
     }
 
     #[test]
-    fn tsjs_deferred_script_src_uses_empty_hash_for_unknown_module() {
+    fn tsjs_deferred_script_src_documents_unregistered_module_fallback() {
         assert_eq!(
             tsjs_deferred_script_src("unknown-module"),
             "/static/tsjs=tsjs-unknown-module.min.js?v=",
-            "should fall back to an empty hash for unknown deferred modules",
+            "should preserve the current fallback until callers validate registered modules",
         );
     }
 

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -112,16 +112,21 @@ mod tests {
 
     #[test]
     fn tsjs_unified_helpers_use_all_module_ids() {
-        let src = tsjs_unified_script_src();
+        let unified = tsjs_unified_script_src();
+        let manual = tsjs_script_src(&all_module_ids());
 
+        assert_eq!(
+            unified, manual,
+            "unified helpers must hash every registered module",
+        );
         assert!(
-            src.starts_with("/static/tsjs=tsjs-unified.min.js?v="),
+            unified.starts_with("/static/tsjs=tsjs-unified.min.js?v="),
             "should include the unified bundle path and cache-busting parameter",
         );
-        assert_sha256_hex_hash(&src);
+        assert_sha256_hex_hash(&unified);
         assert_eq!(
             tsjs_unified_script_tag(),
-            format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>"),
+            format!("<script src=\"{unified}\" id=\"trustedserver-js\"></script>"),
             "should wrap the unified bundle source in the standard script tag",
         );
     }
@@ -129,17 +134,16 @@ mod tests {
     #[test]
     fn tsjs_deferred_helpers_format_single_module_urls_and_tags() {
         let module_id = "prebid";
-        let expected_hash = single_module_hash(module_id).expect("should hash known module");
-        let expected_src = format!("/static/tsjs=tsjs-{module_id}.min.js?v={expected_hash}");
+        let src = tsjs_deferred_script_src(module_id);
 
-        assert_eq!(
-            tsjs_deferred_script_src(module_id),
-            expected_src,
-            "should include the deferred module path and hash",
+        assert!(
+            src.starts_with("/static/tsjs=tsjs-prebid.min.js?v="),
+            "should include the deferred module path and cache-busting parameter",
         );
+        assert_sha256_hex_hash(&src);
         assert_eq!(
             tsjs_deferred_script_tag(module_id),
-            format!("<script src=\"{expected_src}\" defer></script>"),
+            format!("<script src=\"{src}\" defer></script>"),
             "should render a deferred script tag for the module",
         );
     }
@@ -155,16 +159,24 @@ mod tests {
 
     #[test]
     fn tsjs_deferred_script_tags_concatenates_tags_in_input_order() {
-        let module_ids = ["prebid", "creative"];
-        let expected = module_ids
-            .iter()
-            .map(|id| tsjs_deferred_script_tag(id))
-            .collect::<String>();
+        let result = tsjs_deferred_script_tags(&["prebid", "creative"]);
+        let prebid_pos = result
+            .find("tsjs-prebid")
+            .expect("should contain prebid script");
+        let creative_pos = result
+            .find("tsjs-creative")
+            .expect("should contain creative script");
 
+        assert!(prebid_pos < creative_pos, "should preserve input order");
         assert_eq!(
-            tsjs_deferred_script_tags(&module_ids),
-            expected,
-            "should concatenate one deferred script tag per module in order",
+            result.matches("<script ").count(),
+            2,
+            "should emit one tag per module",
+        );
+        assert_eq!(
+            result.matches(" defer></script>").count(),
+            2,
+            "should mark each deferred script tag with defer",
         );
     }
 }

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -64,3 +64,96 @@ pub fn tsjs_deferred_script_tags(module_ids: &[&str]) -> String {
         .map(|id| tsjs_deferred_script_tag(id))
         .collect::<String>()
 }
+
+#[cfg(test)]
+mod tests {
+    use trusted_server_js::{all_module_ids, concatenated_hash, single_module_hash};
+
+    use super::*;
+
+    #[test]
+    fn tsjs_script_src_formats_unified_bundle_url_with_hash() {
+        let module_ids = ["core", "creative"];
+        let expected_hash = concatenated_hash(&module_ids);
+
+        assert_eq!(
+            tsjs_script_src(&module_ids),
+            format!("/static/tsjs=tsjs-unified.min.js?v={expected_hash}"),
+            "should include the unified bundle path and cache-busting hash",
+        );
+    }
+
+    #[test]
+    fn tsjs_script_tag_wraps_source_in_a_single_tag() {
+        let module_ids = ["core", "creative"];
+        let expected_src = tsjs_script_src(&module_ids);
+
+        assert_eq!(
+            tsjs_script_tag(&module_ids),
+            format!("<script src=\"{expected_src}\" id=\"trustedserver-js\"></script>"),
+            "should render the injected trustedserver script tag",
+        );
+    }
+
+    #[test]
+    fn tsjs_unified_helpers_use_all_module_ids() {
+        let all_ids = all_module_ids();
+        let expected_src = format!(
+            "/static/tsjs=tsjs-unified.min.js?v={}",
+            concatenated_hash(&all_ids)
+        );
+
+        assert_eq!(
+            tsjs_unified_script_src(),
+            expected_src,
+            "should hash all compiled modules for the unified bundle",
+        );
+        assert_eq!(
+            tsjs_unified_script_tag(),
+            format!("<script src=\"{expected_src}\" id=\"trustedserver-js\"></script>"),
+            "should wrap the unified bundle source in the standard script tag",
+        );
+    }
+
+    #[test]
+    fn tsjs_deferred_helpers_format_single_module_urls_and_tags() {
+        let module_id = "prebid";
+        let expected_hash = single_module_hash(module_id).expect("should hash known module");
+        let expected_src = format!("/static/tsjs=tsjs-{module_id}.min.js?v={expected_hash}");
+
+        assert_eq!(
+            tsjs_deferred_script_src(module_id),
+            expected_src,
+            "should include the deferred module path and hash",
+        );
+        assert_eq!(
+            tsjs_deferred_script_tag(module_id),
+            format!("<script src=\"{expected_src}\" defer></script>"),
+            "should render a deferred script tag for the module",
+        );
+    }
+
+    #[test]
+    fn tsjs_deferred_script_src_uses_empty_hash_for_unknown_module() {
+        assert_eq!(
+            tsjs_deferred_script_src("unknown-module"),
+            "/static/tsjs=tsjs-unknown-module.min.js?v=",
+            "should fall back to an empty hash for unknown deferred modules",
+        );
+    }
+
+    #[test]
+    fn tsjs_deferred_script_tags_concatenates_tags_in_input_order() {
+        let module_ids = ["prebid", "creative"];
+        let expected = module_ids
+            .iter()
+            .map(|id| tsjs_deferred_script_tag(id))
+            .collect::<String>();
+
+        assert_eq!(
+            tsjs_deferred_script_tags(&module_ids),
+            expected,
+            "should concatenate one deferred script tag per module in order",
+        );
+    }
+}


### PR DESCRIPTION
## Superseded

This PR is superseded and should not be merged as the canonical solution for the #396 backlog cleanup.

- #448 and #450 are covered by #688.
- #454 and #456 were already handled on `main` by #660.
- This branch is currently conflicting and has unresolved requested changes, while #688 is the active consolidation branch.

Keeping this PR open only for historical review context unless/until we close it.

## Original Summary

- add exhaustive unit coverage for `TrustedServerError::status_code()` so each public variant is pinned to its expected HTTP response
- add direct `tsjs` formatting tests for unified and deferred script URL/tag helpers using computed hashes
- cover invalid UTF-8 cookie-header handling and simplify duplicate callback serde rename tests

## Original Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/error.rs` | Added a table-driven test covering HTTP status code mapping for every `TrustedServerError` variant. |
| `crates/trusted-server-core/src/tsjs.rs` | Added direct unit tests for unified and deferred TS/JS script URL and tag helpers. |
| `crates/trusted-server-core/src/cookies.rs` | Added a unit test for invalid UTF-8 `Cookie` header handling in `handle_request_cookies()`. |
| `crates/trusted-server-core/src/models.rs` | Consolidated duplicate callback serde rename tests into one focused test. |

## Duplicate closure note

This PR intentionally no longer uses `Closes` keywords. Closure ownership moved to:

- #688 for #448 and #450
- #660 for #454 and #456

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] JS tests: `cd crates/js/lib && npx vitest run`
- [ ] JS format: `cd crates/js/lib && npm run format`
- [ ] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [ ] Other: <!-- describe -->

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `log` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
