### PR TITLE
Pin Viceroy install to v0.16.4 in test workflow

### DIFF
--- a/.github/actions/setup-integration-test-env/action.yml
+++ b/.github/actions/setup-integration-test-env/action.yml
@@ -45,6 +45,15 @@ runs:
       shell: bash
       run: echo "node-version=$(grep '^nodejs ' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
+    - name: Retrieve Viceroy version
+      id: viceroy-version
+      if: ${{ inputs.install-viceroy == 'true' }}
+      shell: bash
+      # `.tool-versions` is the single source of truth for the Viceroy pin.
+      # The pin matters because upstream Viceroy > v0.16.4 has bumped MSRV
+      # beyond the rustc pin in `rust-toolchain.toml`.
+      run: echo "viceroy-version=$(grep '^viceroy ' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
     - name: Set up Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
@@ -58,12 +67,12 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cargo/bin/viceroy
-        key: viceroy-${{ runner.os }}-v0.16.4
+        key: viceroy-${{ runner.os }}-v${{ steps.viceroy-version.outputs.viceroy-version }}
 
     - name: Install Viceroy
       if: ${{ inputs.install-viceroy == 'true' && steps.cache-viceroy.outputs.cache-hit != 'true' }}
       shell: bash
-      run: cargo install --git https://github.com/fastly/Viceroy --tag v0.16.4 viceroy
+      run: cargo install --git https://github.com/fastly/Viceroy --tag v${{ steps.viceroy-version.outputs.viceroy-version }} viceroy
 
     - name: Build WASM binary
       if: ${{ inputs.build-wasm == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,20 +28,19 @@ jobs:
           target: wasm32-wasip1
           cache-shared-key: cargo-${{ runner.os }}
 
-      - name: Get Viceroy cache key
-        id: viceroy-rev
-        run: echo "sha=$(git ls-remote https://github.com/fastly/Viceroy HEAD | cut -f1)" >> $GITHUB_OUTPUT
-
+      # Pin Viceroy to a tag that supports the repo's rustc pin (1.91.1).
+      # Upstream 0.16.6 bumped MSRV to rustc 1.95, so HEAD installs break CI.
+      # Keep in sync with .github/actions/setup-integration-test-env/action.yml.
       - name: Cache Viceroy binary
         id: cache-viceroy
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/viceroy
-          key: viceroy-${{ runner.os }}-${{ steps.viceroy-rev.outputs.sha }}
+          key: viceroy-${{ runner.os }}-v0.16.4
 
-      - name: Install Viceroy (from main since 0.14.3 is broken)
+      - name: Install Viceroy
         if: steps.cache-viceroy.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/fastly/Viceroy viceroy
+        run: cargo install --git https://github.com/fastly/Viceroy --tag v0.16.4 viceroy
 
       - name: Run tests
         run: cargo test --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,15 @@ jobs:
         run: echo "rust-version=$(grep '^rust ' .tool-versions | awk '{print $2}')" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: Retrieve Viceroy version
+        id: viceroy-version
+        # `.tool-versions` is the single source of truth so this workflow and
+        # `.github/actions/setup-integration-test-env/action.yml` can't drift.
+        # The pin matters because upstream Viceroy > v0.16.4 has bumped MSRV
+        # beyond the rustc pin in `rust-toolchain.toml`.
+        run: echo "viceroy-version=$(grep '^viceroy ' .tool-versions | awk '{print $2}')" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -28,19 +37,16 @@ jobs:
           target: wasm32-wasip1
           cache-shared-key: cargo-${{ runner.os }}
 
-      # Pin Viceroy to a tag that supports the repo's rustc pin (1.91.1).
-      # Upstream 0.16.6 bumped MSRV to rustc 1.95, so HEAD installs break CI.
-      # Keep in sync with .github/actions/setup-integration-test-env/action.yml.
       - name: Cache Viceroy binary
         id: cache-viceroy
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/viceroy
-          key: viceroy-${{ runner.os }}-v0.16.4
+          key: viceroy-${{ runner.os }}-v${{ steps.viceroy-version.outputs.viceroy-version }}
 
       - name: Install Viceroy
         if: steps.cache-viceroy.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/fastly/Viceroy --tag v0.16.4 viceroy
+        run: cargo install --git https://github.com/fastly/Viceroy --tag v${{ steps.viceroy-version.outputs.viceroy-version }} viceroy
 
       - name: Run tests
         run: cargo test --workspace

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 fastly 13.3.0
 rust 1.91.1
 nodejs 24.12.0
+viceroy 0.16.4


### PR DESCRIPTION
## Summary
- `.github/workflows/test.yml` installed Viceroy from `HEAD`. CI then started picking up `viceroy-lib@0.16.6`, which bumped MSRV to rustc 1.95, while `rust-toolchain.toml` pins rustc 1.91.1 — failing with `viceroy-lib@0.16.6 requires rustc 1.95`.
- Make `.tool-versions` the single source of truth for the Viceroy pin. Both `test.yml` and `.github/actions/setup-integration-test-env/action.yml` now read the version via `grep '^viceroy ' .tool-versions`, so the two workflows can no longer drift.
- Pin is currently `0.16.4`, the latest tag whose MSRV is compatible with this repo's rustc pin. Follow-up tracked in #657.

## Test plan
- [ ] CI `Run Tests / cargo test` job succeeds
- [ ] Viceroy cache populates on first run (miss) and hits on subsequent runs
- [ ] Integration tests still find the same Viceroy version via the composite action