### PR TITLE
Add publisher origin Host header override

### DIFF
--- a/crates/trusted-server-core/build.rs
+++ b/crates/trusted-server-core/build.rs
@@ -15,6 +15,9 @@ mod redacted;
 #[path = "src/consent_config.rs"]
 mod consent_config;
 
+#[path = "src/host_header.rs"]
+mod host_header;
+
 #[path = "src/settings.rs"]
 mod settings;
 

--- a/crates/trusted-server-core/src/backend.rs
+++ b/crates/trusted-server-core/src/backend.rs
@@ -5,6 +5,7 @@ use fastly::backend::Backend;
 use url::Url;
 
 use crate::error::TrustedServerError;
+use crate::host_header::validate_host_header_override_value;
 
 /// Returns the default port for the given scheme (443 for HTTPS, 80 for HTTP).
 #[inline]
@@ -33,6 +34,19 @@ fn compute_host_header(scheme: &str, host: &str, port: u16) -> String {
     }
 }
 
+fn sanitize_backend_name_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 /// Default first-byte timeout for backends (15 seconds).
 pub(crate) const DEFAULT_FIRST_BYTE_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -46,6 +60,7 @@ pub struct BackendConfig<'a> {
     port: Option<u16>,
     certificate_check: bool,
     first_byte_timeout: Duration,
+    host_header_override: Option<&'a str>,
 }
 
 impl<'a> BackendConfig<'a> {
@@ -61,6 +76,7 @@ impl<'a> BackendConfig<'a> {
             port: None,
             certificate_check: true,
             first_byte_timeout: DEFAULT_FIRST_BYTE_TIMEOUT,
+            host_header_override: None,
         }
     }
 
@@ -90,6 +106,13 @@ impl<'a> BackendConfig<'a> {
         self
     }
 
+    /// Set the outbound Host header sent to the backend origin.
+    #[must_use]
+    pub fn host_header_override(mut self, host: Option<&'a str>) -> Self {
+        self.host_header_override = host;
+        self
+    }
+
     /// Compute the deterministic backend name and resolved port without
     /// registering anything.
     ///
@@ -114,12 +137,23 @@ impl<'a> BackendConfig<'a> {
                 message: "scheme contains control characters".to_string(),
             }));
         }
+        if let Some(host_header_override) = self.host_header_override {
+            validate_host_header_override_value(host_header_override).map_err(|reason| {
+                Report::new(TrustedServerError::Proxy {
+                    message: format!("host header override {reason}"),
+                })
+            })?;
+        }
 
         let target_port = self
             .port
             .unwrap_or_else(|| default_port_for_scheme(self.scheme));
 
         let name_base = format!("{}_{}_{}", self.scheme, self.host, target_port);
