### PR TITLE
Replace placeholder hosts in user-facing docs with RFC 2606 .example TLDs

### DIFF
--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -172,8 +172,8 @@ Click tracking redirect endpoint.
 **Example:**
 
 ```bash
-curl -I "https://edge.example.com/first-party/click?tsurl=https://advertiser.com/landing&campaign=123&tstoken=xyz..."
-# → 302 Location: https://advertiser.com/landing?campaign=123&ts-ec=abc123
+curl -I "https://edge.example.com/first-party/click?tsurl=https://advertiser.example/landing&campaign=123&tstoken=xyz..."
+# → 302 Location: https://advertiser.example/landing?campaign=123&ts-ec=abc123
 ```
 
 ---
@@ -187,7 +187,7 @@ URL signing endpoint. Returns signed first-party proxy URL for a given target UR
 **GET Request:**
 
 ```bash
-curl "https://edge.example.com/first-party/sign?url=https://external.com/pixel.gif"
+curl "https://edge.example.com/first-party/sign?url=https://external.example/pixel.gif"
 ```
 
 **POST Request:**
@@ -195,14 +195,14 @@ curl "https://edge.example.com/first-party/sign?url=https://external.com/pixel.g
 ```bash
 curl -X POST https://edge.example.com/first-party/sign \
   -H "Content-Type: application/json" \
-  -d '{"url":"https://external.com/pixel.gif"}'
+  -d '{"url":"https://external.example/pixel.gif"}'
 ```
 
 **Response:**
 
 ```json
 {
-  "signed_url": "https://edge.example.com/first-party/proxy?tsurl=https://external.com/pixel.gif&tstoken=abc123..."
+  "signed_url": "https://edge.example.com/first-party/proxy?tsurl=https://external.example/pixel.gif&tstoken=abc123..."
 }
 ```
 
@@ -222,7 +222,7 @@ URL mutation recovery endpoint. Rebuilds signed proxy URL after creative JavaScr
 
 ```json
 {
-  "tsclick": "https://edge.example.com/first-party/click?tsurl=https://advertiser.com&campaign=123&tstoken=original...",
+  "tsclick": "https://edge.example.com/first-party/click?tsurl=https://advertiser.example&campaign=123&tstoken=original...",
   "add": {
     "utm_source": "banner"
   },
@@ -234,7 +234,7 @@ URL mutation recovery endpoint. Rebuilds signed proxy URL after creative JavaScr
 
 ```json
 {
-  "url": "https://edge.example.com/first-party/click?tsurl=https://advertiser.com&campaign=123&utm_source=banner&tstoken=new..."
+  "url": "https://edge.example.com/first-party/click?tsurl=https://advertiser.example&campaign=123&utm_source=banner&tstoken=new..."
 }
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -20,7 +20,7 @@ Create `trusted-server.toml` in your project root:
 [publisher]
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
-origin_url = "https://origin.publisher.com"
+origin_url = "https://origin.publisher.example"
 proxy_secret = "your-secure-secret-here"
 
 [edge_cookie]
@@ -36,7 +36,7 @@ at runtime.
 ```bash
 # Format: TRUSTED_SERVER__SECTION__FIELD
 export TRUSTED_SERVER__PUBLISHER__DOMAIN=publisher.com
-export TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.com
+export TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.example
 export TRUSTED_SERVER__EDGE_COOKIE__SECRET_KEY=your-secret
 ```
 
@@ -72,7 +72,7 @@ openssl rand -base64 32
 [publisher]
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
-origin_url = "https://origin.publisher.com"
+origin_url = "https://origin.publisher.example"
 proxy_secret = "change-me-to-secure-value"
 
 [edge_cookie]
@@ -85,7 +85,7 @@ secret_store_id = "01GYYY"
 
 [integrations.prebid]
 enabled = true
-server_url = "https://prebid-server.com/openrtb2/auction"
+server_url = "https://prebid-server.example/openrtb2/auction"
 timeout_ms = 1200
 bidders = ["kargo", "appnexus", "openx"]
 client_side_bidders = ["rubicon"]
@@ -166,7 +166,7 @@ Core publisher settings for domain, origin, and proxy configuration.
 [publisher]
 domain = "publisher.com"
 cookie_domain = ".publisher.com"  # Includes subdomains
-origin_url = "https://origin.publisher.com"
+origin_url = "https://origin.publisher.example"
 proxy_secret = "change-me-to-secure-random-value"
 ```
 
@@ -175,7 +175,7 @@ proxy_secret = "change-me-to-secure-random-value"
 ```bash
 TRUSTED_SERVER__PUBLISHER__DOMAIN=publisher.com
 TRUSTED_SERVER__PUBLISHER__COOKIE_DOMAIN=.publisher.com
-TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.com
+TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.example
 TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
 ```
 
@@ -194,7 +194,7 @@ TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
 
 - ✅ `publisher.com`
 - ✅ `www.publisher.com`
-- ❌ `https://publisher.com`
+- ❌ `https://publisher.example`
 - ❌ `publisher.com/path`
 
 #### `cookie_domain`
@@ -225,10 +225,10 @@ TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
 
 **Format**: Full URL with protocol
 
-- ✅ `https://origin.publisher.com`
-- ✅ `https://origin.publisher.com:8080`
+- ✅ `https://origin.publisher.example`
+- ✅ `https://origin.publisher.example:8080`
 - ✅ `http://192.168.1.1:9000`
-- ❌ `origin.publisher.com` (missing protocol)
+- ❌ `origin.publisher.example` (missing protocol)
 
 **Port Handling**: Includes port if non-standard (not 80/443).
 
@@ -564,7 +564,7 @@ Matches:
 - ✅ `assets.cdn.example.com`
 - ✅ `images.cdn.example.com`
 - ✅ `cdn.example.com` (base domain)
-- ❌ `cdn.example.com.evil.com` (different domain)
+- ❌ `cdn.example.com.evil.example` (different domain)
 
 **Exact Patterns** (no `*`):
 
@@ -576,14 +576,14 @@ Matches:
 
 - ✅ `api.example.com`
 - ❌ `www.api.example.com`
-- ❌ `api.example.com.evil.com`
+- ❌ `api.example.com.evil.example`
 
 ### Use Cases
 
 **Trusted Partners**:
 
 ```toml
-exclude_domains = ["*.approved-cdn.com"]
+exclude_domains = ["*.approved-cdn.example"]
 ```
 
 **First-Party Resources**:
@@ -621,7 +621,7 @@ Controls first-party proxy security settings.
 ```toml
 [proxy]
 allowed_domains = [
-  "tracker.com",         # Exact match
+  "tracker.example",         # Exact match
   "*.adserver.com",      # Wildcard: adserver.com and all subdomains
   "*.trusted-cdn.net",
 ]
@@ -631,14 +631,14 @@ allowed_domains = [
 
 ```bash
 # JSON array
-TRUSTED_SERVER__PROXY__ALLOWED_DOMAINS='["tracker.com","*.adserver.com"]'
+TRUSTED_SERVER__PROXY__ALLOWED_DOMAINS='["tracker.example","*.adserver.com"]'
 
 # Indexed
-TRUSTED_SERVER__PROXY__ALLOWED_DOMAINS__0="tracker.com"
+TRUSTED_SERVER__PROXY__ALLOWED_DOMAINS__0="tracker.example"
 TRUSTED_SERVER__PROXY__ALLOWED_DOMAINS__1="*.adserver.com"
 
 # Comma-separated
-TRUSTED_SERVER__PROXY__ALLOWED_DOMAINS="tracker.com,*.adserver.com"
+TRUSTED_SERVER__PROXY__ALLOWED_DOMAINS="tracker.example,*.adserver.com"
 ```
 
 ### Field Details
@@ -653,10 +653,10 @@ TRUSTED_SERVER__PROXY__ALLOWED_DOMAINS="tracker.com,*.adserver.com"
 
 **Pattern Matching**:
 
-| Pattern         | Matches                                             | Does not match     |
-| --------------- | --------------------------------------------------- | ------------------ |
-| `tracker.com`   | `tracker.com`                                       | `sub.tracker.com`  |
-| `*.tracker.com` | `tracker.com`, `sub.tracker.com`, `a.b.tracker.com` | `evil-tracker.com` |
+| Pattern             | Matches                                                         | Does not match         |
+| ------------------- | --------------------------------------------------------------- | ---------------------- |
+| `tracker.example`   | `tracker.example`                                               | `sub.tracker.example`  |
+| `*.tracker.example` | `tracker.example`, `sub.tracker.example`, `a.b.tracker.example` | `evil-tracker.example` |
 
 - `"example.com"` — exact match only.
 - `"*.example.com"` — matches the base domain and any subdomain at any depth.
@@ -961,7 +961,7 @@ proxy_secret = "dev-secret"
 
 ```bash
 # .env.staging
-TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://staging.publisher.com
+TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://staging.publisher.example
 TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=$(cat /run/secrets/proxy_secret_staging)
 ```
 

--- a/docs/guide/creative-processing.md
+++ b/docs/guide/creative-processing.md
@@ -17,9 +17,9 @@ Creative processing transforms third-party ad creatives by rewriting URLs to go 
 ```
 ┌──────────────────────────────────────────────────────┐
 │  Original Creative HTML                              │
-│  <img src="https://tracker.com/pixel.gif">          │
-│  <iframe src="https://cdn.com/ad.html">             │
-│  <style> .bg { background: url(cdn.com/bg.jpg); }   │
+│  <img src="https://tracker.example/pixel.gif">          │
+│  <iframe src="https://cdn.example/ad.html">             │
+│  <style> .bg { background: url(cdn.example/bg.jpg); }   │
 └──────────────────────────────────────────────────────┘
                         ↓
 ┌──────────────────────────────────────────────────────┐
@@ -166,11 +166,11 @@ When `with_streaming()` is enabled in `ProxyRequestConfig`, HTML/CSS processing 
 
 ```html
 <!-- Original -->
-<iframe src="https://advertiser.com/creative.html"></iframe>
+<iframe src="https://advertiser.example/creative.html"></iframe>
 
 <!-- Rewritten -->
 <iframe
-  src="/first-party/proxy?tsurl=https://advertiser.com/creative.html&tstoken=sig"
+  src="/first-party/proxy?tsurl=https://advertiser.example/creative.html&tstoken=sig"
 ></iframe>
 ```
 
@@ -226,11 +226,11 @@ If the iframe content itself contains HTML, it will be processed recursively. Ea
 
 ```html
 <!-- Original -->
-<a href="https://advertiser.com/product?id=123">Buy Now</a>
+<a href="https://advertiser.example/product?id=123">Buy Now</a>
 
 <!-- Rewritten -->
 <a
-  href="/first-party/click?tsurl=https://advertiser.com/product&id=123&tstoken=sig"
+  href="/first-party/click?tsurl=https://advertiser.example/product&id=123&tstoken=sig"
   >Buy Now</a
 >
 ```
@@ -435,18 +435,18 @@ Descriptors are preserved exactly as written:
 <!-- Original -->
 <img
   srcset="
-    https://cdn.com/small.jpg   480w,
-    https://cdn.com/medium.jpg  800w,
-    https://cdn.com/large.jpg  1200w
+    https://cdn.example/small.jpg   480w,
+    https://cdn.example/medium.jpg  800w,
+    https://cdn.example/large.jpg  1200w
   "
 />
 
 <!-- Rewritten -->
 <img
   srcset="
-    /first-party/proxy?tsurl=https://cdn.com/small.jpg&tstoken=sig1   480w,
-    /first-party/proxy?tsurl=https://cdn.com/medium.jpg&tstoken=sig2  800w,
-    /first-party/proxy?tsurl=https://cdn.com/large.jpg&tstoken=sig3  1200w
+    /first-party/proxy?tsurl=https://cdn.example/small.jpg&tstoken=sig1   480w,
+    /first-party/proxy?tsurl=https://cdn.example/medium.jpg&tstoken=sig2  800w,
+    /first-party/proxy?tsurl=https://cdn.example/large.jpg&tstoken=sig3  1200w
   "
 />
 ```
@@ -457,13 +457,13 @@ Srcset can mix absolute and relative URLs:
 
 ```html
 <!-- Original -->
-<img srcset="/local/small.jpg 1x, https://cdn.com/large.jpg 2x" />
+<img srcset="/local/small.jpg 1x, https://cdn.example/large.jpg 2x" />
 
 <!-- Rewritten (only absolute URL) -->
 <img
   srcset="
-    /local/small.jpg                                               1x,
-    /first-party/proxy?tsurl=https://cdn.com/large.jpg&tstoken=sig 2x
+    /local/small.jpg                                                   1x,
+    /first-party/proxy?tsurl=https://cdn.example/large.jpg&tstoken=sig 2x
   "
 />
 ```
@@ -496,23 +496,23 @@ Common properties with `url()` values:
 
 ```css
 /* Background images */
