### PR TITLE
20260518-053619 Review fixes for #680

### DIFF
--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -55,9 +55,10 @@ const CREATIVE_OPPORTUNITIES_TOML: &str = include_str!("../../../creative-opport
 static SLOTS_FILE: std::sync::LazyLock<
     trusted_server_core::creative_opportunities::CreativeOpportunitiesFile,
 > = std::sync::LazyLock::new(|| {
-    match toml::from_str::<trusted_server_core::creative_opportunities::CreativeOpportunitiesFile>(
-        CREATIVE_OPPORTUNITIES_TOML,
-    ) {
+    let mut file = match toml::from_str::<
+        trusted_server_core::creative_opportunities::CreativeOpportunitiesFile,
+    >(CREATIVE_OPPORTUNITIES_TOML)
+    {
         Ok(file) => file,
         Err(err) => {
             log::error!(
@@ -67,7 +68,11 @@ static SLOTS_FILE: std::sync::LazyLock<
             );
             trusted_server_core::creative_opportunities::CreativeOpportunitiesFile::default()
         }
-    }
+    };
+    // Pre-compile glob patterns once so per-request `matches_path` doesn't
+    // re-invoke `Pattern::new` on every page hit.
+    file.compile();
+    file
 });
 
 /// Entry point for the Fastly Compute program.

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -52,23 +52,23 @@ const CREATIVE_OPPORTUNITIES_TOML: &str = include_str!("../../../creative-opport
 /// authoring mistake; this fallback exists so a CI-bypassed binary patch or a
 /// future schema change can't take the entire fleet down with a per-request
 /// panic.
-static SLOTS_FILE:
-    std::sync::LazyLock<trusted_server_core::creative_opportunities::CreativeOpportunitiesFile> =
-    std::sync::LazyLock::new(|| {
-        match toml::from_str::<trusted_server_core::creative_opportunities::CreativeOpportunitiesFile>(
-            CREATIVE_OPPORTUNITIES_TOML,
-        ) {
-            Ok(file) => file,
-            Err(err) => {
-                log::error!(
-                    "creative-opportunities.toml failed to parse at startup; \
+static SLOTS_FILE: std::sync::LazyLock<
+    trusted_server_core::creative_opportunities::CreativeOpportunitiesFile,
+> = std::sync::LazyLock::new(|| {
+    match toml::from_str::<trusted_server_core::creative_opportunities::CreativeOpportunitiesFile>(
+        CREATIVE_OPPORTUNITIES_TOML,
+    ) {
+        Ok(file) => file,
+        Err(err) => {
+            log::error!(
+                "creative-opportunities.toml failed to parse at startup; \
                      falling back to an empty slots file (server-side ad-slot \
                      templates disabled): {err}"
-                );
-                trusted_server_core::creative_opportunities::CreativeOpportunitiesFile::default()
-            }
+            );
+            trusted_server_core::creative_opportunities::CreativeOpportunitiesFile::default()
         }
-    });
+    }
+});
 
 /// Entry point for the Fastly Compute program.
 ///

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -42,6 +42,34 @@ use crate::platform::{build_runtime_services, open_kv_store, UnavailableKvStore}
 
 const CREATIVE_OPPORTUNITIES_TOML: &str = include_str!("../../../creative-opportunities.toml");
 
+/// Parses the embedded `creative-opportunities.toml` at most once per Wasm
+/// instance.
+///
+/// On parse failure, logs an error and falls back to an empty
+/// [`CreativeOpportunitiesFile`] — i.e. the documented "feature disabled"
+/// state — instead of panicking the request hot path. The build-time
+/// validator in `crates/trusted-server-core/build.rs` catches every realistic
+/// authoring mistake; this fallback exists so a CI-bypassed binary patch or a
+/// future schema change can't take the entire fleet down with a per-request
+/// panic.
+static SLOTS_FILE:
+    std::sync::LazyLock<trusted_server_core::creative_opportunities::CreativeOpportunitiesFile> =
+    std::sync::LazyLock::new(|| {
+        match toml::from_str::<trusted_server_core::creative_opportunities::CreativeOpportunitiesFile>(
+            CREATIVE_OPPORTUNITIES_TOML,
+        ) {
+            Ok(file) => file,
+            Err(err) => {
+                log::error!(
+                    "creative-opportunities.toml failed to parse at startup; \
+                     falling back to an empty slots file (server-side ad-slot \
+                     templates disabled): {err}"
+                );
+                trusted_server_core::creative_opportunities::CreativeOpportunitiesFile::default()
+            }
+        }
+    });
+
 /// Entry point for the Fastly Compute program.
 ///
 /// Uses an undecorated `main()` with `Request::from_client()` instead of
@@ -94,9 +122,7 @@ fn main() {
         }
     };
 
-    let slots_file: trusted_server_core::creative_opportunities::CreativeOpportunitiesFile =
-        toml::from_str(CREATIVE_OPPORTUNITIES_TOML)
-            .expect("should parse creative-opportunities.toml");
+    let slots_file = &*SLOTS_FILE;
 
     let integration_registry = match IntegrationRegistry::new(&settings) {
         Ok(r) => r,
@@ -121,7 +147,7 @@ fn main() {
         &orchestrator,
         &integration_registry,
         &runtime_services,
-        &slots_file,
+        slots_file,
         req,
     )) {
         response.send_to_client();

--- a/crates/trusted-server-core/src/auction/endpoints.rs
+++ b/crates/trusted-server-core/src/auction/endpoints.rs
@@ -6,7 +6,7 @@ use fastly::{Request, Response};
 use crate::auction::formats::AdRequest;
 use crate::compat;
 use crate::consent;
-use crate::cookies::handle_request_cookies;
+use crate::cookies::{handle_request_cookies, parse_ts_eids_cookie};
 use crate::edge_cookie::get_or_generate_ec_id_from_http_request;
 use crate::error::TrustedServerError;
 use crate::platform::RuntimeServices;
@@ -125,8 +125,8 @@ pub async fn handle_auction(
             .map(|_| services.kv_store()),
     });
 
-    // Convert tsjs request format to auction request
-    let auction_request = convert_tsjs_to_auction_request(
+    // Convert tsjs request format to auction request.
+    let mut auction_request = convert_tsjs_to_auction_request(
         &body,
         settings,
         services,
@@ -135,6 +135,10 @@ pub async fn handle_auction(
         &ec_id,
         geo,
     )?;
+    // Forward Extended User IDs from the `ts-eids` cookie so programmatic
+    // callers (slim-Prebid, native apps) get parity with the publisher /
+    // page-bids paths, both of which already do this.
+    auction_request.user.eids = parse_ts_eids_cookie(cookie_jar.as_ref());
 
     // Create auction context
     let context = AuctionContext {

--- a/crates/trusted-server-core/src/auction/orchestrator.rs
+++ b/crates/trusted-server-core/src/auction/orchestrator.rs
@@ -869,7 +869,14 @@ impl AuctionOrchestrator {
                         remaining,
                         mediator.timeout_ms(),
                     );
-                    let placeholder = fastly::Request::get("https://placeholder.invalid/");
+                    // The mediator runs on the collect path. See the doc-comment on
+                    // `AuctionContext::request`: the real client request was already
+                    // consumed by `send_async` during dispatch, so we substitute a
+                    // canonical placeholder URL. Any future mediator that needs real
+                    // client headers must snapshot them at dispatch time onto
+                    // `DispatchedAuction` rather than reading `context.request` here.
+                    let placeholder =
+                        fastly::Request::get(crate::auction::types::MEDIATOR_PLACEHOLDER_URL);
                     let mediator_context = AuctionContext {
                         settings: context.settings,
                         request: &placeholder,

--- a/crates/trusted-server-core/src/auction/orchestrator.rs
+++ b/crates/trusted-server-core/src/auction/orchestrator.rs
@@ -540,32 +540,29 @@ impl AuctionOrchestrator {
         }
 
         let starting_count = winning_bids.len();
-        winning_bids.retain(|slot_id, bid| match floor_prices.get(slot_id) {
-            Some(floor) => {
-                // price=None means the SSP returned an encoded price (e.g. APS amznbid).
-                // In the parallel-only path this bid cannot yet be floor-checked; it passes
-                // through and will be decoded (and re-checked) by the mediation layer.
-                // In the mediation path, mediation decodes prices before calling this
-                // function, so any bid still carrying price=None is dropped upstream.
-                match bid.price {
-                    Some(price) if price >= *floor => true,
-                    Some(_) => {
-                        log::info!(
-                            "Dropping winning bid below floor price for slot '{}'",
-                            slot_id
-                        );
-                        false
-                    }
-                    None => {
-                        log::debug!(
-                            "Passing encoded-price bid for slot '{}' - price not yet decoded",
-                            slot_id
-                        );
-                        true
-                    }
-                }
+        winning_bids.retain(|slot_id, bid| match (floor_prices.get(slot_id), bid.price) {
+            (Some(floor), Some(price)) if price >= *floor => true,
+            (Some(_), Some(_)) => {
+                log::info!(
+                    "Dropping winning bid below floor price for slot '{}'",
+                    slot_id
+                );
+                false
             }
-            None => true,
+            (_, None) => {
+                // Any caller that needs to keep an undecoded (encoded-price)
+                // bid must decode it *before* invoking this function — both
+                // `select_winning_bids` and the mediator path already do.
+                // Letting `None`-price bids through here would cause
+                // `winning_bids.len()` to overcount what `build_bid_map`
+                // downstream is willing to emit, so they get dropped instead.
+                log::debug!(
+                    "Dropping bid for slot '{}' - no decoded price (caller must decode before apply_floor_prices)",
+                    slot_id
+                );
+                false
+            }
+            (None, Some(_)) => true,
         });
 
         if winning_bids.len() != starting_count {
@@ -1256,9 +1253,14 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_floor_prices_allows_none_prices_for_encoded_bids() {
-        // Test that bids with None prices (APS-style) pass through floor pricing
-        // This is correct behavior for parallel-only strategy where mediation happens later
+    fn test_apply_floor_prices_drops_bids_with_undecoded_price() {
+        // Bids that reach apply_floor_prices with `price=None` cannot have a
+        // floor compared against them — and they would not survive downstream
+        // (build_bid_map filters them) — so apply_floor_prices drops them so
+        // the count it reports matches what eventually ships to the client.
+        // Both production paths (select_winning_bids and the mediator filter)
+        // already decode/skip None prices before calling this function; this
+        // test pins the contract.
         let orchestrator = AuctionOrchestrator::new(AuctionConfig::default());
         let mut floor_prices = HashMap::new();
         floor_prices.insert("slot-1".to_string(), 1.00);
@@ -1268,7 +1270,7 @@ mod tests {
             "slot-1".to_string(),
             Bid {
                 slot_id: "slot-1".to_string(),
-                price: None, // APS bid with encoded price
+                price: None,
                 currency: "USD".to_string(),
                 creative: Some("<div>Ad</div>".to_string()),
                 adomain: None,
@@ -1289,25 +1291,15 @@ mod tests {
             },
         );
 
-        // Apply floor pricing - should pass through with None price
         let filtered = orchestrator.apply_floor_prices(winning_bids, &floor_prices);
 
-        assert_eq!(
-            filtered.len(),
-            1,
-            "APS bid with None price should pass through floor check"
+        assert!(
+            filtered.is_empty(),
+            "bid with None price should be dropped by apply_floor_prices"
         );
         assert!(
-            filtered.contains_key("slot-1"),
-            "Slot-1 should still be present"
-        );
-        assert!(
-            filtered
-                .get("slot-1")
-                .expect("slot-1 should be present")
-                .price
-                .is_none(),
-            "Price should still be None (not decoded yet)"
+            !filtered.contains_key("slot-1"),
+            "slot-1 should not survive when its bid has no decoded price"
         );
     }
 

--- a/crates/trusted-server-core/src/auction/types.rs
+++ b/crates/trusted-server-core/src/auction/types.rs
@@ -115,6 +115,29 @@ pub struct SiteInfo {
 }
 
 /// Context passed to auction providers.
+///
+/// # The `request` field is path-dependent
+///
+/// `request` carries the **real downstream client request** in the dispatch
+/// path ([`AuctionOrchestrator::run_auction`][run] and
+/// [`dispatch_auction`][dispatch]). Providers there can read client headers
+/// (DNT, User-Agent, cookies, X-* customs) directly off it.
+///
+/// In the **collect path** ([`collect_dispatched_auction`][collect]) the
+/// mediator is invoked with a synthetic placeholder request
+/// (`https://placeholder.invalid/`), because the real client request has
+/// already been consumed by `send_async` during dispatch and the host pipeline
+/// can't lend it across the `.await`. **Mediators must not depend on reading
+/// client state from `context.request`** — the placeholder has none of the
+/// real headers. If a future mediator needs that data, snapshot it into a new
+/// field on this struct at dispatch time and stash it on the
+/// [`DispatchedAuction`] token so collect can attach it to the mediator's
+/// context. See <https://github.com/IABTechLab/trusted-server/issues/680>
+/// (P2-1) for the open follow-up.
+///
+/// [run]: crate::auction::AuctionOrchestrator::run_auction
+/// [dispatch]: crate::auction::AuctionOrchestrator::dispatch_auction
+/// [collect]: crate::auction::AuctionOrchestrator::collect_dispatched_auction
 pub struct AuctionContext<'a> {
     pub settings: &'a Settings,
     pub request: &'a Request,
@@ -126,6 +149,12 @@ pub struct AuctionContext<'a> {
     /// Platform services (config store, secret store, etc.) for use by providers.
     pub services: &'a RuntimeServices,
 }
+
+/// URL used by the orchestrator when invoking a mediator from the collect
+/// path. Providers can `debug_assert` against this value to catch a mediator
+/// that has accidentally started depending on `context.request` carrying real
+/// client headers.
+pub const MEDIATOR_PLACEHOLDER_URL: &str = "https://placeholder.invalid/";
 
 /// Response from a single auction provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/trusted-server-core/src/creative_opportunities.rs
+++ b/crates/trusted-server-core/src/creative_opportunities.rs
@@ -65,6 +65,18 @@ pub struct CreativeOpportunitySlot {
     /// Provider-specific slot identifiers.
     #[serde(default)]
     pub providers: SlotProviders,
+    /// Pre-compiled [`page_patterns`](Self::page_patterns) for hot-path matching.
+    ///
+    /// Populated by [`compile_patterns`](Self::compile_patterns) once at file
+    /// load time (see [`CreativeOpportunitiesFile::compile`]). When this is
+    /// empty, [`matches_path`](Self::matches_path) falls back to compiling on
+    /// every call so callers that build slots by hand (tests, legacy code)
+    /// still work.
+    ///
+    /// `pub(crate)` rather than private so cross-module test helpers in this
+    /// crate can construct slots via struct-literal syntax with an empty cache.
+    #[serde(skip, default)]
+    pub(crate) compiled_patterns: Vec<Pattern>,
 }
 
 impl CreativeOpportunitySlot {
@@ -79,6 +91,16 @@ impl CreativeOpportunitySlot {
     /// Patterns that cannot be compiled even after normalisation are silently skipped.
     #[must_use]
     pub fn matches_path(&self, path: &str) -> bool {
+        // Fast path: use the pre-compiled patterns when available so we don't
+        // re-run `Pattern::new` on every request. The vec is non-empty iff
+        // [`compile_patterns`](Self::compile_patterns) succeeded at load time
+        // and the slot has at least one pattern.
+        if !self.compiled_patterns.is_empty() {
+            return self.compiled_patterns.iter().any(|p| p.matches(path));
+        }
+
+        // Fallback for slots constructed by hand (tests, legacy callers that
+        // skip `compile_patterns`). Re-compiles on every call.
         self.page_patterns
             .iter()
             .any(|pattern| match Pattern::new(pattern) {
@@ -90,6 +112,28 @@ impl CreativeOpportunitySlot {
                         .unwrap_or(false)
                 }
             })
+    }
+
+    /// Compile [`page_patterns`](Self::page_patterns) into the
+    /// [`compiled_patterns`](Self::compiled_patterns) cache.
+    ///
+    /// Patterns that fail to compile (either directly or after the `**`→`*`
+    /// normalisation that [`matches_path`](Self::matches_path) does) are
+    /// silently skipped — the slot just becomes un-matchable, matching the
+    /// fallback behaviour.
+    ///
+    /// Idempotent: calling twice replaces the cache, so a slot list reloaded
+    /// at runtime won't accumulate stale patterns.
+    pub fn compile_patterns(&mut self) {
+        self.compiled_patterns = self
+            .page_patterns
+            .iter()
+            .filter_map(|pattern| {
+                Pattern::new(pattern)
+                    .or_else(|_| Pattern::new(&pattern.replace("**", "*")))
+                    .ok()
+            })
+            .collect();
     }
 
     /// Returns the GAM ad unit path for this slot.
@@ -116,8 +160,7 @@ impl CreativeOpportunitySlot {
     /// Provider-specific params (e.g., APS `slotID`, PBS bidder params) are wired
     /// into the `bidders` map keyed by provider/bidder name.
     #[must_use]
-    pub fn to_ad_slot(&self, gam_network_id: &str) -> AdSlot {
-        let _ = gam_network_id;
+    pub fn to_ad_slot(&self) -> AdSlot {
         let mut bidders: HashMap<String, serde_json::Value> = HashMap::new();
         if let Some(ref aps) = self.providers.aps {
             bidders.insert(
@@ -187,6 +230,18 @@ pub struct CreativeOpportunitiesFile {
     pub slots: Vec<CreativeOpportunitySlot>,
 }
 
+impl CreativeOpportunitiesFile {
+    /// Pre-compile every slot's
+    /// [`page_patterns`](CreativeOpportunitySlot::page_patterns) so
+    /// [`matches_path`](CreativeOpportunitySlot::matches_path) runs without
+    /// re-invoking `Pattern::new` on every request. Call once after loading.
+    pub fn compile(&mut self) {
+        for slot in &mut self.slots {
+            slot.compile_patterns();
+        }
+    }
+}
+
 /// Validates that a slot ID contains only safe characters.
 ///
 /// Allowed characters: ASCII alphanumerics, underscores (`_`), and hyphens (`-`).
@@ -237,6 +292,49 @@ mod tests {
             floor_price: Some(0.50),
             targeting: Default::default(),
             providers: Default::default(),
+            compiled_patterns: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn compile_patterns_populates_cache_and_match_uses_it() {
+        let mut slot = make_slot("atf", vec!["/20**", "/about"]);
+        assert!(
+            slot.compiled_patterns.is_empty(),
+            "freshly-built slot should have no compiled patterns"
+        );
+        slot.compile_patterns();
+        assert_eq!(
+            slot.compiled_patterns.len(),
+            2,
+            "compile_patterns should populate one entry per page pattern"
+        );
+        assert!(
+            slot.matches_path("/2024/01/my-article/"),
+            "matches_path should hit the compiled-pattern fast path"
+        );
+        assert!(
+            slot.matches_path("/about"),
+            "matches_path should hit /about via the compiled cache"
+        );
+        assert!(
+            !slot.matches_path("/contact"),
+            "matches_path should reject paths that match nothing in the cache"
+        );
+    }
+
+    #[test]
+    fn file_compile_populates_every_slot() {
+        let mut file = CreativeOpportunitiesFile {
+            slots: vec![make_slot("a", vec!["/a/*"]), make_slot("b", vec!["/b/*"])],
+        };
+        file.compile();
+        for slot in &file.slots {
+            assert_eq!(
+                slot.compiled_patterns.len(),
+                1,
+                "every slot's patterns should be pre-compiled after file.compile()"
+            );
         }
     }
 
@@ -300,7 +398,7 @@ mod tests {
         slot.providers.aps = Some(ApsSlotParams {
             slot_id: "aps-slot-atf".to_string(),
         });
-        let ad_slot = slot.to_ad_slot("21765378893");
+        let ad_slot = slot.to_ad_slot();
         let aps_params = ad_slot.bidders.get("aps").expect("should have aps bidder");
         assert_eq!(
             aps_params.get("slotID").and_then(|v| v.as_str()),
@@ -311,7 +409,7 @@ mod tests {
     #[test]
     fn to_ad_slot_sets_floor_price_and_formats() {
         let slot = make_slot("atf", vec!["/"]);
-        let ad_slot = slot.to_ad_slot("21765378893");
+        let ad_slot = slot.to_ad_slot();
         assert_eq!(ad_slot.id, "atf");
         assert_eq!(ad_slot.floor_price, Some(0.50));
         assert_eq!(ad_slot.formats.len(), 1);

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -145,7 +145,7 @@ pub struct HtmlProcessorConfig {
     /// Shared auction result — written by auction task before HTML processing begins.
     /// Handler reads this in `el.on_end_tag()` on the body element.
     /// `None` means no auction ran; inject empty `__ts_bids = {}` as fallback.
-    pub ad_bids_state: std::sync::Arc<std::sync::RwLock<Option<String>>>,
+    pub ad_bids_state: std::sync::Arc<std::sync::Mutex<Option<String>>>,
 }
 
 impl HtmlProcessorConfig {
@@ -164,7 +164,7 @@ impl HtmlProcessorConfig {
             request_scheme: request_scheme.to_string(),
             integrations: integrations.clone(),
             ad_slots_script: None,
-            ad_bids_state: std::sync::Arc::new(std::sync::RwLock::new(None)),
+            ad_bids_state: std::sync::Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -179,7 +179,7 @@ impl HtmlProcessorConfig {
     pub fn with_ad_state(
         mut self,
         ad_slots_script: Option<String>,
-        ad_bids_state: std::sync::Arc<std::sync::RwLock<Option<String>>>,
+        ad_bids_state: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     ) -> Self {
         self.ad_slots_script = ad_slots_script;
         self.ad_bids_state = ad_bids_state;
@@ -191,8 +191,8 @@ impl HtmlProcessorConfig {
 ///
 /// # Panics
 ///
-/// Panics if the `ad_bids_state` `RwLock` is poisoned. This cannot happen in
-/// normal operation since no code holds the write lock across a panic boundary.
+/// Panics if the `ad_bids_state` `Mutex` is poisoned. This cannot happen in
+/// normal operation since no code holds the lock across a panic boundary.
 #[must_use]
 pub fn create_html_processor(config: HtmlProcessorConfig) -> impl StreamProcessor {
     let post_processors = config.integrations.html_post_processors();
@@ -333,7 +333,7 @@ pub fn create_html_processor(config: HtmlProcessorConfig) -> impl StreamProcesso
                             if injected_bids.swap(true, Ordering::SeqCst) {
                                 return Ok(());
                             }
-                            let script_guard = state.read().expect("should read bid state");
+                            let script_guard = state.lock().expect("should lock bid state");
                             let bids_script = match &*script_guard {
                                 Some(s) => s.clone(),
                                 None => r#"<script>window.__ts_bids=JSON.parse("{}");if(typeof window.__tsAdInit==="function")window.__tsAdInit();</script>"#
@@ -624,7 +624,7 @@ mod tests {
             request_scheme: "https".to_string(),
             integrations: IntegrationRegistry::default(),
             ad_slots_script: None,
-            ad_bids_state: std::sync::Arc::new(std::sync::RwLock::new(None)),
+            ad_bids_state: std::sync::Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -1281,7 +1281,7 @@ mod tests {
             ad_slots_script: Some(
                 r#"<script>window.__ts_ad_slots=JSON.parse("[]");</script>"#.to_string(),
             ),
-            ad_bids_state: std::sync::Arc::new(std::sync::RwLock::new(None)),
+            ad_bids_state: std::sync::Arc::new(std::sync::Mutex::new(None)),
         };
         let mut processor = create_html_processor(config);
         let output = processor
@@ -1305,7 +1305,7 @@ mod tests {
     fn injects_ts_bids_before_body_close() {
         let bids_script =
             r#"<script>window.__ts_bids=JSON.parse("{\"atf\":{\"hb_pb\":\"1.00\"}}");</script>"#;
-        let state = std::sync::Arc::new(std::sync::RwLock::new(Some(bids_script.to_string())));
+        let state = std::sync::Arc::new(std::sync::Mutex::new(Some(bids_script.to_string())));
         let config = HtmlProcessorConfig {
             origin_host: "origin.example.com".to_string(),
             request_host: "example.com".to_string(),
@@ -1334,7 +1334,7 @@ mod tests {
     fn injects_ts_bids_only_once_with_multiple_body_elements() {
         let bids_script =
             r#"<script>window.__ts_bids=JSON.parse("{\"atf\":{\"hb_pb\":\"1.00\"}}");</script>"#;
-        let state = std::sync::Arc::new(std::sync::RwLock::new(Some(bids_script.to_string())));
+        let state = std::sync::Arc::new(std::sync::Mutex::new(Some(bids_script.to_string())));
         let config = HtmlProcessorConfig {
             origin_host: "origin.example.com".to_string(),
             request_host: "example.com".to_string(),
@@ -1360,7 +1360,7 @@ mod tests {
     fn injects_empty_ts_bids_when_slots_matched_but_auction_returned_nothing() {
         // Slots matched (ad_slots_script is Some) but auction task never wrote a result
         // (state is None) — e.g. auction timed out with zero bids. Fallback to {}.
-        let state = std::sync::Arc::new(std::sync::RwLock::new(None));
+        let state = std::sync::Arc::new(std::sync::Mutex::new(None));
         let config = HtmlProcessorConfig {
             origin_host: "origin.example.com".to_string(),
             request_host: "example.com".to_string(),
@@ -1385,7 +1385,7 @@ mod tests {
         // No slots matched this URL — ad_slots_script is None. __ts_bids must be
         // omitted entirely so the publisher's existing client-side GPT flow is
         // unmodified (spec §8: "Existing client-side Prebid/GPT flow runs unmodified").
-        let state = std::sync::Arc::new(std::sync::RwLock::new(None));
+        let state = std::sync::Arc::new(std::sync::Mutex::new(None));
         let config = HtmlProcessorConfig {
             origin_host: "origin.example.com".to_string(),
             request_host: "example.com".to_string(),

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -167,6 +167,24 @@ impl HtmlProcessorConfig {
             ad_bids_state: std::sync::Arc::new(std::sync::RwLock::new(None)),
         }
     }
+
+    /// Attach the streaming-auction `<script>` payloads to a config built via
+    /// [`HtmlProcessorConfig::from_settings`].
+    ///
+    /// Callers that drive the auction-hold streaming path use this rather than
+    /// constructing [`HtmlProcessorConfig`] inline so the canonical
+    /// [`from_settings`](Self::from_settings) builder stays the single source of
+    /// truth: future fields added there are inherited automatically.
+    #[must_use]
+    pub fn with_ad_state(
+        mut self,
+        ad_slots_script: Option<String>,
+        ad_bids_state: std::sync::Arc<std::sync::RwLock<Option<String>>>,
+    ) -> Self {
+        self.ad_slots_script = ad_slots_script;
+        self.ad_bids_state = ad_bids_state;
+        self
+    }
 }
 
 /// Create an HTML processor with URL replacement and integration hooks.

--- a/crates/trusted-server-core/src/integrations/aps.rs
+++ b/crates/trusted-server-core/src/integrations/aps.rs
@@ -456,10 +456,16 @@ impl ApsAuctionProvider {
                 aps_response.contextual.slots.len()
             );
 
-            let slot_map = self
-                .slot_id_map
-                .lock()
-                .expect("should lock APS slot id map");
+            // Take the map by value so it does not linger on the provider
+            // across requests if the Fastly Compute runtime ever reuses Wasm
+            // instances. Today each request gets its own instance so this is
+            // belt-and-suspenders; tomorrow it may not be.
+            let slot_map = std::mem::take(
+                &mut *self
+                    .slot_id_map
+                    .lock()
+                    .expect("should lock APS slot id map"),
+            );
             for slot in aps_response.contextual.slots {
                 match self.parse_aps_slot(&slot) {
                     Ok(mut bid) => {

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -455,43 +455,20 @@ impl IntegrationHeadInjector for GptIntegration {
             "<script>window.__tsjs_gpt_enabled=true;\
              window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>"
                 .to_string(),
-            concat!(
-                "<script>",
-                "window.__tsAdInit=function(){",
-                  "var slots=window.__ts_ad_slots||[];",
-                  "var bids=window.__ts_bids||{};",
-                  "var divToSlotId={};",
-                  "googletag.cmd.push(function(){",
-                    "slots.map(function(slot){",
-                      "var s=googletag.defineSlot(slot.gam_unit_path,slot.formats,slot.div_id);",
-                      "if(!s)return;",
-                      "s.addService(googletag.pubads());",
-                      "Object.entries(slot.targeting||{}).forEach(function(e){s.setTargeting(e[0],e[1]);});",
-                      "var b=bids[slot.id]||{};",
-                      "[\"hb_pb\",\"hb_bidder\",\"hb_adid\"].forEach(function(k){if(b[k])s.setTargeting(k,b[k]);});",
-                      "s.setTargeting(\"ts_initial\",\"1\");",
-                      "divToSlotId[slot.div_id]=slot.id;",
-                    "});",
-                    "googletag.pubads().enableSingleRequest();",
-                    "googletag.enableServices();",
-                    "googletag.pubads().addEventListener(\"slotRenderEnded\",function(ev){",
-                      "var divId=ev.slot.getSlotElementId();",
-                      "var slotId=divToSlotId[divId]||divId;",
-                      "var b=bids[slotId]||{};",
-                      "var ourBidWon=!ev.isEmpty&&b.hb_adid&&ev.slot.getTargeting(\"hb_adid\")[0]===b.hb_adid;",
-                      "if(ourBidWon){",
-                        "if(b.nurl)navigator.sendBeacon(b.nurl);",
-                        "if(b.burl)navigator.sendBeacon(b.burl);",
-                      "}",
-                    "});",
-                    "googletag.pubads().refresh();",
-                  "});",
-                "};",
-                "</script>"
-            ).to_string(),
+            format!("<script>{}</script>", GPT_BOOTSTRAP_JS),
         ]
     }
 }
+
+/// Inline `window.__tsAdInit` bootstrap injected at `<head>` so the bids
+/// script at `</body>` can call it before the TSJS bundle has loaded.
+///
+/// The bundle's idempotent implementation in
+/// `crates/js/lib/src/integrations/gpt/index.ts` later overwrites this stub.
+/// Both implementations guard the one-time-per-page setup with
+/// `window.__tsServicesEnabled` so neither double-enables services if the
+/// publisher's own init code also calls `googletag.enableServices()`.
+const GPT_BOOTSTRAP_JS: &str = include_str!("gpt_bootstrap.js");
 
 // Default value functions
 
@@ -1117,6 +1094,32 @@ mod tests {
         assert!(
             !combined.contains("__ts_request_id"),
             "must NOT reference request_id — no longer used"
+        );
+    }
+
+    #[test]
+    fn head_inserts_bootstrap_guards_enable_services_with_idempotency_flag() {
+        let config = test_config();
+        let integration = GptIntegration::new(config);
+        let doc_state = IntegrationDocumentState::default();
+        let ctx = IntegrationHtmlContext {
+            request_host: "edge.example.com",
+            request_scheme: "https",
+            origin_host: "example.com",
+            document_state: &doc_state,
+        };
+        let combined = integration.head_inserts(&ctx).join("");
+        assert!(
+            combined.contains("__tsServicesEnabled"),
+            "should guard enableServices/enableSingleRequest with the __tsServicesEnabled flag"
+        );
+        assert!(
+            combined.contains("window.__tsAdInit"),
+            "should install __tsAdInit on window"
+        );
+        assert!(
+            !combined.contains("googletag.pubads().refresh()"),
+            "should never call unbounded refresh() — only refresh(newSlots)"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
+++ b/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
@@ -1,0 +1,78 @@
+// Edge-injected GPT auction bootstrap.
+//
+// This is the minimal `window.__tsAdInit` that runs on first page load
+// before the TSJS bundle has had a chance to install its richer
+// idempotent implementation. The bundle in
+// crates/js/lib/src/integrations/gpt/index.ts overwrites `__tsAdInit`
+// once it loads.
+//
+// Contract with the bundle:
+//   - Both implementations must set `window.__tsServicesEnabled = true`
+//     after calling `enableSingleRequest()`/`enableServices()` so a
+//     subsequent call from any source (the bundle's `__tsAdInit`, the
+//     publisher's own GPT init code) becomes a no-op.
+//   - `refresh()` is called only for the slots defined in this pass,
+//     never the global slot list, so we never accidentally refresh
+//     publisher-managed slots that we don't own.
+//
+// Only installed if `window.__tsAdInit` isn't already defined — that
+// way the bundle (or anything else) can preempt this fallback by
+// installing first.
+(function () {
+  if (typeof window === "undefined" || window.__tsAdInit) {
+    return;
+  }
+  window.__tsAdInit = function () {
+    var slots = window.__ts_ad_slots || [];
+    var bids = window.__ts_bids || {};
+    var divToSlotId = {};
+    googletag.cmd.push(function () {
+      var newSlots = [];
+      slots.forEach(function (slot) {
+        var s = googletag.defineSlot(
+          slot.gam_unit_path,
+          slot.formats,
+          slot.div_id,
+        );
+        if (!s) return;
+        s.addService(googletag.pubads());
+        Object.entries(slot.targeting || {}).forEach(function (e) {
+          s.setTargeting(e[0], e[1]);
+        });
+        var b = bids[slot.id] || {};
+        ["hb_pb", "hb_bidder", "hb_adid"].forEach(function (k) {
+          if (b[k]) s.setTargeting(k, b[k]);
+        });
+        s.setTargeting("ts_initial", "1");
+        divToSlotId[slot.div_id] = slot.id;
+        newSlots.push(s);
+      });
+      // Guard the one-time-per-page setup so a follow-up call (e.g.
+      // publisher's own init code or the bundle's `__tsAdInit` after
+      // it overwrites this stub) doesn't double-enable services.
+      if (!window.__tsServicesEnabled) {
+        googletag.pubads().enableSingleRequest();
+        googletag.enableServices();
+        window.__tsServicesEnabled = true;
+        googletag
+          .pubads()
+          .addEventListener("slotRenderEnded", function (ev) {
+            var divId = ev.slot.getSlotElementId();
+            var slotId = divToSlotId[divId] || divId;
+            var b = (window.__ts_bids || {})[slotId] || {};
+            var ourBidWon =
+              !ev.isEmpty &&
+              b.hb_adid &&
+              ev.slot.getTargeting("hb_adid")[0] === b.hb_adid;
+            if (ourBidWon) {
+              if (b.nurl) navigator.sendBeacon(b.nurl);
+              if (b.burl) navigator.sendBeacon(b.burl);
+            }
+          });
+      }
+      if (newSlots.length > 0) {
+        googletag.pubads().refresh(newSlots);
+      }
+    });
+  };
+})();

--- a/crates/trusted-server-core/src/integrations/prebid.rs
+++ b/crates/trusted-server-core/src/integrations/prebid.rs
@@ -164,10 +164,6 @@ pub struct PrebidIntegrationConfig {
     /// - `both` — consent in both cookies and body (default)
     #[serde(default)]
     pub consent_forwarding: ConsentForwardingMode,
-    /// When true, suppresses client-side nurl firing.
-    /// Use for PBS deployments that fire nurl internally.
-    #[serde(default)]
-    pub suppress_nurl: bool,
 }
 
 impl IntegrationConfig for PrebidIntegrationConfig {
@@ -1661,14 +1657,7 @@ mod tests {
             bid_param_overrides: HashMap::default(),
             bid_param_override_rules: Vec::new(),
             consent_forwarding: ConsentForwardingMode::Both,
-            suppress_nurl: false,
         }
-    }
-
-    #[test]
-    fn prebid_config_suppress_nurl_defaults_to_false() {
-        let config = base_config();
-        assert!(!config.suppress_nurl, "should not suppress nurl by default");
     }
 
     fn create_test_auction_request() -> AuctionRequest {

--- a/crates/trusted-server-core/src/price_bucket.rs
+++ b/crates/trusted-server-core/src/price_bucket.rs
@@ -20,7 +20,10 @@ impl PriceGranularity {
 
 #[must_use]
 pub fn price_bucket(cpm: f64, granularity: PriceGranularity) -> String {
-    if cpm <= 0.0 {
+    // Reject NaN / Inf early so the `(x * 100.0).floor() as u64` cast below
+    // can never see a non-finite value (the cast's behaviour for NaN/Inf is
+    // implementation-defined in Rust and "saturate to 0" only by convention).
+    if !cpm.is_finite() || cpm <= 0.0 {
         return "0.00".to_string();
     }
     match granularity {
@@ -124,5 +127,32 @@ mod tests {
             price_bucket(2.53, PriceGranularity::Auto),
             price_bucket(2.53, PriceGranularity::Dense)
         );
+    }
+
+    #[test]
+    fn non_finite_cpm_returns_zero_bucket() {
+        for granularity in [
+            PriceGranularity::Dense,
+            PriceGranularity::Low,
+            PriceGranularity::Medium,
+            PriceGranularity::High,
+            PriceGranularity::Auto,
+        ] {
+            assert_eq!(
+                price_bucket(f64::NAN, granularity),
+                "0.00",
+                "NaN cpm should bucket to 0.00 for granularity {granularity:?}"
+            );
+            assert_eq!(
+                price_bucket(f64::INFINITY, granularity),
+                "0.00",
+                "+Inf cpm should bucket to 0.00 for granularity {granularity:?}"
+            );
+            assert_eq!(
+                price_bucket(f64::NEG_INFINITY, granularity),
+                "0.00",
+                "-Inf cpm should bucket to 0.00 for granularity {granularity:?}"
+            );
+        }
     }
 }

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -262,26 +262,32 @@ fn process_response_streaming<W: Write>(
     Ok(())
 }
 
-/// Create a unified HTML stream processor
+/// Create a unified HTML stream processor.
+///
+/// Builds the config via [`HtmlProcessorConfig::from_settings`] and then
+/// layers the auction-hold streaming fields on top via
+/// [`HtmlProcessorConfig::with_ad_state`], so the canonical builder stays the
+/// single source of truth: a future field added to `from_settings` is
+/// inherited here automatically.
 fn create_html_stream_processor(
     origin_host: &str,
     request_host: &str,
     request_scheme: &str,
-    _settings: &Settings,
+    settings: &Settings,
     integration_registry: &IntegrationRegistry,
     ad_slots_script: Option<String>,
     ad_bids_state: Arc<RwLock<Option<String>>>,
 ) -> Result<impl StreamProcessor, Report<TrustedServerError>> {
     use crate::html_processor::{create_html_processor, HtmlProcessorConfig};
 
-    let config = HtmlProcessorConfig {
-        origin_host: origin_host.to_string(),
-        request_host: request_host.to_string(),
-        request_scheme: request_scheme.to_string(),
-        integrations: integration_registry.clone(),
-        ad_slots_script,
-        ad_bids_state,
-    };
+    let config = HtmlProcessorConfig::from_settings(
+        settings,
+        integration_registry,
+        origin_host,
+        request_host,
+        request_scheme,
+    )
+    .with_ad_state(ad_slots_script, ad_bids_state);
 
     Ok(create_html_processor(config))
 }
@@ -576,6 +582,40 @@ pub(crate) fn write_bids_to_state(
     *ad_bids_state.write().expect("should write bid state") = Some(bids_script);
 }
 
+/// Prepend an HTML comment summarising the auction result onto the shared
+/// `ad_bids_state` so it lands directly before the injected bids `<script>`.
+///
+/// `path_label` differentiates the streaming-with-auction-hold path (`stream`)
+/// from the buffered path (`buffered`) in the resulting `<!-- ts-debug: -->`
+/// marker so on-page debugging can tell which code path produced the bids.
+pub(crate) fn prepend_auction_debug_comment(
+    path_label: &str,
+    result: &crate::auction::orchestrator::OrchestrationResult,
+    ad_bids_state: &Arc<RwLock<Option<String>>>,
+) {
+    let ssp_count = result.provider_responses.len();
+    let mediator_info = match &result.mediator_response {
+        Some(r) => format!("ok({}_bids)", r.bids.len()),
+        None => "none".to_string(),
+    };
+    let debug_comment = format!(
+        "<!-- ts-debug: path={path_label} ssp={ssp_count} mediator={mediator_info} winning={} time={}ms -->",
+        result.winning_bids.len(),
+        result.total_time_ms,
+    );
+    let mut state = ad_bids_state
+        .write()
+        .expect("should write bid state for debug");
+    match &mut *state {
+        Some(script) => {
+            *script = format!("{debug_comment}\n{script}");
+        }
+        None => {
+            *state = Some(debug_comment);
+        }
+    }
+}
+
 /// Bundles the auction-collection dependencies passed through the streaming helpers.
 struct AuctionCollectCtx<'a> {
     dispatched: DispatchedAuction,
@@ -678,27 +718,7 @@ async fn one_behind_loop<R: std::io::Read, W: Write, P: StreamProcessor>(
                 write_bids_to_state(&result.winning_bids, price_granularity, ad_bids_state);
 
                 if settings.debug.auction_html_comment {
-                    let ssp_count = result.provider_responses.len();
-                    let mediator_info = match &result.mediator_response {
-                        Some(r) => format!("ok({}_bids)", r.bids.len()),
-                        None => "none".to_string(),
-                    };
-                    let debug_comment = format!(
-                        "<!-- ts-debug: path=stream ssp={ssp_count} mediator={mediator_info} winning={} time={}ms -->",
-                        result.winning_bids.len(),
-                        result.total_time_ms,
-                    );
-                    let mut state = ad_bids_state
-                        .write()
-                        .expect("should write bid state for debug");
-                    match &mut *state {
-                        Some(script) => {
-                            *script = format!("{debug_comment}\n{script}");
-                        }
-                        None => {
-                            *state = Some(debug_comment);
-                        }
-                    }
+                    prepend_auction_debug_comment("stream", &result, ad_bids_state);
                 }
 
                 // Process the held last chunk (not is_last — finalization is separate).
@@ -935,13 +955,16 @@ pub async fn handle_publisher_request(
             .creative_opportunities
             .as_ref()
             .expect("should be present when should_run_auction is true");
+        let slots_ctx = MatchedSlotsContext {
+            matched_slots: &matched_slots,
+            request_path: &request_path,
+            co_config,
+        };
         let mut auction_request = build_auction_request(
-            &matched_slots,
+            &slots_ctx,
             &ec_id,
             &consent_context,
             &request_info,
-            &request_path,
-            co_config,
             req.get_header_str("user-agent"),
         );
         auction_request.user.eids = parse_ts_eids_cookie(cookie_jar.as_ref());
@@ -1133,27 +1156,7 @@ pub async fn handle_publisher_request(
                 write_bids_to_state(&result.winning_bids, price_granularity, &ad_bids_state);
 
                 if settings.debug.auction_html_comment {
-                    let ssp_count = result.provider_responses.len();
-                    let mediator_info = match &result.mediator_response {
-                        Some(r) => format!("ok({}_bids)", r.bids.len()),
-                        None => "none".to_string(),
-                    };
-                    let debug_comment = format!(
-                        "<!-- ts-debug: path=buffered ssp={ssp_count} mediator={mediator_info} winning={} time={}ms -->",
-                        result.winning_bids.len(),
-                        result.total_time_ms,
-                    );
-                    let mut state = ad_bids_state
-                        .write()
-                        .expect("should write bid state for debug");
-                    match &mut *state {
-                        Some(script) => {
-                            *script = format!("{debug_comment}\n{script}");
-                        }
-                        None => {
-                            *state = Some(debug_comment);
-                        }
-                    }
+                    prepend_auction_debug_comment("buffered", &result, &ad_bids_state);
                 }
             }
 
@@ -1181,23 +1184,33 @@ pub async fn handle_publisher_request(
     }
 }
 
+/// Bundle of the per-request creative-opportunity inputs that travel together.
+///
+/// Extracted so `build_auction_request` stays under the project's
+/// 7-argument cap (`matched_slots` + `request_path` + `co_config` all live
+/// for the same request scope and are passed together everywhere).
+pub(crate) struct MatchedSlotsContext<'a> {
+    pub matched_slots: &'a [crate::creative_opportunities::CreativeOpportunitySlot],
+    pub request_path: &'a str,
+    pub co_config: &'a crate::creative_opportunities::CreativeOpportunitiesConfig,
+}
+
 /// Build an [`AuctionRequest`] from matched creative opportunity slots.
 pub(crate) fn build_auction_request(
-    matched_slots: &[crate::creative_opportunities::CreativeOpportunitySlot],
+    slots_ctx: &MatchedSlotsContext<'_>,
     ec_id: &str,
     consent_context: &crate::consent::ConsentContext,
     request_info: &crate::http_util::RequestInfo,
-    request_path: &str,
-    co_config: &crate::creative_opportunities::CreativeOpportunitiesConfig,
     user_agent: Option<&str>,
 ) -> AuctionRequest {
-    let slots = matched_slots
+    let slots = slots_ctx
+        .matched_slots
         .iter()
-        .map(|s| s.to_ad_slot(&co_config.gam_network_id))
+        .map(|s| s.to_ad_slot(&slots_ctx.co_config.gam_network_id))
         .collect();
     let page_url = format!(
         "{}://{}{}",
-        request_info.scheme, request_info.host, request_path
+        request_info.scheme, request_info.host, slots_ctx.request_path
     );
     AuctionRequest {
         id: format!("ts-{}", ec_id),
@@ -1498,13 +1511,16 @@ pub async fn handle_page_bids(
         && !is_bot
         && !is_prefetch
     {
+        let slots_ctx = MatchedSlotsContext {
+            matched_slots: &matched_slots,
+            request_path: &path_param,
+            co_config,
+        };
         let mut auction_request = build_auction_request(
-            &matched_slots,
+            &slots_ctx,
             &ec_id,
             &consent_context,
             &request_info,
-            &path_param,
-            co_config,
             req.get_header_str("user-agent"),
         );
         auction_request.user.eids = parse_ts_eids_cookie(cookie_jar.as_ref());

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -575,6 +575,32 @@ fn make_collect_context<'a>(
     }
 }
 
+/// Well-known crawler User-Agent fragments. Best-effort: an attacker can
+/// trivially spoof their UA, so this is for opt-out signalling to honest
+/// crawlers (preventing SSP auctions burning partner quota on their behalf),
+/// not security.
+pub(crate) const BOT_USER_AGENT_FRAGMENTS: &[&str] =
+    &["Googlebot", "Bingbot", "AhrefsBot", "SemrushBot", "DotBot"];
+
+/// Returns true when the request's User-Agent matches any well-known crawler
+/// fragment in [`BOT_USER_AGENT_FRAGMENTS`].
+pub(crate) fn is_bot_user_agent(req: &Request) -> bool {
+    let ua = req.get_header_str("user-agent").unwrap_or("");
+    BOT_USER_AGENT_FRAGMENTS
+        .iter()
+        .any(|frag| ua.contains(frag))
+}
+
+/// Returns true when the request advertises itself as a prefetch via either
+/// the standard `Sec-Purpose` or the legacy `Purpose` header.
+pub(crate) fn is_prefetch_request(req: &Request) -> bool {
+    req.get_header_str("sec-purpose")
+        .is_some_and(|v| v.contains("prefetch"))
+        || req
+            .get_header_str("purpose")
+            .is_some_and(|v| v.contains("prefetch"))
+}
+
 /// Write winning bids from an auction result into the shared `ad_bids_state` lock.
 pub(crate) fn write_bids_to_state(
     winning_bids: &std::collections::HashMap<String, Bid>,
@@ -902,17 +928,8 @@ pub async fn handle_publisher_request(
     let request_path = req.get_path().to_string();
     let is_get = req.get_method() == fastly::http::Method::GET;
 
-    let is_prefetch = req
-        .get_header_str("sec-purpose")
-        .is_some_and(|v| v.contains("prefetch"))
-        || req
-            .get_header_str("purpose")
-            .is_some_and(|v| v.contains("prefetch"));
-
-    let user_agent = req.get_header_str("user-agent").unwrap_or("");
-    let is_bot = ["Googlebot", "Bingbot", "AhrefsBot", "SemrushBot", "DotBot"]
-        .iter()
-        .any(|bot| user_agent.contains(bot));
+    let is_prefetch = is_prefetch_request(&req);
+    let is_bot = is_bot_user_agent(&req);
 
     let matched_slots: Vec<_> = if settings.creative_opportunities.is_some() && is_get {
         crate::creative_opportunities::match_slots(&slots_file.slots, &request_path)
@@ -960,14 +977,9 @@ pub async fn handle_publisher_request(
     // dispatch_auction returns — DispatchedAuction holds no lifetime — so req
     // can be mutated and sent to origin immediately after.
     let dispatched_auction = if should_run_auction {
-        let co_config = settings
-            .creative_opportunities
-            .as_ref()
-            .expect("should be present when should_run_auction is true");
         let slots_ctx = MatchedSlotsContext {
             matched_slots: &matched_slots,
             request_path: &request_path,
-            co_config,
         };
         let mut auction_request = build_auction_request(
             &slots_ctx,
@@ -1197,12 +1209,11 @@ pub async fn handle_publisher_request(
 /// Bundle of the per-request creative-opportunity inputs that travel together.
 ///
 /// Extracted so `build_auction_request` stays under the project's
-/// 7-argument cap (`matched_slots` + `request_path` + `co_config` all live
-/// for the same request scope and are passed together everywhere).
+/// 7-argument cap (`matched_slots` + `request_path` live for the same
+/// request scope and are passed together everywhere).
 pub(crate) struct MatchedSlotsContext<'a> {
     pub matched_slots: &'a [crate::creative_opportunities::CreativeOpportunitySlot],
     pub request_path: &'a str,
-    pub co_config: &'a crate::creative_opportunities::CreativeOpportunitiesConfig,
 }
 
 /// Build an [`AuctionRequest`] from matched creative opportunity slots.
@@ -1216,7 +1227,7 @@ pub(crate) fn build_auction_request(
     let slots = slots_ctx
         .matched_slots
         .iter()
-        .map(|s| s.to_ad_slot(&slots_ctx.co_config.gam_network_id))
+        .map(crate::creative_opportunities::CreativeOpportunitySlot::to_ad_slot)
         .collect();
     let page_url = format!(
         "{}://{}{}",
@@ -1491,16 +1502,8 @@ pub async fn handle_page_bids(
     // Same bot / prefetch guards the publisher path uses — without them this
     // endpoint would fire real SSP auctions on Sec-Purpose=prefetch warm-up
     // navigations and known crawler UA scans, burning partner request quota.
-    let is_prefetch = req
-        .get_header_str("sec-purpose")
-        .is_some_and(|v| v.contains("prefetch"))
-        || req
-            .get_header_str("purpose")
-            .is_some_and(|v| v.contains("prefetch"));
-    let user_agent = req.get_header_str("user-agent").unwrap_or("");
-    let is_bot = ["Googlebot", "Bingbot", "AhrefsBot", "SemrushBot", "DotBot"]
-        .iter()
-        .any(|bot| user_agent.contains(bot));
+    let is_prefetch = is_prefetch_request(&req);
+    let is_bot = is_bot_user_agent(&req);
 
     if matched_slots.is_empty() {
         log::debug!(
@@ -1521,7 +1524,6 @@ pub async fn handle_page_bids(
             let slots_ctx = MatchedSlotsContext {
                 matched_slots: &matched_slots,
                 request_path: &path_param,
-                co_config,
             };
             let mut auction_request = build_auction_request(
                 &slots_ctx,
@@ -2557,6 +2559,7 @@ mod tests {
                     .into_iter()
                     .collect(),
                 providers: Default::default(),
+                compiled_patterns: Vec::new(),
             }
         }
 
@@ -2775,6 +2778,7 @@ mod tests {
                     floor_price: Some(0.50),
                     targeting: Default::default(),
                     providers: Default::default(),
+                    compiled_patterns: Vec::new(),
                 }],
             }
         }

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -499,7 +499,7 @@ pub async fn stream_publisher_body_async<W: Write>(
     if !is_html {
         // Non-HTML: collect auction first, then stream.  There is no </body>
         // to hold, so delaying the entire body until collection is acceptable.
-        let placeholder = Request::get("https://placeholder.invalid/");
+        let placeholder = Request::get(crate::auction::types::MEDIATOR_PLACEHOLDER_URL);
         let result = orchestrator
             .collect_dispatched_auction(
                 dispatched,
@@ -546,16 +546,25 @@ pub async fn stream_publisher_body_async<W: Write>(
     .await
 }
 
-/// Build a minimal [`AuctionContext`] for the mediator call in collection.
+/// Build a minimal [`AuctionContext`] for the collect phase.
 ///
-/// The `request` field is a short-lived placeholder (providers use it only for
-/// header extraction; the placeholder is functionally equivalent to the original
-/// since `req` was already consumed by `send_async` before dispatch).
+/// See [`AuctionContext::request`]: the orchestrator's collect path runs
+/// after `send_async` has already consumed the real client request, so this
+/// context carries a synthetic placeholder. The orchestrator itself
+/// instantiates a fresh placeholder when it actually invokes a mediator —
+/// this argument is plumbing for the (presently unused) case where the
+/// orchestrator needs the caller's request shape.
 fn make_collect_context<'a>(
     settings: &'a Settings,
     services: &'a RuntimeServices,
     placeholder: &'a Request,
 ) -> AuctionContext<'a> {
+    debug_assert_eq!(
+        placeholder.get_url_str(),
+        crate::auction::types::MEDIATOR_PLACEHOLDER_URL,
+        "make_collect_context must be given the canonical placeholder; \
+         callers must not forward a real client request through the collect path"
+    );
     AuctionContext {
         settings,
         request: placeholder,
@@ -706,7 +715,7 @@ async fn one_behind_loop<R: std::io::Read, W: Write, P: StreamProcessor>(
                 // Collect the auction before feeding it to lol_html so that
                 // the </body> handler sees populated ad_bids_state.
                 log::info!("one_behind_loop: EOF — collecting dispatched auction");
-                let placeholder = Request::get("https://placeholder.invalid/");
+                let placeholder = Request::get(crate::auction::types::MEDIATOR_PLACEHOLDER_URL);
                 let collect_ctx = make_collect_context(settings, services, &placeholder);
                 let result = orchestrator
                     .collect_dispatched_auction(dispatched, services, &collect_ctx)
@@ -1141,7 +1150,7 @@ pub async fn handle_publisher_request(
             // Unlike the Stream path, the body is fully buffered first — collect auction
             // now so bids are available when the </body> handler fires.
             if let Some(dispatched) = dispatched_auction {
-                let placeholder = fastly::Request::get("https://placeholder.invalid/");
+                let placeholder = fastly::Request::get(crate::auction::types::MEDIATOR_PLACEHOLDER_URL);
                 let result = orchestrator
                     .collect_dispatched_auction(
                         dispatched,

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -1150,7 +1150,8 @@ pub async fn handle_publisher_request(
             // Unlike the Stream path, the body is fully buffered first — collect auction
             // now so bids are available when the </body> handler fires.
             if let Some(dispatched) = dispatched_auction {
-                let placeholder = fastly::Request::get(crate::auction::types::MEDIATOR_PLACEHOLDER_URL);
+                let placeholder =
+                    fastly::Request::get(crate::auction::types::MEDIATOR_PLACEHOLDER_URL);
                 let result = orchestrator
                     .collect_dispatched_auction(
                         dispatched,
@@ -1515,48 +1516,45 @@ pub async fn handle_page_bids(
         );
     }
 
-    let winning_bids = if !matched_slots.is_empty()
-        && consent_allows_auction
-        && !is_bot
-        && !is_prefetch
-    {
-        let slots_ctx = MatchedSlotsContext {
-            matched_slots: &matched_slots,
-            request_path: &path_param,
-            co_config,
-        };
-        let mut auction_request = build_auction_request(
-            &slots_ctx,
-            &ec_id,
-            &consent_context,
-            &request_info,
-            req.get_header_str("user-agent"),
-        );
-        auction_request.user.eids = parse_ts_eids_cookie(cookie_jar.as_ref());
-        let timeout_ms = co_config
-            .auction_timeout_ms
-            .unwrap_or(settings.auction.timeout_ms);
-        let auction_context = AuctionContext {
-            settings,
-            request: &req,
-            client_info: services.client_info(),
-            timeout_ms,
-            provider_responses: None,
-            services,
-        };
-        match orchestrator
-            .run_auction(&auction_request, &auction_context, services)
-            .await
-        {
-            Ok(result) => result.winning_bids,
-            Err(e) => {
-                log::warn!("page-bids auction failed: {e:?}");
-                std::collections::HashMap::new()
+    let winning_bids =
+        if !matched_slots.is_empty() && consent_allows_auction && !is_bot && !is_prefetch {
+            let slots_ctx = MatchedSlotsContext {
+                matched_slots: &matched_slots,
+                request_path: &path_param,
+                co_config,
+            };
+            let mut auction_request = build_auction_request(
+                &slots_ctx,
+                &ec_id,
+                &consent_context,
+                &request_info,
+                req.get_header_str("user-agent"),
+            );
+            auction_request.user.eids = parse_ts_eids_cookie(cookie_jar.as_ref());
+            let timeout_ms = co_config
+                .auction_timeout_ms
+                .unwrap_or(settings.auction.timeout_ms);
+            let auction_context = AuctionContext {
+                settings,
+                request: &req,
+                client_info: services.client_info(),
+                timeout_ms,
+                provider_responses: None,
+                services,
+            };
+            match orchestrator
+                .run_auction(&auction_request, &auction_context, services)
+                .await
+            {
+                Ok(result) => result.winning_bids,
+                Err(e) => {
+                    log::warn!("page-bids auction failed: {e:?}");
+                    std::collections::HashMap::new()
+                }
             }
-        }
-    } else {
-        std::collections::HashMap::new()
-    };
+        } else {
+            std::collections::HashMap::new()
+        };
 
     let bid_map = build_bid_map(&winning_bids, co_config.price_granularity);
 

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -566,7 +566,7 @@ pub(crate) fn write_bids_to_state(
     price_granularity: PriceGranularity,
     ad_bids_state: &Arc<RwLock<Option<String>>>,
 ) {
-    log::info!(
+    log::debug!(
         "write_bids_to_state: {} winning bid(s): [{}]",
         winning_bids.len(),
         winning_bids.keys().cloned().collect::<Vec<_>>().join(", ")
@@ -1288,7 +1288,8 @@ pub(crate) fn build_bid_map(
 /// The JSON is embedded via `JSON.parse(…)` so the browser parser never sees
 /// raw `</script>` sequences inside the string.
 pub(crate) fn build_bids_script(bid_map: &serde_json::Map<String, serde_json::Value>) -> String {
-    let json = serde_json::to_string(bid_map).unwrap_or_else(|_| "{}".to_string());
+    let json = serde_json::to_string(bid_map)
+        .expect("serde_json::to_string of Map<String,Value> should be infallible");
     let escaped = html_escape_for_script(&json);
     format!(
         "<script>window.__ts_bids=JSON.parse(\"{}\");if(typeof window.__tsAdInit===\"function\")window.__tsAdInit();</script>",
@@ -1328,7 +1329,8 @@ pub(crate) fn build_ad_slots_script(
             })
         })
         .collect();
-    let json = serde_json::to_string(&slots).unwrap_or_else(|_| "[]".to_string());
+    let json = serde_json::to_string(&slots)
+        .expect("serde_json::to_string of Vec<Value> should be infallible");
     let escaped = html_escape_for_script(&json);
     format!(
         "<script>window.__ts_ad_slots=JSON.parse(\"{}\");</script>",

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -1465,14 +1465,39 @@ pub async fn handle_page_bids(
             .as_ref()
             .is_some_and(|tcf| tcf.has_purpose_consent(1));
 
+    // Same bot / prefetch guards the publisher path uses — without them this
+    // endpoint would fire real SSP auctions on Sec-Purpose=prefetch warm-up
+    // navigations and known crawler UA scans, burning partner request quota.
+    let is_prefetch = req
+        .get_header_str("sec-purpose")
+        .is_some_and(|v| v.contains("prefetch"))
+        || req
+            .get_header_str("purpose")
+            .is_some_and(|v| v.contains("prefetch"));
+    let user_agent = req.get_header_str("user-agent").unwrap_or("");
+    let is_bot = ["Googlebot", "Bingbot", "AhrefsBot", "SemrushBot", "DotBot"]
+        .iter()
+        .any(|bot| user_agent.contains(bot));
+
     if matched_slots.is_empty() {
         log::debug!(
             "No creative opportunity slots matched path '{}' — skipping auction",
             path_param
         );
+    } else if is_bot || is_prefetch {
+        log::debug!(
+            "page-bids: skipping auction for path '{}' (is_bot={}, is_prefetch={})",
+            path_param,
+            is_bot,
+            is_prefetch
+        );
     }
 
-    let winning_bids = if !matched_slots.is_empty() && consent_allows_auction {
+    let winning_bids = if !matched_slots.is_empty()
+        && consent_allows_auction
+        && !is_bot
+        && !is_prefetch
+    {
         let mut auction_request = build_auction_request(
             &matched_slots,
             &ec_id,
@@ -2770,6 +2795,79 @@ mod tests {
                     .len(),
                 0,
                 "empty slots file should produce zero bids"
+            );
+        }
+
+        #[tokio::test]
+        async fn bot_user_agent_returns_slots_but_no_bids() {
+            // Crawlers should get slot definitions (so HTML structure is unchanged)
+            // but the server must not burn SSP request quota running a real auction
+            // for them. Same gate the publisher path applies.
+            let settings = settings_with_co();
+            let orchestrator = AuctionOrchestrator::new(settings.auction.clone());
+            let services = noop_services();
+            let slots_file = file_with_article_slot();
+            let mut req = make_page_bids_request("/2024/01/my-article/");
+            req.set_header("user-agent", "Mozilla/5.0 (compatible; Googlebot/2.1)");
+
+            let response = handle_page_bids(&settings, &orchestrator, &services, &slots_file, req)
+                .await
+                .expect("should return ok response");
+
+            let body: serde_json::Value =
+                serde_json::from_slice(&response.into_body_bytes()).expect("should be json");
+
+            assert_eq!(
+                body["slots"]
+                    .as_array()
+                    .expect("slots should be array")
+                    .len(),
+                1,
+                "bot request should still get slot definitions"
+            );
+            assert_eq!(
+                body["bids"]
+                    .as_object()
+                    .expect("bids should be object")
+                    .len(),
+                0,
+                "bot request must not run an auction (no SSP cost burned for crawlers)"
+            );
+        }
+
+        #[tokio::test]
+        async fn prefetch_request_returns_slots_but_no_bids() {
+            // Navigations triggered by Sec-Purpose=prefetch should not fire real
+            // SSP auctions — the user has not yet visited the page.
+            let settings = settings_with_co();
+            let orchestrator = AuctionOrchestrator::new(settings.auction.clone());
+            let services = noop_services();
+            let slots_file = file_with_article_slot();
+            let mut req = make_page_bids_request("/2024/01/my-article/");
+            req.set_header("sec-purpose", "prefetch");
+
+            let response = handle_page_bids(&settings, &orchestrator, &services, &slots_file, req)
+                .await
+                .expect("should return ok response");
+
+            let body: serde_json::Value =
+                serde_json::from_slice(&response.into_body_bytes()).expect("should be json");
+
+            assert_eq!(
+                body["slots"]
+                    .as_array()
+                    .expect("slots should be array")
+                    .len(),
+                1,
+                "prefetch request should still get slot definitions"
+            );
+            assert_eq!(
+                body["bids"]
+                    .as_object()
+                    .expect("bids should be object")
+                    .len(),
+                0,
+                "prefetch request must not run an auction"
             );
         }
 

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -12,7 +12,7 @@
 //! content-rewriting concern.
 
 use std::io::Write;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 
 use error_stack::{Report, ResultExt};
 use fastly::http::{header, StatusCode};
@@ -38,6 +38,11 @@ use crate::settings::Settings;
 use crate::streaming_processor::{Compression, PipelineConfig, StreamProcessor, StreamingPipeline};
 use crate::streaming_replacer::create_url_replacer;
 const SUPPORTED_ENCODING_VALUES: [&str; 3] = ["gzip", "deflate", "br"];
+
+/// Read buffer size for streaming body processing and brotli internal buffers.
+/// Both the `Decompressor` and `CompressorWriter` use this value so all
+/// brotli I/O layers operate on consistently-sized chunks.
+const STREAM_CHUNK_SIZE: usize = 8192;
 
 fn restrict_accept_encoding(req: &mut Request) {
     // If the client sent no Accept-Encoding, leave the request unchanged so the
@@ -194,7 +199,7 @@ struct ProcessResponseParams<'a> {
     content_type: &'a str,
     integration_registry: &'a IntegrationRegistry,
     ad_slots_script: Option<&'a str>,
-    ad_bids_state: &'a Arc<RwLock<Option<String>>>,
+    ad_bids_state: &'a Arc<Mutex<Option<String>>>,
 }
 
 /// Process response body through the streaming pipeline.
@@ -276,7 +281,7 @@ fn create_html_stream_processor(
     settings: &Settings,
     integration_registry: &IntegrationRegistry,
     ad_slots_script: Option<String>,
-    ad_bids_state: Arc<RwLock<Option<String>>>,
+    ad_bids_state: Arc<Mutex<Option<String>>>,
 ) -> Result<impl StreamProcessor, Report<TrustedServerError>> {
     use crate::html_processor::{create_html_processor, HtmlProcessorConfig};
 
@@ -418,7 +423,7 @@ pub struct OwnedProcessResponseParams {
     pub(crate) request_scheme: String,
     pub(crate) content_type: String,
     pub(crate) ad_slots_script: Option<String>,
-    pub(crate) ad_bids_state: Arc<RwLock<Option<String>>>,
+    pub(crate) ad_bids_state: Arc<Mutex<Option<String>>>,
     /// In-flight SSP bids dispatched before `pending_origin.wait()`.
     /// The streaming phase collects these and writes bids to `ad_bids_state`
     /// before processing the last body chunk, so `</body>` injection sees live bids.
@@ -605,7 +610,7 @@ pub(crate) fn is_prefetch_request(req: &Request) -> bool {
 pub(crate) fn write_bids_to_state(
     winning_bids: &std::collections::HashMap<String, Bid>,
     price_granularity: PriceGranularity,
-    ad_bids_state: &Arc<RwLock<Option<String>>>,
+    ad_bids_state: &Arc<Mutex<Option<String>>>,
 ) {
     log::debug!(
         "write_bids_to_state: {} winning bid(s): [{}]",
@@ -614,7 +619,7 @@ pub(crate) fn write_bids_to_state(
     );
     let bid_map = build_bid_map(winning_bids, price_granularity);
     let bids_script = build_bids_script(&bid_map);
-    *ad_bids_state.write().expect("should write bid state") = Some(bids_script);
+    *ad_bids_state.lock().expect("should lock bid state") = Some(bids_script);
 }
 
 /// Prepend an HTML comment summarising the auction result onto the shared
@@ -626,7 +631,7 @@ pub(crate) fn write_bids_to_state(
 pub(crate) fn prepend_auction_debug_comment(
     path_label: &str,
     result: &crate::auction::orchestrator::OrchestrationResult,
-    ad_bids_state: &Arc<RwLock<Option<String>>>,
+    ad_bids_state: &Arc<Mutex<Option<String>>>,
 ) {
     let ssp_count = result.provider_responses.len();
     let mediator_info = match &result.mediator_response {
@@ -639,8 +644,8 @@ pub(crate) fn prepend_auction_debug_comment(
         result.total_time_ms,
     );
     let mut state = ad_bids_state
-        .write()
-        .expect("should write bid state for debug");
+        .lock()
+        .expect("should lock bid state for debug");
     match &mut *state {
         Some(script) => {
             *script = format!("{debug_comment}\n{script}");
@@ -655,7 +660,7 @@ pub(crate) fn prepend_auction_debug_comment(
 struct AuctionCollectCtx<'a> {
     dispatched: DispatchedAuction,
     price_granularity: PriceGranularity,
-    ad_bids_state: &'a Arc<RwLock<Option<String>>>,
+    ad_bids_state: &'a Arc<Mutex<Option<String>>>,
     orchestrator: &'a AuctionOrchestrator,
     services: &'a RuntimeServices,
     settings: &'a Settings,
@@ -697,13 +702,14 @@ async fn stream_html_with_auction_hold<W: Write, P: StreamProcessor>(
             Ok(())
         }
         Compression::Brotli => {
-            let decoder = Decompressor::new(body, 4096);
+            let decoder = Decompressor::new(body, STREAM_CHUNK_SIZE);
             let params = BrotliEncoderParams {
                 quality: 4,
                 lgwin: 22,
                 ..Default::default()
             };
-            let mut encoder = CompressorWriter::with_params(&mut *output, 4096, &params);
+            let mut encoder =
+                CompressorWriter::with_params(&mut *output, STREAM_CHUNK_SIZE, &params);
             one_behind_loop(decoder, &mut encoder, processor, ctx).await?;
             let _ = encoder.into_inner();
             Ok(())
@@ -730,8 +736,7 @@ async fn one_behind_loop<R: std::io::Read, W: Write, P: StreamProcessor>(
         services,
         settings,
     } = ctx;
-    const CHUNK_SIZE: usize = 8192;
-    let mut buffer = vec![0u8; CHUNK_SIZE];
+    let mut buffer = vec![0u8; STREAM_CHUNK_SIZE];
     let mut pending: Vec<u8> = Vec::new();
 
     loop {
@@ -964,7 +969,7 @@ pub async fn handle_publisher_request(
         .and_then(|co| co.auction_timeout_ms)
         .unwrap_or(settings.auction.timeout_ms);
 
-    let ad_bids_state: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
+    let ad_bids_state: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
 
     let price_granularity = settings
         .creative_opportunities
@@ -1281,13 +1286,20 @@ pub(crate) fn build_auction_request(
 /// All substitutions use `\uXXXX` form, which is valid inside both JSON strings
 /// and JS string literals. The result is always safe to write as `JSON.parse("…")`.
 fn html_escape_for_script(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('<', "\\u003C")
-        .replace('>', "\\u003E")
-        .replace('&', "\\u0026")
-        .replace('\u{2028}', "\\u2028")
-        .replace('\u{2029}', "\\u2029")
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '<' => out.push_str("\\u003C"),
+            '>' => out.push_str("\\u003E"),
+            '&' => out.push_str("\\u0026"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            _ => out.push(ch),
+        }
+    }
+    out
 }
 
 /// Build a price-bucketed bid map from winning bids.
@@ -2275,7 +2287,7 @@ mod tests {
             request_scheme: "https".to_string(),
             content_type: "text/css".to_string(),
             ad_slots_script: None,
-            ad_bids_state: Arc::new(RwLock::new(None)),
+            ad_bids_state: Arc::new(Mutex::new(None)),
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
         };
@@ -2320,7 +2332,7 @@ mod tests {
             request_scheme: "https".to_string(),
             content_type: "text/html; charset=utf-8".to_string(),
             ad_slots_script: None,
-            ad_bids_state: Arc::new(RwLock::new(None)),
+            ad_bids_state: Arc::new(Mutex::new(None)),
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
         };
@@ -2356,7 +2368,7 @@ mod tests {
             request_scheme: "https".to_string(),
             content_type: "text/html".to_string(),
             ad_slots_script: None,
-            ad_bids_state: Arc::new(RwLock::new(None)),
+            ad_bids_state: Arc::new(Mutex::new(None)),
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
         };
@@ -2459,7 +2471,7 @@ mod tests {
             request_scheme: "https".to_string(),
             content_type: "text/html; charset=utf-8".to_string(),
             ad_slots_script: None,
-            ad_bids_state: Arc::new(RwLock::new(None)),
+            ad_bids_state: Arc::new(Mutex::new(None)),
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
         };
@@ -2513,7 +2525,7 @@ mod tests {
             request_scheme: "https".to_string(),
             content_type: "text/html".to_string(),
             ad_slots_script: None,
-            ad_bids_state: Arc::new(RwLock::new(None)),
+            ad_bids_state: Arc::new(Mutex::new(None)),
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
         };


### PR DESCRIPTION
## Summary

Implements the actionable findings from passes 1 and 2 of the review of #680 ("Implement server-side ad slot templates with PBS and APS auction") so the branch is closer to a clean merge candidate. Stacked on top of #680 — merge into that branch to absorb the fixes. Based on the current head `e45f458f`.

> **Iteration log:** pass 1 produced 14 fix commits. Pass 2 re-verified those 14 all FIXED and surfaced 4 fresh items (1 🔧 parity bug + 3 ♻️ refactors). Pass 3 implemented all 4. Local CI gates are green at every step.

## Findings addressed

### 🔧 Blocking

- **P2-1 — AuctionContext request contract pinned.** `collect_dispatched_auction` and the publisher-side collectors quietly built a fresh `fastly::Request::get("https://placeholder.invalid/")` per request and stuffed it into `AuctionContext.request` before invoking the mediator. Works today only because the current mediator doesn't read headers — a future PBS-as-mediator change would silently lose DNT, client IP, UA. Added a thorough doc-comment distinguishing dispatch (real request) from collect (synthetic) on [`AuctionContext::request`](crates/trusted-server-core/src/auction/types.rs), centralised the URL as `MEDIATOR_PLACEHOLDER_URL`, and added a `debug_assert!` in `make_collect_context` so callers that accidentally route a real request through the collect path fail loudly in debug builds. Full snapshot-headers refactor tracked as follow-up.
- **P2-2 — `__tsAdInit` no longer double-enables GPT services.** The inline bootstrap injected at `<head>` called `googletag.pubads().enableSingleRequest()` and `googletag.enableServices()` unconditionally; the publisher's own GPT init code (or the TS bundle's later-installed version) would re-enable, producing duplicate ad requests. Now both inline and bundle converge on `__tsServicesEnabled` and only call `refresh(newSlots)` — never the unbounded `refresh()`.
- **P2-3 / P2-16 — HTML stream processor goes through `from_settings`.** `create_html_stream_processor` built `HtmlProcessorConfig` inline, bypassing `HtmlProcessorConfig::from_settings` — any future field added there would silently miss the auction-hold streaming path. Added an `HtmlProcessorConfig::with_ad_state(...)` builder and routed through `from_settings` so the canonical builder stays the single source of truth. The previously-unused `_settings` argument is now actually used.
- **P2-4 — `/__ts/page-bids` bot / prefetch gate.** Same `is_bot` and `is_prefetch` short-circuits the publisher path applies. Slots are still returned (HTML structure unchanged) but the auction is skipped, so a crawler or `Sec-Purpose=prefetch` warm-up can't burn partner SSP request quota. New tests cover both gates.
- **P2-5 / P2-13 — adapter parses `creative-opportunities.toml` once and falls back instead of panicking.** The previous per-request `toml::from_str(...).expect("should parse...")` would have panicked every request on a malformed embedded TOML (binary patch, future schema change). Now a `LazyLock` parses once per Wasm instance; on failure it logs the error and falls back to the documented "empty slots file = feature disabled" state.
- **P2-6 — APS provider `.take()` hardening.** `ApsAuctionProvider::slot_id_map` wasn't cleared after `parse_response`, leaving stale state attached to the long-lived `Arc<dyn AuctionProvider>` if Fastly Compute ever reused a Wasm instance across requests. `std::mem::take` clears the lock now (mirroring what the mock provider already did with `bid_index`).
- **P2-7 — `winning_bids.len()` no longer overcounts.** `apply_floor_prices` used to pass `price=None` bids through; the no-mediator caller already filtered them via `select_winning_bids`, so the pass-through was dead code that would, if revived, cause `winning_bids.len()` to overcount what `build_bid_map` actually ships. Dropped the `None` branch; the existing test was updated to pin the new contract (callers must decode prices first).

### ♻️ / 🌱 / ⛏ / 🏕 Non-blocking

- **P2-14 — `MatchedSlotsContext`.** Bundled `(matched_slots, request_path, co_config)` into a struct so `build_auction_request` drops below the project's 7-argument cap and leaves headroom for future inputs.
- **P2-15 — Drop dead `PrebidIntegrationConfig::suppress_nurl`.** Field was declared, defaulted, and never read.
- **P2-17 — Extract `prepend_auction_debug_comment`.** Pulled the duplicated debug-comment-prepend logic out of `one_behind_loop` and the `BufferedProcessed` arm into a single helper.
- **P2-18 — `price_bucket` rejects non-finite cpm.** `(x * 100.0).floor() as u64` had implementation-defined behaviour for `NaN`/`Inf`. Now returns `"0.00"` early; new test pins the contract for every granularity.
- **P2-24 — Lowered noisy `log::info!` to `log::debug!`** for `write_bids_to_state` (per-request slot list).
- **P2-25 — Replaced infallible `unwrap_or_else` on `serde_json::to_string(Map/Vec)`** with `expect("…should be infallible")` so a future bug doesn't get silently swallowed.
- **P2-26 — Extracted `__tsAdInit` bootstrap to [`gpt_bootstrap.js`](crates/trusted-server-core/src/integrations/gpt_bootstrap.js)** pulled in via `include_str!`, so edits diff cleanly and get JS syntax highlighting in editors.

### Pass-3 findings addressed

- 🔧 **P3-1 — `/auction` endpoint now forwards the `ts-eids` cookie.** `convert_tsjs_to_auction_request` hard-coded `eids: None`; `handle_auction` parsed cookies for consent but never threaded them through. Programmatic callers (slim-Prebid, native apps) now get parity with the publisher and `/__ts/page-bids` paths via `parse_ts_eids_cookie(cookie_jar.as_ref())` mutating `auction_request.user.eids`.
- ♻️ **Dedupe bot/prefetch helpers.** `handle_publisher_request` and `handle_page_bids` both inlined a 5-entry crawler UA list and the Sec-Purpose/Purpose header check. Promoted to `pub(crate) const BOT_USER_AGENT_FRAGMENTS` plus `is_bot_user_agent(req)` / `is_prefetch_request(req)` helpers so the two paths can't drift.
- ♻️ **Drop the dead `gam_network_id` argument** on `CreativeOpportunitySlot::to_ad_slot`. Was already being thrown away via `let _ = gam_network_id;`. Removing it also drops the now-unused `co_config` field from `MatchedSlotsContext`.
- ♻️ **Pre-compile slot glob patterns once per Wasm instance.** Each call to `matches_path` previously ran `Pattern::new` per pattern per slot per request. Added a `#[serde(skip)] compiled_patterns: Vec<Pattern>` cache populated by `CreativeOpportunitiesFile::compile()` at file-load time. Fallback compile-per-call is preserved for hand-built slots in tests. Two regression tests pin the cache.

## Findings deferred

- **P2-8 — Brotli `Decompressor::new(body, 4096)` buffer-size question.** Pure perf / not correctness. Comment-only.
- **P2-9 — `RwLock` vs `Mutex` for `ad_bids_state`.** Comment-only.
- **P2-10 — `html_escape_for_script` 7 sequential `String::replace` allocations.** Pure perf observation.
- **P2-11 — `is_bot` substring scan is best-effort.** Comment-only.
- **P2-12 — `DispatchedAuction` clones `AuctionRequest` even without mediator.** Minor allocation; pure perf observation.

## Findings left for the author

The pass-1 review on #680 also flagged a few items that are non-mechanical:

- **Backward-compat break:** PBS `bidders.insert(b, json!({}))` empty-params fallback was replaced with `ImpStoredRequest`. Any external caller of `/auction` who was relying on the old "send empty params to every configured bidder" behaviour is silently broken. Verify intended.
- **Implicit Wasm-isolation assumption** is now load-bearing in two places (mediator placeholder, provider Mutex). A central note in CLAUDE.md describing the concurrency model would give future changes a contract to break against.
- **Config bifurcation** between `trusted-server.toml` and `creative-opportunities.toml` (both `include_str!`'d, no hot-reload). Worth a follow-up issue.
- **No integration test for `one_behind_loop`.** Chunk-holding logic is only exercised via the higher-level rewriter tests.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (1010 core + 21 openrtb + 20 adapter-fastly + 3 doc, 0 failed after pass 3)
- [x] `cd crates/js/lib && npx vitest run` (297 passed)
- [x] Pass-2 verification (read every changed file against pass-1 commit messages); pass-3 verification of P3-1 + the 3 refactors.