+        let host_override_suffix = self
+            .host_header_override
+            .map(|host| format!("_oh_{}", sanitize_backend_name_component(host)))
+            .unwrap_or_default();
         let cert_suffix = if self.certificate_check {
             ""
         } else {
@@ -127,8 +161,9 @@ impl<'a> BackendConfig<'a> {
         };
         let timeout_ms = self.first_byte_timeout.as_millis();
         let backend_name = format!(
-            "backend_{}{}_t{}",
-            name_base.replace(['.', ':'], "_"),
+            "backend_{}{}{}_t{}",
+            sanitize_backend_name_component(&name_base),
+            host_override_suffix,
             cert_suffix,
             timeout_ms
         );
@@ -165,7 +200,10 @@ impl<'a> BackendConfig<'a> {
 
         let host_with_port = format!("{}:{}", self.host, target_port);
 
-        let host_header = compute_host_header(self.scheme, self.host, target_port);
+        let host_header = self
+            .host_header_override
+            .map(str::to_owned)
+            .unwrap_or_else(|| compute_host_header(self.scheme, self.host, target_port));
 
         // Target base is host[:port]; SSL is enabled only for https scheme
         let mut builder = Backend::builder(&backend_name, &host_with_port)
@@ -219,6 +257,7 @@ impl<'a> BackendConfig<'a> {
     ///
     /// Centralises URL parsing so that [`from_url`](Self::from_url),
     /// [`from_url_with_first_byte_timeout`](Self::from_url_with_first_byte_timeout),
+    /// [`from_url_with_host_header_override`](Self::from_url_with_host_header_override),
     /// and [`backend_name_for_url`](Self::backend_name_for_url) share one
     /// code-path.
     fn parse_origin(
@@ -279,12 +318,46 @@ impl<'a> BackendConfig<'a> {
         certificate_check: bool,
         first_byte_timeout: Duration,
     ) -> Result<String, Report<TrustedServerError>> {
+        Self::from_url_with_first_byte_timeout_and_host_header_override(
+            origin_url,
+            certificate_check,
+            first_byte_timeout,
+            None,
+        )
+    }
+
+    /// Parse an origin URL and ensure a dynamic backend with a custom Host header.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URL cannot be parsed or lacks a host, or if
+    /// backend creation fails.
+    pub fn from_url_with_host_header_override(
+        origin_url: &str,
+        certificate_check: bool,
+        host_header_override: Option<&str>,
+    ) -> Result<String, Report<TrustedServerError>> {
+        Self::from_url_with_first_byte_timeout_and_host_header_override(
+            origin_url,
+            certificate_check,
+            DEFAULT_FIRST_BYTE_TIMEOUT,
+            host_header_override,
+        )
+    }
+
+    fn from_url_with_first_byte_timeout_and_host_header_override(
+        origin_url: &str,
+        certificate_check: bool,
+        first_byte_timeout: Duration,
+        host_header_override: Option<&str>,
+    ) -> Result<String, Report<TrustedServerError>> {
         let (scheme, host, port) = Self::parse_origin(origin_url)?;
 
         BackendConfig::new(&scheme, &host)
             .port(port)
             .certificate_check(certificate_check)
             .first_byte_timeout(first_byte_timeout)
+            .host_header_override(host_header_override)
             .ensure()
     }
 
@@ -435,6 +508,65 @@ mod tests {
             first, second,
             "should return same backend name on repeat call"
         );
+    }
+
+    #[test]
+    fn host_header_overrides_produce_different_names() {
+        let (name_a, _) = BackendConfig::new("https", "origin.example.com")
+            .host_header_override(Some("www.example.com"))
+            .compute_name()
+            .expect("should compute name with host header override");
+        let (name_b, _) = BackendConfig::new("https", "origin.example.com")
+            .host_header_override(Some("m.example.com"))
+            .compute_name()
+            .expect("should compute name with different host header override");
+
+        assert_ne!(
+            name_a, name_b,
+            "backends with different host header overrides should have different names"
+        );
+        assert_eq!(
+            name_a,
+            "backend_https_origin_example_com_443_oh_www_example_com_t15000"
+        );
+        assert_eq!(
+            name_b,
+            "backend_https_origin_example_com_443_oh_m_example_com_t15000"
+        );
+    }
+
+    #[test]
+    fn host_header_override_rejects_control_characters() {
+        let err = BackendConfig::new("https", "origin.example.com")
+            .host_header_override(Some("www\n.example.com"))
+            .predict_name()
+            .expect_err("should reject host header override containing newline");
+
+        assert!(
+            err.to_string().contains("control characters"),
+            "should report control characters in error message"
+        );
+    }
+
+    #[test]
+    fn host_header_override_rejects_invalid_values() {
+        for host_header_override in [
+            "https://www.example.com",
+            "www.example.com/path",
+            "www.example.com:",
+            "example..com",
+            "-",
+        ] {
+            let err = BackendConfig::new("https", "origin.example.com")
+                .host_header_override(Some(host_header_override))
+                .predict_name()
+                .expect_err("should reject invalid host header override");
+
+            assert!(
+                err.to_string().contains("host header override"),
+                "should report host header override error for {host_header_override:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/trusted-server-core/src/host_header.rs
+++ b/crates/trusted-server-core/src/host_header.rs
@@ -1,0 +1,204 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+pub(crate) fn validate_host_header_override_value(value: &str) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("must not be empty");
+    }
+    if value.trim() != value {
+        return Err("must not include leading or trailing whitespace");
+    }
+    if value.contains("://") {
+        return Err("must not include a scheme");
+    }
+    if value.contains(['/', '\\', '?', '#', '@']) {
+        return Err("must not include userinfo, path, query, or fragment");
+    }
+    if value
+        .chars()
+        .any(|ch| ch.is_control() || ch.is_whitespace())
+    {
+        return Err("must not contain whitespace or control characters");
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | ':' | '[' | ']'))
+    {
+        return Err("contains invalid characters");
+    }
+
+    if value.starts_with('[') {
+        validate_ipv6_literal_host(value)
+    } else {
+        validate_dns_or_ipv4_host_with_optional_port(value)
+    }
+}
+
+fn validate_ipv6_literal_host(value: &str) -> Result<(), &'static str> {
+    let closing_bracket = value
+        .find(']')
+        .ok_or("IPv6 literals must be enclosed in brackets")?;
+    let host = &value[1..closing_bracket];
+    if host.is_empty() {
+        return Err("must include a host");
+    }
+    if host.parse::<Ipv6Addr>().is_err() {
+        return Err("invalid IPv6 address");
+    }
+
+    validate_port_suffix(&value[closing_bracket + 1..])
+}
+
+fn validate_port_suffix(value: &str) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Ok(());
+    }
+
+    let port = value
+        .strip_prefix(':')
+        .ok_or("only an optional :port may follow the host")?;
+    validate_port(port)
+}
+
+fn validate_dns_or_ipv4_host_with_optional_port(value: &str) -> Result<(), &'static str> {
+    if value.contains(['[', ']']) {
+        return Err("IPv6 literals must be enclosed in brackets");
+    }
+
+    let (host, port) = split_host_and_port(value)?;
+    validate_dns_or_ipv4_host(host)?;
+    if let Some(port) = port {
+        validate_port(port)?;
+    }
+
+    Ok(())
+}
+
+fn split_host_and_port(value: &str) -> Result<(&str, Option<&str>), &'static str> {
+    if let Some((host, port)) = value.rsplit_once(':') {
+        if host.contains(':') {
+            return Err("IPv6 literals must be enclosed in brackets");
+        }
+        if host.is_empty() {
+            return Err("must include a host");
+        }
+        return Ok((host, Some(port)));
+    }
+
+    if value.contains(':') {
+        return Err("IPv6 literals must be enclosed in brackets");
+    }
+
+    Ok((value, None))
+}
+
+fn validate_dns_or_ipv4_host(host: &str) -> Result<(), &'static str> {
+    if host.is_empty() {
+        return Err("must include a host");
+    }
+    if host.len() > 253 {
+        return Err("host is too long");
+    }
+
+    if host.contains('.') && host.chars().all(|ch| ch.is_ascii_digit() || ch == '.') {
+        return host
+            .parse::<Ipv4Addr>()
+            .map(|_| ())
+            .map_err(|_| "invalid IPv4 address");
+    }
+
+    for label in host.split('.') {
+        if label.is_empty() {
+            return Err("host labels must not be empty");
+        }
+        if label.len() > 63 {
+            return Err("host labels must not exceed 63 characters");
+        }
+        let bytes = label.as_bytes();
+        if bytes.first() == Some(&b'-') || bytes.last() == Some(&b'-') {
+            return Err("host labels must not start or end with '-'");
+        }
+        if !bytes
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
+        {
+            return Err("host labels may only contain ASCII letters, digits, or '-'");
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_port(port: &str) -> Result<(), &'static str> {
+    if port.is_empty() {
+        return Err("port must not be empty");
+    }
+    if !port.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err("port must contain only digits");
+    }
+
+    match port.parse::<u16>() {
+        Ok(0) => Err("port must be between 1 and 65535"),
+        Ok(_) => Ok(()),
+        Err(_) => Err("port must be between 1 and 65535"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_host_header_override_value;
+
+    #[test]
+    fn accepts_valid_host_header_override_values() {
+        for value in [
+            "www.example.com",
+            "www.example.com:8443",
+            "localhost",
+            "localhost:9090",
+            "192.168.1.1",
+            "192.168.1.1:8080",
+            "[::1]",
+            "[::1]:8443",
+            "[2001:db8::1]",
+        ] {
+            assert!(
+                validate_host_header_override_value(value).is_ok(),
+                "{value:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_host_header_override_values() {
+        for value in [
+            "",
+            " www.example.com",
+            "www.example.com ",
+            "https://www.example.com",
+            "www.example.com/path",
+            "www.example.com?query=1",
+            "www.example.com#fragment",
+            "user@www.example.com",
+            "www.example.com\n",
+            "www.example.com:",
+            "www.example.com:0",
+            "www.example.com:99999",
+            "example..com",
+            ".example.com",
+            "example.com.",
+            "-",
+            "-example.com",
+            "example-.com",
+            "999.999.999.999",
+            "::1",
+            "[::1",
+            "[::1]suffix",
+            "[not-ipv6]",
+            "www_example.com",
+        ] {
+            assert!(
+                validate_host_header_override_value(value).is_err(),
+                "{value:?} should be rejected"
+            );
+        }
+    }
+}

--- a/crates/trusted-server-core/src/lib.rs
+++ b/crates/trusted-server-core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod creative;
 pub mod ec;
 pub mod error;
 pub mod geo;
+pub(crate) mod host_header;
 pub(crate) mod host_rewrite;
 pub mod html_processor;
 pub mod http_util;

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -478,11 +478,13 @@ pub fn handle_publisher_request(
         ec_context.ec_value(),
     );
 
-    let backend_name = BackendConfig::from_url(
+    let backend_name = BackendConfig::from_url_with_host_header_override(
         &settings.publisher.origin_url,
         settings.proxy.certificate_check,
+        settings.publisher.origin_host_header_override.as_deref(),
     )?;
     let origin_host = settings.publisher.origin_host();
+    let origin_host_header = settings.publisher.origin_host_header();
 
     // lgtm[rust/cleartext-logging]
     // This debug log records backend routing metadata only; `Settings` secrets remain redacted.
@@ -493,6 +495,7 @@ pub fn handle_publisher_request(
     );
     // Only advertise encodings the rewrite pipeline can decode and re-encode.
     restrict_accept_encoding(&mut req);
+    req.set_header("host", &origin_host_header);
 
     let mut response = req
         .send(&backend_name)

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -13,6 +13,7 @@ use validator::{Validate, ValidationError};
 use crate::auction_config_types::AuctionConfig;
 use crate::consent_config::ConsentConfig;
 use crate::error::TrustedServerError;
+use crate::host_header::validate_host_header_override_value;
 use crate::redacted::Redacted;
 
 pub const ENVIRONMENT_VARIABLE_PREFIX: &str = "TRUSTED_SERVER";
@@ -28,6 +29,10 @@ pub struct Publisher {
     pub cookie_domain: String,
     #[validate(custom(function = validate_no_trailing_slash))]
     pub origin_url: String,
+    /// Optional outbound Host header to send while connecting to `origin_url`.
+    #[serde(default)]
+    #[validate(custom(function = validate_host_header_override))]
+    pub origin_host_header_override: Option<String>,
     /// Secret used to encrypt/decrypt proxied URLs in `/first-party/proxy`.
     /// Keep this secret stable to allow existing links to decode.
     #[validate(custom(function = validate_redacted_not_empty))]
@@ -69,6 +74,7 @@ impl Publisher {
     ///     domain: "example.com".to_string(),
     ///     cookie_domain: ".example.com".to_string(),
     ///     origin_url: "https://origin.example.com:8080".to_string(),
+    ///     origin_host_header_override: None,
     ///     proxy_secret: Redacted::new("proxy-secret".to_string()),
     /// };
     /// assert_eq!(publisher.origin_host(), "origin.example.com:8080");
@@ -85,6 +91,14 @@ impl Publisher {
                 })
             })
             .unwrap_or_else(|| self.origin_url.clone())
+    }
+
+    /// Returns the outbound Host header for proxied publisher-origin requests.
+    #[must_use]
+    pub fn origin_host_header(&self) -> String {
+        self.origin_host_header_override
+            .clone()
+            .unwrap_or_else(|| self.origin_host())
     }
 }
 
@@ -1952,6 +1966,21 @@ fn validate_no_trailing_slash(value: &str) -> Result<(), ValidationError> {
     Ok(())
 }
 
+fn validate_host_header_override(value: &str) -> Result<(), ValidationError> {
+    if let Err(reason) = validate_host_header_override_value(value) {
+        let mut err = ValidationError::new("invalid_host_header_override");
+        err.add_param("value".into(), &value);
+        err.add_param("reason".into(), &reason);
+        err.message = Some(
+            "origin_host_header_override must be a valid host or host:port without scheme, path, query, or fragment"
+                .into(),
+        );
+        return Err(err);
+    }
+
+    Ok(())
+}
+
 fn validate_redacted_not_empty(value: &Redacted<String>) -> Result<(), ValidationError> {
     if value.expose().is_empty() {
         return Err(ValidationError::new("empty_value"));
@@ -2240,6 +2269,7 @@ mod tests {
             settings.publisher.origin_url,
             "https://origin.test-publisher.com"
         );
+        assert_eq!(settings.publisher.origin_host_header_override, None);
         assert_eq!(
             settings.ec.passphrase.expose(),
             "test-secret-key-32-bytes-minimum"
@@ -2317,6 +2347,57 @@ mod tests {
             assert!(
                 result.is_err(),
                 "should reject invalid source_domain {source_domain:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_accepts_origin_host_header_override() {
+        let toml_str = crate_test_settings_str().replace(
+            r#"origin_url = "https://origin.test-publisher.com""#,
+            r#"origin_url = "https://origin.test-publisher.com"
+origin_host_header_override = "www.example.com:8443""#,
+        );
+
+        let settings = Settings::from_toml(&toml_str).expect("should accept host header override");
+        assert_eq!(
+            settings.publisher.origin_host_header(),
+            "www.example.com:8443",
+            "should use configured host header override"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_invalid_origin_host_header_overrides() {
+        for override_value in [
+            "",
+            " www.example.com",
+            "www.example.com ",
+            "https://www.example.com",
+            "www.example.com/path",
+            "www.example.com?query=1",
+            "www.example.com#fragment",
+            "www.example.com\n",
+            "www.example.com:",
+            "www.example.com:99999",
+            "example..com",
+            ".",
+            "-",
+            "-example.com",
+            "example-.com",
+            "[::1",
+        ] {
+            let toml_str = crate_test_settings_str().replace(
+                r#"origin_url = "https://origin.test-publisher.com""#,
+                &format!(
+                    "origin_url = \"https://origin.test-publisher.com\"\norigin_host_header_override = {override_value:?}"
+                ),
+            );
+
+            let result = Settings::from_toml(&toml_str);
+            assert!(
+                result.is_err(),
+                "origin_host_header_override {override_value:?} should fail validation"
             );
         }
     }
@@ -2998,12 +3079,34 @@ mod tests {
     }
 
     #[test]
+    fn test_origin_host_header_override_env() {
+        let env_key = format!(
+            "{}{}PUBLISHER{}ORIGIN_HOST_HEADER_OVERRIDE",
+            ENVIRONMENT_VARIABLE_PREFIX,
+            ENVIRONMENT_VARIABLE_SEPARATOR,
+            ENVIRONMENT_VARIABLE_SEPARATOR
+        );
+
+        temp_env::with_var(env_key, Some("www.example.com"), || {
+            let settings = Settings::from_toml_and_env(&crate_test_settings_str())
+                .expect("should load settings with host header override env");
+
+            assert_eq!(
+                settings.publisher.origin_host_header_override.as_deref(),
+                Some("www.example.com")
+            );
+            assert_eq!(settings.publisher.origin_host_header(), "www.example.com");
+        });
+    }
+
+    #[test]
     fn test_publisher_origin_host() {
         // Test with full URL including port
         let publisher = Publisher {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "https://origin.example.com:8080".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "origin.example.com:8080");
@@ -3013,6 +3116,7 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "https://origin.example.com".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "origin.example.com");
@@ -3022,6 +3126,7 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://localhost:9090".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "localhost:9090");
@@ -3031,6 +3136,7 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "localhost:9090".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "localhost:9090");
@@ -3040,6 +3146,7 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://192.168.1.1:8080".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "192.168.1.1:8080");
@@ -3049,9 +3156,36 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://[::1]:8080".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "[::1]:8080");
+    }
+
+    #[test]
+    fn test_publisher_origin_host_header_defaults_to_origin_host() {
+        let publisher = Publisher {
+            domain: "example.com".to_string(),
+            cookie_domain: ".example.com".to_string(),
+            origin_url: "https://origin.example.com:8443".to_string(),
+            origin_host_header_override: None,
+            proxy_secret: Redacted::new("test-secret".to_string()),
+        };
+
+        assert_eq!(publisher.origin_host_header(), "origin.example.com:8443");
+    }
+
+    #[test]
+    fn test_publisher_origin_host_header_uses_override() {
+        let publisher = Publisher {
+            domain: "example.com".to_string(),
+            cookie_domain: ".example.com".to_string(),
+            origin_url: "https://origin.example.com".to_string(),
+            origin_host_header_override: Some("www.example.com".to_string()),
+            proxy_secret: Redacted::new("test-secret".to_string()),
+        };
+
+        assert_eq!(publisher.origin_host_header(), "www.example.com");
     }
 
     #[test]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -154,12 +154,13 @@ Core publisher settings for domain, origin, and proxy configuration.
 
 ### `[publisher]`
 
-| Field           | Type   | Required | Description                                            |
-| --------------- | ------ | -------- | ------------------------------------------------------ |
-| `domain`        | String | Yes      | Publisher's apex domain name                           |
-| `cookie_domain` | String | Yes      | Domain for non-EC cookies (typically with leading dot) |
-| `origin_url`    | String | Yes      | Full URL of publisher origin server                    |
-| `proxy_secret`  | String | Yes      | Secret key for encrypting/signing proxy URLs           |
+| Field                         | Type   | Required | Description                                                   |
+| ----------------------------- | ------ | -------- | ------------------------------------------------------------- |
+| `domain`                      | String | Yes      | Publisher's apex domain name                                  |
+| `cookie_domain`               | String | Yes      | Domain for non-EC cookies (typically with leading dot)        |
+| `origin_url`                  | String | Yes      | Full URL of publisher origin server                           |
+| `origin_host_header_override` | String | No       | Outbound Host header to send while connecting to `origin_url` |
+| `proxy_secret`                | String | Yes      | Secret key for encrypting/signing proxy URLs                  |
 
 > **Note:** EC cookies (`ts-ec`) derive their domain automatically as `.{domain}` and
 > do not use `cookie_domain`. The `cookie_domain` field is used by other cookie helpers.
@@ -171,6 +172,8 @@ Core publisher settings for domain, origin, and proxy configuration.
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
+# Optional: connect to origin_url but send this outbound Host header.
+# origin_host_header_override = "www.publisher.com"
 proxy_secret = "change-me-to-secure-random-value"
 ```
 
@@ -180,6 +183,7 @@ proxy_secret = "change-me-to-secure-random-value"
 TRUSTED_SERVER__PUBLISHER__DOMAIN=publisher.com
 TRUSTED_SERVER__PUBLISHER__COOKIE_DOMAIN=.publisher.com
 TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.com
+TRUSTED_SERVER__PUBLISHER__ORIGIN_HOST_HEADER_OVERRIDE=www.publisher.com
 TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
 ```
 
@@ -235,6 +239,26 @@ TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
 - ❌ `origin.publisher.com` (missing protocol)
 
 **Port Handling**: Includes port if non-standard (not 80/443).
+
+#### `origin_host_header_override`
+
+**Purpose**: Optional Host header to send to the publisher origin while still
+connecting to the host in `origin_url`.
+
+**Usage**:
+
+- Connects, uses SNI, and checks certificates against `origin_url`
+- Sends the configured value as the outbound HTTP `Host` header
+- Useful when the origin endpoint expects a canonical publisher hostname
+
+**Format**: Hostname with optional port, without protocol, path, query, or fragment
+
+- ✅ `www.publisher.com`
+- ✅ `www.publisher.com:8443`
+- ❌ `https://www.publisher.com`
+- ❌ `www.publisher.com/path`
+
+**Default**: When omitted, Trusted Server sends the host from `origin_url`.
 
 #### `proxy_secret`
 

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -12,6 +12,8 @@ password = "replace-with-admin-password-32-bytes"
 domain = "test-publisher.com"
 cookie_domain = ".test-publisher.com"
 origin_url = "https://origin.test-publisher.com"
+# Optional: override outbound Host header while connecting to origin_url.
+# origin_host_header_override = "www.example.com"
 proxy_secret = "change-me-proxy-secret"
 
 [ec]


### PR DESCRIPTION
## Summary

- Adds optional `publisher.origin_host_header_override` configuration for publisher fallback origin requests.
- Registers Fastly dynamic backends with the configured Host override while preserving `origin_url` for connection, SNI, and certificate checks.
- Documents the TOML/env setting and validates host/host:port values.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/settings.rs` | Adds publisher config field, helper, env/default behavior, and validation tests. |
| `crates/trusted-server-core/src/host_header.rs` | Adds shared Host header override validation helper and unit tests. |
| `crates/trusted-server-core/src/backend.rs` | Adds Host header override support and includes override in backend names to avoid dynamic backend collisions. |
| `crates/trusted-server-core/src/publisher.rs` | Uses the configured override for publisher fallback proxy backend registration and outbound `Host`. |
| `crates/trusted-server-core/build.rs`, `crates/trusted-server-core/src/lib.rs` | Wires the validation helper into build/runtime code. |
| `docs/guide/configuration.md` | Documents `origin_host_header_override` and env var usage. |
| `trusted-server.toml` | Adds a commented example setting. |

## Closes

N/A

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] JS tests: `cd crates/js/lib && npx vitest run`
- [ ] JS format: `cd crates/js/lib && npm run format`
- [ ] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: `cd docs && npx prettier --check guide/configuration.md`

Note: full `cd docs && npm run format` currently fails on existing base-branch formatting in `superpowers/specs/2026-05-28-edgezero-image-optimizer-primitive-design.md`; changed docs file passes targeted Prettier check.

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