-background: url(https://cdn.com/bg.jpg);
-background-image: url(https://cdn.com/pattern.png);
+background: url(https://cdn.example/bg.jpg);
+background-image: url(https://cdn.example/pattern.png);
 
 /* Borders */
-border-image: url(https://cdn.com/border.svg);
+border-image: url(https://cdn.example/border.svg);
 
 /* List styles */
-list-style-image: url(https://cdn.com/bullet.png);
+list-style-image: url(https://cdn.example/bullet.png);
 
 /* Cursors */
-cursor: url(https://cdn.com/cursor.cur), pointer;
+cursor: url(https://cdn.example/cursor.cur), pointer;
 
 /* Masks */
-mask-image: url(https://cdn.com/mask.svg);
+mask-image: url(https://cdn.example/mask.svg);
 
 /* Filters */
-filter: url(https://cdn.com/filter.svg#blur);
+filter: url(https://cdn.example/filter.svg#blur);
 ```
 
 **All `url()` occurrences are rewritten** regardless of property.
@@ -525,15 +525,16 @@ Properties can have multiple `url()` values:
 /* Original */
 .element {
   background:
-    url(https://cdn.com/top.png) top,
-    url(https://cdn.com/bottom.png) bottom;
+    url(https://cdn.example/top.png) top,
+    url(https://cdn.example/bottom.png) bottom;
 }
 
 /* Rewritten */
 .element {
   background:
-    url(/first-party/proxy?tsurl=https://cdn.com/top.png&tstoken=sig1) top,
-    url(/first-party/proxy?tsurl=https://cdn.com/bottom.png&tstoken=sig2) bottom;
+    url(/first-party/proxy?tsurl=https://cdn.example/top.png&tstoken=sig1) top,
+    url(/first-party/proxy?tsurl=https://cdn.example/bottom.png&tstoken=sig2)
+      bottom;
 }
 ```
 
@@ -574,7 +575,7 @@ Matches:
   ✅ assets.cdn.example.com
   ✅ images.cdn.example.com
   ❌ cdn.example.com (no subdomain)
-  ❌ cdn.example.com.evil.com (different domain)
+  ❌ cdn.example.com.evil.example (different domain)
 ```
 
 **Exact Patterns**: No `*` requires exact host match
@@ -584,7 +585,7 @@ Pattern: api.example.com
 Matches:
   ✅ api.example.com
   ❌ www.api.example.com
-  ❌ api.example.com.evil.com
+  ❌ api.example.com.evil.example
 ```
 
 ### Use Cases
@@ -592,7 +593,7 @@ Matches:
 **Trusted Partners**:
 
 ```toml
-exclude_domains = ["*.trusted-cdn.com"]
+exclude_domains = ["*.trusted-cdn.example"]
 ```
 
 Skip rewriting for partners already providing first-party scripts.
@@ -834,7 +835,7 @@ log::debug!("creative: skipped non-network scheme {}", url);
 3. Compare output
 
 ```rust
-let original = "<img src=\"https://tracker.com/pixel.gif\">";
+let original = "<img src=\"https://tracker.example/pixel.gif\">";
 let rewritten = rewrite_creative_html(&settings, original);
 assert!(rewritten.contains("/first-party/proxy"));
 ```

--- a/docs/guide/error-reference.md
+++ b/docs/guide/error-reference.md
@@ -60,7 +60,7 @@ Missing required field: publisher.domain
 ```toml
 [publisher]
 domain = "your-publisher-domain.com"
-origin_url = "https://origin.your-publisher-domain.com"
+origin_url = "https://origin.your-publisher-domain.example"
 proxy_secret = "change-me-to-random-string"
 ```
 
@@ -203,7 +203,7 @@ Invalid tstoken signature
 
 ```bash
 # Test URL signing
-curl "https://edge.example.com/first-party/sign?url=https://external.com/pixel.gif"
+curl "https://edge.example.com/first-party/sign?url=https://external.example/pixel.gif"
 ```
 
 ---

--- a/docs/guide/first-party-proxy.md
+++ b/docs/guide/first-party-proxy.md
@@ -16,9 +16,9 @@ The First-Party Proxy system rewrites third-party URLs in ad creatives to route 
 
 ```mermaid
 flowchart TD
-  original["`Creative (Original) &lt;img src='tracker.com/pixel.gif' /&gt;`"]
-  rewritten["Creative (Rewritten)<br/>&lt;img src='/first-party/proxy?<br/>tsurl=https://tracker.com/<br/>pixel.gif&amp;tstoken=abc123...' /&gt;"]
-  server["Trusted Server<br/>1. Validate tstoken<br/>2. Append ts-ec<br/>3. Proxy to tracker.com<br/>4. Return response"]
+  original["`Creative (Original) &lt;img src='tracker.example/pixel.gif' /&gt;`"]
+  rewritten["Creative (Rewritten)<br/>&lt;img src='/first-party/proxy?<br/>tsurl=https://tracker.example/<br/>pixel.gif&amp;tstoken=abc123...' /&gt;"]
+  server["Trusted Server<br/>1. Validate tstoken<br/>2. Append ts-ec<br/>3. Proxy to tracker.example<br/>4. Return response"]
 
   original -->|Rewrite| rewritten -->|Browser Request| server
 ```
@@ -65,14 +65,14 @@ GET /first-party/proxy?tsurl=https://example.com/ad.html&tstoken=signature
 Original URL:
 
 ```
-https://tracker.com/pixel.gif?campaign=123&uid=abc
+https://tracker.example/pixel.gif?campaign=123&uid=abc
 ```
 
 Signed proxy URL:
 
 ```
 /first-party/proxy?
-  tsurl=https://tracker.com/pixel.gif&
+  tsurl=https://tracker.example/pixel.gif&
   campaign=123&
   uid=abc&
   tstoken=HmacSha256Signature
@@ -81,7 +81,7 @@ Signed proxy URL:
 Final proxied request:
 
 ```
-https://tracker.com/pixel.gif?campaign=123&uid=abc&ts-ec=xyz
+https://tracker.example/pixel.gif?campaign=123&uid=abc&ts-ec=xyz
 ```
 
 ### `/first-party/click` - Click Redirects
@@ -91,7 +91,7 @@ Handles click tracking with first-party redirects.
 **Request**:
 
 ```
-GET /first-party/click?tsurl=https://advertiser.com/landing&tstoken=signature
+GET /first-party/click?tsurl=https://advertiser.example/landing&tstoken=signature
 ```
 
 **Query Parameters**: Same as `/first-party/proxy`
@@ -115,7 +115,7 @@ Click URL in creative:
 ```html
 <a
   href="/first-party/click?
-  tsurl=https://advertiser.com/buy&
+  tsurl=https://advertiser.example/buy&
   product=widget&
   tstoken=signature"
 >
@@ -127,7 +127,7 @@ User clicks → Server responds:
 
 ```
 HTTP/1.1 302 Found
-Location: https://advertiser.com/buy?product=widget&ts-ec=xyz
+Location: https://advertiser.example/buy?product=widget&ts-ec=xyz
 ```
 
 ::: tip Click vs Proxy
@@ -278,12 +278,12 @@ For the detailed signing algorithm, validation steps, and security notes, see [P
 ```css
 /* Original */
 .banner {
-  background: url(https://cdn.com/bg.jpg);
+  background: url(https://cdn.example/bg.jpg);
 }
 
 /* Rewritten */
 .banner {
-  background: url(/first-party/proxy?tsurl=https://cdn.com/bg.jpg&tstoken=sig);
+  background: url(/first-party/proxy?tsurl=https://cdn.example/bg.jpg&tstoken=sig);
 }
 ```
 
@@ -306,7 +306,7 @@ For the detailed signing algorithm, validation steps, and security notes, see [P
 **Logging**:
 
 ```
-proxy: likely pixel detected size=43 url=https://tracker.com/p.gif
+proxy: likely pixel detected size=43 url=https://tracker.example/p.gif
 ```
 
 ### Passthrough (Other Types)
@@ -343,8 +343,8 @@ The proxy automatically follows HTTP redirects:
 **Example Flow**:
 
 ```
-Request: /first-party/proxy?tsurl=https://short.link&tstoken=sig
-  → 302 to https://cdn.com/ad.html
+Request: /first-party/proxy?tsurl=https://short.example&tstoken=sig
+  → 302 to https://cdn.example/ad.html
   → 200 with HTML content
   → Rewrite HTML and return
 ```
@@ -365,11 +365,11 @@ When proxying, Trusted Server automatically appends the `ts-ec` parameter:
 
 ```
 Original request to proxy:
-  /first-party/proxy?tsurl=https://tracker.com/pixel.gif&tstoken=sig
+  /first-party/proxy?tsurl=https://tracker.example/pixel.gif&tstoken=sig
   Cookie: ts-ec=user123
 
 Proxied backend request:
-  https://tracker.com/pixel.gif?ts-ec=user123
+  https://tracker.example/pixel.gif?ts-ec=user123
 ```
 
 ### Redirect Propagation
@@ -377,12 +377,12 @@ Proxied backend request:
 EC IDs are re-applied on **every redirect hop**:
 
 ```
-/first-party/proxy?tsurl=https://redirect1.com&tstoken=sig
-  → https://redirect1.com?ts-ec=user123
-  → 302 to https://redirect2.com
-  → https://redirect2.com?ts-ec=user123
-  → 302 to https://final.com
-  → https://final.com?ts-ec=user123
+/first-party/proxy?tsurl=https://redirect1.example&tstoken=sig
+  → https://redirect1.example?ts-ec=user123
+  → 302 to https://redirect2.example
+  → https://redirect2.example?ts-ec=user123
+  → 302 to https://final.example
+  → https://final.example?ts-ec=user123
   → 200 response
 ```
 
@@ -393,14 +393,14 @@ This ensures downstream trackers receive consistent IDs even through redirect ch
 Click redirects also forward EC IDs:
 
 ```html
-<a href="/first-party/click?tsurl=https://advertiser.com&tstoken=sig"></a>
+<a href="/first-party/click?tsurl=https://advertiser.example&tstoken=sig"></a>
 ```
 
 User clicks → redirect includes ID:
 
 ```
 302 Found
-Location: https://advertiser.com?ts-ec=user123
+Location: https://advertiser.example?ts-ec=user123
 ```
 
 ::: tip Privacy Control
@@ -420,7 +420,7 @@ Configure proxy behavior in `trusted-server.toml`:
 ```toml
 [publisher]
 domain = "publisher.com"
-origin_url = "https://origin.publisher.com"
+origin_url = "https://origin.publisher.example"
 proxy_secret = "your-secure-random-secret"
 cookie_domain = ".publisher.com"  # For ts-ec cookies
 ```
@@ -432,7 +432,7 @@ Restrict which domains the proxy may redirect to via the `[proxy]` section:
 ```toml
 [proxy]
 allowed_domains = [
-  "tracker.com",           # Exact match
+  "tracker.example",           # Exact match
   "*.adserver.com",        # Wildcard: adserver.com and all subdomains
   "*.trusted-cdn.net",
 ]
@@ -442,10 +442,10 @@ allowed_domains = [
 
 **Wildcard matching**:
 
-| Pattern         | Matches                                             | Does not match     |
-| --------------- | --------------------------------------------------- | ------------------ |
-| `tracker.com`   | `tracker.com`                                       | `sub.tracker.com`  |
-| `*.tracker.com` | `tracker.com`, `sub.tracker.com`, `a.b.tracker.com` | `evil-tracker.com` |
+| Pattern             | Matches                                                         | Does not match         |
+| ------------------- | --------------------------------------------------------------- | ---------------------- |
+| `tracker.example`   | `tracker.example`                                               | `sub.tracker.example`  |
+| `*.tracker.example` | `tracker.example`, `sub.tracker.example`, `a.b.tracker.example` | `evil-tracker.example` |
 
 - The `*` prefix matches the base domain and any subdomain at any depth.
 - Matching is case-insensitive; entries are normalized to lowercase on startup.
@@ -640,10 +640,10 @@ Signed URLs prevent injection attacks:
 
 ```
 Attacker tries:
-  /first-party/proxy?tsurl=https://evil.com&tstoken=forged
+  /first-party/proxy?tsurl=https://evil.example&tstoken=forged
 
 Trusted Server:
-  1. Computes expected token for https://evil.com
+  1. Computes expected token for https://evil.example
   2. Compares with provided token
   3. Rejects if mismatch (502 Bad Gateway)
 ```
@@ -670,8 +670,8 @@ Proxy requests emit detailed logs:
 
 ```
 proxy: origin response status=200 ct=text/html cl=1234 accept=text/html url=https://...
-proxy: likely pixel detected size=43 url=https://tracker.com/p.gif
-click: tsurl=https://advertiser.com had_params=true target=... referer=... ua=... tsid=...
+proxy: likely pixel detected size=43 url=https://tracker.example/p.gif
+click: tsurl=https://advertiser.example had_params=true target=... referer=... ua=... tsid=...
 ```
 
 ### Diagnostic Headers

--- a/docs/guide/integrations-overview.md
+++ b/docs/guide/integrations-overview.md
@@ -259,7 +259,7 @@ All integrations can be configured via environment variables:
 # Pattern: TRUSTED_SERVER__INTEGRATIONS__{INTEGRATION}__{SETTING}
 
 # Prebid
-TRUSTED_SERVER__INTEGRATIONS__PREBID__SERVER_URL="https://new-server.com"
+TRUSTED_SERVER__INTEGRATIONS__PREBID__SERVER_URL="https://new-server.example"
 TRUSTED_SERVER__INTEGRATIONS__PREBID__TIMEOUT_MS=2000
 
 # Next.js

--- a/docs/guide/integrations/aps.md
+++ b/docs/guide/integrations/aps.md
@@ -225,7 +225,7 @@ APS returns bids in this format:
       "h": 90,
       "adomain": ["amazon.com"],
       "bidId": "bid-123",
-      "nurl": "https://win-notification.com",
+      "nurl": "https://win-notification.example",
       "targeting": {
         "amzniid": "user-id",
         "amznbid": "2.50"

--- a/docs/guide/integrations/datadome.md
+++ b/docs/guide/integrations/datadome.md
@@ -65,7 +65,7 @@ If `rewrite_sdk` is enabled, Trusted Server will automatically rewrite any exist
 
 <!-- Becomes -->
 <script
-  src="https://your-domain.com/integrations/datadome/tags.js"
+  src="https://your-domain.example/integrations/datadome/tags.js"
   async
 ></script>
 ```
@@ -154,7 +154,7 @@ enabled = true
 Verify that signal collection routes are working:
 
 ```bash
-curl -X POST https://your-domain.com/integrations/datadome/js/check
+curl -X POST https://your-domain.example/integrations/datadome/js/check
 ```
 
 ### HTML Rewriting Not Working

--- a/docs/guide/integrations/didomi.md
+++ b/docs/guide/integrations/didomi.md
@@ -82,7 +82,7 @@ Proxies Didomi SDK resources through first-party domain.
 
 ```
 Original: https://sdk.privacy-center.org/24cd1234/loader.js
-Proxied:  https://your-domain.com/integrations/didomi/consent/24cd1234/loader.js
+Proxied:  https://your-domain.example/integrations/didomi/consent/24cd1234/loader.js
 ```
 
 **Headers Forwarded**:
@@ -119,7 +119,7 @@ Proxies Didomi API requests (consent events, user preferences, etc.).
 
 ```
 Original: https://api.privacy-center.org/v1/events
-Proxied:  https://your-domain.com/integrations/didomi/consent/api/v1/events
+Proxied:  https://your-domain.example/integrations/didomi/consent/api/v1/events
 ```
 
 **Methods**: GET, POST, PUT, DELETE, OPTIONS
@@ -258,8 +258,8 @@ Ensure your Didomi organization ID is in the SDK path:
 Add DNS preconnect for faster loading:
 
 ```html
-<link rel="preconnect" href="https://your-domain.com" />
-<link rel="dns-prefetch" href="https://your-domain.com" />
+<link rel="preconnect" href="https://your-domain.example" />
+<link rel="dns-prefetch" href="https://your-domain.example" />
 ```
 
 ### 3. Cache SDK Responses

--- a/docs/guide/integrations/google_tag_manager.md
+++ b/docs/guide/integrations/google_tag_manager.md
@@ -98,7 +98,7 @@ The proxy intercepts requests for the GTM library and modifies it on-the-fly. Th
 
 Analytics data (events, pageviews) normally sent to `google-analytics.com/collect` are now routed to:
 
-`https://your-server.com/integrations/google_tag_manager/collect`
+`https://your-server.example/integrations/google_tag_manager/collect`
 
 Trusted Server acts as a privacy-enhancing gateway. Client IP addresses are not forwarded to Google — Google sees only the edge server IP, not the actual user IP.
 

--- a/docs/guide/key-rotation.md
+++ b/docs/guide/key-rotation.md
@@ -247,7 +247,7 @@ You should see a JWKS response with your public keys.
 Let Trusted Server generate a date-based key ID:
 
 ```bash
-curl -X POST https://your-domain/admin/keys/rotate \
+curl -X POST https://your-domain.example/admin/keys/rotate \
   -H "Content-Type: application/json" \
   -d '{}'
 ```
@@ -276,7 +276,7 @@ curl -X POST https://your-domain/admin/keys/rotate \
 Specify a custom key identifier:
 
 ```bash
-curl -X POST https://your-domain/admin/keys/rotate \
+curl -X POST https://your-domain.example/admin/keys/rotate \
   -H "Content-Type: application/json" \
   -d '{"kid": "production-2024-q1"}'
 ```
@@ -363,7 +363,7 @@ Deactivate old keys after:
 Remove from active rotation but keep in storage:
 
 ```bash
-curl -X POST https://your-domain/admin/keys/deactivate \
+curl -X POST https://your-domain.example/admin/keys/deactivate \
   -H "Content-Type: application/json" \
   -d '{
     "kid": "ts-2024-01-15",
@@ -388,7 +388,7 @@ curl -X POST https://your-domain/admin/keys/deactivate \
 Remove from storage completely:
 
 ```bash
-curl -X POST https://your-domain/admin/keys/deactivate \
+curl -X POST https://your-domain.example/admin/keys/deactivate \
   -H "Content-Type: application/json" \
   -d '{
     "kid": "ts-2024-01-15",
@@ -476,14 +476,14 @@ Regular rotation on a fixed schedule:
 ```bash
 #!/bin/bash
 # Rotate signing keys
-curl -X POST https://your-domain/admin/keys/rotate
+curl -X POST https://your-domain.example/admin/keys/rotate
 
 # Wait 30 days grace period
 sleep $((30 * 24 * 60 * 60))
 
 # Deactivate old key
 OLD_KEY=$(date -d '90 days ago' +ts-%Y-%m-%d)
-curl -X POST https://your-domain/admin/keys/deactivate \
+curl -X POST https://your-domain.example/admin/keys/deactivate \
   -d "{\"kid\": \"$OLD_KEY\", \"delete\": true}"
 ```
 

--- a/docs/guide/request-signing.md
+++ b/docs/guide/request-signing.md
@@ -172,7 +172,7 @@ Partners can fetch and cache your public keys:
 ```javascript
 // Fetch discovery document
 const discovery = await fetch(
-  'https://your-domain/.well-known/trusted-server.json'
+  'https://your-domain.example/.well-known/trusted-server.json'
 ).then((r) => r.json())
 
 // Extract JWKS
@@ -333,7 +333,7 @@ Use the verification endpoint:
 SIGNATURE=$(sign-payload "test message")
 
 # Verify via API
-curl -X POST https://your-domain/verify-signature \
+curl -X POST https://your-domain.example/verify-signature \
   -H "Content-Type: application/json" \
   -d '{
     "payload": "test message",

--- a/docs/guide/rsc-hydration.md
+++ b/docs/guide/rsc-hydration.md
@@ -166,12 +166,12 @@ Trusted Server accounts for JavaScript escape sequences and UTF-8 byte counts:
 
 The rewrite logic handles multiple URL formats in RSC content:
 
-| Pattern              | Example                   | In RSC String             |
-| -------------------- | ------------------------- | ------------------------- |
-| Full HTTPS           | `https://host/path`       | `https://host/path`       |
-| Full HTTP            | `http://host/path`        | `http://host/path`        |
-| Protocol-relative    | `//host/path`             | `//host/path`             |
-| Bare host (boundary) | `origin.example.com/path` | `origin.example.com/path` |
+| Pattern              | Example                    | In RSC String              |
+| -------------------- | -------------------------- | -------------------------- |
+| Full HTTPS           | `https://example.com/path` | `https://example.com/path` |
+| Full HTTP            | `http://example.com/path`  | `http://example.com/path`  |
+| Protocol-relative    | `//host/path`              | `//host/path`              |
+| Bare host (boundary) | `origin.example.com/path`  | `origin.example.com/path`  |
 
 ### Implementation References
 


### PR DESCRIPTION
## Summary

Rewrites ad-hoc placeholder hostnames in `docs/guide/` to RFC 2606 reserved `.example` TLDs. Pure docs change — no code, no tests, no behavior.

## Why

Docs in `docs/guide/` use placeholders like `your-domain.com`, `publisher.com`, `external.com`, `tracker.com`, `cdn.com`, etc. in curl examples and config snippets. Two problems:

1. They **look real** — a reader could copy `https://publisher.com/...` and treat it as a working URL.
2. They **fail the linter** scheduled in #733 (`ts dev lint domains`), which scopes its allowlist tightly. ~80 violations across these files would force per-line `// allow-domain:` markers on otherwise clean prose, polluting the docs.

RFC 2606 reserves `.example`, `example.com`, `example.net`, and `example.org` for exactly this. The linter already allows any `.example` host.

## Mapping

| Before | After |
|---|---|
| `your-domain.com` | `your-domain.example` |
| `origin.publisher.com` | `origin.publisher.example` |
| `publisher.com` | `publisher.example` |
| `external.com` / `advertiser.com` / `tracker.com` / `cdn.com` | `.example` |
| `prebid-server.com` / `staging.publisher.com` / `new-server.com` | `.example` |
| `redirect1.com` / `redirect2.com` / `final.com` | `.example` |
| `evil.com` / `win-notification.com` / `short.link` | `.example` |
| `https://your-domain/...` | `https://your-domain.example/...` |
| `https://host/path` (URL-pattern table) | `https://example.com/path` |

## Out of scope

Real third-party hosts in the docs (`ad.doubleclick.net`, `fonts.googleapis.com`, `aps.amazon.com`, the `192.168.1.1` local-server example) are left as-is. They legitimately document real services and warrant a separate decision: add to the linter allowlist, or keep documenting them as-is. Six lint violations remain on this branch for that reason.

## Test plan

- [x] `cd docs && npm run format` clean
- [x] Spot-checked rewrites preserve URL grammar (curl commands, anchor links, table alignment)
- [ ] No code paths affected