### PR TITLE
Avoid allocation when detecting content encoding

### DIFF
--- a/crates/trusted-server-core/src/streaming_processor.rs
+++ b/crates/trusted-server-core/src/streaming_processor.rs
@@ -52,11 +52,14 @@ impl Compression {
     /// Detect compression from content-encoding header
     #[must_use]
     pub fn from_content_encoding(encoding: &str) -> Self {
-        match encoding.to_lowercase().as_str() {
-            "gzip" => Self::Gzip,
-            "deflate" => Self::Deflate,
-            "br" => Self::Brotli,
-            _ => Self::None,
+        if encoding.eq_ignore_ascii_case("gzip") {
+            Self::Gzip
+        } else if encoding.eq_ignore_ascii_case("deflate") {
+            Self::Deflate
+        } else if encoding.eq_ignore_ascii_case("br") {
+            Self::Brotli
+        } else {
+            Self::None
         }
     }
 }

--- a/crates/trusted-server-core/src/streaming_processor.rs
+++ b/crates/trusted-server-core/src/streaming_processor.rs
@@ -52,14 +52,11 @@ impl Compression {
     /// Detect compression from content-encoding header
     #[must_use]
     pub fn from_content_encoding(encoding: &str) -> Self {
-        if encoding.eq_ignore_ascii_case("gzip") {
-            Self::Gzip
-        } else if encoding.eq_ignore_ascii_case("deflate") {
-            Self::Deflate
-        } else if encoding.eq_ignore_ascii_case("br") {
-            Self::Brotli
-        } else {
-            Self::None
+        match encoding {
+            s if s.eq_ignore_ascii_case("gzip") => Self::Gzip,
+            s if s.eq_ignore_ascii_case("deflate") => Self::Deflate,
+            s if s.eq_ignore_ascii_case("br") => Self::Brotli,
+            _ => Self::None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Avoid allocating a lowercase `String` when detecting response compression from `Content-Encoding`.
- Preserve existing ASCII case-insensitive matching for `gzip`, `deflate`, and `br`.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/streaming_processor.rs` | Replaced `to_lowercase()` matching in `Compression::from_content_encoding` with non-allocating `eq_ignore_ascii_case` checks. |

## Closes

Closes #434

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] JS tests: `cd crates/js/lib && npx vitest run`
- [ ] JS format: `cd crates/js/lib && npm run format`
- [ ] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: `cargo test -p trusted-server-core streaming_processor::tests::test_compression_detection`; `cargo test -p trusted-server-core`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
