### PR TITLE
Add bare host boundary tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,6 +2672,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "edgezero-adapter-fastly",
  "edgezero-core",

--- a/crates/integration-tests/Cargo.lock
+++ b/crates/integration-tests/Cargo.lock
@@ -1131,7 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3151,7 +3151,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3732,10 +3732,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4151,7 +4151,6 @@ dependencies = [
  "trusted-server-js",
  "trusted-server-openrtb",
  "url",
- "urlencoding",
  "uuid",
  "validator",
 ]
@@ -4555,7 +4554,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/js/lib/src/integrations/didomi/index.ts
+++ b/crates/js/lib/src/integrations/didomi/index.ts
@@ -1,19 +1,27 @@
 import { log } from '../../core/log';
 
-const DEFAULT_SDK_PATH = 'https://sdk.privacy-center.org/';
-const CONSENT_PROXY_PATH = '/integrations/didomi/consent/';
+const DEFAULT_CONSENT_PROXY_PATH = '/integrations/didomi/consent/';
 
 type DidomiConfig = {
   sdkPath?: string;
   [key: string]: unknown;
 };
 
-type DidomiWindow = Window & { didomiConfig?: DidomiConfig };
+type DidomiWindow = Window & {
+  didomiConfig?: DidomiConfig;
+  __tsjs_didomi?: { proxyPath?: string };
+};
+
+/** Read the server-injected proxy path, falling back to the default. */
+function getConsentProxyPath(win: DidomiWindow): string {
+  return win.__tsjs_didomi?.proxyPath ?? DEFAULT_CONSENT_PROXY_PATH;
+}
 
 function buildProxySdkPath(win: DidomiWindow): string {
+  const proxyPath = getConsentProxyPath(win);
   const base = win.location?.origin ?? win.location?.href;
-  if (!base) return CONSENT_PROXY_PATH;
-  const url = new URL(CONSENT_PROXY_PATH, base);
+  if (!base) return proxyPath;
+  const url = new URL(proxyPath, base);
   return `${url.origin}${url.pathname}`;
 }
 
@@ -25,7 +33,7 @@ export function installDidomiSdkProxy(): boolean {
   const previousSdkPath =
     typeof config.sdkPath === 'string' && config.sdkPath.length > 0
       ? config.sdkPath
-      : DEFAULT_SDK_PATH;
+      : 'https://sdk.privacy-center.org/';
 
   const proxiedSdkPath = buildProxySdkPath(win);
   config.sdkPath = proxiedSdkPath;

--- a/crates/js/lib/test/integrations/didomi/index.test.ts
+++ b/crates/js/lib/test/integrations/didomi/index.test.ts
@@ -4,10 +4,15 @@ import { installDidomiSdkProxy } from '../../../src/integrations/didomi';
 
 const ORIGINAL_WINDOW = global.window;
 
+type TestDidomiWindow = Window & {
+  didomiConfig?: any;
+  __tsjs_didomi?: { proxyPath?: string };
+};
+
 function createWindow(url: string) {
   return {
     location: new URL(url) as unknown as Location,
-  } as Window & { didomiConfig?: any };
+  } as TestDidomiWindow;
 }
 
 describe('integrations/didomi', () => {
@@ -40,5 +45,13 @@ describe('integrations/didomi', () => {
     expect(testWindow.didomiConfig.sdkPath).toBe(
       'https://example.com/integrations/didomi/consent/'
     );
+  });
+
+  it('uses the server-injected custom proxy path', () => {
+    testWindow.__tsjs_didomi = { proxyPath: '/my-custom-consent/' };
+
+    installDidomiSdkProxy();
+
+    expect(testWindow.didomiConfig.sdkPath).toBe('https://example.com/my-custom-consent/');
   });
 });

--- a/crates/trusted-server-adapter-fastly/Cargo.toml
+++ b/crates/trusted-server-adapter-fastly/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
 edgezero-adapter-fastly = { workspace = true, features = ["fastly"] }
 edgezero-core = { workspace = true }

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -1,6 +1,10 @@
+use edgezero_core::body::Body as EdgeBody;
+use edgezero_core::http::{
+    header, HeaderName, HeaderValue, Method, Request as HttpRequest, Response as HttpResponse,
+};
 use error_stack::Report;
-use fastly::http::{header, Method};
-use fastly::{Error, Request, Response};
+use fastly::http::Method as FastlyMethod;
+use fastly::{Request as FastlyRequest, Response as FastlyResponse};
 
 use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{build_orchestrator, AuctionOrchestrator};
@@ -22,8 +26,9 @@ use trusted_server_core::ec::pull_sync::{
 use trusted_server_core::ec::rate_limiter::{FastlyRateLimiter, RATE_COUNTER_NAME};
 use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::ec::EcContext;
-use trusted_server_core::error::TrustedServerError;
+use trusted_server_core::error::{IntoHttpResponse, TrustedServerError};
 use trusted_server_core::geo::GeoInfo;
+use trusted_server_core::http_util::is_navigation_request;
 use trusted_server_core::integrations::{IntegrationRegistry, ProxyDispatchInput};
 use trusted_server_core::platform::RuntimeServices;
 use trusted_server_core::proxy::{
@@ -32,7 +37,8 @@ use trusted_server_core::proxy::{
     AssetProxyCachePolicy,
 };
 use trusted_server_core::publisher::{
-    handle_publisher_request, handle_tsjs_dynamic, stream_publisher_body, PublisherResponse,
+    handle_publisher_request, handle_tsjs_dynamic, stream_publisher_body,
+    OwnedProcessResponseParams, PublisherResponse,
 };
 use trusted_server_core::request_signing::{
     handle_deactivate_key, handle_rotate_key, handle_trusted_server_discovery,
@@ -52,18 +58,68 @@ use crate::error::to_error_response;
 use crate::logging::init_logger;
 use crate::platform::{build_runtime_services, UnavailableKvStore};
 
-fn main() -> Result<(), Error> {
+/// Result of routing a request, distinguishing buffered from streaming publisher responses.
+///
+/// The streaming arm keeps the publisher body out of WASM heap until it is written directly
+/// to the client via [`fastly::Response::stream_to_client`].  All other routes are buffered.
+///
+/// [`AuthChallenge`](HandlerOutcome::AuthChallenge) marks responses produced by this server's
+/// own `enforce_basic_auth` so the geo-lookup gate can distinguish them from origin-forwarded
+/// 401s, which should still carry geo headers.
+enum HandlerOutcome {
+    Buffered(HttpResponse),
+    AuthChallenge(HttpResponse),
+    Streaming {
+        response: HttpResponse,
+        body: EdgeBody,
+        params: OwnedProcessResponseParams,
+    },
+    AssetStreaming {
+        response: HttpResponse,
+        body: EdgeBody,
+    },
+}
+
+impl HandlerOutcome {
+    #[cfg(test)]
+    fn status(&self) -> edgezero_core::http::StatusCode {
+        match self {
+            HandlerOutcome::Buffered(resp) | HandlerOutcome::AuthChallenge(resp) => resp.status(),
+            HandlerOutcome::Streaming { response, .. }
+            | HandlerOutcome::AssetStreaming { response, .. } => response.status(),
+        }
+    }
+}
+
+/// Combined result from `route_request`, bundling the handler outcome with the
+/// EC context and cookies needed for post-send finalization and pull sync.
+struct RouteResult {
+    outcome: HandlerOutcome,
+    ec_context: EcContext,
+    finalize_kv_graph: Option<KvIdentityGraph>,
+    eids_cookie: Option<String>,
+    sharedid_cookie: Option<String>,
+    is_real_browser: bool,
+    should_finalize_ec: bool,
+    asset_cache_policy: AssetProxyCachePolicy,
+}
+
+/// Entry point for the Fastly Compute program.
+///
+/// Uses an undecorated `main()` with `FastlyRequest::from_client()` instead of
+/// `#[fastly::main]` so we can call `send_to_client()` explicitly when needed.
+fn main() {
     init_logger();
 
-    let req = Request::from_client();
+    let mut req = FastlyRequest::from_client();
 
     // Keep the health probe independent from settings loading and routing so
     // readiness checks still get a cheap liveness response during startup.
-    if req.get_method() == Method::GET && req.get_path() == "/health" {
-        Response::from_status(200)
+    if req.get_method() == FastlyMethod::GET && req.get_path() == "/health" {
+        FastlyResponse::from_status(200)
             .with_body_text_plain("ok")
             .send_to_client();
-        return Ok(());
+        return;
     }
 
     let settings = match get_settings() {
@@ -71,7 +127,7 @@ fn main() -> Result<(), Error> {
         Err(e) => {
             log::error!("Failed to load settings: {:?}", e);
             to_error_response(&e).send_to_client();
-            return Ok(());
+            return;
         }
     };
     // lgtm[rust/cleartext-logging]
@@ -80,13 +136,13 @@ fn main() -> Result<(), Error> {
 
     // Short-circuit the ja4 debug probe before finalize_response so that
     // Cache-Control: no-store, private cannot be replaced by operator [response_headers].
-    if req.get_method() == Method::GET && req.get_path() == "/_ts/debug/ja4" {
+    if req.get_method() == FastlyMethod::GET && req.get_path() == "/_ts/debug/ja4" {
         if settings.debug.ja4_endpoint_enabled {
             build_ja4_debug_response(&req).send_to_client();
         } else {
-            Response::from_status(fastly::http::StatusCode::NOT_FOUND).send_to_client();
+            FastlyResponse::from_status(fastly::http::StatusCode::NOT_FOUND).send_to_client();
         }
-        return Ok(());
+        return;
     }
 
     // Build the auction orchestrator once at startup
@@ -95,7 +151,7 @@ fn main() -> Result<(), Error> {
         Err(e) => {
             log::error!("Failed to build auction orchestrator: {:?}", e);
             to_error_response(&e).send_to_client();
-            return Ok(());
+            return;
         }
     };
 
@@ -104,7 +160,7 @@ fn main() -> Result<(), Error> {
         Err(e) => {
             log::error!("Failed to create integration registry: {:?}", e);
             to_error_response(&e).send_to_client();
-            return Ok(());
+            return;
         }
     };
 
@@ -113,7 +169,7 @@ fn main() -> Result<(), Error> {
         Err(e) => {
             log::error!("Failed to build partner registry: {:?}", e);
             to_error_response(&e).send_to_client();
-            return Ok(());
+            return;
         }
     };
 
@@ -122,37 +178,146 @@ fn main() -> Result<(), Error> {
     // unrelated routes stay available when EC KV is unavailable.
     let kv_store = std::sync::Arc::new(UnavailableKvStore)
         as std::sync::Arc<dyn trusted_server_core::platform::PlatformKvStore>;
-    let runtime_services = build_runtime_services(&req, kv_store);
+    // Strip client-spoofable forwarded headers at the edge before building
+    // any request-derived context or converting to the core HTTP types.
+    compat::sanitize_fastly_forwarded_headers(&mut req);
 
-    let outcome = futures::executor::block_on(route_request(
+    let runtime_services = build_runtime_services(&req, kv_store);
+    let http_req = compat::from_fastly_request(req);
+
+    let route_result = futures::executor::block_on(route_request(
         &settings,
         &orchestrator,
         &integration_registry,
         &partner_registry,
         &runtime_services,
-        req,
-    ))?;
+        http_req,
+    ))
+    .unwrap_or_else(|e| RouteResult {
+        outcome: HandlerOutcome::Buffered(http_error_response(&e)),
+        ec_context: EcContext::default(),
+        finalize_kv_graph: None,
+        eids_cookie: None,
+        sharedid_cookie: None,
+        is_real_browser: false,
+        should_finalize_ec: true,
+        asset_cache_policy: AssetProxyCachePolicy::OriginControlled,
+    });
 
-    let RouteOutcome {
-        response,
-        pull_sync_context,
-    } = outcome;
+    let RouteResult {
+        outcome,
+        ec_context,
+        finalize_kv_graph,
+        eids_cookie,
+        sharedid_cookie,
+        is_real_browser,
+        should_finalize_ec,
+        asset_cache_policy,
+    } = route_result;
 
-    if let Some(response) = response {
-        response.send_to_client();
+    // Skip geo lookup for our own auth challenges: avoids exposing geo headers to
+    // unauthenticated callers.  Origin-forwarded 401s are not AuthChallenge and
+    // do receive geo headers — the client already reached the origin anyway.
+    let geo_info = if matches!(outcome, HandlerOutcome::AuthChallenge(_)) {
+        None
+    } else {
+        runtime_services
+            .geo()
+            .lookup(runtime_services.client_info().client_ip)
+            .unwrap_or_else(|e| {
+                log::warn!("geo lookup failed: {e}");
+                None
+            })
+    };
+
+    match outcome {
+        HandlerOutcome::Buffered(mut response) | HandlerOutcome::AuthChallenge(mut response) => {
+            finalize_response(&settings, geo_info.as_ref(), &mut response);
+            asset_cache_policy.apply_after_route_finalization(&mut response);
+            let mut fastly_resp = compat::to_fastly_response(response);
+            if should_finalize_ec {
+                ec_finalize_response(
+                    &settings,
+                    &ec_context,
+                    finalize_kv_graph.as_ref(),
+                    &partner_registry,
+                    eids_cookie.as_deref(),
+                    sharedid_cookie.as_deref(),
+                    &mut fastly_resp,
+                );
+            }
+            fastly_resp.send_to_client();
+
+            if is_real_browser {
+                if let Some(context) = build_pull_sync_context(&ec_context) {
+                    run_pull_sync_after_send(&settings, &partner_registry, &context);
+                }
+            }
+        }
+        HandlerOutcome::Streaming {
+            mut response,
+            body,
+            params,
+        } => {
+            finalize_response(&settings, geo_info.as_ref(), &mut response);
+            asset_cache_policy.apply_after_route_finalization(&mut response);
+            let mut fastly_resp = compat::to_fastly_response_skeleton(response);
+            if should_finalize_ec {
+                ec_finalize_response(
+                    &settings,
+                    &ec_context,
+                    finalize_kv_graph.as_ref(),
+                    &partner_registry,
+                    eids_cookie.as_deref(),
+                    sharedid_cookie.as_deref(),
+                    &mut fastly_resp,
+                );
+            }
+            let mut streaming_body = fastly_resp.stream_to_client();
+            let mut stream_succeeded = false;
+            match stream_publisher_body(
+                body,
+                &mut streaming_body,
+                &params,
+                &settings,
+                &integration_registry,
+            ) {
+                Ok(()) => {
+                    if let Err(e) = streaming_body.finish() {
+                        log::error!("failed to finish streaming body: {e}");
+                    } else {
+                        stream_succeeded = true;
+                    }
+                }
+                Err(e) => {
+                    log::error!("streaming processing failed: {e:?}");
+                    // Headers already committed. Drop the body so the client sees a
+                    // truncated response (EOF mid-stream) — standard proxy behavior.
+                    drop(streaming_body);
+                }
+            }
+
+            if is_real_browser && stream_succeeded {
+                if let Some(context) = build_pull_sync_context(&ec_context) {
+                    run_pull_sync_after_send(&settings, &partner_registry, &context);
+                }
+            }
+        }
+        HandlerOutcome::AssetStreaming { mut response, body } => {
+            finalize_response(&settings, geo_info.as_ref(), &mut response);
+            asset_cache_policy.apply_after_route_finalization(&mut response);
+            let fastly_resp = compat::to_fastly_response_skeleton(response);
+            let mut streaming_body = fastly_resp.stream_to_client();
+            if let Err(e) =
+                futures::executor::block_on(stream_asset_body(body, &mut streaming_body))
+            {
+                log::error!("asset streaming failed: {e:?}");
+                drop(streaming_body);
+            } else if let Err(e) = streaming_body.finish() {
+                log::error!("failed to finish asset streaming body: {e}");
+            }
+        }
     }
-
-    if let Some(context) = pull_sync_context {
-        run_pull_sync_after_send(&settings, &partner_registry, &context);
-    }
-
-    Ok(())
-}
-
-#[must_use]
-struct RouteOutcome {
-    response: Option<Response>,
-    pull_sync_context: Option<PullSyncContext>,
 }
 
 const FALLBACK_UNAVAILABLE: &str = "unavailable";
@@ -160,7 +325,7 @@ const FALLBACK_NOT_SENT: &str = "not sent";
 const FALLBACK_NONE: &str = "none";
 
 // TODO: remove after JA4 evaluation completes — see #645
-fn build_ja4_debug_response(req: &Request) -> Response {
+fn build_ja4_debug_response(req: &FastlyRequest) -> FastlyResponse {
     let ja4 = req.get_tls_ja4().unwrap_or(FALLBACK_UNAVAILABLE);
     let h2 = req
         .get_client_h2_fingerprint()
@@ -187,10 +352,10 @@ fn build_ja4_debug_response(req: &Request) -> Response {
          ch-platform: {ch_platform}\n"
     );
 
-    Response::from_status(fastly::http::StatusCode::OK)
-        .with_header(header::CACHE_CONTROL, "no-store, private")
+    FastlyResponse::from_status(fastly::http::StatusCode::OK)
+        .with_header(fastly::http::header::CACHE_CONTROL, "no-store, private")
         .with_header(
-            header::VARY,
+            fastly::http::header::VARY,
             "User-Agent, Sec-CH-UA-Mobile, Sec-CH-UA-Platform",
         )
         .with_content_type(fastly::mime::TEXT_PLAIN_UTF_8)
@@ -203,24 +368,16 @@ async fn route_request(
     integration_registry: &IntegrationRegistry,
     partner_registry: &PartnerRegistry,
     runtime_services: &RuntimeServices,
-    mut req: Request,
-) -> Result<RouteOutcome, Error> {
-    // Strip client-spoofable forwarded headers at the edge.
-    // On Fastly this service IS the first proxy — these headers from
-    // clients are untrusted and can hijack URL rewriting (see #409).
-    compat::sanitize_fastly_forwarded_headers(&mut req);
+    req: HttpRequest,
+) -> Result<RouteResult, Report<TrustedServerError>> {
+    // Build a Fastly request reference for APIs that require fastly types
+    // (EcContext, device signals, cookie extraction).  This is headers/method/URI
+    // only — body has already been moved into `req`.
+    let fastly_req_ref = compat::to_fastly_request_ref(&req);
 
-    // Extract geo info before auth check or routing consumes the request.
-    #[allow(deprecated)]
-    let geo_info = GeoInfo::from_request(&req);
-
-    // Extract the Prebid EIDs cookie before routing consumes the request.
-    let eids_cookie = extract_cookie_value(&req, COOKIE_TS_EIDS);
-    let sharedid_cookie = extract_cookie_value(&req, COOKIE_SHAREDID);
-
-    // Derive device signals from TLS/H2/UA for bot detection.
-    // This is pure in-memory computation — no KV I/O.
-    let device_signals = derive_device_signals(&req);
+    // Extract device signals from TLS/H2/UA.  TLS fingerprints are available
+    // on the fastly request reference even without the body.
+    let device_signals = derive_device_signals(&fastly_req_ref);
     let is_real_browser = device_signals.looks_like_browser();
 
     if !is_real_browser {
@@ -232,40 +389,73 @@ async fn route_request(
         );
     }
 
+    // Extract the Prebid EIDs and SharedID cookies before routing.
+    let eids_cookie = extract_cookie_value(&fastly_req_ref, COOKIE_TS_EIDS);
+    let sharedid_cookie = extract_cookie_value(&fastly_req_ref, COOKIE_SHAREDID);
+
+    // Extract geo info.
+    let geo_info = runtime_services
+        .geo()
+        .lookup(runtime_services.client_info().client_ip)
+        .unwrap_or_else(|e| {
+            log::warn!("geo lookup failed during routing: {e}");
+            None
+        });
+
     // S2S batch sync — uses Bearer auth (not EC cookies), so skip EC
     // context creation and the EC finalize middleware entirely.
-    if req.get_method() == Method::POST && req.get_path() == "/_ts/api/v1/batch-sync" {
-        let auth_req = compat::from_fastly_headers_ref(&req);
-        let mut response = match enforce_basic_auth(settings, &auth_req) {
-            Ok(Some(response)) => compat::to_fastly_response(response),
-            Ok(None) => require_identity_graph(settings)
-                .map(|kv| {
-                    let limiter = FastlyRateLimiter::new(RATE_COUNTER_NAME);
-                    handle_batch_sync(&kv, partner_registry, &limiter, req)
-                })
-                .and_then(|r| r)
-                .unwrap_or_else(|e| to_error_response(&e)),
-            Err(e) => {
-                log::error!("Failed to evaluate basic auth: {:?}", e);
-                to_error_response(&e)
+    if req.method() == Method::POST && req.uri().path() == "/_ts/api/v1/batch-sync" {
+        match enforce_basic_auth(settings, &req) {
+            Ok(Some(response)) => {
+                return Ok(RouteResult {
+                    outcome: HandlerOutcome::AuthChallenge(response),
+                    ec_context: EcContext::default(),
+                    finalize_kv_graph: None,
+                    eids_cookie,
+                    sharedid_cookie,
+                    is_real_browser,
+                    should_finalize_ec: true,
+                    asset_cache_policy: AssetProxyCachePolicy::OriginControlled,
+                });
             }
+            Ok(None) => {}
+            Err(e) => return Err(e),
+        }
+        let fastly_req = compat::to_fastly_request(req);
+        let result = require_identity_graph(settings).and_then(|kv| {
+            let limiter = FastlyRateLimiter::new(RATE_COUNTER_NAME);
+            handle_batch_sync(&kv, partner_registry, &limiter, fastly_req)
+        });
+        let outcome = match result {
+            Ok(fastly_resp) => HandlerOutcome::Buffered(compat::from_fastly_response(fastly_resp)),
+            Err(e) => HandlerOutcome::Buffered(http_error_response(&e)),
         };
-        finalize_response(settings, geo_info.as_ref(), &mut response);
-        return Ok(RouteOutcome {
-            response: Some(response),
-            pull_sync_context: None,
+        return Ok(RouteResult {
+            outcome,
+            ec_context: EcContext::default(),
+            finalize_kv_graph: None,
+            eids_cookie,
+            sharedid_cookie,
+            is_real_browser,
+            should_finalize_ec: true,
+            asset_cache_policy: AssetProxyCachePolicy::OriginControlled,
         });
     }
 
+    // Build EC context using the fastly request reference (headers/method/URI).
     let mut ec_context =
-        match EcContext::read_from_request_with_geo(settings, &req, geo_info.as_ref()) {
+        match EcContext::read_from_request_with_geo(settings, &fastly_req_ref, geo_info.as_ref()) {
             Ok(context) => context,
             Err(err) => {
-                let mut response = to_error_response(&err);
-                finalize_response(settings, geo_info.as_ref(), &mut response);
-                return Ok(RouteOutcome {
-                    response: Some(response),
-                    pull_sync_context: None,
+                return Ok(RouteResult {
+                    outcome: HandlerOutcome::Buffered(http_error_response(&err)),
+                    ec_context: EcContext::default(),
+                    finalize_kv_graph: None,
+                    eids_cookie,
+                    sharedid_cookie,
+                    is_real_browser,
+                    should_finalize_ec: true,
+                    asset_cache_policy: AssetProxyCachePolicy::OriginControlled,
                 });
             }
         };
@@ -277,54 +467,40 @@ async fn route_request(
     // consent withdrawals. Revocations need the KV graph so tombstones remain
     // authoritative even for privacy-extension-heavy clients that do not look
     // like known browsers.
-    let kv_graph = if is_real_browser {
-        maybe_identity_graph(settings)
-    } else {
-        None
-    };
+    // Build the KV identity graph once. The write-path (finalize_kv_graph) is
+    // also given to bots when they signal consent withdrawal so tombstones are
+    // authoritative even for privacy-extension-heavy clients.
+    let kv_graph = maybe_identity_graph(settings);
     let finalize_kv_graph = if is_real_browser || ec_consent_withdrawn(ec_context.consent()) {
-        maybe_identity_graph(settings)
+        kv_graph.clone()
     } else {
         None
     };
+    let kv_graph = if is_real_browser { kv_graph } else { None };
 
     // `get_settings()` should already have rejected invalid handler regexes.
     // Keep this fallback so manually-constructed or otherwise unprepared
     // settings still become an error response instead of panicking.
-    let auth_req = compat::from_fastly_headers_ref(&req);
-    match enforce_basic_auth(settings, &auth_req) {
+    match enforce_basic_auth(settings, &req) {
         Ok(Some(response)) => {
-            let mut response = compat::to_fastly_response(response);
-            ec_finalize_response(
-                settings,
-                &ec_context,
-                finalize_kv_graph.as_ref(),
-                partner_registry,
-                eids_cookie.as_deref(),
-                sharedid_cookie.as_deref(),
-                &mut response,
-            );
-            finalize_response(settings, geo_info.as_ref(), &mut response);
-            return Ok(RouteOutcome {
-                response: Some(response),
-                pull_sync_context: None,
+            return Ok(RouteResult {
+                outcome: HandlerOutcome::AuthChallenge(response),
+                ec_context,
+                finalize_kv_graph,
+                eids_cookie,
+                sharedid_cookie,
+                is_real_browser,
+                should_finalize_ec: true,
+                asset_cache_policy: AssetProxyCachePolicy::OriginControlled,
             });
         }
         Ok(None) => {}
-        Err(e) => {
-            log::error!("Failed to evaluate basic auth: {:?}", e);
-            let mut response = to_error_response(&e);
-            finalize_response(settings, geo_info.as_ref(), &mut response);
-            return Ok(RouteOutcome {
-                response: Some(response),
-                pull_sync_context: None,
-            });
-        }
+        Err(e) => return Err(e),
     }
 
     // Get path and method for routing
-    let path = req.get_path().to_string();
-    let method = req.get_method().clone();
+    let path = req.uri().path().to_string();
+    let method = req.method().clone();
 
     let mut asset_cache_policy = AssetProxyCachePolicy::OriginControlled;
     let mut should_finalize_ec = true;
@@ -359,13 +535,19 @@ async fn route_request(
                 false,
             )
         }
-        (Method::GET, "/_ts/api/v1/identify") => (
-            require_identity_graph(settings)
-                .and_then(|kv| handle_identify(settings, &kv, partner_registry, &req, &ec_context)),
-            false,
-        ),
+        (Method::GET, "/_ts/api/v1/identify") => {
+            let fastly_ref = compat::to_fastly_request_ref(&req);
+            let outcome = require_identity_graph(settings).and_then(|kv| {
+                handle_identify(settings, &kv, partner_registry, &fastly_ref, &ec_context)
+                    .map(compat::from_fastly_response)
+            });
+            (outcome, false)
+        }
         (Method::OPTIONS, "/_ts/api/v1/identify") => {
-            (cors_preflight_identify(settings, &req), false)
+            let fastly_ref = compat::to_fastly_request_ref(&req);
+            let outcome =
+                cors_preflight_identify(settings, &fastly_ref).map(compat::from_fastly_response);
+            (outcome, false)
         }
 
         // Unified auction endpoint (returns creative HTML inline)
@@ -390,7 +572,7 @@ async fn route_request(
             )
         }
 
-        // tsjs endpoints
+        // First-party proxy/click/sign/rebuild endpoints
         (Method::GET, "/first-party/proxy") => (
             handle_first_party_proxy(settings, runtime_services, req).await,
             false,
@@ -442,24 +624,17 @@ async fn route_request(
                     {
                         Ok(asset_response) => {
                             asset_cache_policy = asset_response.cache_policy();
-                            let (mut response, stream_body) =
-                                asset_response.into_response_and_body();
+                            let (response, stream_body) = asset_response.into_response_and_body();
                             if let Some(body) = stream_body {
-                                finalize_response(settings, geo_info.as_ref(), &mut response);
-                                asset_cache_policy.apply_after_route_finalization(&mut response);
-
-                                let mut streaming_body = response.stream_to_client();
-                                if let Err(err) = stream_asset_body(body, &mut streaming_body).await
-                                {
-                                    log::error!("Asset streaming failed: {err:?}");
-                                    drop(streaming_body);
-                                } else if let Err(err) = streaming_body.finish() {
-                                    log::error!("Failed to finish asset streaming body: {err}");
-                                }
-
-                                return Ok(RouteOutcome {
-                                    response: None,
-                                    pull_sync_context: None,
+                                return Ok(RouteResult {
+                                    outcome: HandlerOutcome::AssetStreaming { response, body },
+                                    ec_context,
+                                    finalize_kv_graph,
+                                    eids_cookie,
+                                    sharedid_cookie,
+                                    is_real_browser,
+                                    should_finalize_ec,
+                                    asset_cache_policy,
                                 });
                             }
                             Ok(response)
@@ -476,65 +651,45 @@ async fn route_request(
                     path
                 );
 
+                // Generate EC ID if needed — mirrors the integration proxy path in registry.rs.
+                // Only for document navigations by recognised browsers; subresource requests
+                // may lack consent signals such as Sec-GPC.
+                if is_real_browser && is_navigation_request(&req) {
+                    if let Err(err) = ec_context.generate_if_needed(settings, kv_graph.as_ref()) {
+                        log::warn!("EC generation failed for publisher proxy: {err:?}");
+                    }
+                }
+
                 match handle_publisher_request(
                     settings,
                     integration_registry,
                     runtime_services,
-                    kv_graph.as_ref(),
-                    &mut ec_context,
                     req,
-                ) {
+                )
+                .await
+                {
                     Ok(PublisherResponse::Stream {
-                        mut response,
+                        response,
                         body,
                         params,
                     }) => {
-                        // Publisher fallback has multiple delivery modes.
-                        // EC finalization is header-only, so it must happen before
-                        // headers are committed on the streaming path.
-                        ec_finalize_response(
-                            settings,
-                            &ec_context,
-                            finalize_kv_graph.as_ref(),
-                            partner_registry,
-                            eids_cookie.as_deref(),
-                            sharedid_cookie.as_deref(),
-                            &mut response,
-                        );
-                        finalize_response(settings, geo_info.as_ref(), &mut response);
-
-                        let mut streaming_body = response.stream_to_client();
-                        let mut stream_succeeded = false;
-                        if let Err(err) = stream_publisher_body(
-                            body,
-                            &mut streaming_body,
-                            &params,
-                            settings,
-                            integration_registry,
-                        ) {
-                            // Headers are already committed. Log and abort rather
-                            // than trying to replace the response mid-stream.
-                            log::error!("Streaming processing failed: {err:?}");
-                            drop(streaming_body);
-                        } else if let Err(err) = streaming_body.finish() {
-                            log::error!("Failed to finish streaming body: {err}");
-                        } else {
-                            stream_succeeded = true;
-                        }
-
-                        let pull_sync_context = if is_real_browser && stream_succeeded {
-                            build_pull_sync_context(&ec_context)
-                        } else {
-                            None
-                        };
-
-                        return Ok(RouteOutcome {
-                            response: None,
-                            pull_sync_context,
+                        return Ok(RouteResult {
+                            outcome: HandlerOutcome::Streaming {
+                                response,
+                                body,
+                                params,
+                            },
+                            ec_context,
+                            finalize_kv_graph,
+                            eids_cookie,
+                            sharedid_cookie,
+                            is_real_browser,
+                            should_finalize_ec,
+                            asset_cache_policy,
                         });
                     }
                     Ok(PublisherResponse::PassThrough { mut response, body }) => {
-                        response.set_body(body);
+                        *response.body_mut() = body;
                         (Ok(response), true)
                     }
                     Ok(PublisherResponse::Buffered(response)) => (Ok(response), true),
@@ -547,42 +702,21 @@ async fn route_request(
         }
     };
 
-    let route_succeeded = result.is_ok();
+    let _ = organic_route;
 
-    // Convert any errors to HTTP error responses
-    let mut response = result.unwrap_or_else(|e| to_error_response(&e));
+    let outcome = result
+        .map(HandlerOutcome::Buffered)
+        .unwrap_or_else(|e| HandlerOutcome::Buffered(http_error_response(&e)));
 
-    // Bot gate still suppresses generated EC writes and pull sync via
-    // `kv_graph = None`, but withdrawal finalization uses `finalize_kv_graph`
-    // so revocation tombstones are not lost for bot-classified clients.
-    if should_finalize_ec {
-        ec_finalize_response(
-            settings,
-            &ec_context,
-            finalize_kv_graph.as_ref(),
-            partner_registry,
-            eids_cookie.as_deref(),
-            sharedid_cookie.as_deref(),
-            &mut response,
-        );
-    }
-
-    finalize_response(settings, geo_info.as_ref(), &mut response);
-    asset_cache_policy.apply_after_route_finalization(&mut response);
-
-    let pull_sync_context = if is_real_browser && organic_route && route_succeeded {
-        // Pull sync is intentionally refreshed only from successful organic
-        // browser traffic. This keeps the trigger narrow in the current PR;
-        // broadening it to auction-heavy or SPA-only flows is a follow-up
-        // product decision rather than an implicit behavior change here.
-        build_pull_sync_context(&ec_context)
-    } else {
-        None
-    };
-
-    Ok(RouteOutcome {
-        response: Some(response),
-        pull_sync_context,
+    Ok(RouteResult {
+        outcome,
+        ec_context,
+        finalize_kv_graph,
+        eids_cookie,
+        sharedid_cookie,
+        is_real_browser,
+        should_finalize_ec,
+        asset_cache_policy,
     })
 }
 
@@ -615,26 +749,53 @@ fn run_pull_sync_after_send(
 /// Header precedence (last write wins): geo headers are set first, then
 /// version/staging, then operator-configured `settings.response_headers`.
 /// This means operators can intentionally override any managed header.
-fn finalize_response(settings: &Settings, geo_info: Option<&GeoInfo>, response: &mut Response) {
+fn finalize_response(settings: &Settings, geo_info: Option<&GeoInfo>, response: &mut HttpResponse) {
     if let Some(geo) = geo_info {
         geo.set_response_headers(response);
     } else {
-        response.set_header(HEADER_X_GEO_INFO_AVAILABLE, "false");
+        response.headers_mut().insert(
+            HEADER_X_GEO_INFO_AVAILABLE,
+            HeaderValue::from_static("false"),
+        );
     }
 
     if let Ok(v) = ::std::env::var(ENV_FASTLY_SERVICE_VERSION) {
-        response.set_header(HEADER_X_TS_VERSION, v);
+        if let Ok(value) = HeaderValue::from_str(&v) {
+            response.headers_mut().insert(HEADER_X_TS_VERSION, value);
+        } else {
+            log::warn!("Skipping invalid FASTLY_SERVICE_VERSION response header value");
+        }
     }
     if ::std::env::var(ENV_FASTLY_IS_STAGING).as_deref() == Ok("1") {
-        response.set_header(HEADER_X_TS_ENV, "staging");
+        response
+            .headers_mut()
+            .insert(HEADER_X_TS_ENV, HeaderValue::from_static("staging"));
     }
 
     for (key, value) in &settings.response_headers {
-        response.set_header(key, value);
+        let header_name = HeaderName::from_bytes(key.as_bytes())
+            .expect("settings.response_headers validated at load time");
+        let header_value =
+            HeaderValue::from_str(value).expect("settings.response_headers validated at load time");
+        response.headers_mut().insert(header_name, header_value);
     }
 }
 
-/// Constructs a `KvIdentityGraph` from settings, or returns 503 if the
+fn http_error_response(report: &Report<TrustedServerError>) -> HttpResponse {
+    let root_error = report.current_context();
+    log::error!("Error occurred: {:?}", report);
+
+    let mut response =
+        HttpResponse::new(EdgeBody::from(format!("{}\n", root_error.user_message())));
+    *response.status_mut() = root_error.status_code();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    response
+}
+
+/// Constructs a `KvIdentityGraph` from settings, or returns an error if the
 /// `ec_store` config is not set.
 fn require_identity_graph(
     settings: &Settings,
@@ -649,7 +810,7 @@ fn require_identity_graph(
 }
 
 /// Extracts a named cookie value from the request's `Cookie` header.
-fn extract_cookie_value(req: &Request, name: &str) -> Option<String> {
+fn extract_cookie_value(req: &FastlyRequest, name: &str) -> Option<String> {
     let cookie_header = req.get_header_str("cookie")?;
     for pair in cookie_header.split(';') {
         let pair = pair.trim();
@@ -666,7 +827,7 @@ fn extract_cookie_value(req: &Request, name: &str) -> Option<String> {
 ///
 /// All extraction is pure in-memory — no KV I/O. The Fastly SDK provides
 /// `get_tls_ja4()` and `get_client_h2_fingerprint()` on client requests.
-fn derive_device_signals(req: &Request) -> DeviceSignals {
+fn derive_device_signals(req: &FastlyRequest) -> DeviceSignals {
     let ua = req.get_header_str("user-agent").unwrap_or("");
     let ja4 = req.get_tls_ja4();
     let h2_fp = req.get_client_h2_fingerprint();
@@ -681,7 +842,7 @@ mod tests {
 
     #[test]
     fn ja4_debug_response_uses_plain_text_and_fallback_values() {
-        let req = Request::get("https://example.com/_ts/debug/ja4");
+        let req = FastlyRequest::get("https://example.com/_ts/debug/ja4");
 
         let mut response = build_ja4_debug_response(&req);
 
@@ -696,7 +857,7 @@ mod tests {
             "should return plain text content"
         );
         assert_eq!(
-            response.get_header_str(header::CACHE_CONTROL),
+            response.get_header_str(fastly::http::header::CACHE_CONTROL),
             Some("no-store, private"),
             "should disable caching for the debug response"
         );

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -27,8 +27,9 @@ use trusted_server_core::geo::GeoInfo;
 use trusted_server_core::integrations::{IntegrationRegistry, ProxyDispatchInput};
 use trusted_server_core::platform::RuntimeServices;
 use trusted_server_core::proxy::{
-    handle_first_party_click, handle_first_party_proxy, handle_first_party_proxy_rebuild,
-    handle_first_party_proxy_sign,
+    handle_asset_proxy_request, handle_first_party_click, handle_first_party_proxy,
+    handle_first_party_proxy_rebuild, handle_first_party_proxy_sign, stream_asset_body,
+    AssetProxyCachePolicy,
 };
 use trusted_server_core::publisher::{
     handle_publisher_request, handle_tsjs_dynamic, stream_publisher_body, PublisherResponse,
@@ -325,6 +326,9 @@ async fn route_request(
     let path = req.get_path().to_string();
     let method = req.get_method().clone();
 
+    let mut asset_cache_policy = AssetProxyCachePolicy::OriginControlled;
+    let mut should_finalize_ec = true;
+
     // Match known routes and handle them
     let (result, organic_route) = match (method, path.as_str()) {
         // Serve the tsjs library
@@ -387,18 +391,22 @@ async fn route_request(
         }
 
         // tsjs endpoints
-        (Method::GET, "/first-party/proxy") => {
-            (handle_first_party_proxy(settings, req).await, false)
-        }
-        (Method::GET, "/first-party/click") => {
-            (handle_first_party_click(settings, req).await, false)
-        }
-        (Method::GET, "/first-party/sign") | (Method::POST, "/first-party/sign") => {
-            (handle_first_party_proxy_sign(settings, req).await, false)
-        }
-        (Method::POST, "/first-party/proxy-rebuild") => {
-            (handle_first_party_proxy_rebuild(settings, req).await, false)
-        }
+        (Method::GET, "/first-party/proxy") => (
+            handle_first_party_proxy(settings, runtime_services, req).await,
+            false,
+        ),
+        (Method::GET, "/first-party/click") => (
+            handle_first_party_click(settings, runtime_services, req).await,
+            false,
+        ),
+        (Method::GET, "/first-party/sign") | (Method::POST, "/first-party/sign") => (
+            handle_first_party_proxy_sign(settings, runtime_services, req).await,
+            false,
+        ),
+        (Method::POST, "/first-party/proxy-rebuild") => (
+            handle_first_party_proxy_rebuild(settings, runtime_services, req).await,
+            false,
+        ),
         (m, path) if integration_registry.has_route(&m, path) => {
             let result = integration_registry
                 .handle_proxy(ProxyDispatchInput {
@@ -407,6 +415,7 @@ async fn route_request(
                     settings,
                     kv: kv_graph.as_ref(),
                     ec_context: &mut ec_context,
+                    services: runtime_services,
                     req,
                 })
                 .await
@@ -418,78 +427,121 @@ async fn route_request(
             (result, true)
         }
 
-        // No known route matched, proxy to publisher origin as fallback
-        _ => {
-            log::info!(
-                "No known route matched for path: {}, proxying to publisher origin",
-                path
-            );
+        // No known route matched, proxy to an asset origin or publisher origin as fallback
+        (method, _) => {
+            let matched_asset_route = matches!(method, Method::GET | Method::HEAD)
+                .then(|| settings.asset_route_for_path(&path))
+                .flatten();
 
-            match handle_publisher_request(
-                settings,
-                integration_registry,
-                runtime_services,
-                kv_graph.as_ref(),
-                &mut ec_context,
-                req,
-            ) {
-                Ok(PublisherResponse::Stream {
-                    mut response,
-                    body,
-                    params,
-                }) => {
-                    // Publisher fallback has multiple delivery modes.
-                    // EC finalization is header-only, so it must happen before
-                    // headers are committed on the streaming path.
-                    ec_finalize_response(
-                        settings,
-                        &ec_context,
-                        finalize_kv_graph.as_ref(),
-                        partner_registry,
-                        eids_cookie.as_deref(),
-                        sharedid_cookie.as_deref(),
-                        &mut response,
-                    );
-                    finalize_response(settings, geo_info.as_ref(), &mut response);
+            if let Some(asset_route) = matched_asset_route {
+                should_finalize_ec = false;
+                log::info!("No explicit route matched; proxying via configured asset route");
+                let result =
+                    match handle_asset_proxy_request(settings, runtime_services, req, asset_route)
+                        .await
+                    {
+                        Ok(asset_response) => {
+                            asset_cache_policy = asset_response.cache_policy();
+                            let (mut response, stream_body) =
+                                asset_response.into_response_and_body();
+                            if let Some(body) = stream_body {
+                                finalize_response(settings, geo_info.as_ref(), &mut response);
+                                asset_cache_policy.apply_after_route_finalization(&mut response);
 
-                    let mut streaming_body = response.stream_to_client();
-                    let mut stream_succeeded = false;
-                    if let Err(err) = stream_publisher_body(
-                        body,
-                        &mut streaming_body,
-                        &params,
-                        settings,
-                        integration_registry,
-                    ) {
-                        // Headers are already committed. Log and abort rather
-                        // than trying to replace the response mid-stream.
-                        log::error!("Streaming processing failed: {err:?}");
-                        drop(streaming_body);
-                    } else if let Err(err) = streaming_body.finish() {
-                        log::error!("Failed to finish streaming body: {err}");
-                    } else {
-                        stream_succeeded = true;
-                    }
+                                let mut streaming_body = response.stream_to_client();
+                                if let Err(err) = stream_asset_body(body, &mut streaming_body).await
+                                {
+                                    log::error!("Asset streaming failed: {err:?}");
+                                    drop(streaming_body);
+                                } else if let Err(err) = streaming_body.finish() {
+                                    log::error!("Failed to finish asset streaming body: {err}");
+                                }
 
-                    let pull_sync_context = if is_real_browser && stream_succeeded {
-                        build_pull_sync_context(&ec_context)
-                    } else {
-                        None
+                                return Ok(RouteOutcome {
+                                    response: None,
+                                    pull_sync_context: None,
+                                });
+                            }
+                            Ok(response)
+                        }
+                        Err(e) => {
+                            asset_cache_policy = AssetProxyCachePolicy::NoStorePrivate;
+                            Err(e)
+                        }
                     };
+                (result, false)
+            } else {
+                log::info!(
+                    "No known route matched for path: {}, proxying to publisher origin",
+                    path
+                );
 
-                    return Ok(RouteOutcome {
-                        response: None,
-                        pull_sync_context,
-                    });
-                }
-                Ok(PublisherResponse::PassThrough { mut response, body }) => {
-                    response.set_body(body);
-                    (Ok(response), true)
-                }
-                Ok(PublisherResponse::Buffered(response)) => (Ok(response), true),
-                Err(e) => {
-                    log::error!("Failed to proxy to publisher origin: {:?}", e);
-                    (Err(e), true)
+                match handle_publisher_request(
+                    settings,
+                    integration_registry,
+                    runtime_services,
+                    kv_graph.as_ref(),
+                    &mut ec_context,
+                    req,
+                ) {
+                    Ok(PublisherResponse::Stream {
+                        mut response,
+                        body,
+                        params,
+                    }) => {
+                        // Publisher fallback has multiple delivery modes.
+                        // EC finalization is header-only, so it must happen before
+                        // headers are committed on the streaming path.
+                        ec_finalize_response(
+                            settings,
+                            &ec_context,
+                            finalize_kv_graph.as_ref(),
+                            partner_registry,
+                            eids_cookie.as_deref(),
+                            sharedid_cookie.as_deref(),
+                            &mut response,
+                        );
+                        finalize_response(settings, geo_info.as_ref(), &mut response);
+
+                        let mut streaming_body = response.stream_to_client();
+                        let mut stream_succeeded = false;
+                        if let Err(err) = stream_publisher_body(
+                            body,
+                            &mut streaming_body,
+                            &params,
+                            settings,
+                            integration_registry,
+                        ) {
+                            // Headers are already committed. Log and abort rather
+                            // than trying to replace the response mid-stream.
+                            log::error!("Streaming processing failed: {err:?}");
+                            drop(streaming_body);
+                        } else if let Err(err) = streaming_body.finish() {
+                            log::error!("Failed to finish streaming body: {err}");
+                        } else {
+                            stream_succeeded = true;
+                        }
+
+                        let pull_sync_context = if is_real_browser && stream_succeeded {
+                            build_pull_sync_context(&ec_context)
+                        } else {
+                            None
+                        };
+
+                        return Ok(RouteOutcome {
+                            response: None,
+                            pull_sync_context,
+                        });
+                    }
+                    Ok(PublisherResponse::PassThrough { mut response, body }) => {
+                        response.set_body(body);
+                        (Ok(response), true)
+                    }
+                    Ok(PublisherResponse::Buffered(response)) => (Ok(response), true),
+                    Err(e) => {
+                        log::error!("Failed to proxy to publisher origin: {:?}", e);
+                        (Err(e), true)
+                    }
                 }
             }
         }
@@ -503,17 +555,20 @@ async fn route_request(
     // Bot gate still suppresses generated EC writes and pull sync via
     // `kv_graph = None`, but withdrawal finalization uses `finalize_kv_graph`
     // so revocation tombstones are not lost for bot-classified clients.
-    ec_finalize_response(
-        settings,
-        &ec_context,
-        finalize_kv_graph.as_ref(),
-        partner_registry,
-        eids_cookie.as_deref(),
-        sharedid_cookie.as_deref(),
-        &mut response,
-    );
+    if should_finalize_ec {
+        ec_finalize_response(
+            settings,
+            &ec_context,
+            finalize_kv_graph.as_ref(),
+            partner_registry,
+            eids_cookie.as_deref(),
+            sharedid_cookie.as_deref(),
+            &mut response,
+        );
+    }
 
     finalize_response(settings, geo_info.as_ref(), &mut response);
+    asset_cache_policy.apply_after_route_finalization(&mut response);
 
     let pull_sync_context = if is_real_browser && organic_route && route_succeeded {
         // Pull sync is intentionally refreshed only from successful organic

--- a/crates/trusted-server-adapter-fastly/src/platform.rs
+++ b/crates/trusted-server-adapter-fastly/src/platform.rs
@@ -5,9 +5,11 @@
 //! constructs a [`RuntimeServices`] instance once at the entry point from the
 //! incoming Fastly request.
 
+use std::io::Read as _;
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use edgezero_adapter_fastly::key_value_store::FastlyKvStore;
 use edgezero_core::key_value_store::KvError;
 use error_stack::{Report, ResultExt};
@@ -19,9 +21,10 @@ use trusted_server_core::geo::geo_from_fastly;
 pub(crate) use trusted_server_core::platform::UnavailableKvStore;
 use trusted_server_core::platform::{
     ClientInfo, GeoInfo, PlatformBackend, PlatformBackendSpec, PlatformConfigStore, PlatformError,
-    PlatformGeo, PlatformHttpClient, PlatformHttpRequest, PlatformKvStore, PlatformPendingRequest,
-    PlatformResponse, PlatformSecretStore, PlatformSelectResult, RuntimeServices, StoreId,
-    StoreName,
+    PlatformGeo, PlatformHttpClient, PlatformHttpRequest, PlatformImageOptimizerCrop,
+    PlatformImageOptimizerCropMode, PlatformImageOptimizerOptions, PlatformImageOptimizerParams,
+    PlatformImageOptimizerRegion, PlatformKvStore, PlatformPendingRequest, PlatformResponse,
+    PlatformSecretStore, PlatformSelectResult, RuntimeServices, StoreId, StoreName,
 };
 
 // ---------------------------------------------------------------------------
@@ -176,6 +179,122 @@ impl PlatformBackend for FastlyPlatformBackend {
 // FastlyPlatformHttpClient — helpers
 // ---------------------------------------------------------------------------
 
+fn fastly_image_optimizer_region(
+    region: &str,
+) -> Result<fastly::image_optimizer::ImageOptimizerRegion, Report<PlatformError>> {
+    use fastly::image_optimizer::ImageOptimizerRegion;
+
+    match PlatformImageOptimizerRegion::parse(region) {
+        Some(PlatformImageOptimizerRegion::UsEast) => Ok(ImageOptimizerRegion::UsEast),
+        Some(PlatformImageOptimizerRegion::UsCentral) => Ok(ImageOptimizerRegion::UsCentral),
+        Some(PlatformImageOptimizerRegion::UsWest) => Ok(ImageOptimizerRegion::UsWest),
+        Some(PlatformImageOptimizerRegion::EuCentral) => Ok(ImageOptimizerRegion::EuCentral),
+        Some(PlatformImageOptimizerRegion::EuWest) => Ok(ImageOptimizerRegion::EuWest),
+        Some(PlatformImageOptimizerRegion::Asia) => Ok(ImageOptimizerRegion::Asia),
+        Some(PlatformImageOptimizerRegion::Australia) => Ok(ImageOptimizerRegion::Australia),
+        None => Err(Report::new(PlatformError::HttpClient)
+            .attach(format!("unsupported Image Optimizer region: {region}"))),
+    }
+}
+
+fn fastly_image_optimizer_format(
+    format: &str,
+) -> Result<fastly::image_optimizer::Format, Report<PlatformError>> {
+    use fastly::image_optimizer::Format;
+
+    match format.trim().to_ascii_lowercase().as_str() {
+        "auto" => Ok(Format::Auto),
+        "avif" => Ok(Format::AVIF),
+        "gif" => Ok(Format::GIF),
+        "jpeg" | "jpg" => Ok(Format::JPEG),
+        "jxl" | "jpegxl" => Ok(Format::JPEGXL),
+        "mp4" => Ok(Format::MP4),
+        "png" => Ok(Format::PNG),
+        "webp" => Ok(Format::WebP),
+        other => Err(Report::new(PlatformError::HttpClient)
+            .attach(format!("unsupported Image Optimizer format: {other}"))),
+    }
+}
+
+fn fastly_resize_filter(
+    resize_filter: &str,
+) -> Result<fastly::image_optimizer::ResizeAlgorithm, Report<PlatformError>> {
+    use fastly::image_optimizer::ResizeAlgorithm;
+
+    match resize_filter.trim().to_ascii_lowercase().as_str() {
+        "nearest" => Ok(ResizeAlgorithm::Nearest),
+        "bilinear" => Ok(ResizeAlgorithm::Bilinear),
+        "bicubic" => Ok(ResizeAlgorithm::Bicubic),
+        "lanczos2" => Ok(ResizeAlgorithm::Lanczos2),
+        "lanczos3" => Ok(ResizeAlgorithm::Lanczos3),
+        other => Err(Report::new(PlatformError::HttpClient).attach(format!(
+            "unsupported Image Optimizer resize filter: {other}"
+        ))),
+    }
+}
+
+fn fastly_crop(crop: &PlatformImageOptimizerCrop) -> fastly::image_optimizer::Crop {
+    use fastly::image_optimizer::{Area, Crop, CropMode, PointOrOffset, Position};
+
+    let position = match (crop.offset_x, crop.offset_y) {
+        (Some(x), Some(y)) => Some(Position {
+            x: Some(PointOrOffset::Offset(x)),
+            y: Some(PointOrOffset::Offset(y)),
+        }),
+        _ => None,
+    };
+    let mode = crop
+        .mode
+        .map(|PlatformImageOptimizerCropMode::Smart| CropMode::Smart);
+
+    Crop {
+        size: Area::AspectRatio((crop.width, crop.height)),
+        position,
+        mode,
+    }
+}
+
+fn apply_fastly_image_optimizer_params(
+    target: &mut fastly::image_optimizer::ImageOptimizerOptions,
+    params: PlatformImageOptimizerParams,
+) -> Result<(), Report<PlatformError>> {
+    use fastly::image_optimizer::PixelsOrPercentage;
+
+    if let Some(format) = params.format {
+        target.format = Some(fastly_image_optimizer_format(&format)?);
+    }
+    if let Some(quality) = params.quality {
+        target.quality = Some(quality);
+    }
+    if let Some(resize_filter) = params.resize_filter {
+        target.resize_filter = Some(fastly_resize_filter(&resize_filter)?);
+    }
+    if let Some(width) = params.width {
+        target.width = Some(PixelsOrPercentage::Pixels(width));
+    }
+    if let Some(height) = params.height {
+        target.height = Some(PixelsOrPercentage::Pixels(height));
+    }
+    if let Some(crop) = params.crop {
+        target.crop = Some(fastly_crop(&crop));
+    }
+
+    Ok(())
+}
+
+fn apply_fastly_image_optimizer(
+    req: &mut fastly::Request,
+    options: PlatformImageOptimizerOptions,
+) -> Result<(), Report<PlatformError>> {
+    let region = fastly_image_optimizer_region(&options.region)?;
+    let mut fastly_options = fastly::image_optimizer::ImageOptimizerOptions::from_region(region);
+    fastly_options.preserve_query_string_on_origin_request =
+        Some(options.preserve_query_string_on_origin_request);
+    apply_fastly_image_optimizer_params(&mut fastly_options, options.params)?;
+    req.set_image_optimizer(fastly_options);
+    Ok(())
+}
+
 /// Convert a platform-neutral [`edgezero_core::http::Request`] to a [`fastly::Request`].
 ///
 /// Only buffered `Body::Once` bodies are supported on this path.
@@ -205,19 +324,41 @@ fn edge_request_to_fastly(
     Ok(fastly_req)
 }
 
+fn fastly_body_to_edge_stream(body: fastly::Body) -> edgezero_core::body::Body {
+    let stream = futures::stream::unfold(Some(body), |state| async move {
+        let mut body = state?;
+        let mut chunk = vec![0; 8192];
+        match body.read(&mut chunk) {
+            Ok(0) => None,
+            Ok(bytes_read) => {
+                chunk.truncate(bytes_read);
+                Some((Ok(Bytes::from(chunk)), Some(body)))
+            }
+            Err(err) => Some((Err(err), None)),
+        }
+    });
+
+    edgezero_core::body::Body::from_stream(stream)
+}
+
 /// Convert a [`fastly::Response`] to a [`PlatformResponse`] with the given backend name.
 fn fastly_response_to_platform(
     mut resp: fastly::Response,
     backend_name: impl Into<String>,
+    stream_response: bool,
 ) -> Result<PlatformResponse, Report<PlatformError>> {
     let status = resp.get_status();
     let mut builder = edgezero_core::http::response_builder().status(status);
     for (name, value) in resp.get_headers() {
         builder = builder.header(name.as_str(), value.as_bytes());
     }
-    let body_bytes = resp.take_body_bytes();
+    let body = if stream_response {
+        fastly_body_to_edge_stream(resp.take_body())
+    } else {
+        edgezero_core::body::Body::from(resp.take_body_bytes())
+    };
     let edge_response = builder
-        .body(edgezero_core::body::Body::from(body_bytes))
+        .body(body)
         .change_context(PlatformError::HttpClient)?;
     Ok(PlatformResponse::new(edge_response).with_backend_name(backend_name))
 }
@@ -228,11 +369,14 @@ fn fastly_response_to_platform(
 
 /// Fastly implementation of [`PlatformHttpClient`].
 ///
-/// - [`send`](PlatformHttpClient::send) — converts the platform request to a
-///   `fastly::Request`, calls `.send()`, and wraps the response.
-/// - [`send_async`](PlatformHttpClient::send_async) — same conversion but
-///   calls `.send_async()` and wraps the `fastly::PendingRequest`.
-/// - [`select`](PlatformHttpClient::select) — downcasts each
+/// - [`send`](PlatformHttpClient::send) converts the platform request to a
+///   `fastly::Request`, applies Image Optimizer metadata when present, calls
+///   `.send()`, and wraps the response. Asset requests can ask to preserve the
+///   response body as a stream instead of buffering it into a single `Vec`.
+/// - [`send_async`](PlatformHttpClient::send_async) converts the request and
+///   calls `.send_async()`. It rejects Image Optimizer metadata because Fastly's
+///   async request path does not expose the IO attachment used by asset routes.
+/// - [`select`](PlatformHttpClient::select) downcasts each
 ///   [`PlatformPendingRequest`] back to `fastly::PendingRequest` and calls
 ///   `fastly::http::request::select()`.
 pub struct FastlyPlatformHttpClient;
@@ -244,11 +388,16 @@ impl PlatformHttpClient for FastlyPlatformHttpClient {
         request: PlatformHttpRequest,
     ) -> Result<PlatformResponse, Report<PlatformError>> {
         let backend_name = request.backend_name.clone();
-        let fastly_req = edge_request_to_fastly(request.request)?;
+        let image_optimizer = request.image_optimizer;
+        let stream_response = request.stream_response;
+        let mut fastly_req = edge_request_to_fastly(request.request)?;
+        if let Some(options) = image_optimizer {
+            apply_fastly_image_optimizer(&mut fastly_req, options)?;
+        }
         let fastly_resp = fastly_req
             .send(&backend_name)
             .change_context(PlatformError::HttpClient)?;
-        fastly_response_to_platform(fastly_resp, backend_name)
+        fastly_response_to_platform(fastly_resp, backend_name, stream_response)
     }
 
     async fn send_async(
@@ -256,6 +405,14 @@ impl PlatformHttpClient for FastlyPlatformHttpClient {
         request: PlatformHttpRequest,
     ) -> Result<PlatformPendingRequest, Report<PlatformError>> {
         let backend_name = request.backend_name.clone();
+        if request.image_optimizer.is_some() {
+            return Err(Report::new(PlatformError::HttpClient)
+                .attach("Image Optimizer is not supported with Fastly send_async"));
+        }
+        if request.stream_response {
+            return Err(Report::new(PlatformError::HttpClient)
+                .attach("streaming responses are not supported with Fastly send_async"));
+        }
         let fastly_req = edge_request_to_fastly(request.request)?;
         let pending = fastly_req
             .send_async(&backend_name)
@@ -305,7 +462,7 @@ impl PlatformHttpClient for FastlyPlatformHttpClient {
                         ""
                     })
                     .to_string();
-                fastly_response_to_platform(fastly_resp, backend_name)
+                fastly_response_to_platform(fastly_resp, backend_name, false)
             }
             Err(e) => {
                 Err(Report::new(PlatformError::HttpClient)
@@ -608,6 +765,49 @@ mod tests {
         assert!(
             format!("{err:?}").contains("streaming request body"),
             "should describe the unsupported streaming body: {err:?}"
+        );
+    }
+
+    #[test]
+    fn fastly_platform_http_client_send_async_rejects_image_optimizer_metadata() {
+        let client = FastlyPlatformHttpClient;
+        let request = request_builder()
+            .method("GET")
+            .uri("https://example.com/image.jpg")
+            .body(Body::empty())
+            .expect("should build test request");
+        let platform_request = PlatformHttpRequest::new(request, "nonexistent-backend")
+            .with_image_optimizer(PlatformImageOptimizerOptions::new(
+                "us_east",
+                PlatformImageOptimizerParams::default(),
+            ));
+
+        let err = futures::executor::block_on(client.send_async(platform_request))
+            .expect_err("should reject async Image Optimizer requests");
+
+        assert!(
+            format!("{err:?}").contains("Image Optimizer"),
+            "should explain unsupported async IO path: {err:?}"
+        );
+    }
+
+    #[test]
+    fn fastly_platform_http_client_send_async_rejects_stream_response() {
+        let client = FastlyPlatformHttpClient;
+        let request = request_builder()
+            .method("GET")
+            .uri("https://example.com/image.jpg")
+            .body(Body::empty())
+            .expect("should build test request");
+        let platform_request =
+            PlatformHttpRequest::new(request, "nonexistent-backend").with_stream_response();
+
+        let err = futures::executor::block_on(client.send_async(platform_request))
+            .expect_err("should reject async streaming-response requests");
+
+        assert!(
+            format!("{err:?}").contains("streaming responses"),
+            "should explain unsupported async streaming-response path: {err:?}"
         );
     }
 

--- a/crates/trusted-server-adapter-fastly/src/platform.rs
+++ b/crates/trusted-server-adapter-fastly/src/platform.rs
@@ -324,6 +324,15 @@ fn edge_request_to_fastly(
     Ok(fastly_req)
 }
 
+/// Maximum origin response body size copied into WASM heap.
+///
+/// `take_body_bytes()` copies the full origin response into a single
+/// allocation.  This cap prevents oversized origin responses from exhausting
+/// the WASM address space.  The Content-Length pre-check avoids the copy
+/// entirely for responses that declare their size.  Streaming response support
+/// will remove this limit in PR 15.
+const MAX_PLATFORM_RESPONSE_BODY_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
+
 fn fastly_body_to_edge_stream(body: fastly::Body) -> edgezero_core::body::Body {
     let stream = futures::stream::unfold(Some(body), |state| async move {
         let mut body = state?;
@@ -347,6 +356,24 @@ fn fastly_response_to_platform(
     backend_name: impl Into<String>,
     stream_response: bool,
 ) -> Result<PlatformResponse, Report<PlatformError>> {
+    // Pre-flight: reject oversized responses before copying bytes into WASM heap.
+    // Content-Length is advisory but covers most origin responses; chunked
+    // responses without it fall through to the post-materialization check below.
+    if !stream_response {
+        if let Some(claimed_len) = resp
+            .get_header("content-length")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.trim().parse::<usize>().ok())
+        {
+            if claimed_len > MAX_PLATFORM_RESPONSE_BODY_BYTES {
+                return Err(Report::new(PlatformError::HttpClient).attach(format!(
+                    "origin Content-Length {claimed_len} exceeds \
+                     {MAX_PLATFORM_RESPONSE_BODY_BYTES}-byte response body limit"
+                )));
+            }
+        }
+    }
+
     let status = resp.get_status();
     let mut builder = edgezero_core::http::response_builder().status(status);
     for (name, value) in resp.get_headers() {
@@ -355,7 +382,18 @@ fn fastly_response_to_platform(
     let body = if stream_response {
         fastly_body_to_edge_stream(resp.take_body())
     } else {
-        edgezero_core::body::Body::from(resp.take_body_bytes())
+        let body_bytes = resp.take_body_bytes();
+
+        // Belt-and-suspenders: catches chunked responses without Content-Length.
+        if body_bytes.len() > MAX_PLATFORM_RESPONSE_BODY_BYTES {
+            return Err(Report::new(PlatformError::HttpClient).attach(format!(
+                "origin response body {} bytes exceeds \
+                 {MAX_PLATFORM_RESPONSE_BODY_BYTES}-byte limit",
+                body_bytes.len()
+            )));
+        }
+
+        edgezero_core::body::Body::from(body_bytes)
     };
     let edge_response = builder
         .body(body)
@@ -453,7 +491,7 @@ impl PlatformHttpClient for FastlyPlatformHttpClient {
             .map(PlatformPendingRequest::new)
             .collect();
 
-        let ready = match result {
+        let (ready, failed_backend_name) = match result {
             Ok(fastly_resp) => {
                 let backend_name = fastly_resp
                     .get_backend_name()
@@ -462,15 +500,27 @@ impl PlatformHttpClient for FastlyPlatformHttpClient {
                         ""
                     })
                     .to_string();
-                fastly_response_to_platform(fastly_resp, backend_name, false)
+                (
+                    fastly_response_to_platform(fastly_resp, backend_name, false),
+                    None,
+                )
             }
             Err(e) => {
-                Err(Report::new(PlatformError::HttpClient)
-                    .attach(format!("fastly select error: {e}")))
+                let failed_name = e.backend_name().to_string();
+                (
+                    Err(Report::new(PlatformError::HttpClient).attach(format!(
+                        "fastly select error for backend '{failed_name}': {e}"
+                    ))),
+                    Some(failed_name),
+                )
             }
         };
 
-        Ok(PlatformSelectResult { ready, remaining })
+        Ok(PlatformSelectResult {
+            ready,
+            remaining,
+            failed_backend_name,
+        })
     }
 }
 

--- a/crates/trusted-server-adapter-fastly/src/route_tests.rs
+++ b/crates/trusted-server-adapter-fastly/src/route_tests.rs
@@ -1,10 +1,14 @@
+use std::collections::HashMap;
 use std::net::IpAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use bytes::Bytes;
+use edgezero_core::body::Body as EdgeBody;
+use edgezero_core::http::response_builder as edge_response_builder;
 use edgezero_core::key_value_store::NoopKvStore;
 use error_stack::Report;
 use fastly::http::request::PendingRequest;
-use fastly::http::{header, StatusCode};
+use fastly::http::{header, Method, StatusCode};
 use fastly::Request;
 use serde_json::json;
 use trusted_server_core::auction::{
@@ -21,7 +25,10 @@ use trusted_server_core::platform::{
     StoreName,
 };
 use trusted_server_core::request_signing::JWKS_CONFIG_STORE_NAME;
-use trusted_server_core::settings::Settings;
+use trusted_server_core::settings::{
+    AssetImageOptimizerConfig, AssetOriginAuth, ImageOptimizerProfileSet, ImageOptimizerSettings,
+    ProxyAssetRoute, S3SigV4AuthConfig, Settings,
+};
 
 use super::route_request;
 
@@ -54,6 +61,42 @@ impl PlatformConfigStore for StubJwksConfigStore {
 }
 
 struct NoopSecretStore;
+
+struct HashMapSecretStore {
+    data: HashMap<String, Vec<u8>>,
+}
+
+impl HashMapSecretStore {
+    fn new(data: HashMap<String, Vec<u8>>) -> Self {
+        Self { data }
+    }
+}
+
+impl PlatformSecretStore for HashMapSecretStore {
+    fn get_bytes(
+        &self,
+        _store_name: &StoreName,
+        key: &str,
+    ) -> Result<Vec<u8>, Report<PlatformError>> {
+        self.data
+            .get(key)
+            .cloned()
+            .ok_or_else(|| Report::new(PlatformError::SecretStore))
+    }
+
+    fn create(
+        &self,
+        _store_id: &StoreId,
+        _name: &str,
+        _value: &str,
+    ) -> Result<(), Report<PlatformError>> {
+        Err(Report::new(PlatformError::Unsupported))
+    }
+
+    fn delete(&self, _store_id: &StoreId, _name: &str) -> Result<(), Report<PlatformError>> {
+        Err(Report::new(PlatformError::Unsupported))
+    }
+}
 
 impl PlatformSecretStore for NoopSecretStore {
     fn get_bytes(
@@ -91,6 +134,147 @@ impl PlatformBackend for NoopBackend {
 }
 
 struct NoopHttpClient;
+
+struct RecordingHttpClient {
+    calls: Mutex<Vec<RecordedHttpCall>>,
+    response_status: StatusCode,
+    response_headers: Vec<(String, String)>,
+}
+
+struct StreamingRecordingHttpClient {
+    calls: Mutex<Vec<RecordedHttpCall>>,
+}
+
+impl RecordingHttpClient {
+    fn new(response_status: StatusCode) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            response_status,
+            response_headers: Vec::new(),
+        }
+    }
+
+    fn with_response_headers(
+        mut self,
+        headers: Vec<(impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.response_headers = headers
+            .into_iter()
+            .map(|(name, value)| (name.into(), value.into()))
+            .collect();
+        self
+    }
+}
+
+impl StreamingRecordingHttpClient {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+struct RecordedHttpCall {
+    method: Method,
+    uri: String,
+    backend_name: String,
+    stream_response: bool,
+}
+
+struct FixedBackend;
+
+impl PlatformBackend for FixedBackend {
+    fn predict_name(&self, spec: &PlatformBackendSpec) -> Result<String, Report<PlatformError>> {
+        Ok(format!("{}-{}", spec.scheme, spec.host))
+    }
+
+    fn ensure(&self, spec: &PlatformBackendSpec) -> Result<String, Report<PlatformError>> {
+        self.predict_name(spec)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl PlatformHttpClient for RecordingHttpClient {
+    async fn send(
+        &self,
+        request: PlatformHttpRequest,
+    ) -> Result<PlatformResponse, Report<PlatformError>> {
+        self.calls
+            .lock()
+            .expect("should lock calls")
+            .push(RecordedHttpCall {
+                method: request.request.method().clone(),
+                uri: request.request.uri().to_string(),
+                backend_name: request.backend_name,
+                stream_response: request.stream_response,
+            });
+
+        let mut builder = edge_response_builder().status(self.response_status);
+        for (name, value) in &self.response_headers {
+            builder = builder.header(name, value);
+        }
+        let edge_response = builder
+            .body(EdgeBody::from(Vec::new()))
+            .map_err(|_| Report::new(PlatformError::HttpClient))?;
+
+        Ok(PlatformResponse::new(edge_response))
+    }
+
+    async fn send_async(
+        &self,
+        _request: PlatformHttpRequest,
+    ) -> Result<PlatformPendingRequest, Report<PlatformError>> {
+        Err(Report::new(PlatformError::Unsupported))
+    }
+
+    async fn select(
+        &self,
+        _pending_requests: Vec<PlatformPendingRequest>,
+    ) -> Result<PlatformSelectResult, Report<PlatformError>> {
+        Err(Report::new(PlatformError::Unsupported))
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl PlatformHttpClient for StreamingRecordingHttpClient {
+    async fn send(
+        &self,
+        request: PlatformHttpRequest,
+    ) -> Result<PlatformResponse, Report<PlatformError>> {
+        self.calls
+            .lock()
+            .expect("should lock calls")
+            .push(RecordedHttpCall {
+                method: request.request.method().clone(),
+                uri: request.request.uri().to_string(),
+                backend_name: request.backend_name,
+                stream_response: request.stream_response,
+            });
+
+        let edge_response = edge_response_builder()
+            .status(StatusCode::OK)
+            .body(EdgeBody::stream(futures::stream::iter(vec![
+                Bytes::from_static(b"streamed-asset"),
+            ])))
+            .map_err(|_| Report::new(PlatformError::HttpClient))?;
+
+        Ok(PlatformResponse::new(edge_response))
+    }
+
+    async fn send_async(
+        &self,
+        _request: PlatformHttpRequest,
+    ) -> Result<PlatformPendingRequest, Report<PlatformError>> {
+        Err(Report::new(PlatformError::Unsupported))
+    }
+
+    async fn select(
+        &self,
+        _pending_requests: Vec<PlatformPendingRequest>,
+    ) -> Result<PlatformSelectResult, Report<PlatformError>> {
+        Err(Report::new(PlatformError::Unsupported))
+    }
+}
 
 #[async_trait::async_trait(?Send)]
 impl PlatformHttpClient for NoopHttpClient {
@@ -158,6 +342,31 @@ impl AuctionProvider for DisabledRouteProvider {
     fn is_enabled(&self) -> bool {
         false
     }
+}
+
+struct FixedGeo(GeoInfo);
+
+impl PlatformGeo for FixedGeo {
+    fn lookup(&self, _client_ip: Option<IpAddr>) -> Result<Option<GeoInfo>, Report<PlatformError>> {
+        Ok(Some(self.0.clone()))
+    }
+}
+
+fn us_california_geo() -> GeoInfo {
+    GeoInfo {
+        city: "Example City".to_string(),
+        country: "US".to_string(),
+        continent: "NA".to_string(),
+        latitude: 37.0,
+        longitude: -122.0,
+        metro_code: 807,
+        region: Some("CA".to_string()),
+        asn: None,
+    }
+}
+
+fn valid_ec_id() -> String {
+    format!("{}.Abc123", "a".repeat(64))
 }
 
 fn base_route_settings_toml() -> &'static str {
@@ -242,19 +451,65 @@ fn build_route_stack(settings: &Settings) -> (AuctionOrchestrator, IntegrationRe
 }
 
 fn test_runtime_services(req: &Request) -> RuntimeServices {
+    test_runtime_services_with_http_client(
+        req,
+        Arc::new(NoopBackend),
+        Arc::new(NoopHttpClient) as Arc<dyn PlatformHttpClient>,
+    )
+}
+
+fn test_runtime_services_with_http_client(
+    req: &Request,
+    backend: Arc<dyn PlatformBackend>,
+    http_client: Arc<dyn PlatformHttpClient>,
+) -> RuntimeServices {
+    test_runtime_services_with_secret_and_http_client(
+        req,
+        backend,
+        Arc::new(NoopSecretStore),
+        http_client,
+    )
+}
+
+fn test_runtime_services_with_secret_and_http_client(
+    req: &Request,
+    backend: Arc<dyn PlatformBackend>,
+    secret_store: Arc<dyn PlatformSecretStore>,
+    http_client: Arc<dyn PlatformHttpClient>,
+) -> RuntimeServices {
+    test_runtime_services_with_secret_http_client_and_geo(
+        req,
+        backend,
+        secret_store,
+        http_client,
+        Arc::new(NoopGeo),
+    )
+}
+
+fn test_runtime_services_with_secret_http_client_and_geo(
+    req: &Request,
+    backend: Arc<dyn PlatformBackend>,
+    secret_store: Arc<dyn PlatformSecretStore>,
+    http_client: Arc<dyn PlatformHttpClient>,
+    geo: Arc<dyn PlatformGeo>,
+) -> RuntimeServices {
     RuntimeServices::builder()
         .config_store(Arc::new(StubJwksConfigStore))
-        .secret_store(Arc::new(NoopSecretStore))
+        .secret_store(secret_store)
         .kv_store(Arc::new(NoopKvStore) as Arc<dyn PlatformKvStore>)
-        .backend(Arc::new(NoopBackend))
-        .http_client(Arc::new(NoopHttpClient))
-        .geo(Arc::new(NoopGeo))
+        .backend(backend)
+        .http_client(http_client)
+        .geo(geo)
         .client_info(ClientInfo {
             client_ip: req.get_client_ip_addr(),
             tls_protocol: req.get_tls_protocol().map(str::to_string),
             tls_cipher: req.get_tls_cipher_openssl_name().map(str::to_string),
         })
         .build()
+}
+
+fn test_partner_registry(settings: &Settings) -> PartnerRegistry {
+    PartnerRegistry::from_config(&settings.ec.partners).expect("should build partner registry")
 }
 
 fn route_auction(settings: &Settings, body: impl Into<Vec<u8>>) -> fastly::Response {
@@ -289,6 +544,30 @@ fn route_auction_with_stack(
     .expect("should buffer auction response in tests")
 }
 
+fn route_buffered_response(
+    settings: &Settings,
+    orchestrator: &AuctionOrchestrator,
+    integration_registry: &IntegrationRegistry,
+    services: &RuntimeServices,
+    req: Request,
+    expect_message: &str,
+) -> fastly::Response {
+    let partner_registry =
+        PartnerRegistry::from_config(&settings.ec.partners).expect("should build partner registry");
+
+    futures::executor::block_on(route_request(
+        settings,
+        orchestrator,
+        integration_registry,
+        &partner_registry,
+        services,
+        req,
+    ))
+    .expect(expect_message)
+    .response
+    .expect("should buffer route response in tests")
+}
+
 fn valid_banner_ad_unit_body() -> Vec<u8> {
     serde_json::to_vec(&json!({
         "adUnits": [
@@ -311,8 +590,7 @@ fn routes_use_request_local_consent() {
     let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
     let integration_registry =
         IntegrationRegistry::new(&settings).expect("should create integration registry");
-    let partner_registry =
-        PartnerRegistry::from_config(&settings.ec.partners).expect("should build partner registry");
+    let partner_registry = test_partner_registry(&settings);
 
     let discovery_req = Request::get("https://test.com/.well-known/trusted-server.json");
     let discovery_services = test_runtime_services(&discovery_req);
@@ -433,5 +711,588 @@ fn auction_request_with_disabled_provider_returns_bad_gateway() {
         response.get_status(),
         StatusCode::BAD_GATEWAY,
         "should map skipped-provider launch failures to gateway errors"
+    );
+}
+
+#[test]
+fn asset_routes_bypass_publisher_consent_dependencies() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let asset_req = Request::get("https://test.com/.images/logo.png?auto=webp");
+    let http_client = Arc::new(RecordingHttpClient::new(StatusCode::ACCEPTED));
+    let asset_services = test_runtime_services_with_http_client(
+        &asset_req,
+        Arc::new(FixedBackend),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+    );
+    let asset_resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &asset_services,
+        asset_req,
+        "should route asset proxy request",
+    );
+
+    assert_eq!(
+        asset_resp.get_status(),
+        StatusCode::ACCEPTED,
+        "should return the asset-origin response without publisher consent dependencies"
+    );
+    let calls = http_client
+        .calls
+        .lock()
+        .expect("should lock recorded calls");
+    assert_eq!(calls.len(), 1, "should send exactly one asset request");
+    assert_eq!(
+        calls[0].backend_name, "https-assets.example.com",
+        "should resolve the configured asset backend, not the publisher origin"
+    );
+    assert_eq!(
+        calls[0].uri, "https://assets.example.com/.images/logo.png?auto=webp",
+        "should send the request to the configured asset origin"
+    );
+}
+
+#[test]
+fn asset_routes_skip_ec_finalization_cookie_mutations() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let mut req = Request::get("https://test.com/.images/logo.png");
+    req.set_header(header::COOKIE, format!("ts-ec={}", valid_ec_id()));
+    req.set_header("sec-gpc", "1");
+    let http_client = Arc::new(RecordingHttpClient::new(StatusCode::OK));
+    let services = test_runtime_services_with_secret_http_client_and_geo(
+        &req,
+        Arc::new(FixedBackend),
+        Arc::new(NoopSecretStore),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+        Arc::new(FixedGeo(us_california_geo())),
+    );
+
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route asset request without EC finalization",
+    );
+
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::OK,
+        "should return the asset-origin response"
+    );
+    assert_eq!(
+        resp.get_header_str(header::SET_COOKIE),
+        None,
+        "should not expire or set EC cookies on asset responses"
+    );
+    assert_eq!(
+        resp.get_header_str("x-ts-ec"),
+        None,
+        "should not emit EC identity headers on asset responses"
+    );
+}
+
+#[test]
+fn asset_routes_stream_asset_responses_directly() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+    let partner_registry = test_partner_registry(&settings);
+
+    let mut req = Request::get("https://test.com/.images/logo.png");
+    req.set_header(header::COOKIE, format!("ts-ec={}", valid_ec_id()));
+    req.set_header("sec-gpc", "1");
+    let http_client = Arc::new(StreamingRecordingHttpClient::new());
+    let services = test_runtime_services_with_secret_http_client_and_geo(
+        &req,
+        Arc::new(FixedBackend),
+        Arc::new(NoopSecretStore),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+        Arc::new(FixedGeo(us_california_geo())),
+    );
+
+    let outcome = futures::executor::block_on(route_request(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &partner_registry,
+        &services,
+        req,
+    ))
+    .expect("should route streaming asset request");
+
+    assert!(
+        outcome.response.is_none(),
+        "streaming asset route should send directly instead of returning a buffered response"
+    );
+    assert!(
+        outcome.pull_sync_context.is_none(),
+        "asset routes should not schedule publisher pull-sync work"
+    );
+    let calls = http_client
+        .calls
+        .lock()
+        .expect("should lock recorded calls");
+    assert_eq!(calls.len(), 1, "should send exactly one asset request");
+    assert!(
+        calls[0].stream_response,
+        "asset routes should request a streaming origin response from the platform"
+    );
+    assert_eq!(
+        calls[0].backend_name, "https-assets.example.com",
+        "should resolve the configured asset backend, not the publisher origin"
+    );
+    assert_eq!(
+        calls[0].uri, "https://assets.example.com/.images/logo.png",
+        "should send the request to the configured asset origin"
+    );
+    // `stream_to_client` commits headers and bytes into the Fastly host runtime,
+    // leaving no buffered `Response` for this route-level test to inspect. Core
+    // proxy tests assert unsafe header stripping on the real streaming body; this
+    // test pins the adapter contract that successful streaming asset responses
+    // take the `response: None` direct-send path with EC finalization skipped.
+}
+
+#[test]
+fn asset_origin_failure_does_not_fall_back_to_publisher_origin() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::get("https://test.com/.images/logo.png");
+    let http_client = Arc::new(RecordingHttpClient::new(StatusCode::OK));
+    let services = test_runtime_services_with_http_client(
+        &req,
+        Arc::new(NoopBackend),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+    );
+
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should return an error response for failed asset origin",
+    );
+
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::BAD_GATEWAY,
+        "should stop asset-origin backend failures at the asset proxy path"
+    );
+    assert!(
+        http_client
+            .calls
+            .lock()
+            .expect("should lock recorded calls")
+            .is_empty(),
+        "should not invoke the publisher origin when asset backend registration fails"
+    );
+}
+
+#[test]
+fn asset_handler_error_stays_uncacheable_after_global_headers() {
+    let mut settings = create_test_settings();
+    settings.response_headers.insert(
+        header::CACHE_CONTROL.as_str().to_string(),
+        "public, max-age=3600".to_string(),
+    );
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::get("https://test.com/.images/logo.png");
+    let services = test_runtime_services(&req);
+
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route generated asset error response",
+    );
+
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::BAD_GATEWAY,
+        "should return the generated asset proxy error"
+    );
+    assert_eq!(
+        resp.get_header_str(header::CACHE_CONTROL),
+        Some("no-store, private"),
+        "should not let global cache headers make generated asset errors cacheable"
+    );
+}
+
+#[test]
+fn s3_asset_origin_error_stays_uncacheable_after_global_headers() {
+    let mut settings = create_test_settings();
+    settings.response_headers.insert(
+        header::CACHE_CONTROL.as_str().to_string(),
+        "public, max-age=3600".to_string(),
+    );
+    settings.image_optimizer = ImageOptimizerSettings {
+        profile_sets: HashMap::from([(
+            "default_images".to_string(),
+            ImageOptimizerProfileSet {
+                base_params: String::new(),
+                default_profile: "default".to_string(),
+                unknown_profile: Default::default(),
+                profile_param: "profile".to_string(),
+                aspect_ratio_param: "ar".to_string(),
+                debug_param: "_io_debug".to_string(),
+                profiles: HashMap::from([("default".to_string(), "width=100".to_string())]),
+                aspect_ratios: None,
+                crop_offsets: None,
+            },
+        )]),
+    };
+    let mut route = ProxyAssetRoute::new(
+        "/.images/",
+        "https://examplebucket.s3.us-east-1.amazonaws.com",
+    );
+    route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
+        region: "us-east-1".to_string(),
+        secret_store: "s3-auth".to_string(),
+        access_key_id: "access_key_id".to_string(),
+        secret_access_key: "secret_access_key".to_string(),
+        session_token: None,
+        origin_query: None,
+    }));
+    route.image_optimizer = Some(AssetImageOptimizerConfig {
+        enabled: true,
+        region: "us_east".to_string(),
+        profile_set: "default_images".to_string(),
+        origin_query: None,
+    });
+    settings.proxy.asset_routes = vec![route];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::get("https://test.com/.images/missing.png?profile=default");
+    let http_client = Arc::new(RecordingHttpClient::new(StatusCode::NOT_FOUND));
+    let services = test_runtime_services_with_secret_and_http_client(
+        &req,
+        Arc::new(FixedBackend),
+        Arc::new(HashMapSecretStore::new(HashMap::from([
+            (
+                "access_key_id".to_string(),
+                b"AKIAIOSFODNN7EXAMPLE".to_vec(),
+            ),
+            (
+                "secret_access_key".to_string(),
+                b"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_vec(),
+            ),
+        ]))),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+    );
+
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route S3 asset request",
+    );
+
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::NOT_FOUND,
+        "should return the raw S3 origin error status"
+    );
+    assert_eq!(
+        resp.get_header_str(header::CACHE_CONTROL),
+        Some("no-store, private"),
+        "should preserve the S3 origin error no-store policy after global headers"
+    );
+    let calls = http_client
+        .calls
+        .lock()
+        .expect("should lock recorded calls");
+    assert_eq!(
+        calls.len(),
+        2,
+        "should preflight with HEAD and then fetch the S3 error body"
+    );
+}
+
+#[test]
+fn asset_routes_proxy_head_requests() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::head("https://test.com/.images/logo.png");
+    let http_client = Arc::new(RecordingHttpClient::new(StatusCode::NO_CONTENT));
+    let services = test_runtime_services_with_http_client(
+        &req,
+        Arc::new(FixedBackend),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+    );
+
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route HEAD asset request",
+    );
+
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::NO_CONTENT,
+        "should pass through asset-origin HEAD response status"
+    );
+    let calls = http_client
+        .calls
+        .lock()
+        .expect("should lock recorded calls");
+    assert_eq!(calls.len(), 1, "should send exactly one asset request");
+    assert_eq!(
+        calls[0].method,
+        Method::HEAD,
+        "should forward HEAD upstream"
+    );
+    assert!(
+        calls[0].backend_name.contains("assets.example.com"),
+        "should send to the asset backend, got {}",
+        calls[0].backend_name
+    );
+}
+
+#[test]
+fn asset_routes_ignore_query_string_for_matching() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::get("https://test.com/.images/logo.png?auto=webp");
+    let http_client = Arc::new(RecordingHttpClient::new(StatusCode::OK));
+    let services = test_runtime_services_with_http_client(
+        &req,
+        Arc::new(FixedBackend),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+    );
+
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route asset request with query string",
+    );
+
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::OK,
+        "should match by path only"
+    );
+    let calls = http_client
+        .calls
+        .lock()
+        .expect("should lock recorded calls");
+    assert_eq!(calls.len(), 1, "should send exactly one asset request");
+    assert!(
+        calls[0].uri.ends_with("/.images/logo.png?auto=webp"),
+        "should preserve query on the upstream asset request, got {}",
+        calls[0].uri
+    );
+}
+
+#[test]
+fn asset_routes_pass_redirect_responses_through() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::get("https://test.com/.images/logo.png");
+    let http_client = Arc::new(
+        RecordingHttpClient::new(StatusCode::FOUND).with_response_headers(vec![(
+            header::LOCATION.as_str(),
+            "https://cdn.example.com/logo.png",
+        )]),
+    );
+    let services = test_runtime_services_with_http_client(
+        &req,
+        Arc::new(FixedBackend),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+    );
+
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route redirecting asset request",
+    );
+
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::FOUND,
+        "should pass redirect status through without following it"
+    );
+    assert_eq!(
+        resp.get_header_str(header::LOCATION),
+        Some("https://cdn.example.com/logo.png"),
+        "should preserve asset-origin redirect location"
+    );
+}
+
+#[test]
+fn asset_routes_skip_non_get_head_requests() {
+    let mut settings = create_test_settings();
+    settings.publisher.origin_url = "https://".to_string();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.images/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::post("https://test.com/.images/logo.png");
+    let http_client = Arc::new(RecordingHttpClient::new(StatusCode::OK));
+    let services = test_runtime_services_with_http_client(
+        &req,
+        Arc::new(FixedBackend),
+        Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
+    );
+
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route non-asset POST request",
+    );
+
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::BAD_GATEWAY,
+        "should fall through to publisher fallback for POST requests"
+    );
+    assert!(
+        http_client
+            .calls
+            .lock()
+            .expect("should lock recorded calls")
+            .is_empty(),
+        "should not send POST requests through asset routing"
+    );
+}
+
+#[test]
+fn built_in_routes_take_precedence_over_asset_routes() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/.well-known/",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::get("https://test.com/.well-known/trusted-server.json");
+    let services = test_runtime_services(&req);
+    let resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route discovery request",
+    );
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::OK,
+        "should keep explicit built-in routes ahead of asset routes"
+    );
+}
+
+#[test]
+fn integration_routes_take_precedence_over_asset_routes() {
+    let mut settings = create_test_settings();
+    settings.proxy.asset_routes = vec![ProxyAssetRoute::new(
+        "/prebid.js",
+        "https://assets.example.com",
+    )];
+    let orchestrator = build_orchestrator(&settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let req = Request::get("https://test.com/prebid.js");
+    let services = test_runtime_services(&req);
+    let mut resp = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route integration request",
+    );
+    assert_eq!(
+        resp.get_status(),
+        StatusCode::OK,
+        "should keep explicit integration routes ahead of asset routes"
+    );
+    assert_eq!(
+        resp.take_body_str(),
+        "// Script overridden by Trusted Server\n",
+        "should serve the integration response instead of proxying to the asset origin"
     );
 }

--- a/crates/trusted-server-adapter-fastly/src/route_tests.rs
+++ b/crates/trusted-server-adapter-fastly/src/route_tests.rs
@@ -3,10 +3,16 @@ use std::sync::Arc;
 
 use edgezero_core::key_value_store::NoopKvStore;
 use error_stack::Report;
-use fastly::http::StatusCode;
+use fastly::http::request::PendingRequest;
+use fastly::http::{header, StatusCode};
 use fastly::Request;
-use trusted_server_core::auction::build_orchestrator;
+use serde_json::json;
+use trusted_server_core::auction::{
+    build_orchestrator, AuctionContext, AuctionOrchestrator, AuctionProvider, AuctionRequest,
+    AuctionResponse,
+};
 use trusted_server_core::ec::registry::PartnerRegistry;
+use trusted_server_core::error::TrustedServerError;
 use trusted_server_core::integrations::IntegrationRegistry;
 use trusted_server_core::platform::{
     ClientInfo, GeoInfo, PlatformBackend, PlatformBackendSpec, PlatformConfigStore, PlatformError,
@@ -118,9 +124,44 @@ impl PlatformGeo for NoopGeo {
     }
 }
 
-fn create_test_settings() -> Settings {
-    let settings = Settings::from_toml(
-        r#"
+struct DisabledRouteProvider;
+
+impl AuctionProvider for DisabledRouteProvider {
+    fn provider_name(&self) -> &'static str {
+        "disabled-route"
+    }
+
+    fn request_bids(
+        &self,
+        _request: &AuctionRequest,
+        _context: &AuctionContext<'_>,
+    ) -> Result<PendingRequest, Report<TrustedServerError>> {
+        Err(Report::new(TrustedServerError::Auction {
+            message: "disabled route provider should not launch requests".to_string(),
+        }))
+    }
+
+    fn parse_response(
+        &self,
+        _response: fastly::Response,
+        _response_time_ms: u64,
+    ) -> Result<AuctionResponse, Report<TrustedServerError>> {
+        Err(Report::new(TrustedServerError::Auction {
+            message: "disabled route provider should not parse responses".to_string(),
+        }))
+    }
+
+    fn timeout_ms(&self) -> u32 {
+        2000
+    }
+
+    fn is_enabled(&self) -> bool {
+        false
+    }
+}
+
+fn base_route_settings_toml() -> &'static str {
+    r#"
             [[handlers]]
             path = "^/_ts/admin"
             username = "admin"
@@ -139,18 +180,32 @@ fn create_test_settings() -> Settings {
             enabled = false
             config_store_id = "test-config-store-id"
             secret_store_id = "test-secret-store-id"
+        "#
+}
 
+fn prebid_integration_toml() -> &'static str {
+    r#"
             [integrations.prebid]
             enabled = true
             server_url = "https://test-prebid.com/openrtb2/auction"
+        "#
+}
+
+fn create_test_settings() -> Settings {
+    let base = base_route_settings_toml();
+    let prebid = prebid_integration_toml();
+    let config = format!(
+        r#"{base}
+
+{prebid}
 
             [auction]
             enabled = true
             providers = ["prebid"]
             timeout_ms = 2000
         "#,
-    )
-    .expect("should parse adapter route test settings");
+    );
+    let settings = Settings::from_toml(&config).expect("should parse adapter route test settings");
 
     assert_eq!(
         JWKS_CONFIG_STORE_NAME, "jwks_store",
@@ -158,6 +213,32 @@ fn create_test_settings() -> Settings {
     );
 
     settings
+}
+
+fn create_auction_test_settings(providers: &str) -> Settings {
+    let base = base_route_settings_toml();
+    let prebid = prebid_integration_toml();
+    let config = format!(
+        r#"{base}
+
+{prebid}
+
+            [auction]
+            enabled = true
+            providers = {providers}
+            timeout_ms = 2000
+        "#,
+    );
+
+    Settings::from_toml(&config).expect("should parse adapter auction route test settings")
+}
+
+fn build_route_stack(settings: &Settings) -> (AuctionOrchestrator, IntegrationRegistry) {
+    let orchestrator = build_orchestrator(settings).expect("should build auction orchestrator");
+    let integration_registry =
+        IntegrationRegistry::new(settings).expect("should create integration registry");
+
+    (orchestrator, integration_registry)
 }
 
 fn test_runtime_services(req: &Request) -> RuntimeServices {
@@ -174,6 +255,54 @@ fn test_runtime_services(req: &Request) -> RuntimeServices {
             tls_cipher: req.get_tls_cipher_openssl_name().map(str::to_string),
         })
         .build()
+}
+
+fn route_auction(settings: &Settings, body: impl Into<Vec<u8>>) -> fastly::Response {
+    let (orchestrator, integration_registry) = build_route_stack(settings);
+
+    route_auction_with_stack(settings, &orchestrator, &integration_registry, body)
+}
+
+fn route_auction_with_stack(
+    settings: &Settings,
+    orchestrator: &AuctionOrchestrator,
+    integration_registry: &IntegrationRegistry,
+    body: impl Into<Vec<u8>>,
+) -> fastly::Response {
+    let partner_registry =
+        PartnerRegistry::from_config(&settings.ec.partners).expect("should build partner registry");
+    let req = Request::post("https://test.com/auction")
+        .with_header(header::CONTENT_TYPE, "application/json")
+        .with_body(body.into());
+    let services = test_runtime_services(&req);
+
+    futures::executor::block_on(route_request(
+        settings,
+        orchestrator,
+        integration_registry,
+        &partner_registry,
+        &services,
+        req,
+    ))
+    .expect("should route auction request")
+    .response
+    .expect("should buffer auction response in tests")
+}
+
+fn valid_banner_ad_unit_body() -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "adUnits": [
+            {
+                "code": "div-gpt-ad-1",
+                "mediaTypes": {
+                    "banner": {
+                        "sizes": [[300, 250]]
+                    }
+                }
+            }
+        ]
+    }))
+    .expect("should serialize valid auction route test body")
 }
 
 #[test]
@@ -227,4 +356,82 @@ fn routes_use_request_local_consent() {
 
     // Routes no longer depend on a separate consent KV store. Live consent is
     // request-local, and EC lifecycle state uses the EC identity store only.
+}
+
+#[test]
+fn malformed_auction_json_returns_bad_request() {
+    let settings = create_auction_test_settings(r#"["prebid"]"#);
+
+    let mut response = route_auction(&settings, "{not-json");
+
+    assert_eq!(
+        response.get_status(),
+        StatusCode::BAD_REQUEST,
+        "should reject malformed JSON as a client request error"
+    );
+    assert!(
+        response.take_body_str().contains("Bad request"),
+        "should return a client-facing bad request message"
+    );
+}
+
+#[test]
+fn invalid_auction_banner_size_returns_bad_request() {
+    let settings = create_auction_test_settings(r#"["prebid"]"#);
+    let body = serde_json::to_vec(&json!({
+        "adUnits": [
+            {
+                "code": "div-gpt-ad-1",
+                "mediaTypes": {
+                    "banner": {
+                        "sizes": [[300]]
+                    }
+                }
+            }
+        ]
+    }))
+    .expect("should serialize invalid auction route test body");
+
+    let response = route_auction(&settings, body);
+
+    assert_eq!(
+        response.get_status(),
+        StatusCode::BAD_REQUEST,
+        "should reject semantically invalid banner sizes as a client request error"
+    );
+}
+
+#[test]
+fn auction_request_with_empty_provider_list_returns_bad_gateway() {
+    let settings = create_auction_test_settings("[]");
+
+    let response = route_auction(&settings, valid_banner_ad_unit_body());
+
+    assert_eq!(
+        response.get_status(),
+        StatusCode::BAD_GATEWAY,
+        "should surface no-provider orchestration failures as gateway errors"
+    );
+}
+
+#[test]
+fn auction_request_with_disabled_provider_returns_bad_gateway() {
+    let settings = create_auction_test_settings(r#"["disabled-route"]"#);
+    let mut orchestrator = AuctionOrchestrator::new(settings.auction.clone());
+    orchestrator.register_provider(Arc::new(DisabledRouteProvider));
+    let integration_registry =
+        IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+    let response = route_auction_with_stack(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        valid_banner_ad_unit_body(),
+    );
+
+    assert_eq!(
+        response.get_status(),
+        StatusCode::BAD_GATEWAY,
+        "should map skipped-provider launch failures to gateway errors"
+    );
 }

--- a/crates/trusted-server-adapter-fastly/src/route_tests.rs
+++ b/crates/trusted-server-adapter-fastly/src/route_tests.rs
@@ -7,7 +7,6 @@ use edgezero_core::body::Body as EdgeBody;
 use edgezero_core::http::response_builder as edge_response_builder;
 use edgezero_core::key_value_store::NoopKvStore;
 use error_stack::Report;
-use fastly::http::request::PendingRequest;
 use fastly::http::{header, Method, StatusCode};
 use fastly::Request;
 use serde_json::json;
@@ -15,6 +14,8 @@ use trusted_server_core::auction::{
     build_orchestrator, AuctionContext, AuctionOrchestrator, AuctionProvider, AuctionRequest,
     AuctionResponse,
 };
+use trusted_server_core::compat;
+use trusted_server_core::ec::finalize::ec_finalize_response;
 use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::error::TrustedServerError;
 use trusted_server_core::integrations::IntegrationRegistry;
@@ -24,13 +25,14 @@ use trusted_server_core::platform::{
     PlatformResponse, PlatformSecretStore, PlatformSelectResult, RuntimeServices, StoreId,
     StoreName,
 };
+use trusted_server_core::proxy::AssetProxyCachePolicy;
 use trusted_server_core::request_signing::JWKS_CONFIG_STORE_NAME;
 use trusted_server_core::settings::{
     AssetImageOptimizerConfig, AssetOriginAuth, ImageOptimizerProfileSet, ImageOptimizerSettings,
     ProxyAssetRoute, S3SigV4AuthConfig, Settings,
 };
 
-use super::route_request;
+use super::{route_request, HandlerOutcome};
 
 struct StubJwksConfigStore;
 
@@ -310,24 +312,25 @@ impl PlatformGeo for NoopGeo {
 
 struct DisabledRouteProvider;
 
+#[async_trait::async_trait(?Send)]
 impl AuctionProvider for DisabledRouteProvider {
     fn provider_name(&self) -> &'static str {
         "disabled-route"
     }
 
-    fn request_bids(
+    async fn request_bids(
         &self,
         _request: &AuctionRequest,
         _context: &AuctionContext<'_>,
-    ) -> Result<PendingRequest, Report<TrustedServerError>> {
+    ) -> Result<PlatformPendingRequest, Report<TrustedServerError>> {
         Err(Report::new(TrustedServerError::Auction {
             message: "disabled route provider should not launch requests".to_string(),
         }))
     }
 
-    fn parse_response(
+    async fn parse_response(
         &self,
-        _response: fastly::Response,
+        _response: PlatformResponse,
         _response_time_ms: u64,
     ) -> Result<AuctionResponse, Report<TrustedServerError>> {
         Err(Report::new(TrustedServerError::Auction {
@@ -512,6 +515,58 @@ fn test_partner_registry(settings: &Settings) -> PartnerRegistry {
     PartnerRegistry::from_config(&settings.ec.partners).expect("should build partner registry")
 }
 
+fn route_result_to_fastly_response(
+    settings: &Settings,
+    services: &RuntimeServices,
+    partner_registry: &PartnerRegistry,
+    route_result: super::RouteResult,
+) -> fastly::Response {
+    let super::RouteResult {
+        outcome,
+        ec_context,
+        finalize_kv_graph,
+        eids_cookie,
+        sharedid_cookie,
+        should_finalize_ec,
+        asset_cache_policy,
+        ..
+    } = route_result;
+
+    let is_auth_challenge = matches!(&outcome, HandlerOutcome::AuthChallenge(_));
+    let mut response = match outcome {
+        HandlerOutcome::Buffered(response) | HandlerOutcome::AuthChallenge(response) => {
+            Some(response)
+        }
+        _ => None,
+    }
+    .expect("should have a buffered route response");
+
+    let geo_info = if is_auth_challenge {
+        None
+    } else {
+        services
+            .geo()
+            .lookup(services.client_info().client_ip)
+            .unwrap_or(None)
+    };
+    super::finalize_response(settings, geo_info.as_ref(), &mut response);
+    asset_cache_policy.apply_after_route_finalization(&mut response);
+
+    let mut fastly_response = compat::to_fastly_response(response);
+    if should_finalize_ec {
+        ec_finalize_response(
+            settings,
+            &ec_context,
+            finalize_kv_graph.as_ref(),
+            partner_registry,
+            eids_cookie.as_deref(),
+            sharedid_cookie.as_deref(),
+            &mut fastly_response,
+        );
+    }
+    fastly_response
+}
+
 fn route_auction(settings: &Settings, body: impl Into<Vec<u8>>) -> fastly::Response {
     let (orchestrator, integration_registry) = build_route_stack(settings);
 
@@ -531,17 +586,16 @@ fn route_auction_with_stack(
         .with_body(body.into());
     let services = test_runtime_services(&req);
 
-    futures::executor::block_on(route_request(
+    let route_result = futures::executor::block_on(route_request(
         settings,
         orchestrator,
         integration_registry,
         &partner_registry,
         &services,
-        req,
+        compat::from_fastly_request(req),
     ))
-    .expect("should route auction request")
-    .response
-    .expect("should buffer auction response in tests")
+    .expect("should route auction request");
+    route_result_to_fastly_response(settings, &services, &partner_registry, route_result)
 }
 
 fn route_buffered_response(
@@ -555,17 +609,16 @@ fn route_buffered_response(
     let partner_registry =
         PartnerRegistry::from_config(&settings.ec.partners).expect("should build partner registry");
 
-    futures::executor::block_on(route_request(
+    let route_result = futures::executor::block_on(route_request(
         settings,
         orchestrator,
         integration_registry,
         &partner_registry,
         services,
-        req,
+        compat::from_fastly_request(req),
     ))
-    .expect(expect_message)
-    .response
-    .expect("should buffer route response in tests")
+    .expect(expect_message);
+    route_result_to_fastly_response(settings, services, &partner_registry, route_result)
 }
 
 fn valid_banner_ad_unit_body() -> Vec<u8> {
@@ -592,42 +645,36 @@ fn routes_use_request_local_consent() {
         IntegrationRegistry::new(&settings).expect("should create integration registry");
     let partner_registry = test_partner_registry(&settings);
 
-    let discovery_req = Request::get("https://test.com/.well-known/trusted-server.json");
-    let discovery_services = test_runtime_services(&discovery_req);
+    let discovery_fastly_req = Request::get("https://test.com/.well-known/trusted-server.json");
+    let discovery_services = test_runtime_services(&discovery_fastly_req);
     let discovery_resp = futures::executor::block_on(route_request(
         &settings,
         &orchestrator,
         &integration_registry,
         &partner_registry,
         &discovery_services,
-        discovery_req,
+        compat::from_fastly_request(discovery_fastly_req),
     ))
     .expect("should route discovery request");
-    let discovery_response = discovery_resp
-        .response
-        .expect("should buffer discovery response in tests");
     assert_eq!(
-        discovery_response.get_status(),
+        discovery_resp.outcome.status(),
         StatusCode::OK,
         "should keep discovery available with request-local consent"
     );
 
-    let admin_req = Request::post("https://test.com/_ts/admin/keys/rotate");
-    let admin_services = test_runtime_services(&admin_req);
+    let admin_fastly_req = Request::post("https://test.com/_ts/admin/keys/rotate");
+    let admin_services = test_runtime_services(&admin_fastly_req);
     let admin_resp = futures::executor::block_on(route_request(
         &settings,
         &orchestrator,
         &integration_registry,
         &partner_registry,
         &admin_services,
-        admin_req,
+        compat::from_fastly_request(admin_fastly_req),
     ))
     .expect("should route admin request");
-    let admin_response = admin_resp
-        .response
-        .expect("should buffer admin response in tests");
     assert_eq!(
-        admin_response.get_status(),
+        admin_resp.outcome.status(),
         StatusCode::UNAUTHORIZED,
         "should keep admin auth behavior unchanged with request-local consent"
     );
@@ -822,17 +869,18 @@ fn asset_routes_stream_asset_responses_directly() {
         IntegrationRegistry::new(&settings).expect("should create integration registry");
     let partner_registry = test_partner_registry(&settings);
 
-    let mut req = Request::get("https://test.com/.images/logo.png");
-    req.set_header(header::COOKIE, format!("ts-ec={}", valid_ec_id()));
-    req.set_header("sec-gpc", "1");
+    let mut fastly_req = Request::get("https://test.com/.images/logo.png");
+    fastly_req.set_header(header::COOKIE, format!("ts-ec={}", valid_ec_id()));
+    fastly_req.set_header("sec-gpc", "1");
     let http_client = Arc::new(StreamingRecordingHttpClient::new());
     let services = test_runtime_services_with_secret_http_client_and_geo(
-        &req,
+        &fastly_req,
         Arc::new(FixedBackend),
         Arc::new(NoopSecretStore),
         Arc::clone(&http_client) as Arc<dyn PlatformHttpClient>,
         Arc::new(FixedGeo(us_california_geo())),
     );
+    let req = compat::from_fastly_request(fastly_req);
 
     let outcome = futures::executor::block_on(route_request(
         &settings,
@@ -845,12 +893,27 @@ fn asset_routes_stream_asset_responses_directly() {
     .expect("should route streaming asset request");
 
     assert!(
-        outcome.response.is_none(),
-        "streaming asset route should send directly instead of returning a buffered response"
+        !outcome.should_finalize_ec,
+        "asset routes should not emit EC identity headers"
+    );
+    assert_eq!(
+        outcome.asset_cache_policy,
+        AssetProxyCachePolicy::OriginControlled,
+        "successful asset routes should preserve origin cache policy"
+    );
+    let (response, body) = match outcome.outcome {
+        HandlerOutcome::AssetStreaming { response, body } => Some((response, body)),
+        _ => None,
+    }
+    .expect("should return streaming asset outcome");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "should preserve streaming asset response status"
     );
     assert!(
-        outcome.pull_sync_context.is_none(),
-        "asset routes should not schedule publisher pull-sync work"
+        matches!(body, EdgeBody::Stream(_)),
+        "should preserve streaming asset response body"
     );
     let calls = http_client
         .calls

--- a/crates/trusted-server-core/Cargo.toml
+++ b/crates/trusted-server-core/Cargo.toml
@@ -45,7 +45,6 @@ toml = { workspace = true }
 trusted-server-js = { path = "../js" }
 trusted-server-openrtb = { path = "../openrtb" }
 url = { workspace = true }
-urlencoding = { workspace = true }
 uuid = { workspace = true }
 validator = { workspace = true }
 ed25519-dalek = { workspace = true }
@@ -71,6 +70,7 @@ default = []
 criterion = { workspace = true }
 edgezero-core = { workspace = true, features = ["test-utils"] }
 temp-env = { workspace = true }
+urlencoding = { workspace = true }
 
 [[bench]]
 name = "consent_decode"

--- a/crates/trusted-server-core/build.rs
+++ b/crates/trusted-server-core/build.rs
@@ -15,6 +15,16 @@ mod redacted;
 #[path = "src/consent_config.rs"]
 mod consent_config;
 
+#[path = "src/host_header.rs"]
+mod host_header;
+
+#[path = "src/platform/image_optimizer.rs"]
+mod platform_image_optimizer;
+
+mod platform {
+    pub use crate::platform_image_optimizer::PlatformImageOptimizerRegion;
+}
+
 #[path = "src/settings.rs"]
 mod settings;
 

--- a/crates/trusted-server-core/src/asset_image_optimizer.rs
+++ b/crates/trusted-server-core/src/asset_image_optimizer.rs
@@ -1,0 +1,468 @@
+//! Platform-neutral Image Optimizer profile-table handling for asset routes.
+//!
+//! Asset routes accept small, publisher-defined query controls such as
+//! `profile`, `ar`, `x`, and `y`. This module converts those controls into a
+//! closed transformation set before the request reaches a platform adapter. It
+//! does not pass arbitrary client query parameters through as Image Optimizer
+//! options.
+//!
+//! The profile table supports shared base parameters, per-profile overrides,
+//! optional aspect-ratio overrides, crop offset bucketing, and a debug bypass
+//! parameter that disables image optimization for a single request.
+
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+use error_stack::Report;
+use url::form_urlencoded;
+
+use crate::error::TrustedServerError;
+use crate::platform::{
+    PlatformImageOptimizerCrop, PlatformImageOptimizerCropMode, PlatformImageOptimizerOptions,
+    PlatformImageOptimizerParams,
+};
+use crate::settings::{
+    ImageOptimizerCropOffsetsConfig, ImageOptimizerProfileSet, MissingCropOffsetMode,
+    OriginQueryPolicy, ProxyAssetRoute, Settings, UnknownProfilePolicy,
+};
+
+/// Build Image Optimizer metadata for a route and request query.
+///
+/// The incoming query is read only as profile-table input. The asset proxy
+/// applies the route origin-query policy separately before signing or sending
+/// the upstream request.
+///
+/// Returns `Ok(None)` when the route has no enabled IO config or when the
+/// configured debug parameter disables IO for this request.
+///
+/// # Errors
+///
+/// Returns a proxy/configuration error if the configured profile set is missing,
+/// a profile parameter cannot be parsed, or the request references an unknown
+/// profile in `reject` mode.
+pub(crate) fn options_for_asset_request(
+    settings: &Settings,
+    route: &ProxyAssetRoute,
+    query: &str,
+) -> Result<Option<PlatformImageOptimizerOptions>, Report<TrustedServerError>> {
+    let Some(route_config) = &route.image_optimizer else {
+        return Ok(None);
+    };
+    if !route_config.enabled {
+        return Ok(None);
+    }
+
+    let profile_set = settings
+        .image_optimizer
+        .profile_sets
+        .get(&route_config.profile_set)
+        .ok_or_else(|| {
+            Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "proxy.asset_routes prefix `{}` references unknown image_optimizer profile_set `{}`",
+                    route.prefix, route_config.profile_set
+                ),
+            })
+        })?;
+
+    if query_param_value(query, &profile_set.debug_param).as_deref() == Some("1") {
+        return Ok(None);
+    }
+
+    let requested_profile = query_param_value(query, &profile_set.profile_param);
+    let selected_profile = select_profile(profile_set, requested_profile.as_deref())?;
+    let mut params = parse_param_string(&profile_set.base_params)?;
+    let profile_params = profile_set
+        .profiles
+        .get(selected_profile)
+        .ok_or_else(|| {
+            Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "image_optimizer.profile_sets `{}` selected profile `{selected_profile}` is not defined",
+                    route_config.profile_set
+                ),
+            })
+        })?;
+    params.merge_from(parse_param_string(profile_params)?);
+
+    apply_aspect_ratio_override(profile_set, selected_profile, query, &mut params);
+    apply_crop_offsets(profile_set, query, &mut params);
+
+    Ok(Some(
+        PlatformImageOptimizerOptions::new(route_config.region.clone(), params)
+            .with_preserve_query_string_on_origin_request(
+                route.origin_query_policy() == OriginQueryPolicy::Preserve,
+            ),
+    ))
+}
+
+fn select_profile<'a>(
+    profile_set: &'a ImageOptimizerProfileSet,
+    requested_profile: Option<&str>,
+) -> Result<&'a str, Report<TrustedServerError>> {
+    let Some(requested_profile) = requested_profile.filter(|value| !value.is_empty()) else {
+        return Ok(&profile_set.default_profile);
+    };
+
+    if let Some((configured_profile, _)) = profile_set.profiles.get_key_value(requested_profile) {
+        return Ok(configured_profile.as_str());
+    }
+
+    match profile_set.unknown_profile {
+        UnknownProfilePolicy::UseDefault => Ok(&profile_set.default_profile),
+        UnknownProfilePolicy::Reject => Err(Report::new(TrustedServerError::BadRequest {
+            message: format!("Unknown image profile: {requested_profile}"),
+        })),
+    }
+}
+
+fn query_param_value(query: &str, param_name: &str) -> Option<String> {
+    form_urlencoded::parse(query.as_bytes())
+        .find(|(key, _)| key.as_ref() == param_name)
+        .map(|(_, value)| value.into_owned())
+}
+
+fn apply_aspect_ratio_override(
+    profile_set: &ImageOptimizerProfileSet,
+    selected_profile: &str,
+    query: &str,
+    params: &mut PlatformImageOptimizerParams,
+) {
+    let Some(aspect_config) = &profile_set.aspect_ratios else {
+        return;
+    };
+    let Some(aspect_ratio) = query_param_value(query, &profile_set.aspect_ratio_param) else {
+        return;
+    };
+
+    if !aspect_config
+        .profiles
+        .iter()
+        .any(|profile| profile == selected_profile)
+    {
+        return;
+    }
+    if !aspect_config
+        .allowed
+        .iter()
+        .any(|allowed| allowed == &aspect_ratio)
+    {
+        return;
+    }
+    let Some((width, height)) = parse_aspect_ratio_value(&aspect_ratio) else {
+        return;
+    };
+
+    params.crop = Some(PlatformImageOptimizerCrop::aspect_ratio(width, height));
+}
+
+fn apply_crop_offsets(
+    profile_set: &ImageOptimizerProfileSet,
+    query: &str,
+    params: &mut PlatformImageOptimizerParams,
+) {
+    let Some(offset_config) = &profile_set.crop_offsets else {
+        return;
+    };
+    if !offset_config.enabled {
+        return;
+    }
+    let Some(crop) = &mut params.crop else {
+        return;
+    };
+    if !crop.is_bare_aspect_ratio() {
+        return;
+    }
+
+    let x = query_param_value(query, &offset_config.x_param);
+    let y = query_param_value(query, &offset_config.y_param);
+    if x.is_none() && y.is_none() {
+        if offset_config.when_missing == MissingCropOffsetMode::Smart {
+            crop.mode = Some(PlatformImageOptimizerCropMode::Smart);
+        }
+        return;
+    }
+
+    crop.offset_x = Some(normalize_offset(x.as_deref(), offset_config));
+    crop.offset_y = Some(normalize_offset(y.as_deref(), offset_config));
+}
+
+fn normalize_offset(value: Option<&str>, config: &ImageOptimizerCropOffsetsConfig) -> u32 {
+    let Some(raw) = value else {
+        return config.default;
+    };
+    let Ok(parsed) = raw.parse::<u32>() else {
+        return config.default;
+    };
+    if parsed > 100 {
+        return config.default;
+    }
+
+    let Some(first) = config.buckets.first().copied() else {
+        return config.default;
+    };
+    for window in config.buckets.windows(2) {
+        let current = window[0];
+        let next = window[1];
+        let midpoint = current + (next.saturating_sub(current) / 2);
+        if parsed < midpoint {
+            return current;
+        }
+    }
+    config.buckets.last().copied().unwrap_or(first)
+}
+
+fn parse_param_string(
+    params: &str,
+) -> Result<PlatformImageOptimizerParams, Report<TrustedServerError>> {
+    let mut parsed = PlatformImageOptimizerParams::default();
+    if params.trim().is_empty() {
+        return Ok(parsed);
+    }
+
+    for (key, value) in form_urlencoded::parse(params.as_bytes()) {
+        let key = key.as_ref();
+        let value = value.as_ref();
+        match key {
+            "format" => parsed.format = Some(parse_format(value)?),
+            "quality" => parsed.quality = Some(parse_bounded_u32("quality", value, 0, 100)?),
+            "resize-filter" => parsed.resize_filter = Some(parse_resize_filter(value)?),
+            "width" => parsed.width = Some(parse_positive_u32("width", value)?),
+            "height" => parsed.height = Some(parse_positive_u32("height", value)?),
+            "crop" => parsed.crop = Some(parse_crop(value)?),
+            unsupported => {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "unsupported image optimizer profile parameter `{unsupported}`"
+                    ),
+                }));
+            }
+        }
+    }
+
+    Ok(parsed)
+}
+
+fn parse_format(value: &str) -> Result<String, Report<TrustedServerError>> {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "auto" | "avif" | "gif" | "jpeg" | "jpg" | "jxl" | "jpegxl" | "mp4" | "png" | "webp" => {
+            Ok(normalized)
+        }
+        _ => Err(Report::new(TrustedServerError::Configuration {
+            message: format!("unsupported image optimizer format `{value}`"),
+        })),
+    }
+}
+
+fn parse_resize_filter(value: &str) -> Result<String, Report<TrustedServerError>> {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "nearest" | "bilinear" | "bicubic" | "lanczos2" | "lanczos3" => Ok(normalized),
+        _ => Err(Report::new(TrustedServerError::Configuration {
+            message: format!("unsupported image optimizer resize-filter `{value}`"),
+        })),
+    }
+}
+
+fn parse_positive_u32(name: &str, value: &str) -> Result<u32, Report<TrustedServerError>> {
+    let parsed = value.parse::<u32>().map_err(|err| {
+        Report::new(TrustedServerError::Configuration {
+            message: format!("image optimizer `{name}` must be an integer: {err}"),
+        })
+    })?;
+    if parsed == 0 {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!("image optimizer `{name}` must be greater than zero"),
+        }));
+    }
+    Ok(parsed)
+}
+
+fn parse_bounded_u32(
+    name: &str,
+    value: &str,
+    min: u32,
+    max: u32,
+) -> Result<u32, Report<TrustedServerError>> {
+    let parsed = value.parse::<u32>().map_err(|err| {
+        Report::new(TrustedServerError::Configuration {
+            message: format!("image optimizer `{name}` must be an integer: {err}"),
+        })
+    })?;
+    if parsed < min || parsed > max {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!("image optimizer `{name}` must be in {min}..={max}"),
+        }));
+    }
+    Ok(parsed)
+}
+
+fn parse_crop(value: &str) -> Result<PlatformImageOptimizerCrop, Report<TrustedServerError>> {
+    let mut parts = value.split(',');
+    let ratio = parts.next().unwrap_or_default();
+    let (width, height) = parse_crop_ratio(ratio)?;
+    let mut crop = PlatformImageOptimizerCrop::aspect_ratio(width, height);
+    let mut seen_suffixes = HashSet::new();
+
+    for suffix in parts {
+        if suffix == "smart" {
+            crop.mode = Some(PlatformImageOptimizerCropMode::Smart);
+            seen_suffixes.insert(Cow::Borrowed("smart"));
+            continue;
+        }
+        if let Some(offset) = suffix.strip_prefix("offset-x") {
+            crop.offset_x = Some(parse_bounded_u32("crop offset-x", offset, 0, 100)?);
+            seen_suffixes.insert(Cow::Borrowed("offset-x"));
+            continue;
+        }
+        if let Some(offset) = suffix.strip_prefix("offset-y") {
+            crop.offset_y = Some(parse_bounded_u32("crop offset-y", offset, 0, 100)?);
+            seen_suffixes.insert(Cow::Borrowed("offset-y"));
+            continue;
+        }
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!("unsupported image optimizer crop suffix `{suffix}`"),
+        }));
+    }
+
+    if crop.mode.is_some() && (crop.offset_x.is_some() || crop.offset_y.is_some()) {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: "image optimizer crop cannot combine smart mode with explicit offsets"
+                .to_string(),
+        }));
+    }
+    if seen_suffixes.contains(&Cow::Borrowed("offset-x"))
+        != seen_suffixes.contains(&Cow::Borrowed("offset-y"))
+    {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: "image optimizer crop offsets must include both offset-x and offset-y"
+                .to_string(),
+        }));
+    }
+
+    Ok(crop)
+}
+
+fn parse_crop_ratio(value: &str) -> Result<(u32, u32), Report<TrustedServerError>> {
+    let (width, height) = value.split_once(':').ok_or_else(|| {
+        Report::new(TrustedServerError::Configuration {
+            message: format!("image optimizer crop `{value}` must look like `width:height`"),
+        })
+    })?;
+    let width = parse_positive_u32("crop width", width)?;
+    let height = parse_positive_u32("crop height", height)?;
+    Ok((width, height))
+}
+
+fn parse_aspect_ratio_value(value: &str) -> Option<(u32, u32)> {
+    let (width, height) = value.split_once('-')?;
+    let width = width.parse::<u32>().ok()?;
+    let height = height.parse::<u32>().ok()?;
+    if width == 0 || height == 0 {
+        return None;
+    }
+    Some((width, height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{
+        AssetImageOptimizerConfig, ImageOptimizerAspectRatioConfig,
+        ImageOptimizerCropOffsetsConfig, ImageOptimizerProfileSet, ImageOptimizerSettings,
+    };
+
+    fn profile_set() -> ImageOptimizerProfileSet {
+        let mut profiles = std::collections::HashMap::new();
+        profiles.insert("default".to_string(), "width=1920".to_string());
+        profiles.insert("medium".to_string(), "format=auto&width=828".to_string());
+        ImageOptimizerProfileSet {
+            base_params: "quality=70&resize-filter=bicubic".to_string(),
+            default_profile: "default".to_string(),
+            unknown_profile: UnknownProfilePolicy::UseDefault,
+            profile_param: "profile".to_string(),
+            aspect_ratio_param: "ar".to_string(),
+            debug_param: "_io_debug".to_string(),
+            profiles,
+            aspect_ratios: Some(ImageOptimizerAspectRatioConfig {
+                allowed: vec!["1-1".to_string(), "16-9".to_string()],
+                profiles: vec!["medium".to_string()],
+            }),
+            crop_offsets: Some(ImageOptimizerCropOffsetsConfig {
+                enabled: true,
+                x_param: "x".to_string(),
+                y_param: "y".to_string(),
+                buckets: vec![10, 30, 50, 70, 90],
+                default: 50,
+                when_missing: MissingCropOffsetMode::Smart,
+            }),
+        }
+    }
+
+    #[test]
+    fn options_for_asset_request_returns_error_when_selected_profile_is_missing() {
+        let mut settings = crate::test_support::tests::create_test_settings();
+        let mut profile_set = profile_set();
+        profile_set.profiles.remove("default");
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: std::collections::HashMap::from([(
+                "default_images".to_string(),
+                profile_set,
+            )]),
+        };
+        let mut route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
+        route.image_optimizer = Some(AssetImageOptimizerConfig {
+            enabled: true,
+            region: "us_east".to_string(),
+            profile_set: "default_images".to_string(),
+            origin_query: None,
+        });
+
+        let err = options_for_asset_request(&settings, &route, "")
+            .expect_err("should return a configuration error for broken profile sets");
+
+        assert!(
+            format!("{err:?}").contains("selected profile `default` is not defined"),
+            "should describe the missing selected profile without panicking: {err:?}"
+        );
+    }
+
+    #[test]
+    fn profile_conversion_adds_aspect_ratio_and_smart_crop() {
+        let set = profile_set();
+        let selected = select_profile(&set, Some("medium")).expect("should select profile");
+        let mut params = parse_param_string(&set.base_params).expect("should parse base params");
+        params.merge_from(
+            parse_param_string(set.profiles.get(selected).expect("should get profile"))
+                .expect("should parse profile params"),
+        );
+        apply_aspect_ratio_override(&set, selected, "profile=medium&ar=1-1", &mut params);
+        apply_crop_offsets(&set, "profile=medium&ar=1-1", &mut params);
+
+        assert_eq!(params.quality, Some(70));
+        assert_eq!(params.resize_filter.as_deref(), Some("bicubic"));
+        assert_eq!(params.format.as_deref(), Some("auto"));
+        assert_eq!(params.width, Some(828));
+        let crop = params.crop.expect("should add crop");
+        assert_eq!((crop.width, crop.height), (1, 1));
+        assert_eq!(crop.mode, Some(PlatformImageOptimizerCropMode::Smart));
+    }
+
+    #[test]
+    fn profile_conversion_buckets_offsets() {
+        let set = profile_set();
+        let selected = select_profile(&set, Some("medium")).expect("should select profile");
+        let mut params = parse_param_string("width=828").expect("should parse params");
+        apply_aspect_ratio_override(
+            &set,
+            selected,
+            "profile=medium&ar=16-9&x=79&y=bad",
+            &mut params,
+        );
+        apply_crop_offsets(&set, "profile=medium&ar=16-9&x=79&y=bad", &mut params);
+
+        let crop = params.crop.expect("should add crop");
+        assert_eq!((crop.offset_x, crop.offset_y), (Some(70), Some(50)));
+    }
+}

--- a/crates/trusted-server-core/src/auction/README.md
+++ b/crates/trusted-server-core/src/auction/README.md
@@ -24,7 +24,8 @@ The auction orchestration system allows you to:
                           ▼
 ┌─────────────────────────────────────────────────────────┐
 │              AuctionProvider Trait                       │
-│  - request_bids()                                        │
+│  - request_bids() async                                  │
+│  - parse_response()                                      │
 │  - provider_name()                                       │
 │  - timeout_ms()                                          │
 │  - is_enabled()                                          │
@@ -479,6 +480,7 @@ timeout_ms = 500
 use async_trait::async_trait;
 use crate::auction::provider::AuctionProvider;
 use crate::auction::types::{AuctionContext, AuctionRequest, AuctionResponse};
+use crate::platform::{PlatformPendingRequest, PlatformResponse};
 
 pub struct YourAuctionProvider {
     config: YourConfig,
@@ -494,11 +496,19 @@ impl AuctionProvider for YourAuctionProvider {
         &self,
         request: &AuctionRequest,
         _context: &AuctionContext<'_>,
-    ) -> Result<AuctionResponse, Report<TrustedServerError>> {
+    ) -> Result<PlatformPendingRequest, Report<TrustedServerError>> {
         // 1. Transform AuctionRequest to your provider's format
-        // 2. Make HTTP request to your provider
-        // 3. Parse response
-        // 4. Return AuctionResponse with bids
+        // 2. Launch HTTP request through services.http_client().send_async(...)
+        // 3. Return PlatformPendingRequest for the orchestrator to await
+        todo!()
+    }
+
+    async fn parse_response(
+        &self,
+        response: PlatformResponse,
+        response_time_ms: u64,
+    ) -> Result<AuctionResponse, Report<TrustedServerError>> {
+        // 4. Parse PlatformResponse into AuctionResponse
         todo!()
     }
 
@@ -534,7 +544,7 @@ let orchestrator = AuctionOrchestrator::new(config);
 orchestrator.register_provider(Arc::new(PrebidAuctionProvider::try_new(prebid_config)?));
 orchestrator.register_provider(Arc::new(ApsAuctionProvider::new(aps_config)));
 
-let result = orchestrator.run_auction(&request, &context).await?;
+let result = orchestrator.run_auction(&request, &context, &services).await?;
 
 // Check results
 assert_eq!(result.winning_bids.len(), 2);
@@ -543,7 +553,7 @@ assert!(result.total_time_ms < 2000);
 
 ## Performance Considerations
 
-- **Parallel Execution**: Currently runs sequentially in Fastly Compute (no tokio runtime), but structured for easy parallelization
+- **Parallel Execution**: Providers are launched concurrently via `select()` over `PendingRequest`s; responses are processed as they become ready within the auction deadline
 - **Timeouts**: Each provider has independent timeout; global timeout enforced at flow level
 - **Error Handling**: Provider failures don't fail entire auction; partial results returned
 

--- a/crates/trusted-server-core/src/auction/endpoints.rs
+++ b/crates/trusted-server-core/src/auction/endpoints.rs
@@ -1,8 +1,8 @@
 //! HTTP endpoint handlers for auction requests.
 
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::StatusCode;
-use fastly::{Request, Response};
+use http::{header, Request, Response, StatusCode};
 use serde_json::Value as JsonValue;
 
 use crate::auction::formats::AdRequest;
@@ -54,21 +54,41 @@ pub async fn handle_auction(
     registry: Option<&PartnerRegistry>,
     ec_context: &EcContext,
     services: &RuntimeServices,
-    mut req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
-    // Reject oversized bodies before any allocation. The `Content-Length`
+    req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    // Reject oversized bodies before any allocation. The Content-Length
     // pre-check stops well-behaved clients early; the post-read check defends
     // against clients that lie about (or omit) the header.
     let content_length_exceeded = req
-        .get_header_str("content-length")
-        .and_then(|value| value.parse::<usize>().ok())
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<usize>().ok())
         .is_some_and(|length| length > MAX_AUCTION_BODY_SIZE);
     if content_length_exceeded {
-        return Ok(Response::from_status(StatusCode::PAYLOAD_TOO_LARGE));
+        return Response::builder()
+            .status(StatusCode::PAYLOAD_TOO_LARGE)
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(EdgeBody::from(format!(
+                "Request body exceeds {MAX_AUCTION_BODY_SIZE} byte limit"
+            )))
+            .change_context(TrustedServerError::Auction {
+                message: "Auction request body exceeded maximum size".to_string(),
+            });
     }
-    let body_bytes = req.take_body_bytes();
+
+    let (parts, body) = req.into_parts();
+    let body_bytes = body.into_bytes();
     if body_bytes.len() > MAX_AUCTION_BODY_SIZE {
-        return Ok(Response::from_status(StatusCode::PAYLOAD_TOO_LARGE));
+        return Response::builder()
+            .status(StatusCode::PAYLOAD_TOO_LARGE)
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(EdgeBody::from(format!(
+                "Request body exceeds {MAX_AUCTION_BODY_SIZE} byte limit"
+            )))
+            .change_context(TrustedServerError::Auction {
+                message: "Auction request body exceeded maximum size".to_string(),
+            });
     }
     let body: AdRequest =
         serde_json::from_slice(&body_bytes).change_context(TrustedServerError::BadRequest {
@@ -80,18 +100,14 @@ pub async fn handle_auction(
         body.ad_units.len()
     );
 
+    let http_req = Request::from_parts(parts, EdgeBody::empty());
+
     // Story 5 middleware contract: auction is a read-only EC route.
     // It must not generate EC IDs; it only consumes pre-routed context.
     // Only forward the EC ID to auction partners when consent allows it.
-    // A returning user may still have a ts-ec cookie but have since
-    // withdrawn consent — forwarding that revoked ID to bidders would
-    // defeat the consent gating.
     let ec_id = if ec_context.ec_allowed() {
         ec_context.ec_value()
     } else {
-        // Intentionally omit persistent identity when EC is disallowed.
-        // This keeps the no-consent / GPC path conservative rather than
-        // introducing a secondary session-scoped identifier surface here.
         None
     };
     let consent_context = ec_context.consent().clone();
@@ -102,20 +118,35 @@ pub async fn handle_auction(
     // full OpenRTB-style EID structure.
     let client_eids = resolve_client_auction_eids(
         body.eids.as_ref(),
-        extract_cookie_value(&req, COOKIE_TS_EIDS).as_deref(),
+        extract_cookie_value(&http_req, COOKIE_TS_EIDS).as_deref(),
     );
 
     // Resolve partner EIDs from the KV identity graph when the user has
     // a valid EC and both KV and partner stores are available.
     let eids = resolve_auction_eids(kv, registry, ec_context);
 
+    // Look up geo for device info.
+    let geo = services
+        .geo()
+        .lookup(services.client_info().client_ip)
+        .unwrap_or_else(|e| {
+            log::warn!("geo lookup failed: {e}");
+            None
+        });
+
     // Convert tsjs request format to auction request
-    let mut auction_request =
-        convert_tsjs_to_auction_request(&body, settings, &req, consent_context, ec_id)?;
+    let mut auction_request = convert_tsjs_to_auction_request(
+        &body,
+        settings,
+        services,
+        &http_req,
+        consent_context,
+        ec_id,
+        geo,
+    )?;
 
     // Merge current-request client EIDs with KV-resolved EIDs, then apply
     // consent gating before attaching them to the auction request.
-    // `gate_eids_by_consent` checks TCF Purpose 1 + 4.
     let merged_eids = merge_auction_eids(client_eids, eids);
     let had_eids = merged_eids.as_ref().is_some_and(|v| !v.is_empty());
     auction_request.user.eids =
@@ -127,7 +158,7 @@ pub async fn handle_auction(
     // Create auction context
     let context = AuctionContext {
         settings,
-        request: &req,
+        request: &http_req,
         timeout_ms: settings.auction.timeout_ms,
         provider_responses: None,
         services,
@@ -187,8 +218,11 @@ fn resolve_auction_eids(
     Some(to_eids(&resolved))
 }
 
-fn extract_cookie_value(req: &Request, name: &str) -> Option<String> {
-    let cookie_header = req.get_header_str("cookie")?;
+fn extract_cookie_value(req: &Request<EdgeBody>, name: &str) -> Option<String> {
+    let cookie_header = req
+        .headers()
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())?;
     for pair in cookie_header.split(';') {
         let pair = pair.trim();
         if let Some((key, value)) = pair.split_once('=') {
@@ -726,6 +760,45 @@ mod tests {
             merged[0].uids[0].ext,
             Some(json!({ "provider": "server" })),
             "should prefer resolved ext"
+        );
+    }
+
+    #[tokio::test]
+    async fn auction_rejects_oversized_body() {
+        use edgezero_core::body::Body as EdgeBody;
+        use http::{Method, Request as HttpRequest, StatusCode};
+
+        use crate::auction::build_orchestrator;
+        use crate::consent::ConsentContext;
+        use crate::ec::EcContext;
+        use crate::platform::test_support::noop_services;
+        use crate::test_support::tests::create_test_settings;
+
+        let settings = create_test_settings();
+        let orchestrator = build_orchestrator(&settings).expect("should build orchestrator");
+        let services = noop_services();
+        let ec_context = EcContext::new_for_test(None, ConsentContext::default());
+        let oversized = vec![b'x'; MAX_AUCTION_BODY_SIZE + 1];
+        let req = HttpRequest::builder()
+            .method(Method::POST)
+            .uri("https://test.com/auction")
+            .body(EdgeBody::from(oversized))
+            .expect("should build request");
+        let response = handle_auction(
+            &settings,
+            &orchestrator,
+            None,
+            None,
+            &ec_context,
+            &services,
+            req,
+        )
+        .await
+        .expect("should return 413 response for oversized body");
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "should return 413 for auction body over limit"
         );
     }
 }

--- a/crates/trusted-server-core/src/auction/endpoints.rs
+++ b/crates/trusted-server-core/src/auction/endpoints.rs
@@ -71,7 +71,7 @@ pub async fn handle_auction(
         return Ok(Response::from_status(StatusCode::PAYLOAD_TOO_LARGE));
     }
     let body: AdRequest =
-        serde_json::from_slice(&body_bytes).change_context(TrustedServerError::Auction {
+        serde_json::from_slice(&body_bytes).change_context(TrustedServerError::BadRequest {
             message: "Failed to parse auction request body".to_string(),
         })?;
 

--- a/crates/trusted-server-core/src/auction/formats.rs
+++ b/crates/trusted-server-core/src/auction/formats.rs
@@ -78,9 +78,8 @@ pub struct BannerUnit {
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - Fresh EC ID generation fails
-/// - Request contains invalid banner sizes (must be [width, height])
+/// Returns an error if the request contains invalid banner sizes
+/// (must be `[width, height]`).
 pub fn convert_tsjs_to_auction_request(
     body: &AdRequest,
     settings: &Settings,
@@ -338,16 +337,27 @@ pub fn convert_to_openrtb_response(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auction::orchestrator::OrchestrationResult;
-    use crate::auction::types::{AdFormat, AdSlot, MediaType};
-    use crate::constants::{HEADER_X_TS_EC_CONSENT, HEADER_X_TS_EIDS, HEADER_X_TS_EIDS_TRUNCATED};
+    use crate::auction::types::{AuctionResponse, Bid, BidStatus};
     use crate::openrtb::{Eid, Uid};
+    use crate::test_support::tests::create_test_settings;
+    use serde_json::json;
+    use std::collections::HashSet;
 
-    fn make_minimal_auction_request() -> AuctionRequest {
+    fn make_request() -> Request {
+        let mut req = Request::new("POST", "https://publisher.example.com/auction");
+        req.set_header(header::USER_AGENT, "Mozilla/5.0 test");
+        req
+    }
+
+    fn make_settings() -> Settings {
+        create_test_settings()
+    }
+
+    fn make_auction_request() -> AuctionRequest {
         AuctionRequest {
-            id: "test-auction".to_owned(),
+            id: "auction-1".to_string(),
             slots: vec![AdSlot {
-                id: "slot-1".to_owned(),
+                id: "div-gpt-top".to_string(),
                 formats: vec![AdFormat {
                     media_type: MediaType::Banner,
                     width: 300,
@@ -358,12 +368,12 @@ mod tests {
                 bidders: HashMap::new(),
             }],
             publisher: PublisherInfo {
-                domain: "test.com".to_owned(),
-                page_url: None,
+                domain: "publisher.example.com".to_string(),
+                page_url: Some("https://publisher.example.com".to_string()),
             },
             user: UserInfo {
-                id: Some("test-ec-id".to_owned()),
-                consent: None,
+                id: Some("ec-id".to_string()),
+                consent: Some(ConsentContext::default()),
                 eids: None,
             },
             device: None,
@@ -374,21 +384,91 @@ mod tests {
 
     fn make_empty_result() -> OrchestrationResult {
         OrchestrationResult {
-            winning_bids: HashMap::new(),
             provider_responses: Vec::new(),
             mediator_response: None,
+            winning_bids: HashMap::new(),
             total_time_ms: 10,
             metadata: HashMap::new(),
         }
     }
 
-    fn make_settings() -> Settings {
-        crate::test_support::tests::create_test_settings()
+    fn make_bid(slot_id: &str, bidder: &str, price: Option<f64>) -> Bid {
+        Bid {
+            slot_id: slot_id.to_string(),
+            price,
+            currency: "USD".to_string(),
+            creative: Some("<div>Ad</div>".to_string()),
+            adomain: Some(vec!["advertiser.example.com".to_string()]),
+            bidder: bidder.to_string(),
+            width: 300,
+            height: 250,
+            nurl: None,
+            burl: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn make_result(bid: Bid) -> OrchestrationResult {
+        OrchestrationResult {
+            provider_responses: vec![AuctionResponse {
+                provider: "prebid".to_string(),
+                bids: vec![bid.clone()],
+                status: BidStatus::Success,
+                response_time_ms: 42,
+                metadata: HashMap::new(),
+            }],
+            mediator_response: None,
+            winning_bids: HashMap::from([(bid.slot_id.clone(), bid)]),
+            total_time_ms: 50,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn response_json(mut response: Response) -> JsonValue {
+        serde_json::from_slice(&response.take_body_bytes()).expect("should parse JSON response")
+    }
+
+    fn make_banner_body(config: Option<JsonValue>) -> AdRequest {
+        AdRequest {
+            ad_units: vec![AdUnit {
+                code: "div-gpt-top".to_string(),
+                media_types: Some(MediaTypes {
+                    banner: Some(BannerUnit {
+                        sizes: vec![vec![300, 250], vec![728, 90]],
+                    }),
+                }),
+                bids: Some(vec![
+                    BidConfig {
+                        bidder: "appnexus".to_string(),
+                        params: json!({ "placementId": 123 }),
+                    },
+                    BidConfig {
+                        bidder: "rubicon".to_string(),
+                        params: json!({ "accountId": 456 }),
+                    },
+                ]),
+            }],
+            config,
+            eids: None,
+        }
+    }
+
+    fn convert_body_to_auction_request(body: &AdRequest, settings: &Settings) -> AuctionRequest {
+        let req = make_request();
+
+        convert_tsjs_to_auction_request(
+            body,
+            settings,
+            &req,
+            ConsentContext::default(),
+            Some("existing-ec-id"),
+        )
+        .expect("should convert banner request")
     }
 
     #[test]
     fn response_includes_eid_headers_when_eids_present() {
-        let mut request = make_minimal_auction_request();
+        let mut request = make_auction_request();
         request.user.eids = Some(vec![Eid {
             source: "ssp.com".to_owned(),
             uids: vec![Uid {
@@ -423,7 +503,7 @@ mod tests {
 
     #[test]
     fn response_sets_consent_header_even_without_eids() {
-        let request = make_minimal_auction_request();
+        let request = make_auction_request();
         let settings = make_settings();
         let result = make_empty_result();
 
@@ -445,7 +525,7 @@ mod tests {
 
     #[test]
     fn response_omits_consent_header_when_not_allowed() {
-        let request = make_minimal_auction_request();
+        let request = make_auction_request();
         let settings = make_settings();
         let result = make_empty_result();
 
@@ -468,7 +548,7 @@ mod tests {
 
     #[test]
     fn response_omits_ec_header_when_ec_id_is_none() {
-        let mut request = make_minimal_auction_request();
+        let mut request = make_auction_request();
         request.user.id = None;
 
         let settings = make_settings();
@@ -481,5 +561,532 @@ mod tests {
             response.get_header("x-ts-ec").is_none(),
             "should omit x-ts-ec when no EC ID is available"
         );
+    }
+
+    #[test]
+    fn convert_tsjs_to_auction_request_maps_banner_sizes_to_formats() {
+        let settings = make_settings();
+        let body = make_banner_body(None);
+        let auction_request = convert_body_to_auction_request(&body, &settings);
+
+        assert_eq!(auction_request.slots.len(), 1, "should create one slot");
+        let slot = &auction_request.slots[0];
+        assert_eq!(slot.id, "div-gpt-top", "should preserve ad unit code");
+        assert_eq!(
+            slot.formats,
+            vec![
+                AdFormat {
+                    width: 300,
+                    height: 250,
+                    media_type: MediaType::Banner,
+                },
+                AdFormat {
+                    width: 728,
+                    height: 90,
+                    media_type: MediaType::Banner,
+                },
+            ],
+            "should convert banner sizes to formats"
+        );
+    }
+
+    #[test]
+    fn convert_tsjs_to_auction_request_preserves_bidder_params() {
+        let settings = make_settings();
+        let body = make_banner_body(None);
+        let auction_request = convert_body_to_auction_request(&body, &settings);
+        let slot = &auction_request.slots[0];
+
+        assert_eq!(
+            slot.bidders.get("appnexus"),
+            Some(&json!({ "placementId": 123 })),
+            "should preserve bidder params"
+        );
+        assert_eq!(
+            slot.bidders.get("rubicon"),
+            Some(&json!({ "accountId": 456 })),
+            "should preserve all bidder params"
+        );
+    }
+
+    #[test]
+    fn convert_tsjs_to_auction_request_populates_publisher_user_device_and_site_metadata() {
+        let settings = make_settings();
+        let body = make_banner_body(None);
+        let auction_request = convert_body_to_auction_request(&body, &settings);
+
+        assert_eq!(
+            auction_request.publisher.domain, settings.publisher.domain,
+            "should copy publisher domain"
+        );
+        assert_eq!(
+            auction_request
+                .site
+                .as_ref()
+                .map(|site| site.domain.as_str()),
+            Some(settings.publisher.domain.as_str()),
+            "should create site metadata from settings"
+        );
+        assert_eq!(
+            auction_request.user.id.as_deref(),
+            Some("existing-ec-id"),
+            "should use caller-provided EC ID"
+        );
+        assert!(
+            auction_request.user.consent.is_some(),
+            "should preserve consent context"
+        );
+        assert!(
+            auction_request.user.eids.is_none(),
+            "should not attach EIDs during request conversion"
+        );
+        assert_eq!(
+            auction_request
+                .device
+                .as_ref()
+                .and_then(|device| device.user_agent.as_deref()),
+            Some("Mozilla/5.0 test"),
+            "should copy user-agent into device info"
+        );
+    }
+
+    #[test]
+    fn convert_tsjs_to_auction_request_propagates_missing_ec_id() {
+        let settings = make_settings();
+        let req = make_request();
+        let auction_request = convert_tsjs_to_auction_request(
+            &make_banner_body(None),
+            &settings,
+            &req,
+            ConsentContext::default(),
+            None,
+        )
+        .expect("should convert request without EC ID");
+
+        assert!(
+            auction_request.user.id.is_none(),
+            "should leave user ID unset when caller provides no EC ID"
+        );
+    }
+
+    #[test]
+    fn convert_tsjs_to_auction_request_filters_context_values() {
+        let mut settings = make_settings();
+        settings.auction.allowed_context_keys = HashSet::from([
+            "segments".to_string(),
+            "lockr_id".to_string(),
+            "count".to_string(),
+            "unsupported".to_string(),
+        ]);
+        let body = make_banner_body(Some(json!({
+            "segments": ["seg-a", "seg-b"],
+            "lockr_id": "lockr-123",
+            "count": 2,
+            "unsupported": { "nested": true },
+            "blocked": "drop-me"
+        })));
+        let auction_request = convert_body_to_auction_request(&body, &settings);
+
+        assert_eq!(
+            auction_request.context.get("segments"),
+            Some(&ContextValue::StringList(vec![
+                "seg-a".to_string(),
+                "seg-b".to_string()
+            ])),
+            "should keep allowed string-list context values"
+        );
+        assert_eq!(
+            auction_request.context.get("lockr_id"),
+            Some(&ContextValue::Text("lockr-123".to_string())),
+            "should keep allowed text context values"
+        );
+        assert_eq!(
+            auction_request.context.get("count"),
+            Some(&ContextValue::Number(2.0)),
+            "should keep allowed number context values"
+        );
+        assert!(
+            !auction_request.context.contains_key("unsupported"),
+            "should drop allowed keys with unsupported value types"
+        );
+        assert!(
+            !auction_request.context.contains_key("blocked"),
+            "should drop disallowed context keys"
+        );
+    }
+
+    #[test]
+    fn convert_tsjs_to_auction_request_allows_empty_banner_sizes() {
+        let settings = make_settings();
+        let req = make_request();
+        let body = AdRequest {
+            ad_units: vec![AdUnit {
+                code: "div-gpt-top".to_string(),
+                media_types: Some(MediaTypes {
+                    banner: Some(BannerUnit { sizes: vec![] }),
+                }),
+                bids: None,
+            }],
+            config: None,
+            eids: None,
+        };
+
+        let auction_request = convert_tsjs_to_auction_request(
+            &body,
+            &settings,
+            &req,
+            ConsentContext::default(),
+            Some("existing-ec-id"),
+        )
+        .expect("should convert request with empty banner sizes");
+
+        assert_eq!(auction_request.slots.len(), 1, "should create one slot");
+        assert!(
+            auction_request.slots[0].formats.is_empty(),
+            "should preserve current behavior by allowing empty formats"
+        );
+    }
+
+    #[test]
+    fn convert_tsjs_to_auction_request_rejects_banner_sizes_that_are_not_width_height_pairs() {
+        let settings = make_settings();
+        let req = make_request();
+        let body = AdRequest {
+            ad_units: vec![AdUnit {
+                code: "div-gpt-top".to_string(),
+                media_types: Some(MediaTypes {
+                    banner: Some(BannerUnit {
+                        sizes: vec![vec![300, 250, 1]],
+                    }),
+                }),
+                bids: None,
+            }],
+            config: None,
+            eids: None,
+        };
+
+        let err = convert_tsjs_to_auction_request(
+            &body,
+            &settings,
+            &req,
+            ConsentContext::default(),
+            Some("existing-ec-id"),
+        )
+        .expect_err("should reject malformed banner size");
+
+        assert!(
+            format!("{err:?}").contains("Invalid banner size; expected [width, height]"),
+            "should explain invalid banner size"
+        );
+    }
+
+    #[test]
+    fn convert_tsjs_to_auction_request_skips_units_without_banner_media() {
+        let settings = make_settings();
+        let req = make_request();
+        let body = AdRequest {
+            ad_units: vec![
+                AdUnit {
+                    code: "no-media".to_string(),
+                    media_types: None,
+                    bids: None,
+                },
+                AdUnit {
+                    code: "no-banner".to_string(),
+                    media_types: Some(MediaTypes { banner: None }),
+                    bids: None,
+                },
+            ],
+            config: None,
+            eids: None,
+        };
+
+        let auction_request = convert_tsjs_to_auction_request(
+            &body,
+            &settings,
+            &req,
+            ConsentContext::default(),
+            Some("existing-ec-id"),
+        )
+        .expect("should skip unsupported media units");
+
+        assert!(
+            auction_request.slots.is_empty(),
+            "should only create slots for banner media"
+        );
+    }
+
+    #[test]
+    fn convert_to_openrtb_response_serializes_winning_bid_and_orchestrator_ext() {
+        let settings = make_settings();
+        let auction_request = make_auction_request();
+        let result = make_result(make_bid("div-gpt-top", "appnexus", Some(2.75)));
+
+        let response = convert_to_openrtb_response(&result, &settings, &auction_request, true)
+            .expect("should convert auction result to OpenRTB response");
+
+        assert_eq!(response.get_status(), StatusCode::OK, "should return OK");
+        assert_eq!(
+            response.get_header_str(header::CONTENT_TYPE),
+            Some("application/json"),
+            "should set JSON content type"
+        );
+        assert_eq!(
+            response.get_header_str(HEADER_X_TS_EC_CONSENT),
+            Some("ok"),
+            "should set EC consent header when allowed"
+        );
+        assert!(
+            response.get_header("x-ts-ec").is_none(),
+            "should not emit removed EC ID header"
+        );
+
+        let json = response_json(response);
+        assert_eq!(json["id"], json!("auction-1"), "should preserve auction ID");
+        assert_eq!(
+            json["seatbid"][0]["seat"],
+            json!("appnexus"),
+            "should use bidder as seat"
+        );
+        let bid = &json["seatbid"][0]["bid"][0];
+        assert_eq!(bid["id"], json!("appnexus-div-gpt-top"));
+        assert_eq!(bid["impid"], json!("div-gpt-top"));
+        assert_eq!(bid["price"], json!(2.75));
+        assert_eq!(bid["adm"], json!("<div>Ad</div>"));
+        assert_eq!(bid["crid"], json!("appnexus-creative"));
+        assert_eq!(bid["w"], json!(300));
+        assert_eq!(bid["h"], json!(250));
+        assert_eq!(bid["adomain"], json!(["advertiser.example.com"]));
+        assert_eq!(
+            json["ext"]["orchestrator"]["strategy"],
+            json!("parallel_only"),
+            "should use default parallel-only strategy"
+        );
+        assert_eq!(json["ext"]["orchestrator"]["providers"], json!(1));
+        assert_eq!(json["ext"]["orchestrator"]["total_bids"], json!(1));
+        assert_eq!(json["ext"]["orchestrator"]["time_ms"], json!(50));
+        assert_eq!(
+            json["ext"]["orchestrator"]["provider_details"][0]["name"],
+            json!("prebid"),
+            "should include provider summary details"
+        );
+    }
+
+    #[test]
+    fn convert_to_openrtb_response_serializes_missing_creative_as_empty_adm() {
+        let settings = make_settings();
+        let auction_request = make_auction_request();
+        let mut bid = make_bid("div-gpt-top", "appnexus", Some(2.75));
+        bid.creative = None;
+        let result = make_result(bid);
+
+        let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
+            .expect("should convert bid without creative HTML");
+
+        assert_eq!(response.get_status(), StatusCode::OK, "should return OK");
+        let json = response_json(response);
+        assert_eq!(
+            json["seatbid"][0]["bid"][0]["adm"],
+            json!(""),
+            "should serialize missing creative as empty adm"
+        );
+    }
+
+    #[test]
+    fn convert_to_openrtb_response_omits_missing_adomain() {
+        let settings = make_settings();
+        let auction_request = make_auction_request();
+        let mut bid = make_bid("div-gpt-top", "appnexus", Some(2.75));
+        bid.adomain = None;
+        let result = make_result(bid);
+
+        let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
+            .expect("should convert bid without advertiser domains");
+
+        assert_eq!(response.get_status(), StatusCode::OK, "should return OK");
+        let json = response_json(response);
+        let bid = json["seatbid"][0]["bid"][0]
+            .as_object()
+            .expect("should serialize bid as object");
+        assert!(
+            !bid.contains_key("adomain"),
+            "should preserve current wire format by omitting empty adomain"
+        );
+    }
+
+    #[test]
+    fn convert_to_openrtb_response_allows_empty_winning_bids() {
+        let settings = make_settings();
+        let auction_request = make_auction_request();
+        let result = OrchestrationResult {
+            provider_responses: vec![],
+            mediator_response: None,
+            winning_bids: HashMap::new(),
+            total_time_ms: 50,
+            metadata: HashMap::new(),
+        };
+
+        let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
+            .expect("should convert auction result without winning bids");
+
+        assert_eq!(response.get_status(), StatusCode::OK, "should return OK");
+        let json = response_json(response);
+        assert!(
+            json.get("seatbid").is_none(),
+            "should preserve current wire format by omitting empty seatbid"
+        );
+        assert_eq!(
+            json["ext"]["orchestrator"]["total_bids"],
+            json!(0),
+            "should report zero total bids"
+        );
+    }
+
+    #[test]
+    fn convert_to_openrtb_response_serializes_multiple_winning_bids() {
+        let settings = make_settings();
+        let auction_request = make_auction_request();
+        let top_bid = make_bid("div-gpt-top", "appnexus", Some(2.75));
+        let mut sidebar_bid = make_bid("div-gpt-sidebar", "rubicon", Some(1.25));
+        sidebar_bid.creative = Some("<div>Sidebar</div>".to_string());
+        let result = OrchestrationResult {
+            provider_responses: vec![AuctionResponse {
+                provider: "prebid".to_string(),
+                bids: vec![top_bid.clone(), sidebar_bid.clone()],
+                status: BidStatus::Success,
+                response_time_ms: 42,
+                metadata: HashMap::new(),
+            }],
+            mediator_response: None,
+            winning_bids: HashMap::from([
+                (top_bid.slot_id.clone(), top_bid),
+                (sidebar_bid.slot_id.clone(), sidebar_bid),
+            ]),
+            total_time_ms: 50,
+            metadata: HashMap::new(),
+        };
+
+        let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
+            .expect("should convert multiple winning bids");
+        let json = response_json(response);
+        let seatbids = json["seatbid"]
+            .as_array()
+            .expect("should serialize seatbid array");
+
+        assert_eq!(seatbids.len(), 2, "should emit one seatbid per winner");
+
+        let top_seatbid = seatbids
+            .iter()
+            .find(|seatbid| seatbid["bid"][0]["impid"].as_str() == Some("div-gpt-top"))
+            .expect("should include top slot seatbid");
+        assert_eq!(
+            top_seatbid["seat"],
+            json!("appnexus"),
+            "should preserve top bidder as seat"
+        );
+        let top_bid = &top_seatbid["bid"][0];
+        assert_eq!(
+            top_bid["id"],
+            json!("appnexus-div-gpt-top"),
+            "should preserve top bid ID"
+        );
+        assert_eq!(
+            top_bid["impid"],
+            json!("div-gpt-top"),
+            "should preserve top slot impid"
+        );
+        assert_eq!(top_bid["price"], json!(2.75), "should preserve top price");
+        assert_eq!(
+            top_bid["adm"],
+            json!("<div>Ad</div>"),
+            "should preserve top creative"
+        );
+
+        let sidebar_seatbid = seatbids
+            .iter()
+            .find(|seatbid| seatbid["bid"][0]["impid"].as_str() == Some("div-gpt-sidebar"))
+            .expect("should include sidebar slot seatbid");
+        assert_eq!(
+            sidebar_seatbid["seat"],
+            json!("rubicon"),
+            "should preserve sidebar bidder as seat"
+        );
+        let sidebar_bid = &sidebar_seatbid["bid"][0];
+        assert_eq!(
+            sidebar_bid["id"],
+            json!("rubicon-div-gpt-sidebar"),
+            "should preserve sidebar bid ID"
+        );
+        assert_eq!(
+            sidebar_bid["impid"],
+            json!("div-gpt-sidebar"),
+            "should preserve sidebar slot impid"
+        );
+        assert_eq!(
+            sidebar_bid["price"],
+            json!(1.25),
+            "should preserve sidebar price"
+        );
+        assert_eq!(
+            sidebar_bid["adm"],
+            json!("<div>Sidebar</div>"),
+            "should preserve sidebar creative"
+        );
+        assert_eq!(
+            json["ext"]["orchestrator"]["total_bids"],
+            json!(2),
+            "should count both provider bids"
+        );
+    }
+
+    #[test]
+    fn convert_to_openrtb_response_uses_parallel_mediation_when_mediator_configured() {
+        let mut settings = make_settings();
+        settings.auction.mediator = Some("adserver_mock".to_string());
+        let auction_request = make_auction_request();
+        let result = make_result(make_bid("div-gpt-top", "appnexus", Some(2.75)));
+
+        let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
+            .expect("should convert auction result to OpenRTB response");
+        let json = response_json(response);
+
+        assert_eq!(
+            json["ext"]["orchestrator"]["strategy"],
+            json!("parallel_mediation"),
+            "should use mediation strategy when mediator is configured"
+        );
+    }
+
+    #[test]
+    fn convert_to_openrtb_response_errors_when_winning_bid_has_no_price() {
+        let settings = make_settings();
+        let auction_request = make_auction_request();
+        let result = make_result(make_bid("div-gpt-top", "appnexus", None));
+
+        let err = convert_to_openrtb_response(&result, &settings, &auction_request, false)
+            .expect_err("should reject winning bid without decoded price");
+
+        assert!(
+            format!("{err:?}").contains("has no decoded price"),
+            "should explain missing decoded price"
+        );
+    }
+
+    #[test]
+    fn convert_to_openrtb_response_omits_out_of_range_dimensions() {
+        let settings = make_settings();
+        let auction_request = make_auction_request();
+        let mut bid = make_bid("div-gpt-top", "appnexus", Some(2.75));
+        bid.width = u32::MAX;
+        bid.height = u32::MAX;
+        let result = make_result(bid);
+
+        let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
+            .expect("should convert bid with out-of-range OpenRTB dimensions");
+        let json = response_json(response);
+        let bid = &json["seatbid"][0]["bid"][0];
+
+        assert!(bid.get("w").is_none(), "should omit out-of-range width");
+        assert!(bid.get("h").is_none(), "should omit out-of-range height");
     }
 }

--- a/crates/trusted-server-core/src/auction/formats.rs
+++ b/crates/trusted-server-core/src/auction/formats.rs
@@ -4,9 +4,9 @@
 //! - Parsing incoming tsjs/Prebid.js format requests
 //! - Converting internal auction results to `OpenRTB` 2.x responses
 
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{ensure, Report, ResultExt};
-use fastly::http::{header, StatusCode};
-use fastly::{Request, Response};
+use http::{header, HeaderValue, Request, Response, StatusCode};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -20,6 +20,7 @@ use crate::ec::eids::encode_eids_header;
 use crate::error::TrustedServerError;
 use crate::geo::GeoInfo;
 use crate::openrtb::{to_openrtb_i32, OpenRtbBid, OpenRtbResponse, ResponseExt, SeatBid, ToExt};
+use crate::platform::RuntimeServices;
 use crate::settings::Settings;
 
 use super::orchestrator::OrchestrationResult;
@@ -83,9 +84,11 @@ pub struct BannerUnit {
 pub fn convert_tsjs_to_auction_request(
     body: &AdRequest,
     settings: &Settings,
-    req: &Request,
+    services: &RuntimeServices,
+    req: &Request<EdgeBody>,
     consent: ConsentContext,
     ec_id: Option<&str>,
+    geo: Option<GeoInfo>,
 ) -> Result<AuctionRequest, Report<TrustedServerError>> {
     let ec_id = ec_id.map(str::to_owned);
 
@@ -132,11 +135,12 @@ pub fn convert_tsjs_to_auction_request(
     // Build device info with user-agent (always) and geo (if available)
     let device = Some(DeviceInfo {
         user_agent: req
-            .get_header_str("user-agent")
-            .map(std::string::ToString::to_string),
-        ip: req.get_client_ip_addr().map(|ip| ip.to_string()),
-        #[allow(deprecated)]
-        geo: GeoInfo::from_request(req),
+            .headers()
+            .get(header::USER_AGENT)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string),
+        ip: services.client_info().client_ip.map(|ip| ip.to_string()),
+        geo,
     });
 
     // Forward allowed config entries from the JS request into the context map.
@@ -208,7 +212,7 @@ pub fn convert_to_openrtb_response(
     settings: &Settings,
     auction_request: &AuctionRequest,
     ec_allowed: bool,
-) -> Result<Response, Report<TrustedServerError>> {
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     // Build OpenRTB-style seatbid array
     let mut seatbids = Vec::with_capacity(result.winning_bids.len());
 
@@ -308,26 +312,33 @@ pub fn convert_to_openrtb_response(
             message: "Failed to serialize auction response".to_string(),
         })?;
 
-    let mut response = Response::from_status(StatusCode::OK)
-        .with_header(header::CONTENT_TYPE, "application/json")
-        .with_body(body_bytes);
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(EdgeBody::from(body_bytes))
+        .change_context(TrustedServerError::Auction {
+            message: "Failed to build auction response".to_string(),
+        })?;
 
     // Signal consent status independently of whether EIDs were resolved.
-    // A user may have granted consent but have no partner syncs yet;
-    // downstream clients rely on this header to know consent was verified.
     if ec_allowed {
-        response.set_header(HEADER_X_TS_EC_CONSENT, "ok");
+        response
+            .headers_mut()
+            .insert(HEADER_X_TS_EC_CONSENT, HeaderValue::from_static("ok"));
     }
 
     // Attach EID response headers when consent-gated EIDs are available.
-    // `Some(empty)` means "we looked and found no synced partners" — the
-    // header is still set (with an encoded empty array) so clients can
-    // distinguish this from `None` (EIDs not checked / consent denied).
     if let Some(ref eids) = auction_request.user.eids {
         let (encoded, truncated) = encode_eids_header(eids)?;
-        response.set_header(HEADER_X_TS_EIDS, encoded);
+        let header_val =
+            HeaderValue::from_str(&encoded).change_context(TrustedServerError::Auction {
+                message: "Failed to encode EIDs header value".to_string(),
+            })?;
+        response.headers_mut().insert(HEADER_X_TS_EIDS, header_val);
         if truncated {
-            response.set_header(HEADER_X_TS_EIDS_TRUNCATED, "true");
+            response
+                .headers_mut()
+                .insert(HEADER_X_TS_EIDS_TRUNCATED, HeaderValue::from_static("true"));
         }
     }
 
@@ -339,14 +350,19 @@ mod tests {
     use super::*;
     use crate::auction::types::{AuctionResponse, Bid, BidStatus};
     use crate::openrtb::{Eid, Uid};
+    use crate::platform::test_support::noop_services;
     use crate::test_support::tests::create_test_settings;
+    use http::Method;
     use serde_json::json;
     use std::collections::HashSet;
 
-    fn make_request() -> Request {
-        let mut req = Request::new("POST", "https://publisher.example.com/auction");
-        req.set_header(header::USER_AGENT, "Mozilla/5.0 test");
-        req
+    fn make_request() -> Request<EdgeBody> {
+        Request::builder()
+            .method(Method::POST)
+            .uri("https://publisher.example.com/auction")
+            .header(header::USER_AGENT, "Mozilla/5.0 test")
+            .body(EdgeBody::empty())
+            .expect("should build request")
     }
 
     fn make_settings() -> Settings {
@@ -424,8 +440,9 @@ mod tests {
         }
     }
 
-    fn response_json(mut response: Response) -> JsonValue {
-        serde_json::from_slice(&response.take_body_bytes()).expect("should parse JSON response")
+    fn response_json(response: Response<EdgeBody>) -> JsonValue {
+        serde_json::from_slice(&response.into_body().into_bytes())
+            .expect("should parse JSON response")
     }
 
     fn make_banner_body(config: Option<JsonValue>) -> AdRequest {
@@ -455,13 +472,16 @@ mod tests {
 
     fn convert_body_to_auction_request(body: &AdRequest, settings: &Settings) -> AuctionRequest {
         let req = make_request();
+        let services = noop_services();
 
         convert_tsjs_to_auction_request(
             body,
             settings,
+            &services,
             &req,
             ConsentContext::default(),
             Some("existing-ec-id"),
+            None,
         )
         .expect("should convert banner request")
     }
@@ -485,18 +505,22 @@ mod tests {
             .expect("should build response");
 
         assert!(
-            response.get_header(HEADER_X_TS_EIDS).is_some(),
+            response.headers().get(&HEADER_X_TS_EIDS).is_some(),
             "should include x-ts-eids header when EIDs are present"
         );
         assert_eq!(
             response
-                .get_header(HEADER_X_TS_EC_CONSENT)
+                .headers()
+                .get(&HEADER_X_TS_EC_CONSENT)
                 .and_then(|v| v.to_str().ok()),
             Some("ok"),
             "should include x-ts-ec-consent: ok when ec_allowed is true"
         );
         assert!(
-            response.get_header(HEADER_X_TS_EIDS_TRUNCATED).is_none(),
+            response
+                .headers()
+                .get(&HEADER_X_TS_EIDS_TRUNCATED)
+                .is_none(),
             "should not include truncated header for small payload"
         );
     }
@@ -512,13 +536,14 @@ mod tests {
 
         assert_eq!(
             response
-                .get_header(HEADER_X_TS_EC_CONSENT)
+                .headers()
+                .get(&HEADER_X_TS_EC_CONSENT)
                 .and_then(|v| v.to_str().ok()),
             Some("ok"),
             "should set x-ts-ec-consent: ok based on consent, not EID presence"
         );
         assert!(
-            response.get_header(HEADER_X_TS_EIDS).is_none(),
+            response.headers().get(&HEADER_X_TS_EIDS).is_none(),
             "should omit x-ts-eids when no EIDs available"
         );
     }
@@ -533,16 +558,12 @@ mod tests {
             .expect("should build response");
 
         assert!(
-            response.get_header(HEADER_X_TS_EC_CONSENT).is_none(),
+            response.headers().get(&HEADER_X_TS_EC_CONSENT).is_none(),
             "should omit x-ts-ec-consent when ec_allowed is false"
         );
         assert!(
-            response.get_header(HEADER_X_TS_EIDS).is_none(),
+            response.headers().get(&HEADER_X_TS_EIDS).is_none(),
             "should omit x-ts-eids when no EIDs available"
-        );
-        assert!(
-            response.get_header("x-ts-ec").is_none(),
-            "should not emit x-ts-ec when a valid EC is present"
         );
     }
 
@@ -558,7 +579,7 @@ mod tests {
             .expect("should build response");
 
         assert!(
-            response.get_header("x-ts-ec").is_none(),
+            response.headers().get("x-ts-ec").is_none(),
             "should omit x-ts-ec when no EC ID is available"
         );
     }
@@ -654,11 +675,14 @@ mod tests {
     fn convert_tsjs_to_auction_request_propagates_missing_ec_id() {
         let settings = make_settings();
         let req = make_request();
+        let services = noop_services();
         let auction_request = convert_tsjs_to_auction_request(
             &make_banner_body(None),
             &settings,
+            &services,
             &req,
             ConsentContext::default(),
+            None,
             None,
         )
         .expect("should convert request without EC ID");
@@ -719,6 +743,7 @@ mod tests {
     fn convert_tsjs_to_auction_request_allows_empty_banner_sizes() {
         let settings = make_settings();
         let req = make_request();
+        let services = noop_services();
         let body = AdRequest {
             ad_units: vec![AdUnit {
                 code: "div-gpt-top".to_string(),
@@ -734,9 +759,11 @@ mod tests {
         let auction_request = convert_tsjs_to_auction_request(
             &body,
             &settings,
+            &services,
             &req,
             ConsentContext::default(),
             Some("existing-ec-id"),
+            None,
         )
         .expect("should convert request with empty banner sizes");
 
@@ -751,6 +778,7 @@ mod tests {
     fn convert_tsjs_to_auction_request_rejects_banner_sizes_that_are_not_width_height_pairs() {
         let settings = make_settings();
         let req = make_request();
+        let services = noop_services();
         let body = AdRequest {
             ad_units: vec![AdUnit {
                 code: "div-gpt-top".to_string(),
@@ -768,9 +796,11 @@ mod tests {
         let err = convert_tsjs_to_auction_request(
             &body,
             &settings,
+            &services,
             &req,
             ConsentContext::default(),
             Some("existing-ec-id"),
+            None,
         )
         .expect_err("should reject malformed banner size");
 
@@ -784,6 +814,7 @@ mod tests {
     fn convert_tsjs_to_auction_request_skips_units_without_banner_media() {
         let settings = make_settings();
         let req = make_request();
+        let services = noop_services();
         let body = AdRequest {
             ad_units: vec![
                 AdUnit {
@@ -804,9 +835,11 @@ mod tests {
         let auction_request = convert_tsjs_to_auction_request(
             &body,
             &settings,
+            &services,
             &req,
             ConsentContext::default(),
             Some("existing-ec-id"),
+            None,
         )
         .expect("should skip unsupported media units");
 
@@ -825,19 +858,25 @@ mod tests {
         let response = convert_to_openrtb_response(&result, &settings, &auction_request, true)
             .expect("should convert auction result to OpenRTB response");
 
-        assert_eq!(response.get_status(), StatusCode::OK, "should return OK");
+        assert_eq!(response.status(), StatusCode::OK, "should return OK");
         assert_eq!(
-            response.get_header_str(header::CONTENT_TYPE),
+            response
+                .headers()
+                .get(&header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
             Some("application/json"),
             "should set JSON content type"
         );
         assert_eq!(
-            response.get_header_str(HEADER_X_TS_EC_CONSENT),
+            response
+                .headers()
+                .get(&HEADER_X_TS_EC_CONSENT)
+                .and_then(|v| v.to_str().ok()),
             Some("ok"),
             "should set EC consent header when allowed"
         );
         assert!(
-            response.get_header("x-ts-ec").is_none(),
+            response.headers().get("x-ts-ec").is_none(),
             "should not emit removed EC ID header"
         );
 
@@ -883,7 +922,7 @@ mod tests {
         let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
             .expect("should convert bid without creative HTML");
 
-        assert_eq!(response.get_status(), StatusCode::OK, "should return OK");
+        assert_eq!(response.status(), StatusCode::OK, "should return OK");
         let json = response_json(response);
         assert_eq!(
             json["seatbid"][0]["bid"][0]["adm"],
@@ -903,7 +942,7 @@ mod tests {
         let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
             .expect("should convert bid without advertiser domains");
 
-        assert_eq!(response.get_status(), StatusCode::OK, "should return OK");
+        assert_eq!(response.status(), StatusCode::OK, "should return OK");
         let json = response_json(response);
         let bid = json["seatbid"][0]["bid"][0]
             .as_object()
@@ -929,7 +968,7 @@ mod tests {
         let response = convert_to_openrtb_response(&result, &settings, &auction_request, false)
             .expect("should convert auction result without winning bids");
 
-        assert_eq!(response.get_status(), StatusCode::OK, "should return OK");
+        assert_eq!(response.status(), StatusCode::OK, "should return OK");
         let json = response_json(response);
         assert!(
             json.get("seatbid").is_none(),

--- a/crates/trusted-server-core/src/auction/mod.rs
+++ b/crates/trusted-server-core/src/auction/mod.rs
@@ -73,10 +73,89 @@ pub fn build_orchestrator(
         }
     }
 
+    orchestrator.validate_configured_provider_names()?;
+
     log::info!(
         "Auction orchestrator built with {} providers",
         orchestrator.provider_count()
     );
 
     Ok(orchestrator)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::settings::Settings;
+    use crate::test_support::tests::crate_test_settings_str;
+
+    use super::build_orchestrator;
+
+    fn settings_with_auction_config(auction_config: &str) -> Settings {
+        let settings_str = format!("{}\n{auction_config}", crate_test_settings_str());
+        Settings::from_toml(&settings_str)
+            .expect("should parse auction provider validation test settings")
+    }
+
+    fn assert_orchestrator_error_contains(settings: &Settings, expected: &str) {
+        let err = match build_orchestrator(settings) {
+            Ok(_) => panic!("build_orchestrator should reject invalid auction providers"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains(expected),
+            "should include expected validation message: {expected}"
+        );
+    }
+
+    #[test]
+    fn configured_unregistered_provider_fails_startup() {
+        let settings = settings_with_auction_config(
+            r#"
+            [auction]
+            enabled = true
+            providers = ["missing-provider"]
+            timeout_ms = 2000
+        "#,
+        );
+
+        assert_orchestrator_error_contains(
+            &settings,
+            "Auction provider `missing-provider` is listed in [auction] but no enabled integration provides it",
+        );
+    }
+
+    #[test]
+    fn mixed_registered_and_unregistered_providers_fail_startup() {
+        let settings = settings_with_auction_config(
+            r#"
+            [auction]
+            enabled = true
+            providers = ["prebid", "missing-provider"]
+            timeout_ms = 2000
+        "#,
+        );
+
+        assert_orchestrator_error_contains(
+            &settings,
+            "Auction provider `missing-provider` is listed in [auction] but no enabled integration provides it",
+        );
+    }
+
+    #[test]
+    fn configured_unregistered_mediator_fails_startup() {
+        let settings = settings_with_auction_config(
+            r#"
+            [auction]
+            enabled = true
+            providers = ["prebid"]
+            mediator = "missing-mediator"
+            timeout_ms = 2000
+        "#,
+        );
+
+        assert_orchestrator_error_contains(
+            &settings,
+            "Auction provider `missing-mediator` is listed in [auction] but no enabled integration provides it",
+        );
+    }
 }

--- a/crates/trusted-server-core/src/auction/orchestrator.rs
+++ b/crates/trusted-server-core/src/auction/orchestrator.rs
@@ -186,12 +186,7 @@ impl AuctionOrchestrator {
             let remaining_ms = remaining_budget_ms(mediation_start, context.timeout_ms);
 
             if remaining_ms == 0 {
-                // lgtm[rust/cleartext-logging]
-                // This warning reports timeout budget metadata only; no secret settings are logged.
-                log::warn!(
-                    "Auction timeout ({}ms) exhausted during bidding phase — skipping mediator",
-                    context.timeout_ms
-                );
+                log::warn!("Auction timeout exhausted during bidding phase; skipping mediator");
                 let winning = self.select_winning_bids(&provider_responses, &floor_prices);
                 return Ok(OrchestrationResult {
                     provider_responses,
@@ -343,13 +338,7 @@ impl AuctionOrchestrator {
             let effective_timeout = remaining_ms.min(provider.timeout_ms());
 
             if effective_timeout == 0 {
-                // lgtm[rust/cleartext-logging]
-                // This warning reports timeout budget metadata only; no secret settings are logged.
-                log::warn!(
-                    "Auction timeout ({}ms) exhausted before launching '{}' — skipping",
-                    context.timeout_ms,
-                    provider.provider_name()
-                );
+                log::warn!("Auction timeout exhausted before launching provider request; skipping");
                 continue;
             }
 
@@ -420,12 +409,9 @@ impl AuctionOrchestrator {
         }
 
         let deadline = Duration::from_millis(u64::from(context.timeout_ms));
-        // lgtm[rust/cleartext-logging]
-        // This info log reports request counts and timeout budget only; no secret settings are logged.
         log::info!(
-            "Launched {} concurrent requests, waiting for responses (timeout: {}ms)...",
-            pending_requests.len(),
-            context.timeout_ms
+            "Launched {} concurrent provider request(s); waiting for responses",
+            pending_requests.len()
         );
 
         // Phase 2: Wait for responses using select() to process as they become ready.
@@ -501,11 +487,8 @@ impl AuctionOrchestrator {
             // Remaining PendingRequests are dropped, which abandons the
             // in-flight HTTP calls on the Fastly host.
             if auction_start.elapsed() >= deadline && !remaining.is_empty() {
-                // lgtm[rust/cleartext-logging]
-                // This warning reports timeout budget metadata only; no secret settings are logged.
                 log::warn!(
-                    "Auction timeout ({}ms) reached, dropping {} remaining request(s)",
-                    context.timeout_ms,
+                    "Auction timeout reached; dropping {} remaining request(s)",
                     remaining.len()
                 );
                 break;

--- a/crates/trusted-server-core/src/auction/orchestrator.rs
+++ b/crates/trusted-server-core/src/auction/orchestrator.rs
@@ -89,6 +89,32 @@ impl AuctionOrchestrator {
         self.providers.len()
     }
 
+    /// Validate that every configured provider name has an enabled provider integration.
+    pub(crate) fn validate_configured_provider_names(
+        &self,
+    ) -> Result<(), Report<TrustedServerError>> {
+        if !self.config.enabled {
+            return Ok(());
+        }
+
+        for provider_name in self
+            .config
+            .providers
+            .iter()
+            .chain(self.config.mediator.iter())
+        {
+            if !self.providers.contains_key(provider_name) {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "Auction provider `{provider_name}` is listed in [auction] but no enabled integration provides it"
+                    ),
+                }));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Execute an auction using the auto-detected strategy.
     ///
     /// Strategy is determined by mediator configuration:
@@ -384,6 +410,15 @@ impl AuctionOrchestrator {
             }
         }
 
+        if pending_requests.is_empty() {
+            return Err(Report::new(TrustedServerError::Auction {
+                message: format!(
+                    "All {} configured provider(s) skipped or failed to launch",
+                    provider_names.len()
+                ),
+            }));
+        }
+
         let deadline = Duration::from_millis(u64::from(context.timeout_ms));
         // lgtm[rust/cleartext-logging]
         // This info log reports request counts and timeout budget only; no secret settings are logged.
@@ -647,15 +682,19 @@ impl OrchestrationResult {
 #[cfg(test)]
 mod tests {
     use crate::auction::config::AuctionConfig;
+    use crate::auction::provider::AuctionProvider;
     use crate::auction::test_support::create_test_auction_context;
     use crate::auction::types::{
-        AdFormat, AdSlot, AuctionRequest, Bid, BidStatus, MediaType, PublisherInfo, UserInfo,
+        AdFormat, AdSlot, AuctionContext, AuctionRequest, AuctionResponse, Bid, BidStatus,
+        MediaType, PublisherInfo, UserInfo,
     };
     use crate::error::TrustedServerError;
     use crate::test_support::tests::crate_test_settings_str;
     use error_stack::Report;
-    use fastly::Request;
+    use fastly::http::request::PendingRequest;
+    use fastly::{Request, Response};
     use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
 
     use super::AuctionOrchestrator;
 
@@ -704,6 +743,42 @@ mod tests {
     fn create_test_settings() -> crate::settings::Settings {
         let settings_str = crate_test_settings_str();
         crate::settings::Settings::from_toml(&settings_str).expect("should parse test settings")
+    }
+
+    struct LaunchFailingProvider;
+
+    impl AuctionProvider for LaunchFailingProvider {
+        fn provider_name(&self) -> &'static str {
+            "launch-failing"
+        }
+
+        fn request_bids(
+            &self,
+            _request: &AuctionRequest,
+            _context: &AuctionContext<'_>,
+        ) -> Result<PendingRequest, Report<TrustedServerError>> {
+            Err(Report::new(TrustedServerError::Auction {
+                message: "launch failed in test provider".to_string(),
+            }))
+        }
+
+        fn parse_response(
+            &self,
+            _response: Response,
+            _response_time_ms: u64,
+        ) -> Result<AuctionResponse, Report<TrustedServerError>> {
+            Err(Report::new(TrustedServerError::Auction {
+                message: "launch-failing provider should not parse responses".to_string(),
+            }))
+        }
+
+        fn timeout_ms(&self) -> u32 {
+            2000
+        }
+
+        fn backend_name(&self, _timeout_ms: u32) -> Option<String> {
+            Some("launch-failing-backend".to_string())
+        }
     }
 
     #[test]
@@ -875,6 +950,32 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(format!("{}", err).contains("No providers configured"));
+    }
+
+    #[tokio::test]
+    async fn provider_launch_failures_error_when_no_requests_launch() {
+        let config = AuctionConfig {
+            enabled: true,
+            providers: vec!["launch-failing".to_string()],
+            timeout_ms: 2000,
+            ..Default::default()
+        };
+        let mut orchestrator = AuctionOrchestrator::new(config);
+        orchestrator.register_provider(Arc::new(LaunchFailingProvider));
+
+        let request = create_test_auction_request();
+        let settings = create_test_settings();
+        let req = Request::get("https://test.com/test");
+        let context = create_test_auction_context(&settings, &req, 2000);
+
+        let result = orchestrator.run_auction(&request, &context).await;
+
+        let err = result.expect_err("should fail when every provider launch fails");
+        assert!(
+            err.to_string()
+                .contains("All 1 configured provider(s) skipped or failed to launch"),
+            "should explain that no configured provider request launched"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/auction/orchestrator.rs
+++ b/crates/trusted-server-core/src/auction/orchestrator.rs
@@ -1,7 +1,6 @@
 //! Auction orchestrator for managing multi-provider auctions.
 
 use error_stack::{Report, ResultExt};
-use fastly::http::request::{select, PendingRequest};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -14,9 +13,9 @@ use super::types::{AuctionContext, AuctionRequest, AuctionResponse, Bid, BidStat
 
 const PROVIDER_ERROR_MESSAGE_CHARS: usize = 500;
 
-pub(crate) const ERROR_TYPE_HTTP_STATUS: &str = "http_status";
 const ERROR_TYPE_PARSE_RESPONSE: &str = "parse_response";
 const ERROR_TYPE_LAUNCH_FAILED: &str = "launch_failed";
+const ERROR_TYPE_TRANSPORT: &str = "transport";
 
 // SECURITY: the returned string is included verbatim (truncated to
 // PROVIDER_ERROR_MESSAGE_CHARS) in the public /auction response via
@@ -48,6 +47,18 @@ fn provider_launch_failed_response(provider_name: &str, response_time_ms: u64) -
     AuctionResponse::error(provider_name, response_time_ms)
         .with_metadata("error_type", serde_json::json!(ERROR_TYPE_LAUNCH_FAILED))
         .with_metadata("message", serde_json::json!("Provider launch failed"))
+}
+
+// Transport failures carry a static message: the underlying select() error is a
+// `Report<PlatformError>` that may reference upstream-controlled content, so it
+// is logged server-side rather than surfaced in the public /auction response.
+fn provider_transport_failed_response(
+    provider_name: &str,
+    response_time_ms: u64,
+) -> AuctionResponse {
+    AuctionResponse::error(provider_name, response_time_ms)
+        .with_metadata("error_type", serde_json::json!(ERROR_TYPE_TRANSPORT))
+        .with_metadata("message", serde_json::json!("Provider request failed"))
 }
 
 /// Compute the remaining time budget from a deadline.
@@ -208,17 +219,24 @@ impl AuctionOrchestrator {
             let start_time = Instant::now();
             let pending = mediator
                 .request_bids(request, &mediator_context)
+                .await
                 .change_context(TrustedServerError::Auction {
                     message: format!("Mediator {} failed to launch", mediator.provider_name()),
                 })?;
 
-            let backend_response = pending.wait().change_context(TrustedServerError::Auction {
-                message: format!("Mediator {} request failed", mediator.provider_name()),
-            })?;
+            let platform_resp = mediator_context
+                .services
+                .http_client()
+                .wait(pending)
+                .await
+                .change_context(TrustedServerError::Auction {
+                    message: format!("Mediator {} request failed", mediator.provider_name()),
+                })?;
 
             let response_time_ms = start_time.elapsed().as_millis() as u64;
             let mediator_resp = mediator
-                .parse_response_with_context(backend_response, response_time_ms, &mediator_context)
+                .parse_response(platform_resp, response_time_ms)
+                .await
                 .change_context(TrustedServerError::Auction {
                     message: format!("Mediator {} parse failed", mediator.provider_name()),
                 })?;
@@ -283,7 +301,7 @@ impl AuctionOrchestrator {
 
     /// Run all providers in parallel and collect responses.
     ///
-    /// Uses `fastly::http::request::select()` to process responses as they
+    /// Uses `PlatformHttpClient::select()` to process responses as they
     /// become ready, rather than waiting for each response sequentially.
     async fn run_providers_parallel(
         &self,
@@ -310,7 +328,7 @@ impl AuctionOrchestrator {
         // Maps backend_name -> (provider_name, start_time, provider)
         let mut backend_to_provider: HashMap<String, (&str, Instant, &dyn AuctionProvider)> =
             HashMap::new();
-        let mut pending_requests: Vec<PendingRequest> = Vec::new();
+        let mut pending_requests: Vec<crate::platform::PlatformPendingRequest> = Vec::new();
         let mut responses = Vec::new();
 
         for provider_name in provider_names {
@@ -372,10 +390,22 @@ impl AuctionOrchestrator {
             );
 
             let start_time = Instant::now();
-            match provider.request_bids(request, &provider_context) {
+            match provider.request_bids(request, &provider_context).await {
                 Ok(pending) => {
+                    let request_backend_name = pending
+                        .backend_name()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| {
+                            log::warn!(
+                                "Provider '{}' pending request returned no backend name; \
+                             using predicted name '{}'",
+                                provider.provider_name(),
+                                backend_name,
+                            );
+                            backend_name.clone()
+                        });
                     backend_to_provider.insert(
-                        backend_name,
+                        request_backend_name.clone(),
                         (provider.provider_name(), start_time, provider.as_ref()),
                     );
                     pending_requests.push(pending);
@@ -425,24 +455,35 @@ impl AuctionOrchestrator {
         let mut remaining = pending_requests;
 
         while !remaining.is_empty() {
-            let (result, rest) = select(remaining);
-            remaining = rest;
+            let platform_result = match context.services.http_client().select(remaining).await {
+                Ok(r) => r,
+                Err(e) => {
+                    log::warn!("select() failed: {:?}", e);
+                    break;
+                }
+            };
+            let crate::platform::PlatformSelectResult {
+                ready,
+                remaining: new_remaining,
+                failed_backend_name,
+            } = platform_result;
+            remaining = new_remaining;
 
-            match result {
+            match ready {
                 Ok(response) => {
                     // Identify the provider from the backend name
-                    let backend_name = response.get_backend_name().unwrap_or_default().to_string();
+                    let backend_name = response
+                        .backend_name
+                        .as_deref()
+                        .unwrap_or_default()
+                        .to_string();
 
                     if let Some((provider_name, start_time, provider)) =
                         backend_to_provider.remove(&backend_name)
                     {
                         let response_time_ms = start_time.elapsed().as_millis() as u64;
 
-                        match provider.parse_response_with_context(
-                            response,
-                            response_time_ms,
-                            context,
-                        ) {
+                        match provider.parse_response(response, response_time_ms).await {
                             Ok(auction_response) => {
                                 log::info!(
                                     "Provider '{}' returned {} bids (status: {:?}, time: {}ms)",
@@ -477,9 +518,29 @@ impl AuctionOrchestrator {
                     }
                 }
                 Err(e) => {
-                    // When select() returns an error, we can't easily identify which
-                    // provider failed since the PendingRequest is consumed
-                    log::warn!("A provider request failed: {:?}", e);
+                    if let Some(ref backend_name) = failed_backend_name {
+                        if let Some((provider_name, start_time, _)) =
+                            backend_to_provider.remove(backend_name)
+                        {
+                            let response_time_ms = start_time.elapsed().as_millis() as u64;
+                            log::warn!("Provider '{}' request failed: {:?}", provider_name, e);
+                            responses.push(provider_transport_failed_response(
+                                provider_name,
+                                response_time_ms,
+                            ));
+                        } else {
+                            log::warn!(
+                                "A provider request failed (backend '{}' not tracked): {:?}",
+                                backend_name,
+                                e
+                            );
+                        }
+                    } else {
+                        log::warn!(
+                            "A provider request failed (backend not identified): {:?}",
+                            e
+                        );
+                    }
                 }
             }
 
@@ -672,14 +733,75 @@ mod tests {
         MediaType, PublisherInfo, UserInfo,
     };
     use crate::error::TrustedServerError;
+    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
+    use crate::platform::{
+        PlatformHttpRequest, PlatformPendingRequest, PlatformResponse, RuntimeServices,
+    };
     use crate::test_support::tests::crate_test_settings_str;
-    use error_stack::Report;
-    use fastly::http::request::PendingRequest;
-    use fastly::{Request, Response};
+    use error_stack::{Report, ResultExt};
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
     use super::AuctionOrchestrator;
+
+    // ---------------------------------------------------------------------------
+    // Minimal test double for AuctionProvider
+    // ---------------------------------------------------------------------------
+
+    struct StubAuctionProvider {
+        name: &'static str,
+        backend: &'static str,
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl AuctionProvider for StubAuctionProvider {
+        fn provider_name(&self) -> &'static str {
+            self.name
+        }
+
+        async fn request_bids(
+            &self,
+            _request: &AuctionRequest,
+            context: &AuctionContext<'_>,
+        ) -> Result<PlatformPendingRequest, Report<TrustedServerError>> {
+            let req = PlatformHttpRequest::new(
+                http::Request::builder()
+                    .method("POST")
+                    .uri("https://example.com/bid")
+                    .body(edgezero_core::body::Body::empty())
+                    .expect("should build stub bid request"),
+                self.backend,
+            );
+            context
+                .services
+                .http_client()
+                .send_async(req)
+                .await
+                .change_context(TrustedServerError::Auction {
+                    message: "stub launch failed".to_string(),
+                })
+        }
+
+        async fn parse_response(
+            &self,
+            _response: PlatformResponse,
+            response_time_ms: u64,
+        ) -> Result<AuctionResponse, Report<TrustedServerError>> {
+            Ok(AuctionResponse::success(
+                self.name,
+                vec![],
+                response_time_ms,
+            ))
+        }
+
+        fn timeout_ms(&self) -> u32 {
+            2000
+        }
+
+        fn backend_name(&self, _timeout_ms: u32) -> Option<String> {
+            Some(self.backend.to_string())
+        }
+    }
 
     fn create_test_auction_request() -> AuctionRequest {
         AuctionRequest {
@@ -730,24 +852,25 @@ mod tests {
 
     struct LaunchFailingProvider;
 
+    #[async_trait::async_trait(?Send)]
     impl AuctionProvider for LaunchFailingProvider {
         fn provider_name(&self) -> &'static str {
             "launch-failing"
         }
 
-        fn request_bids(
+        async fn request_bids(
             &self,
             _request: &AuctionRequest,
             _context: &AuctionContext<'_>,
-        ) -> Result<PendingRequest, Report<TrustedServerError>> {
+        ) -> Result<PlatformPendingRequest, Report<TrustedServerError>> {
             Err(Report::new(TrustedServerError::Auction {
                 message: "launch failed in test provider".to_string(),
             }))
         }
 
-        fn parse_response(
+        async fn parse_response(
             &self,
-            _response: Response,
+            _response: PlatformResponse,
             _response_time_ms: u64,
         ) -> Result<AuctionResponse, Report<TrustedServerError>> {
             Err(Report::new(TrustedServerError::Auction {
@@ -816,6 +939,27 @@ mod tests {
             response.metadata["message"],
             serde_json::json!("Provider launch failed"),
             "should use a safe, stable public launch failure message"
+        );
+    }
+
+    #[test]
+    fn transport_failed_response_has_safe_static_message() {
+        let response = super::provider_transport_failed_response("prebid", 64);
+
+        assert_eq!(
+            response.status,
+            BidStatus::Error,
+            "should mark transport failures as errors"
+        );
+        assert_eq!(
+            response.metadata["error_type"],
+            serde_json::json!("transport"),
+            "should classify transport failures consistently with other failure modes"
+        );
+        assert_eq!(
+            response.metadata["message"],
+            serde_json::json!("Provider request failed"),
+            "should use a safe, stable public transport failure message"
         );
     }
 
@@ -896,8 +1040,9 @@ mod tests {
     }
 
     // TODO: Re-enable provider integration tests after implementing mock support
-    // for send_async(). Mock providers can't create PendingRequest without real
-    // Fastly backends.
+    // for `PlatformHttpClient::send_async()`. Mock providers currently cannot
+    // create realistic pending requests for the select loop without real
+    // platform-backed transport handles.
     //
     // Untested timeout enforcement paths (require real backends):
     // - Deadline check in select() loop (drops remaining requests)
@@ -905,9 +1050,9 @@ mod tests {
     // - Provider skip when effective_timeout == 0 (budget exhausted before launch)
     // - Provider context receives reduced timeout_ms per remaining budget
     //
-    // Follow-up: introduce a thin abstraction over `select()` (e.g. a trait)
+    // Follow-up: introduce a thin abstraction over `PlatformHttpClient::select()`
     // so the deadline/drop logic can be unit-tested with mock futures instead
-    // of requiring real Fastly backends.  An `#[ignore]` integration test
+    // of requiring real platform backends. An `#[ignore]` integration test
     // exercising the full path via Viceroy would also catch regressions.
 
     #[tokio::test]
@@ -925,7 +1070,11 @@ mod tests {
 
         let request = create_test_auction_request();
         let settings = create_test_settings();
-        let req = Request::get("https://test.com/test");
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://test.com/test")
+            .body(edgezero_core::body::Body::empty())
+            .expect("should build request");
         let context = create_test_auction_context(&settings, &req, 2000);
 
         let result = orchestrator.run_auction(&request, &context).await;
@@ -948,7 +1097,11 @@ mod tests {
 
         let request = create_test_auction_request();
         let settings = create_test_settings();
-        let req = Request::get("https://test.com/test");
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://test.com/test")
+            .body(edgezero_core::body::Body::empty())
+            .expect("should build request");
         let context = create_test_auction_context(&settings, &req, 2000);
 
         let result = orchestrator.run_auction(&request, &context).await;
@@ -1010,6 +1163,89 @@ mod tests {
         assert!(
             result > 1900,
             "should still have most of the budget, got {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_error_is_attributed_to_correct_provider() {
+        // Arrange: two stub providers backed by distinct backend names.
+        // The stub HTTP client injects a select() error for the first request
+        // that completes (backend-a). backend-b should still produce a success.
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"{}".to_vec()); // consumed by send_async for backend-a
+        stub.push_response(200, b"{}".to_vec()); // consumed by send_async for backend-b
+        stub.push_select_error(); // first select() reports backend-a as failed
+
+        let services = build_services_with_http_client(stub);
+        // SAFETY: `Box::leak` creates a `'static` reference for test use only.
+        // The leaked allocation is bounded to the test process lifetime.
+        let services: &'static RuntimeServices = Box::leak(Box::new(services));
+
+        let config = AuctionConfig {
+            enabled: true,
+            providers: vec!["provider-a".to_string(), "provider-b".to_string()],
+            timeout_ms: 2000,
+            mediator: None,
+            ..Default::default()
+        };
+        let mut orchestrator = AuctionOrchestrator::new(config);
+        orchestrator.register_provider(Arc::new(StubAuctionProvider {
+            name: "provider-a",
+            backend: "backend-a",
+        }));
+        orchestrator.register_provider(Arc::new(StubAuctionProvider {
+            name: "provider-b",
+            backend: "backend-b",
+        }));
+
+        let request = create_test_auction_request();
+        let settings = create_test_settings();
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://example.com/test")
+            .body(edgezero_core::body::Body::empty())
+            .expect("should build request");
+        let context = AuctionContext {
+            settings: &settings,
+            request: &req,
+            timeout_ms: 2000,
+            provider_responses: None,
+            services,
+        };
+
+        // Act
+        let result = orchestrator
+            .run_auction(&request, &context)
+            .await
+            .expect("should complete auction even when one provider errors");
+
+        // Assert: exactly two responses — one error, one success.
+        assert_eq!(
+            result.provider_responses.len(),
+            2,
+            "should collect responses from both providers"
+        );
+
+        let provider_a = result
+            .provider_responses
+            .iter()
+            .find(|r| r.provider == "provider-a")
+            .expect("should have provider-a response");
+        let provider_b = result
+            .provider_responses
+            .iter()
+            .find(|r| r.provider == "provider-b")
+            .expect("should have provider-b response");
+
+        assert_eq!(
+            provider_a.status,
+            BidStatus::Error,
+            "provider-a should be marked error — select() Err was attributed via failed_backend_name"
+        );
+        assert_eq!(
+            provider_b.status,
+            BidStatus::Success,
+            "provider-b should succeed — error was correctly isolated to provider-a"
         );
     }
 

--- a/crates/trusted-server-core/src/auction/provider.rs
+++ b/crates/trusted-server-core/src/auction/provider.rs
@@ -81,7 +81,7 @@ pub trait AuctionProvider: Send + Sync {
     ///
     /// `timeout_ms` is the effective timeout that will be used when the backend
     /// is registered in [`request_bids`](Self::request_bids).  It must be
-    /// forwarded to [`BackendConfig::backend_name_for_url()`] so the predicted
+    /// forwarded to [`crate::backend::BackendConfig::backend_name_for_url()`] so the predicted
     /// name matches the actual registration (the timeout is part of the name).
     fn backend_name(&self, _timeout_ms: u32) -> Option<String> {
         None

--- a/crates/trusted-server-core/src/auction/provider.rs
+++ b/crates/trusted-server-core/src/auction/provider.rs
@@ -1,13 +1,15 @@
 //! Trait definition for auction providers.
 
+use async_trait::async_trait;
 use error_stack::Report;
-use fastly::http::request::PendingRequest;
 
 use crate::error::TrustedServerError;
+use crate::platform::{PlatformPendingRequest, PlatformResponse};
 
 use super::types::{AuctionContext, AuctionRequest, AuctionResponse};
 
 /// Trait implemented by all auction providers (Prebid, APS, GAM, etc.).
+#[async_trait(?Send)]
 pub trait AuctionProvider: Send + Sync {
     /// Unique identifier for this provider (e.g., "prebid", "aps", "gam").
     fn provider_name(&self) -> &'static str;
@@ -16,52 +18,36 @@ pub trait AuctionProvider: Send + Sync {
     ///
     /// Implementations should:
     /// - Transform `AuctionRequest` to provider-specific format
-    /// - Make HTTP call to provider endpoint using `send_async()`
-    /// - Return `PendingRequest` for orchestrator to await
+    /// - Make an HTTP call through `context.services.http_client().send_async(...)`
+    /// - Return [`PlatformPendingRequest`] for the orchestrator to await
     ///
     /// The orchestrator will handle waiting for responses and parsing them.
     ///
     /// # Errors
     ///
     /// Returns an error if the request cannot be created or if the provider endpoint
-    /// cannot be reached (though usually network errors happen during `PendingRequest` await).
-    fn request_bids(
+    /// cannot be reached (though usually network errors happen while the returned
+    /// [`PlatformPendingRequest`] is polled).
+    async fn request_bids(
         &self,
         request: &AuctionRequest,
         context: &AuctionContext<'_>,
-    ) -> Result<PendingRequest, Report<TrustedServerError>>;
+    ) -> Result<PlatformPendingRequest, Report<TrustedServerError>>;
 
     /// Parse the response from the provider into an `AuctionResponse`.
     ///
-    /// Called by the orchestrator after the `PendingRequest` completes.
+    /// Called by the orchestrator after the [`PlatformPendingRequest`] completes.
+    /// Declared async so implementations can safely drain streaming response bodies
+    /// without panicking on the `Body::Stream` variant.
     ///
     /// # Errors
     ///
     /// Returns an error if the response cannot be parsed into a valid `AuctionResponse`.
-    fn parse_response(
+    async fn parse_response(
         &self,
-        response: fastly::Response,
+        response: PlatformResponse,
         response_time_ms: u64,
     ) -> Result<AuctionResponse, Report<TrustedServerError>>;
-
-    /// Parse the response with access to the original auction context.
-    ///
-    /// Providers that need request-local metadata while transforming responses
-    /// can override this method. The default preserves the existing
-    /// response-only provider contract.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the response cannot be parsed into a valid [`AuctionResponse`].
-    fn parse_response_with_context(
-        &self,
-        response: fastly::Response,
-        response_time_ms: u64,
-        context: &AuctionContext<'_>,
-    ) -> Result<AuctionResponse, Report<TrustedServerError>> {
-        let _ = context;
-        self.parse_response(response, response_time_ms)
-    }
 
     /// Check if this provider supports a specific media type.
     fn supports_media_type(&self, media_type: &super::types::MediaType) -> bool {

--- a/crates/trusted-server-core/src/auction/test_support.rs
+++ b/crates/trusted-server-core/src/auction/test_support.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
-use fastly::Request;
+use edgezero_core::body::Body as EdgeBody;
+use http::Request;
 
 use super::AuctionContext;
 use crate::platform::{test_support::noop_services, RuntimeServices};
@@ -10,7 +11,7 @@ static TEST_SERVICES: LazyLock<RuntimeServices> = LazyLock::new(noop_services);
 
 pub(crate) fn create_test_auction_context<'a>(
     settings: &'a Settings,
-    request: &'a Request,
+    request: &'a Request<EdgeBody>,
     timeout_ms: u32,
 ) -> AuctionContext<'a> {
     let services: &'static RuntimeServices = &TEST_SERVICES;

--- a/crates/trusted-server-core/src/auction/types.rs
+++ b/crates/trusted-server-core/src/auction/types.rs
@@ -1,6 +1,7 @@
 //! Core types for auction requests and responses.
 
-use fastly::Request;
+use edgezero_core::body::Body as EdgeBody;
+use http::Request;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -109,7 +110,7 @@ pub struct SiteInfo {
 /// Context passed to auction providers.
 pub struct AuctionContext<'a> {
     pub settings: &'a Settings,
-    pub request: &'a Request,
+    pub request: &'a Request<EdgeBody>,
     pub timeout_ms: u32,
     /// Provider responses from the bidding phase, used by mediators.
     /// This is `None` for regular bidders and `Some` when calling a mediator.

--- a/crates/trusted-server-core/src/backend.rs
+++ b/crates/trusted-server-core/src/backend.rs
@@ -5,6 +5,7 @@ use fastly::backend::Backend;
 use url::Url;
 
 use crate::error::TrustedServerError;
+use crate::host_header::validate_host_header_override_value;
 
 /// Returns the default port for the given scheme (443 for HTTPS, 80 for HTTP).
 #[inline]
@@ -33,6 +34,19 @@ fn compute_host_header(scheme: &str, host: &str, port: u16) -> String {
     }
 }
 
+fn sanitize_backend_name_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 /// Default first-byte timeout for backends (15 seconds).
 pub(crate) const DEFAULT_FIRST_BYTE_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -46,6 +60,7 @@ pub struct BackendConfig<'a> {
     port: Option<u16>,
     certificate_check: bool,
     first_byte_timeout: Duration,
+    host_header_override: Option<&'a str>,
 }
 
 impl<'a> BackendConfig<'a> {
@@ -61,6 +76,7 @@ impl<'a> BackendConfig<'a> {
             port: None,
             certificate_check: true,
             first_byte_timeout: DEFAULT_FIRST_BYTE_TIMEOUT,
+            host_header_override: None,
         }
     }
 
@@ -90,6 +106,13 @@ impl<'a> BackendConfig<'a> {
         self
     }
 
+    /// Set the outbound Host header sent to the backend origin.
+    #[must_use]
+    pub fn host_header_override(mut self, host: Option<&'a str>) -> Self {
+        self.host_header_override = host;
+        self
+    }
+
     /// Compute the deterministic backend name and resolved port without
     /// registering anything.
     ///
@@ -114,12 +137,23 @@ impl<'a> BackendConfig<'a> {
                 message: "scheme contains control characters".to_string(),
             }));
         }
+        if let Some(host_header_override) = self.host_header_override {
+            validate_host_header_override_value(host_header_override).map_err(|reason| {
+                Report::new(TrustedServerError::Proxy {
+                    message: format!("host header override {reason}"),
+                })
+            })?;
+        }
 
         let target_port = self
             .port
             .unwrap_or_else(|| default_port_for_scheme(self.scheme));
 
         let name_base = format!("{}_{}_{}", self.scheme, self.host, target_port);
+        let host_override_suffix = self
+            .host_header_override
+            .map(|host| format!("_oh_{}", sanitize_backend_name_component(host)))
+            .unwrap_or_default();
         let cert_suffix = if self.certificate_check {
             ""
         } else {
@@ -127,8 +161,9 @@ impl<'a> BackendConfig<'a> {
         };
         let timeout_ms = self.first_byte_timeout.as_millis();
         let backend_name = format!(
-            "backend_{}{}_t{}",
-            name_base.replace(['.', ':'], "_"),
+            "backend_{}{}{}_t{}",
+            sanitize_backend_name_component(&name_base),
+            host_override_suffix,
             cert_suffix,
             timeout_ms
         );
@@ -138,7 +173,7 @@ impl<'a> BackendConfig<'a> {
 
     /// Return the deterministic backend name without registering anything.
     ///
-    /// Convenience wrapper over [`Self::compute_name`] that discards the
+    /// Convenience wrapper over `Self::compute_name` that discards the
     /// resolved port, used by [`crate::platform::PlatformBackend`]
     /// implementations that only need the name for correlation.
     ///
@@ -165,7 +200,10 @@ impl<'a> BackendConfig<'a> {
 
         let host_with_port = format!("{}:{}", self.host, target_port);
 
-        let host_header = compute_host_header(self.scheme, self.host, target_port);
+        let host_header = self
+            .host_header_override
+            .map(str::to_owned)
+            .unwrap_or_else(|| compute_host_header(self.scheme, self.host, target_port));
 
         // Target base is host[:port]; SSL is enabled only for https scheme
         let mut builder = Backend::builder(&backend_name, &host_with_port)
@@ -219,6 +257,7 @@ impl<'a> BackendConfig<'a> {
     ///
     /// Centralises URL parsing so that [`from_url`](Self::from_url),
     /// [`from_url_with_first_byte_timeout`](Self::from_url_with_first_byte_timeout),
+    /// [`from_url_with_host_header_override`](Self::from_url_with_host_header_override),
     /// and [`backend_name_for_url`](Self::backend_name_for_url) share one
     /// code-path.
     fn parse_origin(
@@ -279,12 +318,46 @@ impl<'a> BackendConfig<'a> {
         certificate_check: bool,
         first_byte_timeout: Duration,
     ) -> Result<String, Report<TrustedServerError>> {
+        Self::from_url_with_first_byte_timeout_and_host_header_override(
+            origin_url,
+            certificate_check,
+            first_byte_timeout,
+            None,
+        )
+    }
+
+    /// Parse an origin URL and ensure a dynamic backend with a custom Host header.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URL cannot be parsed or lacks a host, or if
+    /// backend creation fails.
+    pub fn from_url_with_host_header_override(
+        origin_url: &str,
+        certificate_check: bool,
+        host_header_override: Option<&str>,
+    ) -> Result<String, Report<TrustedServerError>> {
+        Self::from_url_with_first_byte_timeout_and_host_header_override(
+            origin_url,
+            certificate_check,
+            DEFAULT_FIRST_BYTE_TIMEOUT,
+            host_header_override,
+        )
+    }
+
+    fn from_url_with_first_byte_timeout_and_host_header_override(
+        origin_url: &str,
+        certificate_check: bool,
+        first_byte_timeout: Duration,
+        host_header_override: Option<&str>,
+    ) -> Result<String, Report<TrustedServerError>> {
         let (scheme, host, port) = Self::parse_origin(origin_url)?;
 
         BackendConfig::new(&scheme, &host)
             .port(port)
             .certificate_check(certificate_check)
             .first_byte_timeout(first_byte_timeout)
+            .host_header_override(host_header_override)
             .ensure()
     }
 
@@ -435,6 +508,65 @@ mod tests {
             first, second,
             "should return same backend name on repeat call"
         );
+    }
+
+    #[test]
+    fn host_header_overrides_produce_different_names() {
+        let (name_a, _) = BackendConfig::new("https", "origin.example.com")
+            .host_header_override(Some("www.example.com"))
+            .compute_name()
+            .expect("should compute name with host header override");
+        let (name_b, _) = BackendConfig::new("https", "origin.example.com")
+            .host_header_override(Some("m.example.com"))
+            .compute_name()
+            .expect("should compute name with different host header override");
+
+        assert_ne!(
+            name_a, name_b,
+            "backends with different host header overrides should have different names"
+        );
+        assert_eq!(
+            name_a,
+            "backend_https_origin_example_com_443_oh_www_example_com_t15000"
+        );
+        assert_eq!(
+            name_b,
+            "backend_https_origin_example_com_443_oh_m_example_com_t15000"
+        );
+    }
+
+    #[test]
+    fn host_header_override_rejects_control_characters() {
+        let err = BackendConfig::new("https", "origin.example.com")
+            .host_header_override(Some("www\n.example.com"))
+            .predict_name()
+            .expect_err("should reject host header override containing newline");
+
+        assert!(
+            err.to_string().contains("control characters"),
+            "should report control characters in error message"
+        );
+    }
+
+    #[test]
+    fn host_header_override_rejects_invalid_values() {
+        for host_header_override in [
+            "https://www.example.com",
+            "www.example.com/path",
+            "www.example.com:",
+            "example..com",
+            "-",
+        ] {
+            let err = BackendConfig::new("https", "origin.example.com")
+                .host_header_override(Some(host_header_override))
+                .predict_name()
+                .expect_err("should reject invalid host header override");
+
+            assert!(
+                err.to_string().contains("host header override"),
+                "should report host header override error for {host_header_override:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/trusted-server-core/src/compat.rs
+++ b/crates/trusted-server-core/src/compat.rs
@@ -35,6 +35,20 @@ fn build_http_request(req: &fastly::Request, body: EdgeBody) -> http::Request<Ed
         .expect("should build http request from fastly request")
 }
 
+/// Convert an owned `fastly::Request` into an `http::Request<EdgeBody>`.
+///
+/// # PR 15 removal target
+///
+/// # Panics
+///
+/// Does not panic in practice — URL parse failure falls back to `"/"` (logged
+/// as a warning), and the subsequent `builder.body()` cannot fail given a valid
+/// method and URI. Listed here only because clippy cannot prove it statically.
+pub fn from_fastly_request(mut req: fastly::Request) -> http::Request<EdgeBody> {
+    let body = EdgeBody::from(req.take_body_bytes());
+    build_http_request(&req, body)
+}
+
 /// Convert a borrowed `fastly::Request` into an `http::Request<EdgeBody>` for reading.
 ///
 /// Headers are copied; the body is empty.
@@ -50,6 +64,70 @@ pub fn from_fastly_headers_ref(req: &fastly::Request) -> http::Request<EdgeBody>
     build_http_request(req, EdgeBody::empty())
 }
 
+/// Convert an `http::Request<EdgeBody>` into a `fastly::Request`.
+///
+/// # PR 15 removal target
+pub fn to_fastly_request(req: http::Request<EdgeBody>) -> fastly::Request {
+    let (parts, body) = req.into_parts();
+    let mut fastly_req = fastly::Request::new(parts.method, parts.uri.to_string());
+    for (name, value) in &parts.headers {
+        fastly_req.append_header(name.as_str(), value.as_bytes());
+    }
+
+    match body {
+        EdgeBody::Once(bytes) => {
+            if !bytes.is_empty() {
+                // bytes.to_vec() is an O(N) copy at the compat boundary; goes away in PR 15.
+                fastly_req.set_body(bytes.to_vec());
+            }
+        }
+        EdgeBody::Stream(_) => {
+            // Audited call sites: only integration proxy routes, which always carry buffered
+            // Once bodies from from_fastly_request.  No streaming body reaches this path today.
+            log::warn!("streaming body in compat::to_fastly_request; body will be empty");
+        }
+    }
+
+    fastly_req
+}
+
+/// Convert a borrowed `http::Request<EdgeBody>` into a `fastly::Request`.
+///
+/// Headers, method, and URI are copied; the body is always empty. This function
+/// requires that the caller has already consumed or discarded the body — passing
+/// a request with a non-empty body is a caller error: the body bytes will be
+/// silently lost with no warning or panic.
+///
+/// # PR 15 removal target
+pub fn to_fastly_request_ref(req: &http::Request<EdgeBody>) -> fastly::Request {
+    let mut fastly_req = fastly::Request::new(req.method().clone(), req.uri().to_string());
+    for (name, value) in req.headers() {
+        fastly_req.append_header(name.as_str(), value.as_bytes());
+    }
+
+    fastly_req
+}
+
+/// Convert a `fastly::Response` into an `http::Response<EdgeBody>`.
+///
+/// # PR 15 removal target
+///
+/// # Panics
+///
+/// Panics if the copied Fastly response parts cannot form a valid
+/// `http::Response`.
+pub fn from_fastly_response(mut resp: fastly::Response) -> http::Response<EdgeBody> {
+    let status = resp.get_status();
+    let mut builder = http::Response::builder().status(status);
+    for (name, value) in resp.get_headers() {
+        builder = builder.header(name.as_str(), value.as_bytes());
+    }
+
+    builder
+        .body(EdgeBody::from(resp.take_body_bytes()))
+        .expect("should build http response from fastly response")
+}
+
 /// Convert an `http::Response<EdgeBody>` into a `fastly::Response`.
 ///
 /// # PR 15 removal target
@@ -60,17 +138,17 @@ pub fn to_fastly_response(resp: http::Response<EdgeBody>) -> fastly::Response {
         fastly_resp.append_header(name.as_str(), value.as_bytes());
     }
 
-    debug_assert!(
-        matches!(&body, EdgeBody::Once(_)),
-        "streaming body passed to compat::to_fastly_response will be silently truncated"
-    );
     match body {
         EdgeBody::Once(bytes) => {
             if !bytes.is_empty() {
-                fastly_resp.set_body(bytes.as_ref());
+                // bytes.to_vec() is an O(N) copy at the compat boundary; goes away in PR 15.
+                fastly_resp.set_body(bytes.to_vec());
             }
         }
         EdgeBody::Stream(_) => {
+            // Audited call sites: streaming publisher bodies are dispatched via
+            // to_fastly_response_skeleton + stream_to_client before reaching here.
+            // No streaming body reaches to_fastly_response in the current adapter.
             log::warn!("streaming body in compat::to_fastly_response; body will be empty");
         }
     }
@@ -78,13 +156,41 @@ pub fn to_fastly_response(resp: http::Response<EdgeBody>) -> fastly::Response {
     fastly_resp
 }
 
-/// Sanitize forwarded headers on a `fastly::Request`.
+/// Convert an `http::Response<EdgeBody>` into a `fastly::Response` with headers only.
+///
+/// Body is discarded — use when the caller will stream the body separately via
+/// [`fastly::Response::stream_to_client`]. Audited call sites: only the streaming
+/// publisher dispatch path in the adapter, which streams the body directly to the
+/// client via [`crate::publisher::stream_publisher_body`]. (Removal target: PR 15.)
+///
+/// # PR 15 removal target
+pub fn to_fastly_response_skeleton(resp: http::Response<EdgeBody>) -> fastly::Response {
+    let (parts, _body) = resp.into_parts();
+    let mut fastly_resp = fastly::Response::from_status(parts.status.as_u16());
+    for (name, value) in &parts.headers {
+        fastly_resp.append_header(name.as_str(), value.as_bytes());
+    }
+    fastly_resp
+}
+
+/// Sanitize forwarded and internal headers on a `fastly::Request`.
+///
+/// Strips spoofable forwarded headers (X-Forwarded-Host etc.) and TS-internal
+/// identity headers (x-ts-ec, x-ts-eids, …) that clients must not be able to
+/// inject.  Both sets are stripped at the edge entry point, before any
+/// request-derived context is built or the request is converted to http types.
 ///
 /// # PR 15 removal target
 pub fn sanitize_fastly_forwarded_headers(req: &mut fastly::Request) {
     for &name in SPOOFABLE_FORWARDED_HEADERS {
         if req.get_header(name).is_some() {
             log::debug!("Stripped spoofable header: {name}");
+            req.remove_header(name);
+        }
+    }
+    for &name in crate::constants::INTERNAL_HEADERS {
+        if req.get_header(name).is_some() {
+            log::debug!("Stripped inbound internal header: {name}");
             req.remove_header(name);
         }
     }
@@ -218,6 +324,104 @@ mod tests {
     }
 
     #[test]
+    fn from_fastly_request_copies_body() {
+        let mut fastly_req =
+            fastly::Request::new(fastly::http::Method::POST, "https://example.com/path");
+        fastly_req.set_header("content-type", "application/json");
+        fastly_req.set_body(r#"{"ok":true}"#);
+
+        let http_req = from_fastly_request(fastly_req);
+        let (parts, body) = http_req.into_parts();
+
+        assert_eq!(parts.method, http::Method::POST, "should copy method");
+        assert_eq!(parts.uri.path(), "/path", "should copy uri path");
+        assert_eq!(
+            parts
+                .headers
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json"),
+            "should copy headers"
+        );
+        assert_once_body_eq(body, br#"{"ok":true}"#);
+    }
+
+    #[test]
+    fn to_fastly_request_copies_headers_and_body() {
+        let http_req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://example.com/submit")
+            .header("x-custom", "value")
+            .body(EdgeBody::from(b"payload".as_ref()))
+            .expect("should build request");
+
+        let mut fastly_req = to_fastly_request(http_req);
+
+        assert_eq!(
+            fastly_req.get_method(),
+            &fastly::http::Method::POST,
+            "should copy method"
+        );
+        assert_eq!(
+            fastly_req
+                .get_header("x-custom")
+                .and_then(|v| v.to_str().ok()),
+            Some("value"),
+            "should copy headers"
+        );
+        assert_eq!(
+            fastly_req.take_body_bytes().as_slice(),
+            b"payload",
+            "should copy body bytes"
+        );
+    }
+
+    #[test]
+    fn to_fastly_request_preserves_duplicate_headers() {
+        let http_req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://example.com/")
+            .header("x-custom", "first")
+            .header("x-custom", "second")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let fastly_req = to_fastly_request(http_req);
+
+        let values: Vec<_> = fastly_req
+            .get_headers()
+            .filter(|(name, _)| name.as_str() == "x-custom")
+            .map(|(_, value)| value.to_str().expect("should be valid utf8"))
+            .collect();
+        assert_eq!(
+            values,
+            vec!["first", "second"],
+            "should preserve duplicate headers"
+        );
+    }
+
+    #[test]
+    fn from_fastly_response_copies_status_headers_and_body() {
+        let mut fastly_resp = fastly::Response::from_status(202);
+        fastly_resp.set_header("content-type", "application/json");
+        fastly_resp.set_body(r#"{"ok":true}"#);
+
+        let http_resp = from_fastly_response(fastly_resp);
+        let (parts, body) = http_resp.into_parts();
+
+        assert_eq!(parts.status.as_u16(), 202, "should copy status");
+        assert_eq!(
+            parts
+                .headers
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json"),
+            "should copy headers"
+        );
+        assert_once_body_eq(body, br#"{"ok":true}"#);
+    }
+
+    #[test]
     fn to_fastly_response_copies_status_and_headers() {
         let http_resp = http::Response::builder()
             .status(201)
@@ -231,6 +435,64 @@ mod tests {
         assert!(
             fastly_resp.get_header("content-type").is_some(),
             "should copy content-type header"
+        );
+    }
+
+    #[test]
+    fn to_fastly_request_ref_copies_method_uri_and_headers_without_body() {
+        let http_req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://example.com/path?q=1")
+            .header("x-custom", "value")
+            .body(EdgeBody::from(b"payload".as_ref()))
+            .expect("should build request");
+
+        let mut fastly_req = to_fastly_request_ref(&http_req);
+
+        assert_eq!(
+            fastly_req.get_method(),
+            &fastly::http::Method::POST,
+            "should copy method"
+        );
+        assert_eq!(
+            fastly_req.get_url_str(),
+            "https://example.com/path?q=1",
+            "should copy URI"
+        );
+        assert_eq!(
+            fastly_req
+                .get_header("x-custom")
+                .and_then(|v| v.to_str().ok()),
+            Some("value"),
+            "should copy headers"
+        );
+        assert!(
+            fastly_req.take_body_bytes().is_empty(),
+            "borrowed conversion should not copy body bytes"
+        );
+    }
+
+    #[test]
+    fn to_fastly_request_ref_preserves_duplicate_headers() {
+        let http_req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://example.com/")
+            .header("x-custom", "first")
+            .header("x-custom", "second")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let fastly_req = to_fastly_request_ref(&http_req);
+
+        let values: Vec<_> = fastly_req
+            .get_headers()
+            .filter(|(name, _)| name.as_str() == "x-custom")
+            .map(|(_, value)| value.to_str().expect("should be valid utf8"))
+            .collect();
+        assert_eq!(
+            values,
+            vec!["first", "second"],
+            "should preserve duplicate headers"
         );
     }
 
@@ -373,6 +635,86 @@ mod tests {
                 settings.publisher.domain
             )),
             "should set expected expiry cookie"
+        );
+    }
+
+    #[test]
+    fn to_fastly_response_skeleton_copies_status_and_headers_discards_body() {
+        let http_resp = http::Response::builder()
+            .status(206)
+            .header("content-type", "text/html; charset=utf-8")
+            .header("x-custom", "value")
+            .body(EdgeBody::from(b"some body bytes".as_ref()))
+            .expect("should build response");
+
+        let fastly_resp = to_fastly_response_skeleton(http_resp);
+
+        assert_eq!(
+            fastly_resp.get_status().as_u16(),
+            206,
+            "should copy status code"
+        );
+        assert_eq!(
+            fastly_resp
+                .get_header("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("text/html; charset=utf-8"),
+            "should copy content-type header"
+        );
+        assert_eq!(
+            fastly_resp
+                .get_header("x-custom")
+                .and_then(|v| v.to_str().ok()),
+            Some("value"),
+            "should copy custom header"
+        );
+    }
+
+    #[test]
+    fn to_fastly_request_with_streaming_body_produces_empty_body() {
+        // Stream bodies cannot cross the compat boundary: the Fastly SDK has no
+        // streaming body API, so the shim drops the stream and logs a warning.
+        // This test pins that silent-drop behaviour so it cannot become
+        // accidentally load-bearing.  (Removal target: PR 15.)
+        let body = EdgeBody::stream(futures::stream::iter(vec![bytes::Bytes::from_static(
+            b"data",
+        )]));
+        let http_req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://example.com/")
+            .body(body)
+            .expect("should build request");
+
+        let mut fastly_req = to_fastly_request(http_req);
+
+        assert!(
+            fastly_req.take_body_bytes().is_empty(),
+            "streaming body should be silently dropped; compat shim produces empty body"
+        );
+    }
+
+    #[test]
+    fn to_fastly_response_with_streaming_body_produces_empty_body() {
+        // Same constraint as to_fastly_request: streaming bodies are dropped at
+        // the compat boundary.  (Removal target: PR 15.)
+        let body = EdgeBody::stream(futures::stream::iter(vec![bytes::Bytes::from_static(
+            b"data",
+        )]));
+        let http_resp = http::Response::builder()
+            .status(200)
+            .body(body)
+            .expect("should build response");
+
+        let mut fastly_resp = to_fastly_response(http_resp);
+
+        assert_eq!(
+            fastly_resp.get_status().as_u16(),
+            200,
+            "should copy status code"
+        );
+        assert!(
+            fastly_resp.take_body_bytes().is_empty(),
+            "streaming body should be silently dropped; compat shim produces empty body"
         );
     }
 }

--- a/crates/trusted-server-core/src/consent/gpp.rs
+++ b/crates/trusted-server-core/src/consent/gpp.rs
@@ -44,7 +44,7 @@ const MAX_GPP_STRING_LEN: usize = 8192;
 /// # Errors
 ///
 /// - [`ConsentDecodeError::InvalidGppString`] if the string exceeds
-///   [`MAX_GPP_STRING_LEN`] or the `iab_gpp` parser fails.
+///   `MAX_GPP_STRING_LEN` or the `iab_gpp` parser fails.
 pub fn decode_gpp_string(gpp_string: &str) -> Result<GppConsent, Report<ConsentDecodeError>> {
     if gpp_string.len() > MAX_GPP_STRING_LEN {
         return Err(Report::new(ConsentDecodeError::InvalidGppString {

--- a/crates/trusted-server-core/src/consent/mod.rs
+++ b/crates/trusted-server-core/src/consent/mod.rs
@@ -161,12 +161,7 @@ fn apply_expiration_check(ctx: &mut ConsentContext, config: &ConsentConfig) {
         return;
     }
 
-    // lgtm[rust/cleartext-logging]
-    // This warning logs consent age metadata only; no raw consent string is emitted.
-    log::warn!(
-        "TCF consent expired (age: {age_days}d, max: {}d)",
-        config.max_consent_age_days
-    );
+    log::warn!("TCF consent expired: age_days={age_days}");
     ctx.expired = true;
 
     ctx.tcf = None;

--- a/crates/trusted-server-core/src/consent/tcf.rs
+++ b/crates/trusted-server-core/src/consent/tcf.rs
@@ -67,7 +67,7 @@ const MAX_VENDOR_ID: u16 = 10_000;
 /// # Errors
 ///
 /// - [`ConsentDecodeError::InvalidTcString`] if the string exceeds
-///   [`MAX_TC_STRING_LEN`], base64 decoding fails, the version is not 2, or
+///   `MAX_TC_STRING_LEN`, base64 decoding fails, the version is not 2, or
 ///   the bitfield is too short.
 pub fn decode_tc_string(tc_string: &str) -> Result<TcfConsent, Report<ConsentDecodeError>> {
     if tc_string.len() > MAX_TC_STRING_LEN {

--- a/crates/trusted-server-core/src/consent/types.rs
+++ b/crates/trusted-server-core/src/consent/types.rs
@@ -7,7 +7,6 @@
 //! - [`UsPrivacy`] / [`PrivacyFlag`] — decoded US Privacy (CCPA) 4-char string
 //! - [`TcfConsent`] — decoded TCF v2 core consent data
 //! - [`GppConsent`] — decoded GPP consent data
-//! - [`Jurisdiction`] — the privacy regime applicable to the request
 //! - [`ConsentSource`] — how consent was sourced (cookie, KV store, etc.)
 
 use core::fmt;

--- a/crates/trusted-server-core/src/cookies.rs
+++ b/crates/trusted-server-core/src/cookies.rs
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_request_cookies_malformed_cookie_string() {
+    fn test_handle_request_cookies_invalid_cookie_header() {
         let req = build_request(Some("invalid"));
         let jar = handle_request_cookies(&req)
             .expect("should parse cookies")

--- a/crates/trusted-server-core/src/cookies.rs
+++ b/crates/trusted-server-core/src/cookies.rs
@@ -1,7 +1,7 @@
 //! Cookie handling utilities.
 //!
-//! This module provides functionality for parsing, stripping, and forwarding cookies
-//! used in the trusted server system.
+//! This module provides functionality for parsing, stripping, and forwarding cookies used in the
+//! trusted server system.
 
 use cookie::{Cookie, CookieJar};
 use edgezero_core::body::Body as EdgeBody;

--- a/crates/trusted-server-core/src/creative.rs
+++ b/crates/trusted-server-core/src/creative.rs
@@ -342,7 +342,7 @@ fn is_safe_data_uri(lower: &str) -> bool {
 /// This runs as the first pass in the creative pipeline, before URL rewriting, so the
 /// rewriter only ever sees clean markup.
 ///
-/// Inputs larger than [`MAX_CREATIVE_SIZE`] are rejected (empty string returned) with a warning.
+/// Inputs larger than `MAX_CREATIVE_SIZE` are rejected (empty string returned) with a warning.
 /// On parse errors the markup is also rejected (empty string returned) with a warning.
 #[must_use]
 pub fn sanitize_creative_html(markup: &str) -> String {

--- a/crates/trusted-server-core/src/ec/kv.rs
+++ b/crates/trusted-server-core/src/ec/kv.rs
@@ -105,7 +105,7 @@ fn apply_partner_id_updates(entry: &mut KvEntry, updates: &[PartnerIdUpdate]) ->
 ///
 /// Methods use optimistic concurrency (generation markers) for safe
 /// read-modify-write operations on concurrent requests.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KvIdentityGraph {
     store_name: String,
 }

--- a/crates/trusted-server-core/src/ec/mod.rs
+++ b/crates/trusted-server-core/src/ec/mod.rs
@@ -135,7 +135,7 @@ pub fn get_ec_id(req: &fastly::Request) -> Result<Option<String>, Report<Trusted
 /// Created via [`read_from_request`](Self::read_from_request) during
 /// pre-routing, then optionally mutated by
 /// [`generate_if_needed`](Self::generate_if_needed) in organic handlers.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct EcContext {
     /// The EC ID value, if one exists (from request) or was generated.
     ec_value: Option<String>,
@@ -295,6 +295,9 @@ impl EcContext {
                 );
                 self.ec_value = None;
                 self.ec_generated = false;
+                return Err(err.change_context(TrustedServerError::EdgeCookie {
+                    message: "Failed to persist generated EC ID to KV identity graph".to_string(),
+                }));
             }
         }
 

--- a/crates/trusted-server-core/src/edge_cookie.rs
+++ b/crates/trusted-server-core/src/edge_cookie.rs
@@ -1,0 +1,123 @@
+//! EC ID extraction from incoming HTTP requests.
+//!
+//! Reads an existing EC ID from the `x-ts-ec` header or `ts-ec` cookie.
+//! Generation is handled by [`crate::ec::generation`].
+
+use edgezero_core::body::Body as EdgeBody;
+use error_stack::Report;
+use http::Request;
+
+use crate::constants::{COOKIE_TS_EC, HEADER_X_TS_EC};
+use crate::cookies::handle_request_cookies;
+use crate::ec::cookies::ec_id_has_only_allowed_chars;
+use crate::error::TrustedServerError;
+
+/// Gets an existing EC ID from the request.
+///
+/// Attempts to retrieve an existing EC ID from:
+/// 1. The `x-ts-ec` header
+/// 2. The `ts-ec` cookie
+///
+/// Returns `None` if neither source contains an EC ID.
+///
+/// # Errors
+///
+/// - [`TrustedServerError::InvalidHeaderValue`] if cookie parsing fails
+pub fn get_ec_id(req: &Request<EdgeBody>) -> Result<Option<String>, Report<TrustedServerError>> {
+    if let Some(ec_id) = req
+        .headers()
+        .get(HEADER_X_TS_EC)
+        .and_then(|h| h.to_str().ok())
+    {
+        if ec_id_has_only_allowed_chars(ec_id) {
+            log::trace!("Using existing EC ID from header: {}", ec_id);
+            return Ok(Some(ec_id.to_string()));
+        }
+        log::warn!("Rejected EC ID from x-ts-ec header with disallowed characters");
+    }
+
+    match handle_request_cookies(req)? {
+        Some(jar) => {
+            if let Some(cookie) = jar.get(COOKIE_TS_EC) {
+                let value = cookie.value();
+                if ec_id_has_only_allowed_chars(value) {
+                    log::trace!("Using existing EC ID from cookie: {}", value);
+                    return Ok(Some(value.to_string()));
+                }
+                log::warn!("Rejected EC ID from cookie with disallowed characters");
+            }
+        }
+        None => {
+            log::debug!("No cookie header found in request");
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::{header, HeaderName};
+
+    fn create_test_request(headers: &[(HeaderName, &str)]) -> Request<EdgeBody> {
+        let mut builder = Request::builder().method("GET").uri("http://example.com");
+        for (key, value) in headers {
+            builder = builder.header(key, *value);
+        }
+        builder
+            .body(EdgeBody::empty())
+            .expect("should build test request")
+    }
+
+    #[test]
+    fn get_ec_id_returns_header_value_when_present() {
+        let req = create_test_request(&[(HEADER_X_TS_EC, "existing_ec_id")]);
+        let ec_id = get_ec_id(&req).expect("should get EC ID");
+        assert_eq!(ec_id, Some("existing_ec_id".to_string()));
+    }
+
+    #[test]
+    fn get_ec_id_returns_cookie_value_when_present() {
+        let req = create_test_request(&[(
+            header::COOKIE,
+            &format!("{}=existing_cookie_id", COOKIE_TS_EC),
+        )]);
+        let ec_id = get_ec_id(&req).expect("should get EC ID");
+        assert_eq!(ec_id, Some("existing_cookie_id".to_string()));
+    }
+
+    #[test]
+    fn get_ec_id_returns_none_when_absent() {
+        let req = create_test_request(&[]);
+        let ec_id = get_ec_id(&req).expect("should handle missing ID");
+        assert!(ec_id.is_none());
+    }
+
+    #[test]
+    fn get_ec_id_rejects_header_with_disallowed_chars_falls_back_to_cookie() {
+        let req = create_test_request(&[
+            (HEADER_X_TS_EC, "evil;injected"),
+            (header::COOKIE, &format!("{}=valid_cookie_id", COOKIE_TS_EC)),
+        ]);
+        let ec_id = get_ec_id(&req).expect("should handle invalid header gracefully");
+        assert_eq!(
+            ec_id,
+            Some("valid_cookie_id".to_string()),
+            "should reject tampered header and fall back to valid cookie"
+        );
+    }
+
+    #[test]
+    fn get_ec_id_rejects_cookie_with_disallowed_chars() {
+        let req = create_test_request(&[(
+            header::COOKIE,
+            &format!("{}=bad<script>value", COOKIE_TS_EC),
+        )]);
+        let ec_id = get_ec_id(&req).expect("should handle invalid cookie gracefully");
+        assert!(
+            ec_id.is_none(),
+            "should reject cookie with disallowed characters"
+        );
+    }
+}

--- a/crates/trusted-server-core/src/error.rs
+++ b/crates/trusted-server-core/src/error.rs
@@ -45,6 +45,10 @@ pub enum TrustedServerError {
     #[display("Invalid UTF-8 data: {message}")]
     InvalidUtf8 { message: String },
 
+    /// Request payload exceeded maximum allowed size.
+    #[display("Request payload too large: {message}")]
+    RequestTooLarge { message: String },
+
     /// HTTP header value creation failed.
     #[display("Invalid HTTP header value: {message}")]
     InvalidHeaderValue { message: String },
@@ -122,6 +126,7 @@ impl IntoHttpResponse for TrustedServerError {
             Self::Prebid { .. } => StatusCode::BAD_GATEWAY,
             Self::Integration { .. } => StatusCode::BAD_GATEWAY,
             Self::Proxy { .. } => StatusCode::BAD_GATEWAY,
+            Self::RequestTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
             Self::Forbidden { .. } => StatusCode::FORBIDDEN,
             Self::AllowlistViolation { .. } => StatusCode::FORBIDDEN,
             Self::EdgeCookie { .. } => StatusCode::INTERNAL_SERVER_ERROR,
@@ -258,6 +263,7 @@ mod tests {
             | TrustedServerError::Settings { .. }
             | TrustedServerError::EdgeCookie { .. }
             | TrustedServerError::PartnerNotFound { .. }
+            | TrustedServerError::RequestTooLarge { .. }
             | TrustedServerError::InsecureDefault { .. } => (),
         };
 
@@ -365,6 +371,12 @@ mod tests {
                     message: "proxy failed".to_string(),
                 },
                 StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::RequestTooLarge {
+                    message: "body too large".to_string(),
+                },
+                StatusCode::PAYLOAD_TOO_LARGE,
             ),
         ];
 

--- a/crates/trusted-server-core/src/error.rs
+++ b/crates/trusted-server-core/src/error.rs
@@ -103,7 +103,7 @@ pub trait IntoHttpResponse {
 
     /// Get a safe, user-facing error message.
     ///
-    /// Client errors (4xx) return a brief description; server/integration errors
+    /// Selected client errors return a brief description; all other errors
     /// return a generic message. Full error details are preserved in server logs.
     fn user_message(&self) -> String;
 }
@@ -132,7 +132,7 @@ impl IntoHttpResponse for TrustedServerError {
 
     fn user_message(&self) -> String {
         match self {
-            // Client errors (4xx) — safe to surface a brief description
+            // Selected client errors with safe details to surface.
             Self::BadRequest { message } => format!("Bad request: {message}"),
             // Consent strings may contain user data; return category only.
             Self::GdprConsent { .. } => "GDPR consent error".to_string(),
@@ -183,12 +183,38 @@ mod tests {
             TrustedServerError::InvalidUtf8 {
                 message: "byte 0xff".into(),
             },
+            TrustedServerError::InsecureDefault {
+                field: "ec.passphrase".into(),
+            },
         ];
         for error in &cases {
             assert_eq!(
                 error.user_message(),
                 "An internal error occurred",
                 "should not leak details for {error:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn other_client_errors_return_generic_user_message() {
+        let cases = [
+            TrustedServerError::Forbidden {
+                message: "policy detail".into(),
+            },
+            TrustedServerError::AllowlistViolation {
+                host: "blocked.example.com".into(),
+            },
+            TrustedServerError::PartnerNotFound {
+                partner_id: "partner-1".into(),
+            },
+        ];
+
+        for error in &cases {
+            assert_eq!(
+                error.user_message(),
+                "An internal error occurred",
+                "should not leak client-error details for {error:?}",
             );
         }
     }
@@ -209,5 +235,145 @@ mod tests {
             message: "non-ascii".into(),
         };
         assert_eq!(error.user_message(), "Invalid header value");
+    }
+
+    #[test]
+    fn status_code_maps_each_error_variant_to_expected_http_response() {
+        // Compile-time guard: adding a TrustedServerError variant without
+        // updating this test will fail to compile.
+        let _guard: fn(&TrustedServerError) = |error| match error {
+            TrustedServerError::BadRequest { .. }
+            | TrustedServerError::Configuration { .. }
+            | TrustedServerError::Auction { .. }
+            | TrustedServerError::Gam { .. }
+            | TrustedServerError::GdprConsent { .. }
+            | TrustedServerError::InvalidUtf8 { .. }
+            | TrustedServerError::InvalidHeaderValue { .. }
+            | TrustedServerError::KvStore { .. }
+            | TrustedServerError::Prebid { .. }
+            | TrustedServerError::Integration { .. }
+            | TrustedServerError::Proxy { .. }
+            | TrustedServerError::Forbidden { .. }
+            | TrustedServerError::AllowlistViolation { .. }
+            | TrustedServerError::Settings { .. }
+            | TrustedServerError::EdgeCookie { .. }
+            | TrustedServerError::PartnerNotFound { .. }
+            | TrustedServerError::InsecureDefault { .. } => (),
+        };
+
+        let cases = [
+            (
+                TrustedServerError::BadRequest {
+                    message: "bad input".to_string(),
+                },
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                TrustedServerError::GdprConsent {
+                    message: "missing consent".to_string(),
+                },
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                TrustedServerError::InvalidHeaderValue {
+                    message: "invalid header".to_string(),
+                },
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                TrustedServerError::Forbidden {
+                    message: "not allowed".to_string(),
+                },
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                TrustedServerError::AllowlistViolation {
+                    host: "evil.example.com".to_string(),
+                },
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                TrustedServerError::Configuration {
+                    message: "config failed".to_string(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                TrustedServerError::Settings {
+                    message: "settings failed".to_string(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                TrustedServerError::InvalidUtf8 {
+                    message: "invalid utf-8".to_string(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                TrustedServerError::EdgeCookie {
+                    message: "ec failed".to_string(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                TrustedServerError::PartnerNotFound {
+                    partner_id: "partner-1".to_string(),
+                },
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                TrustedServerError::InsecureDefault {
+                    field: "ec.passphrase".to_string(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                TrustedServerError::KvStore {
+                    store_name: "store".to_string(),
+                    message: "kv failed".to_string(),
+                },
+                StatusCode::SERVICE_UNAVAILABLE,
+            ),
+            (
+                TrustedServerError::Auction {
+                    message: "auction failed".to_string(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::Gam {
+                    message: "gam failed".to_string(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::Prebid {
+                    message: "prebid failed".to_string(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::Integration {
+                    integration: "test".to_string(),
+                    message: "integration failed".to_string(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                TrustedServerError::Proxy {
+                    message: "proxy failed".to_string(),
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(
+                error.status_code(),
+                expected,
+                "should map {error:?} to expected HTTP status"
+            );
+        }
     }
 }

--- a/crates/trusted-server-core/src/geo.rs
+++ b/crates/trusted-server-core/src/geo.rs
@@ -1,14 +1,15 @@
 //! Geographic location utilities for the trusted server.
 //!
-//! This module provides Fastly-specific helpers for extracting geographic
-//! information from incoming requests and writing geo headers to responses.
+//! This module provides a Fastly-to-core geo mapping helper and response-header
+//! injection for the platform-neutral [`GeoInfo`] type.
 //!
 //! The [`GeoInfo`] data type is defined in [`crate::platform`] as platform-
-//! neutral data; this module re-exports it and adds Fastly-coupled `impl`
-//! blocks for construction and response header injection.
+//! neutral data; this module re-exports it and adds helper methods for HTTP
+//! response header injection.
 
-use fastly::geo::{geo_lookup, Geo};
-use fastly::{Request, Response};
+use edgezero_core::body::Body as EdgeBody;
+use fastly::geo::Geo;
+use http::{HeaderValue, Response};
 
 pub use crate::platform::GeoInfo;
 
@@ -19,8 +20,8 @@ use crate::constants::{
 
 /// Convert a Fastly [`Geo`] value into a [`GeoInfo`].
 ///
-/// Shared by `GeoInfo::from_request` (legacy) and adapter geo lookups
-/// so that field mapping is never duplicated.
+/// Shared by `FastlyPlatformGeo::lookup` in `trusted-server-adapter-fastly` so
+/// that field mapping is never duplicated.
 pub fn geo_from_fastly(geo: &Geo) -> GeoInfo {
     let asn = match geo.as_number() {
         0 => None,
@@ -39,51 +40,44 @@ pub fn geo_from_fastly(geo: &Geo) -> GeoInfo {
 }
 
 impl GeoInfo {
-    /// Creates a new `GeoInfo` from a request by performing a geo lookup.
-    ///
-    /// # Legacy
-    ///
-    /// This is a Fastly-coupled convenience method that predates the
-    /// `platform` abstraction. New code should use
-    /// `RuntimeServices::geo.lookup(client_info.client_ip)` instead, which
-    /// goes through [`crate::platform::PlatformGeo`] and does not require
-    /// direct access to the Fastly request.
-    ///
-    /// # Returns
-    ///
-    /// `Some(GeoInfo)` if geo data is available, `None` otherwise
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// if let Some(geo_info) = GeoInfo::from_request(&req) {
-    ///     println!("User is in {} ({})", geo_info.city, geo_info.country);
-    /// }
-    /// ```
-    #[deprecated(note = "Use RuntimeServices::geo().lookup() instead")]
-    pub fn from_request(req: &Request) -> Option<Self> {
-        req.get_client_ip_addr()
-            .and_then(geo_lookup)
-            .map(|geo| geo_from_fastly(&geo))
-    }
-
     /// Sets geo information headers on the response.
     ///
     /// Adds `x-geo-city`, `x-geo-country`, `x-geo-continent`, `x-geo-coordinates`,
     /// `x-geo-metro-code`, `x-geo-region` (when available), and
     /// `x-geo-info-available: true` to the given response.
-    pub fn set_response_headers(&self, response: &mut Response) {
-        response.set_header(HEADER_X_GEO_CITY, &self.city);
-        response.set_header(HEADER_X_GEO_COUNTRY, &self.country);
-        response.set_header(HEADER_X_GEO_CONTINENT, &self.continent);
-        response.set_header(HEADER_X_GEO_COORDINATES, self.coordinates_string());
+    pub fn set_response_headers(&self, response: &mut Response<EdgeBody>) {
+        let headers = response.headers_mut();
+
+        insert_geo_header(headers, HEADER_X_GEO_CITY, &self.city);
+        insert_geo_header(headers, HEADER_X_GEO_COUNTRY, &self.country);
+        insert_geo_header(headers, HEADER_X_GEO_CONTINENT, &self.continent);
+        insert_geo_header(
+            headers,
+            HEADER_X_GEO_COORDINATES,
+            &self.coordinates_string(),
+        );
         if self.has_metro_code() {
-            response.set_header(HEADER_X_GEO_METRO_CODE, self.metro_code.to_string());
+            let metro_code = self.metro_code.to_string();
+            insert_geo_header(headers, HEADER_X_GEO_METRO_CODE, &metro_code);
         }
         if let Some(ref region) = self.region {
-            response.set_header(HEADER_X_GEO_REGION, region);
+            insert_geo_header(headers, HEADER_X_GEO_REGION, region);
         }
-        response.set_header(HEADER_X_GEO_INFO_AVAILABLE, "true");
+        headers.insert(
+            HEADER_X_GEO_INFO_AVAILABLE,
+            HeaderValue::from_static("true"),
+        );
+    }
+}
+
+fn insert_geo_header(headers: &mut http::HeaderMap, name: http::header::HeaderName, value: &str) {
+    match HeaderValue::from_str(value) {
+        Ok(header_value) => {
+            headers.insert(name, header_value);
+        }
+        Err(_) => {
+            log::warn!("Skipping invalid geo header value for {}", name.as_str());
+        }
     }
 }
 
@@ -123,7 +117,8 @@ pub fn is_gdpr_country(country_code: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fastly::Response;
+    use edgezero_core::body::Body as EdgeBody;
+    use http::Response as HttpResponse;
 
     fn sample_geo_info() -> GeoInfo {
         GeoInfo {
@@ -138,16 +133,24 @@ mod tests {
         }
     }
 
+    fn build_response() -> HttpResponse<EdgeBody> {
+        HttpResponse::builder()
+            .status(http::StatusCode::OK)
+            .body(EdgeBody::empty())
+            .expect("should build response")
+    }
+
     #[test]
     fn set_response_headers_sets_all_geo_headers() {
         let geo = sample_geo_info();
-        let mut response = Response::new();
+        let mut response = build_response();
 
         geo.set_response_headers(&mut response);
 
         assert_eq!(
             response
-                .get_header(HEADER_X_GEO_CITY)
+                .headers()
+                .get(HEADER_X_GEO_CITY)
                 .expect("should have city header")
                 .to_str()
                 .expect("should be valid str"),
@@ -156,7 +159,8 @@ mod tests {
         );
         assert_eq!(
             response
-                .get_header(HEADER_X_GEO_COUNTRY)
+                .headers()
+                .get(HEADER_X_GEO_COUNTRY)
                 .expect("should have country header")
                 .to_str()
                 .expect("should be valid str"),
@@ -165,7 +169,8 @@ mod tests {
         );
         assert_eq!(
             response
-                .get_header(HEADER_X_GEO_CONTINENT)
+                .headers()
+                .get(HEADER_X_GEO_CONTINENT)
                 .expect("should have continent header")
                 .to_str()
                 .expect("should be valid str"),
@@ -174,7 +179,8 @@ mod tests {
         );
         assert_eq!(
             response
-                .get_header(HEADER_X_GEO_COORDINATES)
+                .headers()
+                .get(HEADER_X_GEO_COORDINATES)
                 .expect("should have coordinates header")
                 .to_str()
                 .expect("should be valid str"),
@@ -183,7 +189,8 @@ mod tests {
         );
         assert_eq!(
             response
-                .get_header(HEADER_X_GEO_METRO_CODE)
+                .headers()
+                .get(HEADER_X_GEO_METRO_CODE)
                 .expect("should have metro code header")
                 .to_str()
                 .expect("should be valid str"),
@@ -192,7 +199,8 @@ mod tests {
         );
         assert_eq!(
             response
-                .get_header(HEADER_X_GEO_REGION)
+                .headers()
+                .get(HEADER_X_GEO_REGION)
                 .expect("should have region header")
                 .to_str()
                 .expect("should be valid str"),
@@ -201,7 +209,8 @@ mod tests {
         );
         assert_eq!(
             response
-                .get_header(HEADER_X_GEO_INFO_AVAILABLE)
+                .headers()
+                .get(HEADER_X_GEO_INFO_AVAILABLE)
                 .expect("should have info available header")
                 .to_str()
                 .expect("should be valid str"),
@@ -216,16 +225,16 @@ mod tests {
             metro_code: 0,
             ..sample_geo_info()
         };
-        let mut response = Response::new();
+        let mut response = build_response();
 
         geo.set_response_headers(&mut response);
 
         assert!(
-            response.get_header(HEADER_X_GEO_METRO_CODE).is_none(),
+            response.headers().get(HEADER_X_GEO_METRO_CODE).is_none(),
             "should not set metro code header when metro_code is 0"
         );
         assert!(
-            response.get_header(HEADER_X_GEO_CITY).is_some(),
+            response.headers().get(HEADER_X_GEO_CITY).is_some(),
             "should still set city header"
         );
     }
@@ -269,21 +278,22 @@ mod tests {
             region: None,
             ..sample_geo_info()
         };
-        let mut response = Response::new();
+        let mut response = build_response();
 
         geo.set_response_headers(&mut response);
 
         assert!(
-            response.get_header(HEADER_X_GEO_REGION).is_none(),
+            response.headers().get(HEADER_X_GEO_REGION).is_none(),
             "should not set region header when region is None"
         );
         assert!(
-            response.get_header(HEADER_X_GEO_CITY).is_some(),
+            response.headers().get(HEADER_X_GEO_CITY).is_some(),
             "should still set city header"
         );
         assert_eq!(
             response
-                .get_header(HEADER_X_GEO_INFO_AVAILABLE)
+                .headers()
+                .get(HEADER_X_GEO_INFO_AVAILABLE)
                 .expect("should have info available header")
                 .to_str()
                 .expect("should be valid str"),

--- a/crates/trusted-server-core/src/host_header.rs
+++ b/crates/trusted-server-core/src/host_header.rs
@@ -1,0 +1,221 @@
+//! Validation for operator-configured outbound `Host` header overrides.
+//!
+//! These helpers intentionally validate only configuration values. Request input
+//! must not flow into this module because outbound `Host` controls origin
+//! routing and SigV4-style signing decisions.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Validate an outbound `Host` header override value.
+///
+/// Accepts only a DNS name, IPv4 address, or bracketed IPv6 literal with an
+/// optional port. Rejects schemes, userinfo, paths, queries, fragments,
+/// whitespace, control characters, and malformed ports so a configured override
+/// cannot smuggle additional URL components into the upstream request.
+///
+/// # Errors
+///
+/// Returns a static validation reason when the value is not a valid `Host`
+/// header override.
+pub(crate) fn validate_host_header_override_value(value: &str) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("must not be empty");
+    }
+    if value.trim() != value {
+        return Err("must not include leading or trailing whitespace");
+    }
+    if value.contains("://") {
+        return Err("must not include a scheme");
+    }
+    if value.contains(['/', '\\', '?', '#', '@']) {
+        return Err("must not include userinfo, path, query, or fragment");
+    }
+    if value
+        .chars()
+        .any(|ch| ch.is_control() || ch.is_whitespace())
+    {
+        return Err("must not contain whitespace or control characters");
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | ':' | '[' | ']'))
+    {
+        return Err("contains invalid characters");
+    }
+
+    if value.starts_with('[') {
+        validate_ipv6_literal_host(value)
+    } else {
+        validate_dns_or_ipv4_host_with_optional_port(value)
+    }
+}
+
+fn validate_ipv6_literal_host(value: &str) -> Result<(), &'static str> {
+    let closing_bracket = value
+        .find(']')
+        .ok_or("IPv6 literals must be enclosed in brackets")?;
+    let host = &value[1..closing_bracket];
+    if host.is_empty() {
+        return Err("must include a host");
+    }
+    if host.parse::<Ipv6Addr>().is_err() {
+        return Err("invalid IPv6 address");
+    }
+
+    validate_port_suffix(&value[closing_bracket + 1..])
+}
+
+fn validate_port_suffix(value: &str) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Ok(());
+    }
+
+    let port = value
+        .strip_prefix(':')
+        .ok_or("only an optional :port may follow the host")?;
+    validate_port(port)
+}
+
+fn validate_dns_or_ipv4_host_with_optional_port(value: &str) -> Result<(), &'static str> {
+    if value.contains(['[', ']']) {
+        return Err("IPv6 literals must be enclosed in brackets");
+    }
+
+    let (host, port) = split_host_and_port(value)?;
+    validate_dns_or_ipv4_host(host)?;
+    if let Some(port) = port {
+        validate_port(port)?;
+    }
+
+    Ok(())
+}
+
+fn split_host_and_port(value: &str) -> Result<(&str, Option<&str>), &'static str> {
+    if let Some((host, port)) = value.rsplit_once(':') {
+        if host.contains(':') {
+            return Err("IPv6 literals must be enclosed in brackets");
+        }
+        if host.is_empty() {
+            return Err("must include a host");
+        }
+        return Ok((host, Some(port)));
+    }
+
+    if value.contains(':') {
+        return Err("IPv6 literals must be enclosed in brackets");
+    }
+
+    Ok((value, None))
+}
+
+fn validate_dns_or_ipv4_host(host: &str) -> Result<(), &'static str> {
+    if host.is_empty() {
+        return Err("must include a host");
+    }
+    if host.len() > 253 {
+        return Err("host is too long");
+    }
+
+    if host.contains('.') && host.chars().all(|ch| ch.is_ascii_digit() || ch == '.') {
+        return host
+            .parse::<Ipv4Addr>()
+            .map(|_| ())
+            .map_err(|_| "invalid IPv4 address");
+    }
+
+    for label in host.split('.') {
+        if label.is_empty() {
+            return Err("host labels must not be empty");
+        }
+        if label.len() > 63 {
+            return Err("host labels must not exceed 63 characters");
+        }
+        let bytes = label.as_bytes();
+        if bytes.first() == Some(&b'-') || bytes.last() == Some(&b'-') {
+            return Err("host labels must not start or end with '-'");
+        }
+        if !bytes
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
+        {
+            return Err("host labels may only contain ASCII letters, digits, or '-'");
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_port(port: &str) -> Result<(), &'static str> {
+    if port.is_empty() {
+        return Err("port must not be empty");
+    }
+    if !port.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err("port must contain only digits");
+    }
+
+    match port.parse::<u16>() {
+        Ok(0) => Err("port must be between 1 and 65535"),
+        Ok(_) => Ok(()),
+        Err(_) => Err("port must be between 1 and 65535"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_host_header_override_value;
+
+    #[test]
+    fn accepts_valid_host_header_override_values() {
+        for value in [
+            "www.example.com",
+            "www.example.com:8443",
+            "localhost",
+            "localhost:9090",
+            "192.168.1.1",
+            "192.168.1.1:8080",
+            "[::1]",
+            "[::1]:8443",
+            "[2001:db8::1]",
+        ] {
+            assert!(
+                validate_host_header_override_value(value).is_ok(),
+                "{value:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_host_header_override_values() {
+        for value in [
+            "",
+            " www.example.com",
+            "www.example.com ",
+            "https://www.example.com",
+            "www.example.com/path",
+            "www.example.com?query=1",
+            "www.example.com#fragment",
+            "user@www.example.com",
+            "www.example.com\n",
+            "www.example.com:",
+            "www.example.com:0",
+            "www.example.com:99999",
+            "example..com",
+            ".example.com",
+            "example.com.",
+            "-",
+            "-example.com",
+            "example-.com",
+            "999.999.999.999",
+            "::1",
+            "[::1",
+            "[::1]suffix",
+            "[not-ipv6]",
+            "www_example.com",
+        ] {
+            assert!(
+                validate_host_header_override_value(value).is_err(),
+                "{value:?} should be rejected"
+            );
+        }
+    }
+}

--- a/crates/trusted-server-core/src/host_rewrite.rs
+++ b/crates/trusted-server-core/src/host_rewrite.rs
@@ -1,6 +1,9 @@
 /// Rewrite bare host occurrences (e.g. `origin.example.com/news`) only when the match is a full
 /// hostname token, not part of a larger hostname like `cdn.origin.example.com`.
 ///
+/// A numeric `:port` immediately after the host is treated as part of a standalone authority and
+/// is preserved when rewriting the host.
+///
 /// This is used by both HTML (`__next_f` payloads) and Flight (`text/x-component`) rewriting to
 /// avoid corrupting unrelated hostnames.
 pub(crate) fn rewrite_bare_host_at_boundaries(
@@ -16,6 +19,15 @@ pub(crate) fn rewrite_bare_host_at_boundaries(
         byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b':')
     }
 
+    fn has_valid_port_boundary(bytes: &[u8], port_start: usize) -> bool {
+        let mut index = port_start;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+
+        index > port_start && (index == bytes.len() || !is_host_char(bytes[index]))
+    }
+
     let origin_len = origin_host.len();
     let bytes = text.as_bytes();
     let mut out = String::with_capacity(text.len());
@@ -27,7 +39,12 @@ pub(crate) fn rewrite_bare_host_at_boundaries(
         let end = pos + origin_len;
 
         let before_ok = pos == 0 || !is_host_char(bytes[pos - 1]);
-        let after_ok = end == bytes.len() || !is_host_char(bytes[end]);
+        let after_ok = end == bytes.len()
+            || if bytes[end] == b':' {
+                has_valid_port_boundary(bytes, end + 1)
+            } else {
+                !is_host_char(bytes[end])
+            };
 
         if before_ok && after_ok {
             out.push_str(&text[search..pos]);
@@ -46,4 +63,100 @@ pub(crate) fn rewrite_bare_host_at_boundaries(
 
     out.push_str(&text[search..]);
     Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ORIGIN_HOST: &str = "origin.example.com";
+    const REQUEST_HOST: &str = "proxy.example.com";
+
+    fn rewrite(text: &str) -> Option<String> {
+        rewrite_bare_host_at_boundaries(text, ORIGIN_HOST, REQUEST_HOST)
+    }
+
+    #[test]
+    fn rewrites_exact_host() {
+        assert_eq!(
+            rewrite(ORIGIN_HOST),
+            Some(REQUEST_HOST.to_string()),
+            "should rewrite a host that spans the whole input"
+        );
+    }
+
+    #[test]
+    fn rewrites_valid_boundary_separators() {
+        let input = r#"("origin.example.com"), origin.example.com/path origin.example.com?x=1 origin.example.com#frag"#;
+        let expected = r#"("proxy.example.com"), proxy.example.com/path proxy.example.com?x=1 proxy.example.com#frag"#;
+
+        assert_eq!(
+            rewrite(input),
+            Some(expected.to_string()),
+            "should rewrite hosts followed by punctuation and URL separators"
+        );
+    }
+
+    #[test]
+    fn rewrites_multiple_occurrences() {
+        assert_eq!(
+            rewrite("origin.example.com origin.example.com/news origin.example.com?x=1"),
+            Some("proxy.example.com proxy.example.com/news proxy.example.com?x=1".to_string()),
+            "should rewrite every standalone occurrence"
+        );
+    }
+
+    #[test]
+    fn returns_none_for_empty_input_or_missing_origin() {
+        assert_eq!(rewrite(""), None, "should ignore empty input");
+        assert_eq!(
+            rewrite("other.example.com/news"),
+            None,
+            "should ignore input without the origin host"
+        );
+        assert_eq!(
+            rewrite_bare_host_at_boundaries("origin.example.com", "", REQUEST_HOST),
+            None,
+            "should ignore an empty origin host"
+        );
+        assert_eq!(
+            rewrite_bare_host_at_boundaries("origin.example.com", ORIGIN_HOST, ""),
+            None,
+            "should ignore an empty request host"
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_larger_hostname_tokens() {
+        let input = "cdn.origin.example.com notorigin.example.com origin.example.com.evil origin.example.com-extra origin.example.comextra";
+
+        assert_eq!(
+            rewrite(input),
+            None,
+            "should not rewrite subdomains, embedded words, or larger hostname tokens"
+        );
+    }
+
+    #[test]
+    fn rewrites_host_with_valid_numeric_port() {
+        let input = "origin.example.com:8443/path origin.example.com:9443?x=1 origin.example.com:443#frag origin.example.com:8080";
+        let expected = "proxy.example.com:8443/path proxy.example.com:9443?x=1 proxy.example.com:443#frag proxy.example.com:8080";
+
+        assert_eq!(
+            rewrite(input),
+            Some(expected.to_string()),
+            "should rewrite a standalone host while preserving a numeric port"
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_invalid_port_like_suffixes() {
+        let input = "origin.example.com:not-a-port origin.example.com:8443evil origin.example.com:8443.evil origin.example.com:";
+
+        assert_eq!(
+            rewrite(input),
+            None,
+            "should not treat arbitrary colon suffixes as host boundaries"
+        );
+    }
 }

--- a/crates/trusted-server-core/src/host_rewrite.rs
+++ b/crates/trusted-server-core/src/host_rewrite.rs
@@ -47,3 +47,143 @@ pub(crate) fn rewrite_bare_host_at_boundaries(
     out.push_str(&text[search..]);
     Some(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ORIGIN_HOST: &str = "origin.example.com";
+    const REQUEST_HOST: &str = "proxy.example.com";
+
+    fn assert_rewrite(input: &str, expected: &str) {
+        assert_eq!(
+            rewrite_bare_host_at_boundaries(input, ORIGIN_HOST, REQUEST_HOST),
+            Some(expected.to_string()),
+            "should rewrite bare host at valid boundaries"
+        );
+    }
+
+    fn assert_no_rewrite(input: &str, message: &str) {
+        assert_eq!(
+            rewrite_bare_host_at_boundaries(input, ORIGIN_HOST, REQUEST_HOST),
+            None,
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn returns_none_when_origin_or_request_host_is_empty() {
+        assert_eq!(
+            rewrite_bare_host_at_boundaries("origin.example.com", "", REQUEST_HOST),
+            None,
+            "should ignore empty origin host"
+        );
+        assert_eq!(
+            rewrite_bare_host_at_boundaries("origin.example.com", ORIGIN_HOST, ""),
+            None,
+            "should ignore empty request host"
+        );
+    }
+
+    #[test]
+    fn returns_none_when_origin_host_is_absent() {
+        assert_no_rewrite(
+            "https://other.example.com/news",
+            "should return none when origin host is absent",
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_differently_cased_host() {
+        assert_no_rewrite(
+            "ORIGIN.EXAMPLE.COM/news",
+            "should not rewrite differently-cased host occurrences",
+        );
+    }
+
+    #[test]
+    fn rewrites_exact_bare_host() {
+        assert_rewrite("origin.example.com", "proxy.example.com");
+    }
+
+    #[test]
+    fn rewrites_bare_host_with_path_query_and_fragment() {
+        assert_rewrite(
+            "origin.example.com/news?x=1#top",
+            "proxy.example.com/news?x=1#top",
+        );
+    }
+
+    #[test]
+    fn rewrites_bare_host_as_path_segment() {
+        assert_rewrite(
+            "https://cdn.example.com/assets/origin.example.com/image.png",
+            "https://cdn.example.com/assets/proxy.example.com/image.png",
+        );
+    }
+
+    #[test]
+    fn rewrites_multiple_valid_occurrences() {
+        assert_rewrite(
+            "origin.example.com/a and origin.example.com/b",
+            "proxy.example.com/a and proxy.example.com/b",
+        );
+    }
+
+    #[test]
+    fn rewrites_hosts_surrounded_by_punctuation_and_whitespace() {
+        assert_rewrite(
+            r#"{"host":"origin.example.com", "next": (origin.example.com) }"#,
+            r#"{"host":"proxy.example.com", "next": (proxy.example.com) }"#,
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_subdomains_or_embedded_prefixes() {
+        assert_no_rewrite(
+            "cdn.origin.example.com",
+            "should not rewrite host embedded in a subdomain",
+        );
+        assert_no_rewrite(
+            "notorigin.example.com",
+            "should not rewrite host embedded in a larger host token",
+        );
+        assert_no_rewrite(
+            "foo-origin.example.com",
+            "should not rewrite host preceded by host-character punctuation",
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_suffix_domains_or_host_char_continuations() {
+        assert_no_rewrite(
+            "origin.example.com.uk",
+            "should not rewrite host followed by a domain suffix",
+        );
+        assert_no_rewrite(
+            "origin.example.com-prod",
+            "should not rewrite host followed by host-character punctuation",
+        );
+    }
+
+    #[test]
+    fn rewrites_origin_host_with_port_when_origin_includes_port() {
+        assert_eq!(
+            rewrite_bare_host_at_boundaries(
+                "origin.example.com:8443/path",
+                "origin.example.com:8443",
+                REQUEST_HOST,
+            ),
+            Some("proxy.example.com/path".to_string()),
+            "should rewrite host and port when origin host includes the port"
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_host_with_port_when_origin_omits_port() {
+        assert_no_rewrite(
+            "origin.example.com:8443/path",
+            "should not rewrite host with port when origin omits port",
+        );
+    }
+}

--- a/crates/trusted-server-core/src/host_rewrite.rs
+++ b/crates/trusted-server-core/src/host_rewrite.rs
@@ -1,6 +1,9 @@
 /// Rewrite bare host occurrences (e.g. `origin.example.com/news`) only when the match is a full
 /// hostname token, not part of a larger hostname like `cdn.origin.example.com`.
 ///
+/// A numeric `:port` immediately after the host is treated as part of a standalone authority and
+/// is preserved when rewriting the host.
+///
 /// This is used by both HTML (`__next_f` payloads) and Flight (`text/x-component`) rewriting to
 /// avoid corrupting unrelated hostnames.
 pub(crate) fn rewrite_bare_host_at_boundaries(
@@ -16,6 +19,15 @@ pub(crate) fn rewrite_bare_host_at_boundaries(
         byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b':')
     }
 
+    fn has_valid_port_boundary(bytes: &[u8], port_start: usize) -> bool {
+        let mut index = port_start;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+
+        index > port_start && (index == bytes.len() || !is_host_char(bytes[index]))
+    }
+
     let origin_len = origin_host.len();
     let bytes = text.as_bytes();
     let mut out = String::with_capacity(text.len());
@@ -27,7 +39,12 @@ pub(crate) fn rewrite_bare_host_at_boundaries(
         let end = pos + origin_len;
 
         let before_ok = pos == 0 || !is_host_char(bytes[pos - 1]);
-        let after_ok = end == bytes.len() || !is_host_char(bytes[end]);
+        let after_ok = end == bytes.len()
+            || if bytes[end] == b':' {
+                has_valid_port_boundary(bytes, end + 1)
+            } else {
+                !is_host_char(bytes[end])
+            };
 
         if before_ok && after_ok {
             out.push_str(&text[search..pos]);
@@ -86,6 +103,11 @@ mod tests {
     }
 
     #[test]
+    fn returns_none_when_input_is_empty() {
+        assert_no_rewrite("", "should ignore empty input");
+    }
+
+    #[test]
     fn returns_none_when_origin_host_is_absent() {
         assert_no_rewrite(
             "https://other.example.com/news",
@@ -111,6 +133,14 @@ mod tests {
         assert_rewrite(
             "origin.example.com/news?x=1#top",
             "proxy.example.com/news?x=1#top",
+        );
+    }
+
+    #[test]
+    fn rewrites_bare_host_with_url_separators() {
+        assert_rewrite(
+            "origin.example.com/path origin.example.com?x=1 origin.example.com#frag",
+            "proxy.example.com/path proxy.example.com?x=1 proxy.example.com#frag",
         );
     }
 
@@ -164,6 +194,10 @@ mod tests {
             "origin.example.com-prod",
             "should not rewrite host followed by host-character punctuation",
         );
+        assert_no_rewrite(
+            "origin.example.comextra",
+            "should not rewrite host followed by a larger host token",
+        );
     }
 
     #[test]
@@ -180,10 +214,30 @@ mod tests {
     }
 
     #[test]
-    fn does_not_rewrite_host_with_port_when_origin_omits_port() {
+    fn rewrites_host_with_valid_numeric_port_when_origin_omits_port() {
+        assert_rewrite(
+            "origin.example.com:8443/path origin.example.com:9443?x=1 origin.example.com:443#frag origin.example.com:8080 (origin.example.com:5000)",
+            "proxy.example.com:8443/path proxy.example.com:9443?x=1 proxy.example.com:443#frag proxy.example.com:8080 (proxy.example.com:5000)",
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_invalid_port_like_suffixes() {
         assert_no_rewrite(
-            "origin.example.com:8443/path",
-            "should not rewrite host with port when origin omits port",
+            "origin.example.com:not-a-port",
+            "should not treat a non-numeric suffix as a port",
+        );
+        assert_no_rewrite(
+            "origin.example.com:8443evil",
+            "should not treat a port with a trailing word as a boundary",
+        );
+        assert_no_rewrite(
+            "origin.example.com:8443.evil",
+            "should not treat a port with a trailing dot as a boundary",
+        );
+        assert_no_rewrite(
+            "origin.example.com:",
+            "should not treat an empty port as a boundary",
         );
     }
 }

--- a/crates/trusted-server-core/src/host_rewrite.rs
+++ b/crates/trusted-server-core/src/host_rewrite.rs
@@ -128,19 +128,37 @@ mod tests {
 
     #[test]
     fn does_not_rewrite_larger_hostname_tokens() {
-        let input = "cdn.origin.example.com notorigin.example.com origin.example.com.evil origin.example.com-extra origin.example.comextra";
-
         assert_eq!(
-            rewrite(input),
+            rewrite("cdn.origin.example.com"),
             None,
-            "should not rewrite subdomains, embedded words, or larger hostname tokens"
+            "should not rewrite a subdomain prefix"
+        );
+        assert_eq!(
+            rewrite("notorigin.example.com"),
+            None,
+            "should not rewrite an embedded-word prefix"
+        );
+        assert_eq!(
+            rewrite("origin.example.com.evil"),
+            None,
+            "should not rewrite a trailing-dot label"
+        );
+        assert_eq!(
+            rewrite("origin.example.com-extra"),
+            None,
+            "should not rewrite a trailing-hyphen token"
+        );
+        assert_eq!(
+            rewrite("origin.example.comextra"),
+            None,
+            "should not rewrite a trailing-word token"
         );
     }
 
     #[test]
     fn rewrites_host_with_valid_numeric_port() {
-        let input = "origin.example.com:8443/path origin.example.com:9443?x=1 origin.example.com:443#frag origin.example.com:8080";
-        let expected = "proxy.example.com:8443/path proxy.example.com:9443?x=1 proxy.example.com:443#frag proxy.example.com:8080";
+        let input = "origin.example.com:8443/path origin.example.com:9443?x=1 origin.example.com:443#frag origin.example.com:8080 (origin.example.com:5000)";
+        let expected = "proxy.example.com:8443/path proxy.example.com:9443?x=1 proxy.example.com:443#frag proxy.example.com:8080 (proxy.example.com:5000)";
 
         assert_eq!(
             rewrite(input),
@@ -151,12 +169,25 @@ mod tests {
 
     #[test]
     fn does_not_rewrite_invalid_port_like_suffixes() {
-        let input = "origin.example.com:not-a-port origin.example.com:8443evil origin.example.com:8443.evil origin.example.com:";
-
         assert_eq!(
-            rewrite(input),
+            rewrite("origin.example.com:not-a-port"),
             None,
-            "should not treat arbitrary colon suffixes as host boundaries"
+            "should not treat a non-numeric suffix as a port"
+        );
+        assert_eq!(
+            rewrite("origin.example.com:8443evil"),
+            None,
+            "should not treat a port with a trailing word as a boundary"
+        );
+        assert_eq!(
+            rewrite("origin.example.com:8443.evil"),
+            None,
+            "should not treat a port with a trailing dot as a boundary"
+        );
+        assert_eq!(
+            rewrite("origin.example.com:"),
+            None,
+            "should not treat an empty port as a boundary"
         );
     }
 }

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -94,13 +94,7 @@ impl StreamProcessor for HtmlWithPostProcessing {
         }
 
         if changed {
-            // lgtm[rust/cleartext-logging]
-            // This debug log records hostnames and output length only; no sensitive values are logged.
-            log::debug!(
-                "HTML post-processing complete: origin_host={}, output_len={}",
-                self.origin_host,
-                html.len()
-            );
+            log::debug!("HTML post-processing complete: output_len={}", html.len());
         }
 
         Ok(html.into_bytes())

--- a/crates/trusted-server-core/src/http_util.rs
+++ b/crates/trusted-server-core/src/http_util.rs
@@ -1,11 +1,13 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chacha20poly1305::{aead::Aead, aead::KeyInit, XChaCha20Poly1305, XNonce};
 use edgezero_core::body::Body as EdgeBody;
+use error_stack::Report;
 use http::{header, Request, Response, StatusCode};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq as _;
 
 use crate::constants::INTERNAL_HEADERS;
+use crate::error::TrustedServerError;
 use crate::platform::ClientInfo;
 use crate::settings::Settings;
 
@@ -442,6 +444,27 @@ pub fn compute_encrypted_sha256_token(settings: &Settings, full_url: &str) -> St
         .expect("decode must succeed for just-encoded data");
     let digest = Sha256::digest(&raw);
     URL_SAFE_NO_PAD.encode(digest)
+}
+
+/// Return an error if `bytes` exceeds `limit`.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError::RequestTooLarge`] when `bytes.len() > limit`.
+pub fn enforce_max_body_size(
+    bytes: &[u8],
+    limit: usize,
+    what: &str,
+) -> Result<(), Report<TrustedServerError>> {
+    if bytes.len() > limit {
+        return Err(Report::new(TrustedServerError::RequestTooLarge {
+            message: format!(
+                "{what} payload {} exceeds limit of {limit} bytes",
+                bytes.len()
+            ),
+        }));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/trusted-server-core/src/integrations/adserver_mock.rs
+++ b/crates/trusted-server-core/src/integrations/adserver_mock.rs
@@ -4,9 +4,10 @@
 //! This integration acts as a mediator in the auction flow, selecting winning bids
 //! based on price (highest price wins).
 
+use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::Method;
-use fastly::Request;
+use http::{header, Method};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as Json};
 use std::collections::{BTreeMap, HashMap};
@@ -21,6 +22,10 @@ use crate::auction::types::{
 };
 use crate::backend::BackendConfig;
 use crate::error::TrustedServerError;
+use crate::integrations::{
+    collect_response_bounded, ensure_integration_backend, UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+};
+use crate::platform::{PlatformHttpRequest, PlatformPendingRequest, PlatformResponse};
 use crate::settings::{IntegrationConfig, Settings};
 
 // ============================================================================
@@ -269,16 +274,17 @@ impl AdServerMockProvider {
     }
 }
 
+#[async_trait(?Send)]
 impl AuctionProvider for AdServerMockProvider {
     fn provider_name(&self) -> &'static str {
         "adserver_mock"
     }
 
-    fn request_bids(
+    async fn request_bids(
         &self,
         request: &AuctionRequest,
         context: &AuctionContext<'_>,
-    ) -> Result<fastly::http::request::PendingRequest, Report<TrustedServerError>> {
+    ) -> Result<PlatformPendingRequest, Report<TrustedServerError>> {
         // Get bidder responses from context (passed by orchestrator for mediation)
         let bidder_responses = context.provider_responses.unwrap_or(&[]);
 
@@ -301,7 +307,18 @@ impl AuctionProvider for AdServerMockProvider {
         let endpoint_url = self.build_endpoint_url(request);
 
         // Create HTTP POST request
-        let mut req = Request::new(Method::POST, &endpoint_url);
+        let mediation_body =
+            serde_json::to_vec(&mediation_req).change_context(TrustedServerError::Auction {
+                message: "Failed to serialize mediation request".to_string(),
+            })?;
+        let mut req = http::Request::builder()
+            .method(Method::POST)
+            .uri(&endpoint_url)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(EdgeBody::from(mediation_body))
+            .change_context(TrustedServerError::Auction {
+                message: "Failed to build mediation request".to_string(),
+            })?;
 
         // Set Host header with port to ensure mocktioneer generates correct iframe URLs
         if let Ok(url) = url::Url::parse(&self.config.endpoint) {
@@ -311,30 +328,33 @@ impl AuctionProvider for AdServerMockProvider {
                 } else {
                     host.to_string()
                 };
-                req.set_header("Host", &host_with_port);
+                match header::HeaderValue::from_str(&host_with_port) {
+                    Ok(value) => {
+                        req.headers_mut().insert(header::HOST, value);
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to build Host header for '{}': {}",
+                            host_with_port,
+                            e
+                        );
+                    }
+                }
             }
         }
 
-        req.set_body_json(&mediation_req)
-            .change_context(TrustedServerError::Auction {
-                message: "Failed to set mediation request body".to_string(),
-            })?;
-
-        // Send async with auction-scoped timeout
-        let backend_name = BackendConfig::from_url_with_first_byte_timeout(
+        let backend_name = ensure_integration_backend(
+            context.services,
             &self.config.endpoint,
-            true,
-            Duration::from_millis(u64::from(context.timeout_ms)),
-        )
-        .change_context(TrustedServerError::Auction {
-            message: format!(
-                "Failed to resolve backend for mediation endpoint: {}",
-                self.config.endpoint
-            ),
-        })?;
+            "adserver_mock",
+            Some(Duration::from_millis(u64::from(context.timeout_ms))),
+        )?;
 
-        let pending = req
-            .send_async(backend_name)
+        let pending = context
+            .services
+            .http_client()
+            .send_async(PlatformHttpRequest::new(req, backend_name))
+            .await
             .change_context(TrustedServerError::Auction {
                 message: "Failed to send mediation request".to_string(),
             })?;
@@ -342,20 +362,28 @@ impl AuctionProvider for AdServerMockProvider {
         Ok(pending)
     }
 
-    fn parse_response(
+    async fn parse_response(
         &self,
-        mut response: fastly::Response,
+        response: PlatformResponse,
         response_time_ms: u64,
     ) -> Result<AuctionResponse, Report<TrustedServerError>> {
-        if !response.get_status().is_success() {
-            log::warn!(
-                "AdServer Mock returned non-success: {}",
-                response.get_status()
-            );
+        let response = response.response;
+
+        if !response.status().is_success() {
+            log::warn!("AdServer Mock returned non-success: {}", response.status());
             return Ok(AuctionResponse::error("adserver_mock", response_time_ms));
         }
 
-        let body_bytes = response.take_body_bytes();
+        // collect_response_bounded caps memory from misbehaving providers.
+        let body_bytes = collect_response_bounded(
+            response.into_body(),
+            UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+            "adserver_mock",
+        )
+        .await
+        .change_context(TrustedServerError::Auction {
+            message: "Failed to read AdServer Mock response body".to_string(),
+        })?;
         let response_json: Json =
             serde_json::from_slice(&body_bytes).change_context(TrustedServerError::Auction {
                 message: "Failed to parse mediation response".to_string(),

--- a/crates/trusted-server-core/src/integrations/aps.rs
+++ b/crates/trusted-server-core/src/integrations/aps.rs
@@ -2,9 +2,10 @@
 //!
 //! This module provides the APS auction provider for server-side bidding.
 
+use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::Method;
-use fastly::Request;
+use http::{header, Method};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as Json};
 use std::collections::HashMap;
@@ -15,6 +16,10 @@ use crate::auction::provider::AuctionProvider;
 use crate::auction::types::{AuctionContext, AuctionRequest, AuctionResponse, Bid, MediaType};
 use crate::backend::BackendConfig;
 use crate::error::TrustedServerError;
+use crate::integrations::{
+    collect_response_bounded, ensure_integration_backend, UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+};
+use crate::platform::{PlatformHttpRequest, PlatformPendingRequest, PlatformResponse};
 use crate::settings::IntegrationConfig;
 
 // ============================================================================
@@ -468,16 +473,17 @@ impl ApsAuctionProvider {
     }
 }
 
+#[async_trait(?Send)]
 impl AuctionProvider for ApsAuctionProvider {
     fn provider_name(&self) -> &'static str {
         "aps"
     }
 
-    fn request_bids(
+    async fn request_bids(
         &self,
         request: &AuctionRequest,
         context: &AuctionContext<'_>,
-    ) -> Result<fastly::http::request::PendingRequest, Report<TrustedServerError>> {
+    ) -> Result<PlatformPendingRequest, Report<TrustedServerError>> {
         log::info!(
             "APS: requesting bids for {} slots (pub_id: {})",
             request.slots.len(),
@@ -496,50 +502,58 @@ impl AuctionProvider for ApsAuctionProvider {
         log::trace!("APS: sending bid request: {:?}", aps_json);
 
         // Create HTTP POST request
-        let mut aps_req = Request::new(Method::POST, &self.config.endpoint);
-
-        aps_req
-            .set_body_json(&aps_json)
+        let aps_body =
+            serde_json::to_vec(&aps_json).change_context(TrustedServerError::Auction {
+                message: "Failed to serialize APS request body".to_string(),
+            })?;
+        let aps_req = http::Request::builder()
+            .method(Method::POST)
+            .uri(&self.config.endpoint)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(EdgeBody::from(aps_body))
             .change_context(TrustedServerError::Auction {
-                message: "Failed to set APS request body".to_string(),
+                message: "Failed to build APS request".to_string(),
             })?;
 
-        // Send request asynchronously with auction-scoped timeout
-        let backend_name = BackendConfig::from_url_with_first_byte_timeout(
+        let backend_name = ensure_integration_backend(
+            context.services,
             &self.config.endpoint,
-            true,
-            Duration::from_millis(u64::from(context.timeout_ms)),
-        )
-        .change_context(TrustedServerError::Auction {
-            message: format!(
-                "Failed to resolve backend for APS endpoint: {}",
-                self.config.endpoint
-            ),
-        })?;
+            "aps",
+            Some(Duration::from_millis(u64::from(context.timeout_ms))),
+        )?;
 
-        let pending =
-            aps_req
-                .send_async(backend_name)
-                .change_context(TrustedServerError::Auction {
-                    message: "Failed to send async request to APS".to_string(),
-                })?;
+        let pending = context
+            .services
+            .http_client()
+            .send_async(PlatformHttpRequest::new(aps_req, backend_name))
+            .await
+            .change_context(TrustedServerError::Auction {
+                message: "Failed to send async request to APS".to_string(),
+            })?;
 
         Ok(pending)
     }
 
-    fn parse_response(
+    async fn parse_response(
         &self,
-        mut response: fastly::Response,
+        response: PlatformResponse,
         response_time_ms: u64,
     ) -> Result<AuctionResponse, Report<TrustedServerError>> {
+        let response = response.response;
+
         // Check status code
-        if !response.get_status().is_success() {
-            log::warn!("APS returned non-success status: {}", response.get_status());
+        if !response.status().is_success() {
+            log::warn!("APS returned non-success status: {}", response.status());
             return Ok(AuctionResponse::error("aps", response_time_ms));
         }
 
-        // Parse response body
-        let body_bytes = response.take_body_bytes();
+        // Parse response body — collect_response_bounded caps memory from misbehaving providers.
+        let body_bytes =
+            collect_response_bounded(response.into_body(), UPSTREAM_RTB_MAX_RESPONSE_BYTES, "aps")
+                .await
+                .change_context(TrustedServerError::Auction {
+                    message: "Failed to read APS response body".to_string(),
+                })?;
         let response_json: Json =
             serde_json::from_slice(&body_bytes).change_context(TrustedServerError::Auction {
                 message: "Failed to parse APS response JSON".to_string(),

--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -42,7 +42,7 @@
 //!
 //! 1. **SDK Loading**: Browser requests `/integrations/datadome/tags.js`
 //! 2. **Proxy & Rewrite**: Trusted Server fetches from `js.datadome.co`, rewrites internal
-//!    URLs to first-party paths using [`DATADOME_URL_PATTERN`]
+//!    URLs to first-party paths using `DATADOME_URL_PATTERN`
 //! 3. **Signal Collection**: SDK sends signals to `/integrations/datadome/js/`
 //! 4. **Transparent Proxy**: Trusted Server forwards to `api-js.datadome.co`, returns response
 //!
@@ -71,6 +71,7 @@ use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
 };
+use crate::platform::RuntimeServices;
 use crate::settings::{IntegrationConfig, Settings};
 
 const DATADOME_INTEGRATION_ID: &str = "datadome";
@@ -404,6 +405,7 @@ impl IntegrationProxy for DataDomeIntegration {
     async fn handle(
         &self,
         _settings: &Settings,
+        _services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path();

--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -58,20 +58,22 @@
 use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, Method, StatusCode};
-use fastly::{Request, Response};
+use http::header;
+use http::{Method, StatusCode};
 use regex::Regex;
 use serde::Deserialize;
 use validator::Validate;
 
-use crate::backend::BackendConfig;
 use crate::error::TrustedServerError;
 use crate::integrations::{
+    collect_body_bounded, collect_response_bounded, ensure_integration_backend,
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
+    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
+    UPSTREAM_SDK_MAX_RESPONSE_BYTES,
 };
-use crate::platform::RuntimeServices;
+use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
 
 const DATADOME_INTEGRATION_ID: &str = "datadome";
@@ -249,122 +251,163 @@ impl DataDomeIntegration {
     }
 
     /// Handle the /tags.js endpoint - fetch and rewrite the `DataDome` SDK.
-    async fn handle_tags_js(&self, req: Request) -> Result<Response, Report<TrustedServerError>> {
-        let target_url = self.build_sdk_url("/tags.js", req.get_query_str());
+    async fn handle_tags_js(
+        &self,
+        services: &RuntimeServices,
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let target_url = self.build_sdk_url("/tags.js", req.uri().query());
 
         log::info!("[datadome] Fetching tags.js from {}", target_url);
 
-        let backend = BackendConfig::from_url(&target_url, true)
+        let backend = Self::backend_name_for_url(services, &target_url)
             .change_context(Self::error("Invalid SDK URL"))?;
 
         let sdk_host = Self::extract_host(&self.config.sdk_origin);
 
-        let mut backend_req = Request::new(Method::GET, &target_url);
-        backend_req.set_header(header::HOST, sdk_host);
-        backend_req.set_header(header::ACCEPT, "application/javascript, */*");
+        let mut backend_req = http::Request::builder()
+            .method(Method::GET)
+            .uri(&target_url)
+            .header(header::HOST, sdk_host)
+            .header(header::ACCEPT, "application/javascript, */*")
+            .body(EdgeBody::empty())
+            .change_context(Self::error("Failed to build DataDome SDK request"))?;
 
         // Copy relevant headers from original request
-        if let Some(ua) = req.get_header(header::USER_AGENT) {
-            backend_req.set_header(header::USER_AGENT, ua);
+        if let Some(ua) = req.headers().get(header::USER_AGENT) {
+            backend_req
+                .headers_mut()
+                .insert(header::USER_AGENT, ua.clone());
         }
 
-        let mut backend_resp = backend_req
-            .send(&backend)
+        let backend_resp = services
+            .http_client()
+            .send(PlatformHttpRequest::new(backend_req, backend))
+            .await
             .change_context(Self::error("Failed to fetch tags.js from DataDome"))?;
 
-        if backend_resp.get_status() != StatusCode::OK {
+        if backend_resp.response.status() != StatusCode::OK {
             log::warn!(
                 "[datadome] tags.js fetch returned status {}",
-                backend_resp.get_status()
+                backend_resp.response.status()
             );
-            return Ok(backend_resp);
+            return Ok(backend_resp.response);
         }
 
         // Read and rewrite the script content
-        let body = backend_resp.take_body_str();
-        let rewritten = self.rewrite_script_content(&body);
+        let cors_header = backend_resp
+            .response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .cloned();
+        let body = collect_response_bounded(
+            backend_resp.response.into_body(),
+            UPSTREAM_SDK_MAX_RESPONSE_BYTES,
+            DATADOME_INTEGRATION_ID,
+        )
+        .await
+        .change_context(Self::error("Failed to read DataDome SDK response body"))?;
+        let rewritten = self.rewrite_script_content(&String::from_utf8_lossy(&body));
 
         // Build response with caching headers
-        let mut response = Response::new();
-        response.set_status(StatusCode::OK);
-        response.set_header(
-            header::CONTENT_TYPE,
-            "application/javascript; charset=utf-8",
-        );
-        response.set_header(
-            header::CACHE_CONTROL,
-            format!("public, max-age={}", self.config.cache_ttl_seconds),
-        );
+        let mut response = http::Response::builder()
+            .status(StatusCode::OK)
+            .header(
+                header::CONTENT_TYPE,
+                "application/javascript; charset=utf-8",
+            )
+            .header(
+                header::CACHE_CONTROL,
+                format!("public, max-age={}", self.config.cache_ttl_seconds),
+            )
+            .body(EdgeBody::from(rewritten.into_bytes()))
+            .change_context(Self::error("Failed to build DataDome SDK response"))?;
 
         // Copy CORS headers if present
-        if let Some(cors) = backend_resp.get_header(header::ACCESS_CONTROL_ALLOW_ORIGIN) {
-            response.set_header(header::ACCESS_CONTROL_ALLOW_ORIGIN, cors);
+        if let Some(cors) = cors_header {
+            response
+                .headers_mut()
+                .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, cors);
         }
 
-        response.set_body(rewritten);
         Ok(response)
     }
 
     /// Handle the /js/* signal collection endpoint - proxy pass-through to api-js.datadome.co.
-    async fn handle_js_api(&self, req: Request) -> Result<Response, Report<TrustedServerError>> {
-        let original_path = req.get_path();
+    async fn handle_js_api(
+        &self,
+        services: &RuntimeServices,
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let (parts, body) = req.into_parts();
+        let original_path = parts.uri.path().to_string();
 
         // Strip our prefix to get the DataDome path
         let datadome_path = original_path
             .strip_prefix("/integrations/datadome")
-            .unwrap_or(original_path);
+            .unwrap_or(&original_path);
 
         // Use api_origin (api-js.datadome.co) for signal collection requests
-        let target_url = self.build_api_url(datadome_path, req.get_query_str());
+        let target_url = self.build_api_url(datadome_path, parts.uri.query());
         let api_host = Self::extract_host(&self.config.api_origin);
 
         log::info!(
             "[datadome] Proxying signal request to {} (method: {}, host: {})",
             target_url,
-            req.get_method(),
+            parts.method,
             api_host
         );
 
-        let backend = BackendConfig::from_url(&target_url, true)
+        let backend = Self::backend_name_for_url(services, &target_url)
             .change_context(Self::error("Invalid API URL"))?;
 
-        let mut backend_req = Request::new(req.get_method().clone(), &target_url);
-        backend_req.set_header(header::HOST, api_host);
+        let request_body = if parts.method == Method::POST || parts.method == Method::PUT {
+            let bytes =
+                collect_body_bounded(body, INTEGRATION_MAX_BODY_BYTES, DATADOME_INTEGRATION_ID)
+                    .await?;
+            EdgeBody::from(bytes)
+        } else {
+            EdgeBody::empty()
+        };
 
-        // Copy relevant headers
+        let mut backend_req = http::Request::builder()
+            .method(parts.method.clone())
+            .uri(&target_url)
+            .header(header::HOST, api_host)
+            .body(request_body)
+            .change_context(Self::error("Failed to build DataDome API request"))?;
+
+        // Copy relevant headers from the original client request.
+        // CONTENT_LENGTH is intentionally omitted: the body is re-materialized
+        // via collect_body_bounded, so its length may differ from the original.
         let headers_to_copy = [
             header::USER_AGENT,
             header::ACCEPT,
             header::ACCEPT_LANGUAGE,
             header::ACCEPT_ENCODING,
             header::CONTENT_TYPE,
-            header::CONTENT_LENGTH,
             header::ORIGIN,
             header::REFERER,
         ];
 
         for h in &headers_to_copy {
-            if let Some(value) = req.get_header(h) {
-                backend_req.set_header(h, value);
+            if let Some(value) = parts.headers.get(h) {
+                backend_req.headers_mut().insert(h, value.clone());
             }
         }
 
-        // Copy body for POST/PUT requests
-        if req.get_method() == Method::POST || req.get_method() == Method::PUT {
-            let body = req.into_body();
-            backend_req.set_body(body);
-        }
-
-        let backend_resp = backend_req
-            .send(&backend)
+        let backend_resp = services
+            .http_client()
+            .send(PlatformHttpRequest::new(backend_req, backend))
+            .await
             .change_context(Self::error("Failed to proxy signal request to DataDome"))?;
 
         log::info!(
             "[datadome] Signal request returned status {}",
-            backend_resp.get_status()
+            backend_resp.response.status()
         );
 
-        Ok(backend_resp)
+        Ok(backend_resp.response)
     }
 
     /// Extract the path portion after the `DataDome` domain from a URL.
@@ -380,6 +423,13 @@ impl DataDomeIntegration {
                 }
             })
             .unwrap_or("/tags.js")
+    }
+
+    fn backend_name_for_url(
+        services: &RuntimeServices,
+        target_url: &str,
+    ) -> Result<String, Report<TrustedServerError>> {
+        ensure_integration_backend(services, target_url, DATADOME_INTEGRATION_ID, None)
     }
 }
 
@@ -405,15 +455,15 @@ impl IntegrationProxy for DataDomeIntegration {
     async fn handle(
         &self,
         _settings: &Settings,
-        _services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let path = req.get_path();
+        services: &RuntimeServices,
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let path = req.uri().path().to_string();
 
         if path == "/integrations/datadome/tags.js" {
-            self.handle_tags_js(req).await
+            self.handle_tags_js(services, req).await
         } else if path.starts_with("/integrations/datadome/js/") {
-            self.handle_js_api(req).await
+            self.handle_js_api(services, req).await
         } else {
             Err(Report::new(Self::error(format!(
                 "Unknown DataDome route: {}",
@@ -503,7 +553,11 @@ pub fn register(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
+    use crate::test_support::tests::create_test_settings;
 
     fn test_config() -> DataDomeConfig {
         DataDomeConfig {
@@ -819,5 +873,35 @@ mod tests {
             }
             _ => panic!("Expected Replace action for bare domain"),
         }
+    }
+
+    #[test]
+    fn datadome_proxy_uses_platform_http_client() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let integration = DataDomeIntegration::new(test_config());
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://publisher.example/integrations/datadome/js/check")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let response = futures::executor::block_on(integration.handle(&settings, &services, req))
+            .expect("should proxy request");
+
+        assert_eq!(
+            response.status(),
+            http::StatusCode::OK,
+            "should return stubbed response"
+        );
+        assert_eq!(
+            stub.recorded_backend_names(),
+            vec!["stub-backend".to_string()],
+            "should route outbound request through PlatformHttpClient"
+        );
     }
 }

--- a/crates/trusted-server-core/src/integrations/didomi.rs
+++ b/crates/trusted-server-core/src/integrations/didomi.rs
@@ -11,6 +11,7 @@ use validator::Validate;
 use crate::backend::BackendConfig;
 use crate::error::TrustedServerError;
 use crate::integrations::{IntegrationEndpoint, IntegrationProxy, IntegrationRegistration};
+use crate::platform::RuntimeServices;
 use crate::settings::{IntegrationConfig, Settings};
 
 const DIDOMI_INTEGRATION_ID: &str = "didomi";
@@ -198,6 +199,7 @@ impl IntegrationProxy for DidomiIntegration {
     async fn handle(
         &self,
         _settings: &Settings,
+        _services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path();

--- a/crates/trusted-server-core/src/integrations/didomi.rs
+++ b/crates/trusted-server-core/src/integrations/didomi.rs
@@ -1,20 +1,20 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, Method};
-use fastly::{Request, Response};
+use http::header::{self, HeaderMap, HeaderValue};
+use http::Method;
 use serde::{Deserialize, Serialize};
 use url::Url;
 use validator::{Validate, ValidationError};
 
-use crate::backend::BackendConfig;
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
-    IntegrationRegistration,
+    collect_body_bounded, ensure_integration_backend, IntegrationEndpoint, IntegrationHeadInjector,
+    IntegrationHtmlContext, IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
 };
-use crate::platform::RuntimeServices;
+use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
 
 const DIDOMI_INTEGRATION_ID: &str = "didomi";
@@ -152,33 +152,42 @@ impl DidomiIntegration {
     fn copy_headers(
         &self,
         backend: &DidomiBackend,
-        original_req: &Request,
-        proxy_req: &mut Request,
+        client_ip: Option<std::net::IpAddr>,
+        original_headers: &HeaderMap<HeaderValue>,
+        proxy_headers: &mut HeaderMap<HeaderValue>,
     ) {
-        if let Some(client_ip) = original_req.get_client_ip_addr() {
-            proxy_req.set_header("X-Forwarded-For", client_ip.to_string());
+        if let Some(ip) = client_ip {
+            proxy_headers.insert(
+                "X-Forwarded-For",
+                HeaderValue::from_str(&ip.to_string())
+                    .expect("should format X-Forwarded-For header"),
+            );
         }
 
         for header_name in [
             header::ACCEPT,
             header::ACCEPT_LANGUAGE,
             header::ACCEPT_ENCODING,
+            header::CONTENT_TYPE,
             header::USER_AGENT,
             header::REFERER,
             header::ORIGIN,
             header::AUTHORIZATION,
         ] {
-            if let Some(value) = original_req.get_header(&header_name) {
-                proxy_req.set_header(&header_name, value);
+            if let Some(value) = original_headers.get(&header_name) {
+                proxy_headers.insert(header_name, value.clone());
             }
         }
 
         if matches!(backend, DidomiBackend::Sdk) {
-            Self::copy_geo_headers(original_req, proxy_req);
+            Self::copy_geo_headers(original_headers, proxy_headers);
         }
     }
 
-    fn copy_geo_headers(original_req: &Request, proxy_req: &mut Request) {
+    fn copy_geo_headers(
+        original_headers: &HeaderMap<HeaderValue>,
+        proxy_headers: &mut HeaderMap<HeaderValue>,
+    ) {
         let geo_headers = [
             ("X-Geo-Country", "FastlyGeo-CountryCode"),
             ("X-Geo-Region", "FastlyGeo-Region"),
@@ -186,22 +195,32 @@ impl DidomiIntegration {
         ];
 
         for (target, source) in geo_headers {
-            if let Some(value) = original_req.get_header(source) {
-                proxy_req.set_header(target, value);
+            if let Some(value) = original_headers.get(source) {
+                proxy_headers.insert(target, value.clone());
             }
         }
     }
 
-    fn add_cors_headers(response: &mut Response) {
-        response.set_header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-        response.set_header(
+    fn add_cors_headers(response: &mut http::Response<EdgeBody>) {
+        response.headers_mut().insert(
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            HeaderValue::from_static("*"),
+        );
+        response.headers_mut().insert(
             header::ACCESS_CONTROL_ALLOW_HEADERS,
-            "Content-Type, Authorization, X-Requested-With",
+            HeaderValue::from_static("Content-Type, Authorization, X-Requested-With"),
         );
-        response.set_header(
+        response.headers_mut().insert(
             header::ACCESS_CONTROL_ALLOW_METHODS,
-            "GET, POST, PUT, DELETE, OPTIONS",
+            HeaderValue::from_static("GET, POST, PUT, DELETE, OPTIONS"),
         );
+    }
+
+    fn backend_name_for_origin(
+        services: &RuntimeServices,
+        origin: &str,
+    ) -> Result<String, Report<TrustedServerError>> {
+        ensure_integration_backend(services, origin, DIDOMI_INTEGRATION_ID, None)
     }
 }
 
@@ -255,12 +274,13 @@ impl IntegrationProxy for DidomiIntegration {
     async fn handle(
         &self,
         _settings: &Settings,
-        _services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let path = req.get_path();
+        services: &RuntimeServices,
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let (parts, body) = req.into_parts();
+        let path = parts.uri.path().to_string();
         let prefix = self.resolved_prefix();
-        let consent_path = path.strip_prefix(&prefix).unwrap_or(path);
+        let consent_path = path.strip_prefix(&prefix).unwrap_or(&path);
         let backend = self.backend_for_path(consent_path);
         let base_origin = match backend {
             DidomiBackend::Sdk => self.config.sdk_origin.as_str(),
@@ -268,30 +288,43 @@ impl IntegrationProxy for DidomiIntegration {
         };
 
         let target_url = self
-            .build_target_url(base_origin, consent_path, req.get_query_str())
+            .build_target_url(base_origin, consent_path, parts.uri.query())
             .change_context(Self::error("Failed to build Didomi target URL"))?;
-        let backend_name = BackendConfig::from_url(base_origin, true)
+        let backend_name = Self::backend_name_for_origin(services, base_origin)
             .change_context(Self::error("Failed to configure Didomi backend"))?;
 
-        let mut proxy_req = Request::new(req.get_method().clone(), &target_url);
-        self.copy_headers(&backend, &req, &mut proxy_req);
+        let request_body = if parts.method == Method::POST {
+            let bytes =
+                collect_body_bounded(body, INTEGRATION_MAX_BODY_BYTES, DIDOMI_INTEGRATION_ID)
+                    .await?;
+            EdgeBody::from(bytes)
+        } else {
+            EdgeBody::empty()
+        };
 
-        if matches!(req.get_method(), &Method::POST | &Method::PUT) {
-            if let Some(content_type) = req.get_header(header::CONTENT_TYPE) {
-                proxy_req.set_header(header::CONTENT_TYPE, content_type);
-            }
-            proxy_req.set_body(req.into_body());
-        }
+        let mut proxy_req = http::Request::builder()
+            .method(parts.method.clone())
+            .uri(&target_url)
+            .body(request_body)
+            .change_context(Self::error("Failed to build Didomi proxy request"))?;
+        self.copy_headers(
+            &backend,
+            services.client_info().client_ip,
+            &parts.headers,
+            proxy_req.headers_mut(),
+        );
 
-        let mut response = proxy_req
-            .send(&backend_name)
+        let mut response = services
+            .http_client()
+            .send(PlatformHttpRequest::new(proxy_req, backend_name))
+            .await
             .change_context(Self::error("Didomi upstream request failed"))?;
 
         if matches!(backend, DidomiBackend::Sdk) {
-            Self::add_cors_headers(&mut response);
+            Self::add_cors_headers(&mut response.response);
         }
 
-        Ok(response)
+        Ok(response.response)
     }
 }
 
@@ -327,10 +360,14 @@ impl IntegrationHeadInjector for DidomiIntegration {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::integrations::{IntegrationDocumentState, IntegrationRegistry};
+    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
     use crate::test_support::tests::create_test_settings;
-    use fastly::http::Method;
+    use http::Method;
+    use std::net::{IpAddr, Ipv4Addr};
 
     fn config(enabled: bool) -> DidomiIntegrationConfig {
         DidomiIntegrationConfig {
@@ -375,6 +412,39 @@ mod tests {
         assert!(registry.has_route(&Method::GET, "/integrations/didomi/consent/loader.js"));
         assert!(registry.has_route(&Method::POST, "/integrations/didomi/consent/api/events"));
         assert!(!registry.has_route(&Method::GET, "/other"));
+    }
+
+    #[test]
+    fn copy_headers_sets_x_forwarded_for_from_client_ip() {
+        let integration = DidomiIntegration::new(Arc::new(config(true)));
+        let backend = DidomiBackend::Sdk;
+        let original_req = http::Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/test")
+            .body(EdgeBody::empty())
+            .expect("should build original request");
+        let mut proxy_req = http::Request::builder()
+            .method(Method::GET)
+            .uri("https://sdk.privacy-center.org/test")
+            .body(EdgeBody::empty())
+            .expect("should build proxy request");
+        let client_ip = Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+
+        integration.copy_headers(
+            &backend,
+            client_ip,
+            original_req.headers(),
+            proxy_req.headers_mut(),
+        );
+
+        assert_eq!(
+            proxy_req
+                .headers()
+                .get("X-Forwarded-For")
+                .and_then(|v| v.to_str().ok()),
+            Some("1.2.3.4"),
+            "should set X-Forwarded-For from client_ip"
+        );
     }
 
     #[test]
@@ -460,6 +530,64 @@ mod tests {
         assert_eq!(
             inserts[0],
             r#"<script>window.__tsjs_didomi={"proxyPath":"/my-consent/"};</script>"#
+        );
+    }
+
+    #[test]
+    fn copy_headers_omits_x_forwarded_for_when_no_client_ip() {
+        let integration = DidomiIntegration::new(Arc::new(config(true)));
+        let backend = DidomiBackend::Sdk;
+        let original_req = http::Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/test")
+            .body(EdgeBody::empty())
+            .expect("should build original request");
+        let mut proxy_req = http::Request::builder()
+            .method(Method::GET)
+            .uri("https://sdk.privacy-center.org/test")
+            .body(EdgeBody::empty())
+            .expect("should build proxy request");
+
+        integration.copy_headers(
+            &backend,
+            None,
+            original_req.headers(),
+            proxy_req.headers_mut(),
+        );
+
+        assert!(
+            proxy_req.headers().get("X-Forwarded-For").is_none(),
+            "should omit X-Forwarded-For when client_ip is None"
+        );
+    }
+
+    #[test]
+    fn didomi_proxy_uses_platform_http_client() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let integration = DidomiIntegration::new(Arc::new(config(true)));
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://publisher.example/integrations/didomi/consent/api/events")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let response = futures::executor::block_on(integration.handle(&settings, &services, req))
+            .expect("should proxy request");
+
+        assert_eq!(
+            response.status(),
+            http::StatusCode::OK,
+            "should return stubbed response"
+        );
+        assert_eq!(
+            stub.recorded_backend_names(),
+            vec!["stub-backend".to_string()],
+            "should route outbound request through PlatformHttpClient"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/didomi.rs
+++ b/crates/trusted-server-core/src/integrations/didomi.rs
@@ -6,16 +6,19 @@ use fastly::http::{header, Method};
 use fastly::{Request, Response};
 use serde::{Deserialize, Serialize};
 use url::Url;
-use validator::Validate;
+use validator::{Validate, ValidationError};
 
 use crate::backend::BackendConfig;
 use crate::error::TrustedServerError;
-use crate::integrations::{IntegrationEndpoint, IntegrationProxy, IntegrationRegistration};
+use crate::integrations::{
+    IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
+    IntegrationRegistration,
+};
 use crate::platform::RuntimeServices;
 use crate::settings::{IntegrationConfig, Settings};
 
 const DIDOMI_INTEGRATION_ID: &str = "didomi";
-const DIDOMI_PREFIX: &str = "/integrations/didomi/consent";
+const DIDOMI_DEFAULT_PREFIX: &str = "/integrations/didomi/consent";
 
 /// Configuration for the Didomi consent notice reverse proxy.
 #[derive(Debug, Clone, Deserialize, Serialize, Validate)]
@@ -23,6 +26,11 @@ pub struct DidomiIntegrationConfig {
     /// Whether the integration is enabled.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+    /// Custom proxy path prefix to avoid ad-blocker detection.
+    /// Defaults to "integrations/didomi/consent" if not set.
+    #[serde(default)]
+    #[validate(custom(function = "validate_proxy_path"))]
+    pub proxy_path: Option<String>,
     /// Base URL for the Didomi SDK origin.
     #[serde(default = "default_sdk_origin")]
     #[validate(url)]
@@ -31,6 +39,41 @@ pub struct DidomiIntegrationConfig {
     #[serde(default = "default_api_origin")]
     #[validate(url)]
     pub api_origin: String,
+}
+
+/// Validates the optional `proxy_path` value.
+/// Rejects empty, root-only, trailing-slash, dot-segment, and values
+/// containing characters that are unsafe for URL path routing.
+fn validate_proxy_path(value: &str) -> Result<(), ValidationError> {
+    let trimmed = value.trim_start_matches('/');
+
+    if trimmed.is_empty() {
+        return Err(ValidationError::new("proxy_path_empty"));
+    }
+
+    if trimmed.ends_with('/') {
+        return Err(ValidationError::new("proxy_path_trailing_slash"));
+    }
+
+    if trimmed.contains("//") {
+        return Err(ValidationError::new("proxy_path_double_slash"));
+    }
+
+    if trimmed
+        .split('/')
+        .any(|segment| matches!(segment, "." | ".."))
+    {
+        return Err(ValidationError::new("proxy_path_dot_segment"));
+    }
+
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '~' | '/'))
+    {
+        return Err(ValidationError::new("proxy_path_forbidden_chars"));
+    }
+
+    Ok(())
 }
 
 impl IntegrationConfig for DidomiIntegrationConfig {
@@ -69,6 +112,14 @@ impl DidomiIntegration {
         TrustedServerError::Integration {
             integration: DIDOMI_INTEGRATION_ID.to_string(),
             message: message.into(),
+        }
+    }
+
+    /// Returns the canonicalized proxy prefix: always starts with `/`, no trailing slash.
+    fn resolved_prefix(&self) -> String {
+        match &self.config.proxy_path {
+            Some(custom) => format!("/{}", custom.trim_start_matches('/')),
+            None => DIDOMI_DEFAULT_PREFIX.to_string(),
         }
     }
 
@@ -181,7 +232,8 @@ pub fn register(
 
     Ok(Some(
         IntegrationRegistration::builder(DIDOMI_INTEGRATION_ID)
-            .with_proxy(integration)
+            .with_proxy(integration.clone())
+            .with_head_injector(integration)
             .build(),
     ))
 }
@@ -192,8 +244,12 @@ impl IntegrationProxy for DidomiIntegration {
         DIDOMI_INTEGRATION_ID
     }
 
+    fn proxy_prefix(&self) -> String {
+        self.resolved_prefix()
+    }
+
     fn routes(&self) -> Vec<IntegrationEndpoint> {
-        vec![self.get("/consent/*"), self.post("/consent/*")]
+        vec![self.get("/*"), self.post("/*")]
     }
 
     async fn handle(
@@ -203,7 +259,8 @@ impl IntegrationProxy for DidomiIntegration {
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path();
-        let consent_path = path.strip_prefix(DIDOMI_PREFIX).unwrap_or(path);
+        let prefix = self.resolved_prefix();
+        let consent_path = path.strip_prefix(&prefix).unwrap_or(path);
         let backend = self.backend_for_path(consent_path);
         let base_origin = match backend {
             DidomiBackend::Sdk => self.config.sdk_origin.as_str(),
@@ -238,16 +295,47 @@ impl IntegrationProxy for DidomiIntegration {
     }
 }
 
+impl IntegrationHeadInjector for DidomiIntegration {
+    fn integration_id(&self) -> &'static str {
+        DIDOMI_INTEGRATION_ID
+    }
+
+    fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct InjectedDidomiClientConfig {
+            proxy_path: String,
+        }
+
+        let payload = InjectedDidomiClientConfig {
+            proxy_path: format!("{}/", self.resolved_prefix()),
+        };
+
+        // Escape `</` to prevent breaking out of the script tag.
+        let config_json = serde_json::to_string(&payload)
+            .unwrap_or_else(|e| {
+                log::warn!("Didomi: failed to serialize client config: {e}");
+                "{}".to_string()
+            })
+            .replace("</", "<\\/");
+
+        vec![format!(
+            r#"<script>window.__tsjs_didomi={config_json};</script>"#
+        )]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::integrations::IntegrationRegistry;
+    use crate::integrations::{IntegrationDocumentState, IntegrationRegistry};
     use crate::test_support::tests::create_test_settings;
     use fastly::http::Method;
 
     fn config(enabled: bool) -> DidomiIntegrationConfig {
         DidomiIntegrationConfig {
             enabled,
+            proxy_path: None,
             sdk_origin: default_sdk_origin(),
             api_origin: default_api_origin(),
         }
@@ -287,5 +375,108 @@ mod tests {
         assert!(registry.has_route(&Method::GET, "/integrations/didomi/consent/loader.js"));
         assert!(registry.has_route(&Method::POST, "/integrations/didomi/consent/api/events"));
         assert!(!registry.has_route(&Method::GET, "/other"));
+    }
+
+    #[test]
+    fn registers_custom_proxy_path() {
+        let mut settings = create_test_settings();
+        let custom_config = DidomiIntegrationConfig {
+            enabled: true,
+            proxy_path: Some("my-custom-consent".to_string()),
+            sdk_origin: default_sdk_origin(),
+            api_origin: default_api_origin(),
+        };
+        settings
+            .integrations
+            .insert_config(DIDOMI_INTEGRATION_ID, &custom_config)
+            .expect("should insert config");
+
+        let registry = IntegrationRegistry::new(&settings).expect("should create registry");
+        assert!(registry.has_route(&Method::GET, "/my-custom-consent/loader.js"));
+        assert!(registry.has_route(&Method::POST, "/my-custom-consent/api/events"));
+        assert!(!registry.has_route(&Method::GET, "/integrations/didomi/consent/loader.js"));
+    }
+
+    #[test]
+    fn validates_proxy_path_rejects_empty() {
+        assert!(validate_proxy_path("").is_err());
+        assert!(validate_proxy_path("/").is_err());
+    }
+
+    #[test]
+    fn validates_proxy_path_rejects_trailing_slash() {
+        assert!(validate_proxy_path("my-path/").is_err());
+    }
+
+    #[test]
+    fn validates_proxy_path_rejects_forbidden_chars() {
+        assert!(validate_proxy_path("path?query").is_err());
+        assert!(validate_proxy_path("path#frag").is_err());
+        assert!(validate_proxy_path("{param}").is_err());
+        assert!(validate_proxy_path("wild*card").is_err());
+        assert!(validate_proxy_path("has space").is_err());
+        assert!(validate_proxy_path("has\"quote").is_err());
+        assert!(validate_proxy_path("has\\backslash").is_err());
+        assert!(validate_proxy_path("has\nnewline").is_err());
+        assert!(validate_proxy_path("encoded%2e%2e/path").is_err());
+    }
+
+    #[test]
+    fn validates_proxy_path_rejects_double_slash() {
+        assert!(validate_proxy_path("my//path").is_err());
+    }
+
+    #[test]
+    fn validates_proxy_path_rejects_dot_segments() {
+        assert!(validate_proxy_path("my/./path").is_err());
+        assert!(validate_proxy_path("my/../path").is_err());
+    }
+
+    #[test]
+    fn validates_proxy_path_accepts_valid() {
+        assert!(validate_proxy_path("my-custom-path").is_ok());
+        assert!(validate_proxy_path("nested/path/here").is_ok());
+        assert!(validate_proxy_path("/leading-slash-ok").is_ok());
+    }
+
+    #[test]
+    fn head_injector_emits_proxy_path() {
+        let custom_config = DidomiIntegrationConfig {
+            enabled: true,
+            proxy_path: Some("my-consent".to_string()),
+            sdk_origin: default_sdk_origin(),
+            api_origin: default_api_origin(),
+        };
+        let integration = DidomiIntegration::new(Arc::new(custom_config));
+        let doc_state = IntegrationDocumentState::default();
+        let ctx = IntegrationHtmlContext {
+            request_host: "example.com",
+            request_scheme: "https",
+            origin_host: "example.com",
+            document_state: &doc_state,
+        };
+        let inserts = integration.head_inserts(&ctx);
+        assert_eq!(inserts.len(), 1);
+        assert_eq!(
+            inserts[0],
+            r#"<script>window.__tsjs_didomi={"proxyPath":"/my-consent/"};</script>"#
+        );
+    }
+
+    #[test]
+    fn head_injector_default_path() {
+        let integration = DidomiIntegration::new(Arc::new(config(true)));
+        let doc_state = IntegrationDocumentState::default();
+        let ctx = IntegrationHtmlContext {
+            request_host: "example.com",
+            request_scheme: "https",
+            origin_host: "example.com",
+            document_state: &doc_state,
+        };
+        let inserts = integration.head_inserts(&ctx);
+        assert_eq!(
+            inserts[0],
+            r#"<script>window.__tsjs_didomi={"proxyPath":"/integrations/didomi/consent/"};</script>"#
+        );
     }
 }

--- a/crates/trusted-server-core/src/integrations/google_tag_manager.rs
+++ b/crates/trusted-server-core/src/integrations/google_tag_manager.rs
@@ -28,6 +28,7 @@ use crate::integrations::{
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration, IntegrationScriptContext,
     IntegrationScriptRewriter, ScriptRewriteAction,
 };
+use crate::platform::RuntimeServices;
 use crate::proxy::{proxy_request, ProxyRequestConfig};
 use crate::settings::{IntegrationConfig, Settings};
 
@@ -427,6 +428,7 @@ impl IntegrationProxy for GoogleTagManagerIntegration {
     async fn handle(
         &self,
         settings: &Settings,
+        services: &RuntimeServices,
         mut req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path().to_string();
@@ -482,7 +484,7 @@ impl IntegrationProxy for GoogleTagManagerIntegration {
             }
         };
 
-        let mut response = proxy_request(settings, req, proxy_config)
+        let mut response = proxy_request(settings, req, proxy_config, services)
             .await
             .change_context(Self::error("Failed to proxy GTM request"))?;
 
@@ -611,6 +613,7 @@ mod tests {
         IntegrationDocumentState, IntegrationRegistry, IntegrationScriptContext,
         IntegrationScriptRewriter, ScriptRewriteAction,
     };
+    use crate::platform::test_support::noop_services;
     use crate::settings::Settings;
     use crate::streaming_processor::{Compression, PipelineConfig, StreamingPipeline};
 
@@ -1213,7 +1216,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         let settings = make_settings();
         let response = integration
-            .handle(&settings, req)
+            .handle(&settings, &noop_services(), req)
             .await
             .expect("handle should not return error");
 
@@ -1248,7 +1251,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         let settings = make_settings();
         let response = integration
-            .handle(&settings, req)
+            .handle(&settings, &noop_services(), req)
             .await
             .expect("handle should not return error");
 

--- a/crates/trusted-server-core/src/integrations/google_tag_manager.rs
+++ b/crates/trusted-server-core/src/integrations/google_tag_manager.rs
@@ -15,18 +15,20 @@
 use std::sync::{Arc, LazyLock, Mutex};
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{Method, StatusCode};
-use fastly::{Request, Response};
+use futures::StreamExt as _;
+use http::{header, Method, Request, Response, StatusCode};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration, IntegrationScriptContext,
-    IntegrationScriptRewriter, ScriptRewriteAction,
+    collect_response_bounded, AttributeRewriteAction, IntegrationAttributeContext,
+    IntegrationAttributeRewriter, IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
+    IntegrationScriptContext, IntegrationScriptRewriter, ScriptRewriteAction,
+    UPSTREAM_SDK_MAX_RESPONSE_BYTES,
 };
 use crate::platform::RuntimeServices;
 use crate::proxy::{proxy_request, ProxyRequestConfig};
@@ -38,7 +40,12 @@ const DEFAULT_UPSTREAM: &str = "https://www.googletagmanager.com";
 /// Error type for payload size validation
 #[derive(Debug)]
 enum PayloadSizeError {
-    TooLarge { actual: usize, max: usize },
+    TooLarge {
+        actual: usize,
+        max: usize,
+    },
+    /// Transport error while reading a streaming body chunk.
+    StreamRead(String),
 }
 
 /// Regex pattern for validating GTM container IDs.
@@ -278,7 +285,7 @@ impl GoogleTagManagerIntegration {
         path.ends_with("/gtm.js") || path.ends_with("/gtag/js") || path.ends_with("/gtag.js")
     }
 
-    fn build_target_url(&self, req: &Request, path: &str) -> Option<String> {
+    fn build_target_url(&self, req: &Request<EdgeBody>, path: &str) -> Option<String> {
         let upstream_base = self.upstream_url();
 
         let mut target_url = if path.ends_with("/gtm.js") {
@@ -293,7 +300,7 @@ impl GoogleTagManagerIntegration {
             return None;
         };
 
-        if let Some(query) = req.get_url().query() {
+        if let Some(query) = req.uri().query() {
             target_url = format!("{}?{}", target_url, query);
         } else if path.ends_with("/gtm.js") {
             target_url = format!("{}?id={}", target_url, self.config.container_id);
@@ -302,10 +309,10 @@ impl GoogleTagManagerIntegration {
         Some(target_url)
     }
 
-    fn build_proxy_config<'a>(
+    async fn build_proxy_config<'a>(
         &self,
         path: &str,
-        req: &mut Request,
+        req: &mut Request<EdgeBody>,
         target_url: &'a str,
     ) -> Result<ProxyRequestConfig<'a>, PayloadSizeError> {
         let mut proxy_config = ProxyRequestConfig::new(target_url);
@@ -313,42 +320,11 @@ impl GoogleTagManagerIntegration {
 
         // If it's a POST request (e.g. /collect beacon), we must manually attach the body
         // because ProxyRequestConfig doesn't automatically copy it from the source request.
-        if req.get_method() == Method::POST {
+        if req.method() == Method::POST {
             // Read body with size cap to prevent unbounded memory allocation.
-            // Read in chunks and reject early if body exceeds max_beacon_body_size.
-            let mut body = req.take_body();
-            let mut body_bytes = Vec::new();
-            let max_size = self.config.max_beacon_body_size;
-            const CHUNK_SIZE: usize = 8192; // 8KB chunks
-
-            for chunk_result in body.read_chunks(CHUNK_SIZE) {
-                let chunk = chunk_result.map_err(|e| {
-                    log::error!("Error reading request body: {}", e);
-                    // Convert I/O error to size error for uniform handling
-                    PayloadSizeError::TooLarge {
-                        actual: 0,
-                        max: max_size,
-                    }
-                })?;
-
-                // Check if adding this chunk would exceed the limit
-                // This prevents buffering oversized bodies into memory
-                if body_bytes.len() + chunk.len() > max_size {
-                    let total_size = body_bytes.len() + chunk.len();
-                    log::warn!(
-                        "POST body size {} exceeds max {} (rejected during chunked read)",
-                        total_size,
-                        max_size
-                    );
-                    return Err(PayloadSizeError::TooLarge {
-                        actual: total_size,
-                        max: max_size,
-                    });
-                }
-
-                body_bytes.extend_from_slice(&chunk);
-            }
-
+            let body = std::mem::replace(req.body_mut(), EdgeBody::empty());
+            let body_bytes =
+                Self::collect_request_body_bounded(body, self.config.max_beacon_body_size).await?;
             proxy_config.body = Some(body_bytes);
         }
 
@@ -356,17 +332,64 @@ impl GoogleTagManagerIntegration {
         // The empty value will override any existing header during proxy forwarding.
         proxy_config = proxy_config.with_header(
             crate::constants::HEADER_X_FORWARDED_FOR,
-            fastly::http::HeaderValue::from_static(""),
+            http::HeaderValue::from_static(""),
         );
 
         if self.is_rewritable_script(path) {
             proxy_config = proxy_config.with_header(
-                fastly::http::header::ACCEPT_ENCODING,
-                fastly::http::HeaderValue::from_static("identity"),
+                header::ACCEPT_ENCODING,
+                http::HeaderValue::from_static("identity"),
             );
         }
 
         Ok(proxy_config)
+    }
+
+    async fn collect_request_body_bounded(
+        body: EdgeBody,
+        max_size: usize,
+    ) -> Result<Vec<u8>, PayloadSizeError> {
+        match body {
+            EdgeBody::Once(bytes) => {
+                if bytes.len() > max_size {
+                    log::warn!(
+                        "POST body size {} exceeds max {} (rejected before proxy)",
+                        bytes.len(),
+                        max_size
+                    );
+                    return Err(PayloadSizeError::TooLarge {
+                        actual: bytes.len(),
+                        max: max_size,
+                    });
+                }
+                Ok(bytes.to_vec())
+            }
+            EdgeBody::Stream(mut stream) => {
+                let mut body_bytes = Vec::new();
+                while let Some(chunk_result) = stream.next().await {
+                    let chunk = chunk_result.map_err(|error| {
+                        log::error!("Error reading request body stream: {}", error);
+                        PayloadSizeError::StreamRead(error.to_string())
+                    })?;
+
+                    if body_bytes.len() + chunk.len() > max_size {
+                        let total_size = body_bytes.len() + chunk.len();
+                        log::warn!(
+                            "POST body size {} exceeds max {} (rejected during stream read)",
+                            total_size,
+                            max_size
+                        );
+                        return Err(PayloadSizeError::TooLarge {
+                            actual: total_size,
+                            max: max_size,
+                        });
+                    }
+
+                    body_bytes.extend_from_slice(&chunk);
+                }
+                Ok(body_bytes)
+            }
+        }
     }
 }
 
@@ -429,17 +452,20 @@ impl IntegrationProxy for GoogleTagManagerIntegration {
         &self,
         settings: &Settings,
         services: &RuntimeServices,
-        mut req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let path = req.get_path().to_string();
-        let method = req.get_method();
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let mut req = req;
+        let path = req.uri().path().to_string();
+        let method = req.method().clone();
         log::debug!("Handling GTM request: {} {}", method, path);
 
         // Validate body size for POST requests to prevent memory pressure
         // Check Content-Length header if present for early rejection
         if method == Method::POST {
-            if let Some(content_length_str) =
-                req.get_header_str(fastly::http::header::CONTENT_LENGTH)
+            if let Some(content_length_str) = req
+                .headers()
+                .get(header::CONTENT_LENGTH)
+                .and_then(|value| value.to_str().ok())
             {
                 match content_length_str.parse::<usize>() {
                     Ok(content_length) => {
@@ -450,13 +476,23 @@ impl IntegrationProxy for GoogleTagManagerIntegration {
                                 content_length,
                                 self.config.max_beacon_body_size
                             );
-                            return Ok(Response::from_status(StatusCode::PAYLOAD_TOO_LARGE));
+                            return Response::builder()
+                                .status(StatusCode::PAYLOAD_TOO_LARGE)
+                                .body(EdgeBody::empty())
+                                .change_context(Self::error(
+                                    "Failed to build GTM payload-too-large response",
+                                ));
                         }
                     }
                     Err(_) => {
                         // Invalid Content-Length header
                         log::warn!("POST request with malformed Content-Length header");
-                        return Ok(Response::from_status(StatusCode::BAD_REQUEST));
+                        return Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .body(EdgeBody::empty())
+                            .change_context(Self::error(
+                                "Failed to build GTM bad-request response",
+                            ));
                     }
                 }
             }
@@ -465,13 +501,16 @@ impl IntegrationProxy for GoogleTagManagerIntegration {
         }
 
         let Some(target_url) = self.build_target_url(&req, &path) else {
-            return Ok(Response::from_status(StatusCode::NOT_FOUND));
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(EdgeBody::empty())
+                .change_context(Self::error("Failed to build GTM not-found response"));
         };
 
         log::debug!("Proxying to upstream: {}", target_url);
 
         // Handle payload size errors explicitly to return 413 instead of 502
-        let proxy_config = match self.build_proxy_config(&path, &mut req, &target_url) {
+        let proxy_config = match self.build_proxy_config(&path, &mut req, &target_url).await {
             Ok(config) => config,
             Err(PayloadSizeError::TooLarge { actual, max }) => {
                 // This catches cases where Content-Length was incorrect
@@ -480,33 +519,63 @@ impl IntegrationProxy for GoogleTagManagerIntegration {
                     actual,
                     max
                 );
-                return Ok(Response::from_status(StatusCode::PAYLOAD_TOO_LARGE));
+                return Response::builder()
+                    .status(StatusCode::PAYLOAD_TOO_LARGE)
+                    .body(EdgeBody::empty())
+                    .change_context(Self::error(
+                        "Failed to build GTM payload-too-large response",
+                    ));
+            }
+            Err(PayloadSizeError::StreamRead(error)) => {
+                log::error!("Returning 502: failed to read GTM request body stream: {error}");
+                return Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(EdgeBody::empty())
+                    .change_context(Self::error("Failed to build GTM bad-gateway response"));
             }
         };
 
-        let mut response = proxy_request(settings, req, proxy_config, services)
+        let response = proxy_request(settings, req, proxy_config, services)
             .await
             .change_context(Self::error("Failed to proxy GTM request"))?;
 
         // If we are serving gtm.js or gtag.js, rewrite internal URLs to route beacons through us.
         if self.is_rewritable_script(&path) {
-            if !response.get_status().is_success() {
-                log::warn!("GTM upstream returned status {}", response.get_status());
+            if !response.status().is_success() {
+                log::warn!("GTM upstream returned status {}", response.status());
                 return Ok(response);
             }
             log::debug!("Rewriting GTM/gtag script content");
-            let body_str = response.take_body_str();
-            let rewritten_body = Self::rewrite_gtm_urls(&body_str);
+            let status = response.status();
+            let body_bytes = collect_response_bounded(
+                response.into_body(),
+                UPSTREAM_SDK_MAX_RESPONSE_BYTES,
+                GTM_INTEGRATION_ID,
+            )
+            .await?;
+            let (rewritten_body_bytes, content_type) = match std::str::from_utf8(&body_bytes) {
+                Ok(body_str) => {
+                    let rewritten = Self::rewrite_gtm_urls(body_str);
+                    (
+                        rewritten.into_bytes(),
+                        "application/javascript; charset=utf-8",
+                    )
+                }
+                Err(_) => {
+                    log::warn!("GTM upstream response body is not valid UTF-8; serving original");
+                    (body_bytes.to_vec(), "application/javascript")
+                }
+            };
 
-            response = Response::from_body(rewritten_body)
-                .with_header(
-                    fastly::http::header::CONTENT_TYPE,
-                    "application/javascript; charset=utf-8",
-                )
-                .with_header(
-                    fastly::http::header::CACHE_CONTROL,
+            return Response::builder()
+                .status(status)
+                .header(header::CONTENT_TYPE, content_type)
+                .header(
+                    header::CACHE_CONTROL,
                     format!("public, max-age={}", self.config.cache_max_age),
-                );
+                )
+                .body(EdgeBody::from(rewritten_body_bytes))
+                .change_context(Self::error("Failed to build rewritten GTM response"));
         }
 
         Ok(response)
@@ -613,13 +682,20 @@ mod tests {
         IntegrationDocumentState, IntegrationRegistry, IntegrationScriptContext,
         IntegrationScriptRewriter, ScriptRewriteAction,
     };
-    use crate::platform::test_support::noop_services;
     use crate::settings::Settings;
     use crate::streaming_processor::{Compression, PipelineConfig, StreamingPipeline};
 
     use crate::test_support::tests::crate_test_settings_str;
-    use fastly::http::Method;
+    use http::Method;
     use std::io::Cursor;
+
+    fn build_http_request(method: Method, uri: &str, body: EdgeBody) -> http::Request<EdgeBody> {
+        http::Request::builder()
+            .method(method)
+            .uri(uri)
+            .body(body)
+            .expect("should build HTTP request")
+    }
 
     #[test]
     fn test_rewrite_gtm_urls() {
@@ -1021,8 +1097,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             .any(|r| r.path == "/integrations/google_tag_manager/g/collect"));
     }
 
-    #[test]
-    fn test_post_collect_proxy_config_includes_payload() {
+    #[tokio::test]
+    async fn test_post_collect_proxy_config_includes_payload() {
         let config = GoogleTagManagerConfig {
             enabled: true,
             container_id: "GTM-TEST1234".to_string(),
@@ -1033,18 +1109,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         let integration = GoogleTagManagerIntegration::new(config);
 
         let payload = b"v=2&tid=G-TEST&cid=123&en=page_view".to_vec();
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::POST,
             "https://edge.example.com/integrations/google_tag_manager/g/collect?v=2&tid=G-TEST",
+            EdgeBody::from(payload.clone()),
         );
-        req.set_body(payload.clone());
 
-        let path = req.get_path().to_string();
+        let path = req.uri().path().to_string();
         let target_url = integration
             .build_target_url(&req, &path)
             .expect("should resolve collect target URL");
         let proxy_config = integration
             .build_proxy_config(&path, &mut req, &target_url)
+            .await
             .expect("should build proxy config");
 
         assert_eq!(
@@ -1054,8 +1131,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         );
     }
 
-    #[test]
-    fn test_oversized_post_body_rejected() {
+    #[tokio::test]
+    async fn test_oversized_post_body_rejected() {
         let max_size = default_max_beacon_body_size();
         let config = GoogleTagManagerConfig {
             enabled: true,
@@ -1068,19 +1145,21 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         // Create a payload larger than the configured max size (64KB by default)
         let oversized_payload = vec![b'X'; max_size + 1];
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::POST,
             "https://edge.example.com/integrations/google_tag_manager/collect",
+            EdgeBody::from(oversized_payload.clone()),
         );
-        req.set_body(oversized_payload.clone());
 
-        let path = req.get_path().to_string();
+        let path = req.uri().path().to_string();
         let target_url = integration
             .build_target_url(&req, &path)
             .expect("should resolve collect target URL");
 
         // Attempt to build proxy config should fail due to oversized body
-        let result = integration.build_proxy_config(&path, &mut req, &target_url);
+        let result = integration
+            .build_proxy_config(&path, &mut req, &target_url)
+            .await;
 
         assert!(result.is_err(), "Oversized POST body should be rejected");
 
@@ -1092,8 +1171,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         }
     }
 
-    #[test]
-    fn test_custom_max_beacon_body_size() {
+    #[tokio::test]
+    async fn test_custom_max_beacon_body_size() {
         // Test with a custom smaller limit
         let custom_max_size = 1024; // 1KB
         let config = GoogleTagManagerConfig {
@@ -1107,41 +1186,45 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         // Payload just under the custom limit should succeed
         let acceptable_payload = vec![b'X'; custom_max_size - 1];
-        let mut req1 = Request::new(
+        let mut req1 = build_http_request(
             Method::POST,
             "https://edge.example.com/integrations/google_tag_manager/collect",
+            EdgeBody::from(acceptable_payload.clone()),
         );
-        req1.set_body(acceptable_payload.clone());
 
-        let path = req1.get_path().to_string();
+        let path = req1.uri().path().to_string();
         let target_url = integration
             .build_target_url(&req1, &path)
             .expect("should resolve collect target URL");
 
-        let result = integration.build_proxy_config(&path, &mut req1, &target_url);
+        let result = integration
+            .build_proxy_config(&path, &mut req1, &target_url)
+            .await;
         assert!(result.is_ok(), "Payload under custom limit should succeed");
 
         // Payload over the custom limit should fail
         let oversized_payload = vec![b'X'; custom_max_size + 1];
-        let mut req2 = Request::new(
+        let mut req2 = build_http_request(
             Method::POST,
             "https://edge.example.com/integrations/google_tag_manager/collect",
+            EdgeBody::from(oversized_payload),
         );
-        req2.set_body(oversized_payload);
 
         let target_url2 = integration
             .build_target_url(&req2, &path)
             .expect("should resolve collect target URL");
 
-        let result2 = integration.build_proxy_config(&path, &mut req2, &target_url2);
+        let result2 = integration
+            .build_proxy_config(&path, &mut req2, &target_url2)
+            .await;
         assert!(
             result2.is_err(),
             "Payload over custom limit should be rejected"
         );
     }
 
-    #[test]
-    fn test_incorrect_content_length_returns_413() {
+    #[tokio::test]
+    async fn test_incorrect_content_length_returns_413() {
         // Verify that when Content-Length is incorrect (smaller than actual body),
         // we still catch it and return 413 (not 502)
         let max_size = default_max_beacon_body_size();
@@ -1156,24 +1239,27 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         // Create oversized payload but with incorrect (small) Content-Length
         let oversized_payload = vec![b'X'; max_size + 1];
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::POST,
             "https://edge.example.com/integrations/google_tag_manager/collect",
+            EdgeBody::from(oversized_payload.clone()),
         );
-        req.set_body(oversized_payload.clone());
         // Set Content-Length to a small value (incorrect)
-        req.set_header(
-            fastly::http::header::CONTENT_LENGTH,
-            (max_size / 2).to_string(),
+        req.headers_mut().insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_str(&(max_size / 2).to_string())
+                .expect("should build Content-Length header"),
         );
 
-        let path = req.get_path().to_string();
+        let path = req.uri().path().to_string();
         let target_url = integration
             .build_target_url(&req, &path)
             .expect("should resolve collect target URL");
 
         // build_proxy_config should detect the mismatch and return PayloadSizeError
-        let result = integration.build_proxy_config(&path, &mut req, &target_url);
+        let result = integration
+            .build_proxy_config(&path, &mut req, &target_url)
+            .await;
 
         assert!(
             result.is_err(),
@@ -1204,25 +1290,27 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         // Create oversized payload with correct Content-Length
         let oversized_payload = vec![b'X'; max_size + 1];
-        let mut req = Request::new(
-            Method::POST,
-            "https://edge.example.com/integrations/google_tag_manager/collect",
-        );
-        req.set_body(oversized_payload.clone());
-        req.set_header(
-            fastly::http::header::CONTENT_LENGTH,
-            oversized_payload.len().to_string(),
+        let mut req = http::Request::builder()
+            .method(Method::POST)
+            .uri("https://edge.example.com/integrations/google_tag_manager/collect")
+            .body(EdgeBody::from(oversized_payload.clone()))
+            .expect("should build oversized request");
+        req.headers_mut().insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_str(&oversized_payload.len().to_string())
+                .expect("should build Content-Length header"),
         );
 
         let settings = make_settings();
+        let services = crate::platform::test_support::noop_services();
         let response = integration
-            .handle(&settings, &noop_services(), req)
+            .handle(&settings, &services, req)
             .await
             .expect("handle should not return error");
 
         // Verify we get 413 Payload Too Large, not 502 Bad Gateway
         assert_eq!(
-            response.get_status(),
+            response.status(),
             StatusCode::PAYLOAD_TOO_LARGE,
             "Should return 413 for oversized POST body"
         );
@@ -1242,22 +1330,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         // Create POST request with invalid Content-Length header
         let payload = b"v=2&tid=G-TEST&cid=123".to_vec();
-        let mut req = Request::new(
-            Method::POST,
-            "https://edge.example.com/integrations/google_tag_manager/collect",
+        let mut req = http::Request::builder()
+            .method(Method::POST)
+            .uri("https://edge.example.com/integrations/google_tag_manager/collect")
+            .body(EdgeBody::from(payload))
+            .expect("should build malformed request");
+        req.headers_mut().insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_static("not-a-number"),
         );
-        req.set_body(payload);
-        req.set_header(fastly::http::header::CONTENT_LENGTH, "not-a-number");
 
         let settings = make_settings();
+        let services = crate::platform::test_support::noop_services();
         let response = integration
-            .handle(&settings, &noop_services(), req)
+            .handle(&settings, &services, req)
             .await
             .expect("handle should not return error");
 
         // Verify we get 400 Bad Request for malformed Content-Length
         assert_eq!(
-            response.get_status(),
+            response.status(),
             StatusCode::BAD_REQUEST,
             "Should return 400 for malformed Content-Length"
         );
@@ -1279,20 +1371,22 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         // Create small POST request without Content-Length header
         let small_payload = b"v=2&tid=G-TEST&cid=123".to_vec();
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::POST,
             "https://edge.example.com/integrations/google_tag_manager/collect",
+            EdgeBody::from(small_payload),
         );
-        req.set_body(small_payload);
         // Intentionally NOT setting Content-Length header (HTTP/2 scenario)
 
-        let path = req.get_path().to_string();
+        let path = req.uri().path().to_string();
         let target_url = integration
             .build_target_url(&req, &path)
             .expect("should resolve collect target URL");
 
         // build_proxy_config should accept small payloads even without Content-Length
-        let result = integration.build_proxy_config(&path, &mut req, &target_url);
+        let result = integration
+            .build_proxy_config(&path, &mut req, &target_url)
+            .await;
 
         assert!(
             result.is_ok(),
@@ -1300,8 +1394,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         );
     }
 
-    #[test]
-    fn test_collect_proxy_config_strips_client_ip_forwarding() {
+    #[tokio::test]
+    async fn test_collect_proxy_config_strips_client_ip_forwarding() {
         let config = GoogleTagManagerConfig {
             enabled: true,
             container_id: "GTM-TEST1234".to_string(),
@@ -1311,18 +1405,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         };
         let integration = GoogleTagManagerIntegration::new(config);
 
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::GET,
             "https://edge.example.com/integrations/google_tag_manager/collect?v=2",
+            EdgeBody::empty(),
         );
-        req.set_header(crate::constants::HEADER_X_FORWARDED_FOR, "198.51.100.42");
+        req.headers_mut().insert(
+            crate::constants::HEADER_X_FORWARDED_FOR,
+            http::HeaderValue::from_static("198.51.100.42"),
+        );
 
-        let path = req.get_path().to_string();
+        let path = req.uri().path().to_string();
         let target_url = integration
             .build_target_url(&req, &path)
             .expect("should resolve collect target URL");
         let proxy_config = integration
             .build_proxy_config(&path, &mut req, &target_url)
+            .await
             .expect("should build proxy config");
 
         // We check if X-Forwarded-For is explicitly overridden with an empty string,
@@ -1339,8 +1438,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         );
     }
 
-    #[test]
-    fn test_gtag_proxy_config_requests_identity_encoding() {
+    #[tokio::test]
+    async fn test_gtag_proxy_config_requests_identity_encoding() {
         let config = GoogleTagManagerConfig {
             enabled: true,
             container_id: "GT-123".to_string(),
@@ -1350,22 +1449,25 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         };
         let integration = GoogleTagManagerIntegration::new(config);
 
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::GET,
             "https://edge.example.com/integrations/google_tag_manager/gtag/js?id=G-123",
+            EdgeBody::empty(),
         );
 
-        let path = req.get_path().to_string();
+        let path = req.uri().path().to_string();
         let target_url = integration
             .build_target_url(&req, &path)
             .expect("should resolve gtag target URL");
         let proxy_config = integration
             .build_proxy_config(&path, &mut req, &target_url)
+            .await
             .expect("should build proxy config");
 
-        let has_identity = proxy_config.headers.iter().any(|(name, value)| {
-            name == fastly::http::header::ACCEPT_ENCODING && value == "identity"
-        });
+        let has_identity = proxy_config
+            .headers
+            .iter()
+            .any(|(name, value)| name == http::header::ACCEPT_ENCODING && value == "identity");
 
         assert!(
             has_identity,

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -35,9 +35,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::header;
-use fastly::{Request, Response};
+use http::{header, Request, Response};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use validator::Validate;
@@ -125,7 +125,10 @@ impl GptIntegration {
         ))
     }
 
-    fn build_proxy_config<'a>(target_url: &'a str, req: &Request) -> ProxyRequestConfig<'a> {
+    fn build_proxy_config<'a>(
+        target_url: &'a str,
+        req: &Request<EdgeBody>,
+    ) -> ProxyRequestConfig<'a> {
         let mut config = ProxyRequestConfig::new(target_url)
             .with_streaming()
             .without_forward_headers();
@@ -137,33 +140,33 @@ impl GptIntegration {
 
     fn apply_request_header_allowlist<'a>(
         mut config: ProxyRequestConfig<'a>,
-        req: &Request,
+        req: &Request<EdgeBody>,
     ) -> ProxyRequestConfig<'a> {
         for header_name in [
             &HEADER_ACCEPT,
             &HEADER_ACCEPT_LANGUAGE,
             &HEADER_ACCEPT_ENCODING,
         ] {
-            if let Some(value) = req.get_header(header_name).cloned() {
+            if let Some(value) = req.headers().get(header_name).cloned() {
                 config = config.with_header(header_name.clone(), value);
             }
         }
 
         config.with_header(
             header::USER_AGENT,
-            fastly::http::HeaderValue::from_static("TrustedServer/1.0"),
+            http::HeaderValue::from_static("TrustedServer/1.0"),
         )
     }
 
     fn ensure_successful_gpt_asset_response(
-        response: &Response,
+        response: &Response<EdgeBody>,
         context: &str,
     ) -> Result<(), Report<TrustedServerError>> {
-        if response.get_status().is_success() {
+        if response.status().is_success() {
             return Ok(());
         }
 
-        let status = response.get_status();
+        let status = response.status();
         log::error!(
             "GPT proxy upstream returned status {} for {}",
             status,
@@ -174,45 +177,62 @@ impl GptIntegration {
         ))))
     }
 
-    fn finalize_gpt_asset_response(&self, mut response: Response) -> Response {
-        let status = response.get_status();
-        let content_type = response.get_header(header::CONTENT_TYPE).cloned();
-        let content_encoding = response.get_header(header::CONTENT_ENCODING).cloned();
-        let etag = response.get_header(header::ETAG).cloned();
-        let last_modified = response.get_header(header::LAST_MODIFIED).cloned();
-        let upstream_vary = response
-            .get_header(header::VARY)
+    fn finalize_gpt_asset_response(&self, response: Response<EdgeBody>) -> Response<EdgeBody> {
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let content_type = parts.headers.get(header::CONTENT_TYPE).cloned();
+        let content_encoding = parts.headers.get(header::CONTENT_ENCODING).cloned();
+        let etag = parts.headers.get(header::ETAG).cloned();
+        let last_modified = parts.headers.get(header::LAST_MODIFIED).cloned();
+        let upstream_vary = parts
+            .headers
+            .get(header::VARY)
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
-        let body = response.take_body();
 
-        let mut finalized = Response::from_status(status).with_body(body);
-        finalized.set_header("X-GPT-Proxy", "true");
+        let mut finalized = Response::new(body);
+        *finalized.status_mut() = status;
+        finalized
+            .headers_mut()
+            .insert("X-GPT-Proxy", http::HeaderValue::from_static("true"));
 
         if let Some(content_type) = content_type {
-            finalized.set_header(header::CONTENT_TYPE, content_type);
+            finalized
+                .headers_mut()
+                .insert(header::CONTENT_TYPE, content_type);
         }
 
         if let Some(etag) = etag {
-            finalized.set_header(header::ETAG, etag);
+            finalized.headers_mut().insert(header::ETAG, etag);
         }
 
         if let Some(last_modified) = last_modified {
-            finalized.set_header(header::LAST_MODIFIED, last_modified);
+            finalized
+                .headers_mut()
+                .insert(header::LAST_MODIFIED, last_modified);
         }
 
         if let Some(content_encoding) = content_encoding {
-            finalized.set_header(header::CONTENT_ENCODING, content_encoding);
-            finalized.set_header(
+            finalized
+                .headers_mut()
+                .insert(header::CONTENT_ENCODING, content_encoding);
+            finalized.headers_mut().insert(
                 header::VARY,
-                Self::vary_with_accept_encoding(upstream_vary.as_deref()),
+                http::HeaderValue::from_str(&Self::vary_with_accept_encoding(
+                    upstream_vary.as_deref(),
+                ))
+                .expect("should build GPT Vary header"),
             );
         }
 
         if status.is_success() {
-            finalized.set_header(
+            finalized.headers_mut().insert(
                 header::CACHE_CONTROL,
-                format!("public, max-age={}", self.config.cache_ttl_seconds),
+                http::HeaderValue::from_str(&format!(
+                    "public, max-age={}",
+                    self.config.cache_ttl_seconds
+                ))
+                .expect("should build GPT Cache-Control header"),
             );
         }
 
@@ -240,10 +260,10 @@ impl GptIntegration {
         &self,
         settings: &Settings,
         services: &RuntimeServices,
-        req: Request,
+        req: Request<EdgeBody>,
         target_url: &str,
         context: &str,
-    ) -> Result<Response, Report<TrustedServerError>> {
+    ) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
         let config = Self::build_proxy_config(target_url, &req);
         let response = proxy_request(settings, req, config, services)
             .await
@@ -290,8 +310,8 @@ impl GptIntegration {
         &self,
         settings: &Settings,
         services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
+        req: Request<EdgeBody>,
+    ) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
         let script_url = &self.config.script_url;
         log::info!("Fetching GPT script from: {}", script_url);
         self.proxy_gpt_asset(
@@ -314,12 +334,12 @@ impl GptIntegration {
         &self,
         settings: &Settings,
         services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let original_path = req.get_path();
-        let query = req.get_url().query();
+        req: Request<EdgeBody>,
+    ) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+        let original_path = req.uri().path().to_string();
+        let query = req.uri().query();
 
-        let target_url = Self::build_upstream_url(original_path, query)
+        let target_url = Self::build_upstream_url(&original_path, query)
             .ok_or_else(|| Self::error(format!("Invalid GPT pagead path: {}", original_path)))?;
 
         log::info!("GPT proxy: forwarding to {}", target_url);
@@ -383,9 +403,9 @@ impl IntegrationProxy for GptIntegration {
         &self,
         settings: &Settings,
         services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let path = req.get_path();
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let path = req.uri().path().to_string();
 
         if path == "/integrations/gpt/script" {
             self.handle_script_serving(settings, services, req).await
@@ -473,7 +493,7 @@ mod tests {
     use crate::constants::HEADER_X_FORWARDED_FOR;
     use crate::integrations::IntegrationDocumentState;
     use crate::test_support::tests::create_test_settings;
-    use fastly::http::Method;
+    use http::Method;
 
     fn test_config() -> GptConfig {
         GptConfig {
@@ -491,6 +511,14 @@ mod tests {
             request_scheme: "https",
             origin_host: "origin.example.com",
         }
+    }
+
+    fn build_http_request(method: Method, uri: &str) -> http::Request<EdgeBody> {
+        http::Request::builder()
+            .method(method)
+            .uri(uri)
+            .body(EdgeBody::empty())
+            .expect("should build HTTP request")
     }
 
     // -- URL detection --
@@ -633,7 +661,7 @@ mod tests {
 
     #[test]
     fn build_proxy_config_uses_streaming_without_ec_forwarding_or_redirects() {
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://edge.example.com/integrations/gpt/script",
         );
@@ -658,13 +686,22 @@ mod tests {
 
     #[test]
     fn build_proxy_config_forwards_only_required_headers() {
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::GET,
             "https://edge.example.com/integrations/gpt/script",
         );
-        req.set_header(HEADER_ACCEPT, "application/javascript");
-        req.set_header(HEADER_ACCEPT_LANGUAGE, "en-US,en;q=0.9");
-        req.set_header(HEADER_ACCEPT_ENCODING, "gzip");
+        req.headers_mut().insert(
+            HEADER_ACCEPT,
+            http::HeaderValue::from_static("application/javascript"),
+        );
+        req.headers_mut().insert(
+            HEADER_ACCEPT_LANGUAGE,
+            http::HeaderValue::from_static("en-US,en;q=0.9"),
+        );
+        req.headers_mut().insert(
+            HEADER_ACCEPT_ENCODING,
+            http::HeaderValue::from_static("gzip"),
+        );
 
         let config = GptIntegration::build_proxy_config(
             "https://securepubads.g.doubleclick.net/tag/js/gpt.js",
@@ -734,7 +771,7 @@ mod tests {
 
     #[test]
     fn build_proxy_config_does_not_advertise_accept_encoding_when_client_omits_it() {
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://edge.example.com/integrations/gpt/script",
         );
@@ -758,67 +795,94 @@ mod tests {
     #[test]
     fn finalize_gpt_asset_response_rebuilds_successful_responses_with_safe_headers() {
         let integration = GptIntegration::new(test_config());
-        let response = Response::from_status(fastly::http::StatusCode::OK)
-            .with_header(
+        let response = http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header(
                 header::CONTENT_TYPE,
                 "application/javascript; charset=utf-8",
             )
-            .with_header(header::ETAG, "\"gpt-etag\"")
-            .with_header(header::LAST_MODIFIED, "Thu, 13 Mar 2025 08:00:00 GMT")
-            .with_header(header::CONTENT_ENCODING, "br")
-            .with_header(header::VARY, "Origin")
-            .with_header(header::SET_COOKIE, "gpt=1; Secure");
+            .header(header::ETAG, "\"gpt-etag\"")
+            .header(header::LAST_MODIFIED, "Thu, 13 Mar 2025 08:00:00 GMT")
+            .header(header::CONTENT_ENCODING, "br")
+            .header(header::VARY, "Origin")
+            .header(header::SET_COOKIE, "gpt=1; Secure")
+            .body(EdgeBody::empty())
+            .expect("should build GPT response");
         let response = integration.finalize_gpt_asset_response(response);
 
         assert_eq!(
-            response.get_status(),
-            fastly::http::StatusCode::OK,
+            response.status(),
+            http::StatusCode::OK,
             "should preserve successful upstream statuses"
         );
         assert_eq!(
-            response.get_header_str("X-GPT-Proxy"),
+            response
+                .headers()
+                .get("X-GPT-Proxy")
+                .and_then(|value| value.to_str().ok()),
             Some("true"),
             "should tag proxied GPT responses"
         );
         assert_eq!(
-            response.get_header_str(header::CONTENT_TYPE),
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
             Some("application/javascript; charset=utf-8"),
             "should preserve upstream content type for GPT assets"
         );
         assert_eq!(
-            response.get_header_str(header::ETAG),
+            response
+                .headers()
+                .get(header::ETAG)
+                .and_then(|value| value.to_str().ok()),
             Some("\"gpt-etag\""),
             "should preserve upstream ETag validators for GPT assets"
         );
         assert_eq!(
-            response.get_header_str(header::LAST_MODIFIED),
+            response
+                .headers()
+                .get(header::LAST_MODIFIED)
+                .and_then(|value| value.to_str().ok()),
             Some("Thu, 13 Mar 2025 08:00:00 GMT"),
             "should preserve upstream Last-Modified validators for GPT assets"
         );
         assert_eq!(
-            response.get_header_str(header::CONTENT_ENCODING),
+            response
+                .headers()
+                .get(header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
             Some("br"),
             "should preserve upstream content encoding for GPT assets"
         );
         assert_eq!(
-            response.get_header_str(header::VARY),
+            response
+                .headers()
+                .get(header::VARY)
+                .and_then(|value| value.to_str().ok()),
             Some("Origin, Accept-Encoding"),
             "should normalize Vary when returning encoded GPT assets"
         );
         assert_eq!(
-            response.get_header_str(header::CACHE_CONTROL),
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
             Some("public, max-age=3600"),
             "should add cache headers for successful GPT asset responses"
         );
         assert!(
-            response.get_header(header::SET_COOKIE).is_none(),
+            response.headers().get(header::SET_COOKIE).is_none(),
             "should not project unrelated upstream headers to first-party clients"
         );
     }
 
     #[test]
     fn ensure_successful_gpt_asset_response_rejects_non_success_statuses() {
-        let response = Response::from_status(fastly::http::StatusCode::SERVICE_UNAVAILABLE);
+        let response = http::Response::builder()
+            .status(http::StatusCode::SERVICE_UNAVAILABLE)
+            .body(EdgeBody::empty())
+            .expect("should build service unavailable response");
         let err = GptIntegration::ensure_successful_gpt_asset_response(
             &response,
             "Failed to fetch GPT script from https://securepubads.g.doubleclick.net/tag/js/gpt.js",

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -49,6 +49,7 @@ use crate::integrations::{
     IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
     IntegrationRegistration,
 };
+use crate::platform::RuntimeServices;
 use crate::proxy::{proxy_request, ProxyRequestConfig};
 use crate::settings::{IntegrationConfig, Settings};
 
@@ -238,12 +239,13 @@ impl GptIntegration {
     async fn proxy_gpt_asset(
         &self,
         settings: &Settings,
+        services: &RuntimeServices,
         req: Request,
         target_url: &str,
         context: &str,
     ) -> Result<Response, Report<TrustedServerError>> {
         let config = Self::build_proxy_config(target_url, &req);
-        let response = proxy_request(settings, req, config)
+        let response = proxy_request(settings, req, config, services)
             .await
             .change_context(Self::error(context))?;
 
@@ -287,12 +289,14 @@ impl GptIntegration {
     async fn handle_script_serving(
         &self,
         settings: &Settings,
+        services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let script_url = &self.config.script_url;
         log::info!("Fetching GPT script from: {}", script_url);
         self.proxy_gpt_asset(
             settings,
+            services,
             req,
             script_url,
             &format!("Failed to fetch GPT script from {script_url}"),
@@ -309,6 +313,7 @@ impl GptIntegration {
     async fn handle_pagead_proxy(
         &self,
         settings: &Settings,
+        services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let original_path = req.get_path();
@@ -320,6 +325,7 @@ impl GptIntegration {
         log::info!("GPT proxy: forwarding to {}", target_url);
         self.proxy_gpt_asset(
             settings,
+            services,
             req,
             &target_url,
             &format!("Failed to fetch GPT resource from {target_url}"),
@@ -376,16 +382,17 @@ impl IntegrationProxy for GptIntegration {
     async fn handle(
         &self,
         settings: &Settings,
+        services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path();
 
         if path == "/integrations/gpt/script" {
-            self.handle_script_serving(settings, req).await
+            self.handle_script_serving(settings, services, req).await
         } else if path.starts_with("/integrations/gpt/pagead/")
             || path.starts_with("/integrations/gpt/tag/")
         {
-            self.handle_pagead_proxy(settings, req).await
+            self.handle_pagead_proxy(settings, services, req).await
         } else {
             Err(Report::new(Self::error(format!(
                 "Unknown GPT route: {}",

--- a/crates/trusted-server-core/src/integrations/lockr.rs
+++ b/crates/trusted-server-core/src/integrations/lockr.rs
@@ -23,6 +23,7 @@ use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
 };
+use crate::platform::RuntimeServices;
 use crate::settings::{IntegrationConfig, Settings};
 
 const LOCKR_INTEGRATION_ID: &str = "lockr";
@@ -303,6 +304,7 @@ impl IntegrationProxy for LockrIntegration {
     async fn handle(
         &self,
         settings: &Settings,
+        _services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path();

--- a/crates/trusted-server-core/src/integrations/lockr.rs
+++ b/crates/trusted-server-core/src/integrations/lockr.rs
@@ -10,20 +10,23 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, Method, StatusCode};
-use fastly::{Request, Response};
+use http::header::{self, HeaderMap, HeaderValue};
+use http::{Method, StatusCode};
 use serde::Deserialize;
 use validator::Validate;
 
-use crate::backend::BackendConfig;
-use crate::compat;
+use crate::constants::INTERNAL_HEADERS;
+use crate::cookies::{strip_cookies, CONSENT_COOKIE_NAMES};
 use crate::error::TrustedServerError;
 use crate::integrations::{
+    collect_body_bounded, collect_response_bounded, ensure_integration_backend,
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
+    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
+    UPSTREAM_SDK_MAX_RESPONSE_BYTES,
 };
-use crate::platform::RuntimeServices;
+use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
 
 const LOCKR_INTEGRATION_ID: &str = "lockr";
@@ -106,67 +109,83 @@ impl LockrIntegration {
     async fn handle_sdk_serving(
         &self,
         _settings: &Settings,
-        _req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
+        services: &RuntimeServices,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
         let sdk_url = &self.config.sdk_url;
         log::info!("Fetching Lockr SDK from {}", sdk_url);
 
         // TODO: Check KV store cache first (future enhancement)
 
-        let mut lockr_req = Request::new(Method::GET, sdk_url);
-        lockr_req.set_header(header::USER_AGENT, "TrustedServer/1.0");
-        lockr_req.set_header(header::ACCEPT, "application/javascript, */*");
+        let lockr_req = http::Request::builder()
+            .method(Method::GET)
+            .uri(sdk_url)
+            .header(header::USER_AGENT, "TrustedServer/1.0")
+            .header(header::ACCEPT, "application/javascript, */*")
+            .body(EdgeBody::empty())
+            .change_context(Self::error("Failed to build Lockr SDK request"))?;
 
-        let backend_name = BackendConfig::from_url(sdk_url, true)
+        let backend_name = Self::backend_name_for_url(services, sdk_url)
             .change_context(Self::error("Failed to determine backend for SDK fetch"))?;
 
-        let mut lockr_response =
-            lockr_req
-                .send(backend_name)
-                .change_context(Self::error(format!(
-                    "Failed to fetch Lockr SDK from {}",
-                    sdk_url
-                )))?;
+        let lockr_response = services
+            .http_client()
+            .send(PlatformHttpRequest::new(lockr_req, backend_name))
+            .await
+            .change_context(Self::error(format!(
+                "Failed to fetch Lockr SDK from {}",
+                sdk_url
+            )))?
+            .response;
 
-        if !lockr_response.get_status().is_success() {
+        if !lockr_response.status().is_success() {
             log::error!(
                 "Lockr SDK fetch failed with status {}",
-                lockr_response.get_status()
+                lockr_response.status()
             );
             return Err(Report::new(Self::error(format!(
                 "Lockr SDK returned error status: {}",
-                lockr_response.get_status()
+                lockr_response.status()
             ))));
         }
 
-        let sdk_body = lockr_response.take_body_bytes();
+        let sdk_body = collect_response_bounded(
+            lockr_response.into_body(),
+            UPSTREAM_SDK_MAX_RESPONSE_BYTES,
+            LOCKR_INTEGRATION_ID,
+        )
+        .await
+        .change_context(Self::error("Failed to read Lockr SDK response body"))?;
         log::info!("Fetched Lockr SDK ({} bytes)", sdk_body.len());
 
         // TODO: Cache in KV store (future enhancement)
 
-        Ok(Response::from_status(StatusCode::OK)
-            .with_header(
+        http::Response::builder()
+            .status(StatusCode::OK)
+            .header(
                 header::CONTENT_TYPE,
                 "application/javascript; charset=utf-8",
             )
-            .with_header(
+            .header(
                 header::CACHE_CONTROL,
                 format!("public, max-age={}", self.config.cache_ttl_seconds),
             )
-            .with_header("X-Lockr-SDK-Proxy", "true")
-            .with_header("X-Lockr-SDK-Mode", "trust-server")
-            .with_header("X-SDK-Source", sdk_url)
-            .with_body(sdk_body))
+            .header("X-Lockr-SDK-Proxy", "true")
+            .header("X-Lockr-SDK-Mode", "trust-server")
+            .header("X-SDK-Source", sdk_url)
+            .body(EdgeBody::from(sdk_body))
+            .change_context(Self::error("Failed to build Lockr SDK response"))
     }
 
     /// Handle API proxy — forward requests to the configured Lockr API endpoint.
     async fn handle_api_proxy(
         &self,
         _settings: &Settings,
-        mut req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let original_path = req.get_path();
-        let method = req.get_method();
+        services: &RuntimeServices,
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let (parts, body) = req.into_parts();
+        let original_path = parts.uri.path().to_string();
+        let method = parts.method.clone();
 
         log::info!("Proxying Lockr API request: {} {}", method, original_path);
 
@@ -176,8 +195,8 @@ impl LockrIntegration {
             .strip_prefix("/integrations/lockr/api")
             .ok_or_else(|| Self::error(format!("Invalid Lockr API path: {}", original_path)))?;
 
-        let query = req
-            .get_url()
+        let query = parts
+            .uri
             .query()
             .map(|q| format!("?{}", q))
             .unwrap_or_default();
@@ -185,30 +204,36 @@ impl LockrIntegration {
 
         log::info!("Forwarding to Lockr API: {}", target_url);
 
-        let mut target_req = Request::new(method.clone(), &target_url);
-        self.copy_request_headers(&req, &mut target_req);
-
-        if matches!(method, &Method::POST | &Method::PUT | &Method::PATCH) {
-            let body = req.take_body();
-            target_req.set_body(body);
-        }
-
-        let backend_name = BackendConfig::from_url(&self.config.api_endpoint, true)
-            .change_context(Self::error("Failed to determine backend for API proxy"))?;
-
-        let response = match target_req.send(backend_name) {
-            Ok(res) => res,
-            Err(e) => {
-                return Err(Self::error(format!(
-                    "failed to forward request to {}, {}",
-                    target_url,
-                    e.root_cause()
-                ))
-                .into());
-            }
+        let request_body = if method == Method::POST {
+            let bytes =
+                collect_body_bounded(body, INTEGRATION_MAX_BODY_BYTES, LOCKR_INTEGRATION_ID)
+                    .await?;
+            EdgeBody::from(bytes)
+        } else {
+            EdgeBody::empty()
         };
 
-        log::info!("Lockr API responded with status {}", response.get_status());
+        let mut target_req = http::Request::builder()
+            .method(method.clone())
+            .uri(&target_url)
+            .body(request_body)
+            .change_context(Self::error("Failed to build Lockr API proxy request"))?;
+        self.copy_request_headers(&parts.headers, target_req.headers_mut())?;
+
+        let backend_name = Self::backend_name_for_url(services, &self.config.api_endpoint)
+            .change_context(Self::error("Failed to determine backend for API proxy"))?;
+
+        let response = services
+            .http_client()
+            .send(PlatformHttpRequest::new(target_req, backend_name))
+            .await
+            .change_context(Self::error(format!(
+                "Failed to forward request to {}",
+                target_url
+            )))?
+            .response;
+
+        log::info!("Lockr API responded with status {}", response.status());
 
         Ok(response)
     }
@@ -218,7 +243,11 @@ impl LockrIntegration {
     /// Consent cookies are always stripped — consent signals are forwarded
     /// through the `OpenRTB` body by the Prebid integration, not through
     /// Lockr's cookie-based API calls.
-    fn copy_request_headers(&self, from: &Request, to: &mut Request) {
+    fn copy_request_headers(
+        &self,
+        from: &HeaderMap<HeaderValue>,
+        to: &mut HeaderMap<HeaderValue>,
+    ) -> Result<(), Report<TrustedServerError>> {
         let headers_to_copy = [
             header::CONTENT_TYPE,
             header::ACCEPT,
@@ -229,25 +258,73 @@ impl LockrIntegration {
         ];
 
         for header_name in &headers_to_copy {
-            if let Some(value) = from.get_header(header_name) {
-                to.set_header(header_name, value);
+            if let Some(value) = from.get(header_name) {
+                to.insert(header_name, value.clone());
             }
         }
 
         // Always strip consent cookies — consent travels through the OpenRTB body
-        compat::forward_fastly_cookie_header(from, to, true);
+        self.copy_cookie_header(from, to)?;
 
         // Use origin override if configured, otherwise forward original
-        let origin = self
-            .config
-            .origin_override
-            .as_deref()
-            .or_else(|| from.get_header_str(header::ORIGIN));
+        let origin = self.config.origin_override.as_deref().or_else(|| {
+            from.get(header::ORIGIN)
+                .and_then(|value| value.to_str().ok())
+        });
         if let Some(origin) = origin {
-            to.set_header(header::ORIGIN, origin);
+            match HeaderValue::from_str(origin) {
+                Ok(value) => {
+                    to.insert(header::ORIGIN, value);
+                }
+                Err(error) => {
+                    log::warn!("Skipping invalid Lockr origin header value '{origin}': {error}");
+                }
+            }
         }
 
-        compat::copy_fastly_custom_headers(from, to);
+        for (name, value) in from {
+            let name_str = name.as_str();
+            if name_str.starts_with("x-") && !INTERNAL_HEADERS.contains(&name_str) {
+                to.append(name.clone(), value.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn copy_cookie_header(
+        &self,
+        from: &HeaderMap<HeaderValue>,
+        to: &mut HeaderMap<HeaderValue>,
+    ) -> Result<(), Report<TrustedServerError>> {
+        let Some(cookie_value) = from.get(header::COOKIE) else {
+            return Ok(());
+        };
+
+        match cookie_value.to_str() {
+            Ok(value) => {
+                let stripped = strip_cookies(value, CONSENT_COOKIE_NAMES);
+                if stripped.is_empty() {
+                    return Ok(());
+                }
+
+                let cookie_header = HeaderValue::from_str(&stripped)
+                    .change_context(Self::error("Failed to rebuild stripped cookie header"))?;
+                to.insert(header::COOKIE, cookie_header);
+            }
+            Err(_) => {
+                to.insert(header::COOKIE, cookie_value.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn backend_name_for_url(
+        services: &RuntimeServices,
+        target_url: &str,
+    ) -> Result<String, Report<TrustedServerError>> {
+        ensure_integration_backend(services, target_url, LOCKR_INTEGRATION_ID, None)
     }
 }
 
@@ -304,15 +381,15 @@ impl IntegrationProxy for LockrIntegration {
     async fn handle(
         &self,
         settings: &Settings,
-        _services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let path = req.get_path();
+        services: &RuntimeServices,
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let path = req.uri().path().to_string();
 
         if path == "/integrations/lockr/sdk" {
-            self.handle_sdk_serving(settings, req).await
+            self.handle_sdk_serving(settings, services).await
         } else if path.starts_with("/integrations/lockr/api/") {
-            self.handle_api_proxy(settings, req).await
+            self.handle_api_proxy(settings, services, req).await
         } else {
             Err(Report::new(Self::error(format!(
                 "Unknown Lockr route: {}",
@@ -376,9 +453,13 @@ fn default_rewrite_sdk() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use edgezero_core::http::Method as HttpMethod;
     use serde_json::json;
 
+    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
     use crate::test_support::tests::create_test_settings;
 
     fn test_config() -> LockrConfig {
@@ -487,6 +568,36 @@ mod tests {
             result,
             AttributeRewriteAction::Keep,
             "should keep all URLs when rewrite_sdk is disabled"
+        );
+    }
+
+    #[test]
+    fn lockr_proxy_uses_platform_http_client() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let integration = LockrIntegration::new(test_config());
+        let req = http::Request::builder()
+            .method(HttpMethod::GET)
+            .uri("https://publisher.example/integrations/lockr/api/publisher/app/v1/identityLockr/settings")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let response = futures::executor::block_on(integration.handle(&settings, &services, req))
+            .expect("should proxy request");
+
+        assert_eq!(
+            response.status(),
+            http::StatusCode::OK,
+            "should return stubbed response"
+        );
+        assert_eq!(
+            stub.recorded_backend_names().len(),
+            1,
+            "should route one outbound request through PlatformHttpClient"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/mod.rs
+++ b/crates/trusted-server-core/src/integrations/mod.rs
@@ -1,8 +1,14 @@
 //! Integration module registry and sample implementations.
 
-use error_stack::Report;
+use std::time::Duration;
+
+use edgezero_core::body::Body as EdgeBody;
+use error_stack::{Report, ResultExt};
+use futures::StreamExt as _;
+use url::Url;
 
 use crate::error::TrustedServerError;
+use crate::platform::{PlatformBackendSpec, RuntimeServices};
 use crate::settings::Settings;
 
 pub mod adserver_mock;
@@ -27,6 +33,168 @@ pub use registry::{
     IntegrationRegistry, IntegrationScriptContext, IntegrationScriptRewriter, ProxyDispatchInput,
     ScriptRewriteAction,
 };
+
+/// Registers or retrieves a platform backend for the given URL.
+///
+/// Parses `url`, builds a [`PlatformBackendSpec`] with TLS enabled and a
+/// 15-second first-byte timeout, and delegates to
+/// [`crate::platform::PlatformBackend::ensure`].
+///
+/// # Errors
+///
+/// Returns an error when `url` cannot be parsed, is missing a host, or the
+/// backend registration fails.
+pub(crate) fn ensure_integration_backend(
+    services: &RuntimeServices,
+    url: &str,
+    integration: &'static str,
+    first_byte_timeout: Option<Duration>,
+) -> Result<String, Report<TrustedServerError>> {
+    let parsed = Url::parse(url).change_context(TrustedServerError::Integration {
+        integration: integration.to_string(),
+        message: "Invalid upstream URL".to_string(),
+    })?;
+
+    services
+        .backend()
+        .ensure(&PlatformBackendSpec {
+            scheme: parsed.scheme().to_string(),
+            host: parsed
+                .host_str()
+                .ok_or_else(|| {
+                    Report::new(TrustedServerError::Integration {
+                        integration: integration.to_string(),
+                        message: "Upstream URL missing host".to_string(),
+                    })
+                })?
+                .to_string(),
+            port: parsed.port(),
+            certificate_check: true,
+            first_byte_timeout: first_byte_timeout.unwrap_or_else(|| Duration::from_secs(15)),
+        })
+        .change_context(TrustedServerError::Integration {
+            integration: integration.to_string(),
+            message: "Failed to register backend".to_string(),
+        })
+}
+
+/// Maximum body size accepted by integration proxy endpoints (256 KiB).
+pub(crate) const INTEGRATION_MAX_BODY_BYTES: usize = 256 * 1024;
+
+/// Maximum response body size from RTB providers (prebid, aps, mediator).
+pub(crate) const UPSTREAM_RTB_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+/// Maximum response body size from SDK/proxy integrations.
+pub(crate) const UPSTREAM_SDK_MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Drains an [`EdgeBody`] into a byte vector, rejecting bodies larger than
+/// `max_bytes` with [`TrustedServerError::RequestTooLarge`].
+///
+/// # Errors
+///
+/// Returns an error when:
+/// - The body exceeds `max_bytes`.
+/// - A streaming body chunk cannot be read (mapped to an `Integration` error).
+pub(crate) async fn collect_body_bounded(
+    body: EdgeBody,
+    max_bytes: usize,
+    integration: &'static str,
+) -> Result<Vec<u8>, Report<TrustedServerError>> {
+    match body {
+        EdgeBody::Once(bytes) => {
+            if bytes.len() > max_bytes {
+                return Err(Report::new(TrustedServerError::RequestTooLarge {
+                    message: format!(
+                        "{integration}: request body ({} bytes) exceeds the {max_bytes} byte limit",
+                        bytes.len(),
+                    ),
+                }));
+            }
+            Ok(bytes.to_vec())
+        }
+        EdgeBody::Stream(mut stream) => {
+            let mut body_bytes = Vec::new();
+            while let Some(chunk_result) = stream.next().await {
+                let chunk = chunk_result.map_err(|error| {
+                    Report::new(TrustedServerError::Integration {
+                        integration: integration.to_string(),
+                        message: format!("Failed to read request body: {error}"),
+                    })
+                })?;
+                if body_bytes.len() + chunk.len() > max_bytes {
+                    return Err(Report::new(TrustedServerError::RequestTooLarge {
+                        message: format!(
+                            "{integration}: request body exceeds the {max_bytes} byte limit",
+                        ),
+                    }));
+                }
+                // Size check runs after chunk is materialized — effective bound is
+                // ≤ max_bytes + one_chunk (Fastly H2/H3 chunks are ≤ 16 KiB in practice).
+                body_bytes.extend_from_slice(&chunk);
+            }
+            Ok(body_bytes)
+        }
+    }
+}
+
+/// Drains an upstream [`EdgeBody`] response into a byte vector, rejecting
+/// bodies larger than `max_bytes` with [`TrustedServerError::Integration`].
+///
+/// Use this for upstream (provider/integration) response bodies to bound
+/// memory usage when a third-party server misbehaves. Unlike
+/// [`collect_body_bounded`], oversized bodies are classified as
+/// [`TrustedServerError::Integration`] (502 `BAD_GATEWAY`) rather than
+/// [`TrustedServerError::RequestTooLarge`] (413).
+///
+/// Note: the effective bound for streaming bodies is ≤ `max_bytes` + `one_chunk`
+/// because the size check runs after each chunk is materialized. Fastly
+/// H2/H3 chunks are ≤ 16 KiB in practice, making the overshoot negligible.
+///
+/// # Errors
+///
+/// Returns an error when:
+/// - The body exceeds `max_bytes` (mapped to [`TrustedServerError::Integration`]).
+/// - A streaming body chunk cannot be read (same error type).
+pub(crate) async fn collect_response_bounded(
+    body: EdgeBody,
+    max_bytes: usize,
+    integration: &'static str,
+) -> Result<Vec<u8>, Report<TrustedServerError>> {
+    match body {
+        EdgeBody::Once(bytes) => {
+            if bytes.len() > max_bytes {
+                return Err(Report::new(TrustedServerError::Integration {
+                    integration: integration.to_string(),
+                    message: format!(
+                        "response body ({} bytes) exceeds the {max_bytes} byte limit",
+                        bytes.len(),
+                    ),
+                }));
+            }
+            Ok(bytes.to_vec())
+        }
+        EdgeBody::Stream(mut stream) => {
+            let mut body_bytes = Vec::new();
+            while let Some(chunk_result) = stream.next().await {
+                let chunk = chunk_result.map_err(|error| {
+                    Report::new(TrustedServerError::Integration {
+                        integration: integration.to_string(),
+                        message: format!("Failed to read response body: {error}"),
+                    })
+                })?;
+                // Size check runs after chunk is materialized — effective bound is
+                // ≤ max_bytes + one_chunk (Fastly H2/H3 chunks are ≤ 16 KiB in practice).
+                if body_bytes.len() + chunk.len() > max_bytes {
+                    return Err(Report::new(TrustedServerError::Integration {
+                        integration: integration.to_string(),
+                        message: format!("response body exceeds the {max_bytes} byte limit",),
+                    }));
+                }
+                body_bytes.extend_from_slice(&chunk);
+            }
+            Ok(body_bytes)
+        }
+    }
+}
 
 type IntegrationBuilder =
     fn(&Settings) -> Result<Option<IntegrationRegistration>, Report<TrustedServerError>>;

--- a/crates/trusted-server-core/src/integrations/nextjs/html_post_process.rs
+++ b/crates/trusted-server-core/src/integrations/nextjs/html_post_process.rs
@@ -120,15 +120,10 @@ impl NextJsHtmlPostProcessor {
                 .iter()
                 .map(|p| p.matches(ctx.origin_host).count())
                 .sum();
-            // lgtm[rust/cleartext-logging]
-            // This debug log reports rewrite counts and hostnames only; no secret material is emitted.
             log::debug!(
-                "NextJs post-processor substituting RSC payloads: scripts={}, origin_urls={}, origin={}, proxy={}://{}, html_len={}",
+                "NextJs post-processor substituting RSC payloads: scripts={}, origin_urls={}, html_len={}",
                 rewritten_payloads.len(),
                 origin_count_before,
-                ctx.origin_host,
-                ctx.request_scheme,
-                ctx.request_host,
                 html.len()
             );
         }
@@ -455,15 +450,10 @@ fn post_process_rsc_html_in_place_with_limit(
                 .iter()
                 .map(|p| p.matches(origin_host).count())
                 .sum();
-            // lgtm[rust/cleartext-logging]
-            // This debug log reports rewrite counts and hostnames only; no secret material is emitted.
             log::debug!(
-                "post_process_rsc_html: {} scripts, {} origin URLs, origin={}, proxy={}://{}",
+                "post_process_rsc_html: scripts={}, origin_urls={}",
                 payloads.len(),
-                origin_count_before,
-                origin_host,
-                request_scheme,
-                request_host
+                origin_count_before
             );
         }
 

--- a/crates/trusted-server-core/src/integrations/permutive.rs
+++ b/crates/trusted-server-core/src/integrations/permutive.rs
@@ -6,20 +6,22 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, Method, StatusCode};
-use fastly::{Request, Response};
+use http::header::{self, HeaderMap, HeaderValue};
+use http::{Method, StatusCode};
 use serde::Deserialize;
 use validator::Validate;
 
-use crate::backend::BackendConfig;
-use crate::compat;
+use crate::constants::INTERNAL_HEADERS;
 use crate::error::TrustedServerError;
 use crate::integrations::{
+    collect_body_bounded, collect_response_bounded, ensure_integration_backend,
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
+    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
+    UPSTREAM_SDK_MAX_RESPONSE_BYTES,
 };
-use crate::platform::RuntimeServices;
+use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
 
 const PERMUTIVE_INTEGRATION_ID: &str = "permutive";
@@ -106,8 +108,8 @@ impl PermutiveIntegration {
     async fn handle_sdk_serving(
         &self,
         _settings: &Settings,
-        _req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
+        services: &RuntimeServices,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
         log::info!("Handling Permutive SDK request");
 
         let sdk_url = self.sdk_url();
@@ -116,33 +118,45 @@ impl PermutiveIntegration {
         // TODO: Check KV store cache first (future enhancement)
 
         // Fetch SDK from Permutive CDN
-        let mut permutive_req = Request::new(Method::GET, &sdk_url);
-        permutive_req.set_header(header::USER_AGENT, "TrustedServer/1.0");
-        permutive_req.set_header(header::ACCEPT, "application/javascript, */*");
+        let permutive_req = http::Request::builder()
+            .method(Method::GET)
+            .uri(&sdk_url)
+            .header(header::USER_AGENT, "TrustedServer/1.0")
+            .header(header::ACCEPT, "application/javascript, */*")
+            .body(EdgeBody::empty())
+            .change_context(Self::error("Failed to build Permutive SDK request"))?;
 
-        let backend_name = BackendConfig::from_url(&sdk_url, true)
+        let backend_name = Self::backend_name_for_url(services, &sdk_url)
             .change_context(Self::error("Failed to determine backend for SDK fetch"))?;
 
-        let mut permutive_response =
-            permutive_req
-                .send(backend_name)
-                .change_context(Self::error(format!(
-                    "Failed to fetch Permutive SDK from {}",
-                    sdk_url
-                )))?;
+        let permutive_response = services
+            .http_client()
+            .send(PlatformHttpRequest::new(permutive_req, backend_name))
+            .await
+            .change_context(Self::error(format!(
+                "Failed to fetch Permutive SDK from {}",
+                sdk_url
+            )))?
+            .response;
 
-        if !permutive_response.get_status().is_success() {
+        if !permutive_response.status().is_success() {
             log::error!(
                 "Permutive SDK fetch failed with status: {}",
-                permutive_response.get_status()
+                permutive_response.status()
             );
             return Err(Report::new(Self::error(format!(
                 "Permutive SDK returned error status: {}",
-                permutive_response.get_status()
+                permutive_response.status()
             ))));
         }
 
-        let sdk_body = permutive_response.take_body_bytes();
+        let sdk_body = collect_response_bounded(
+            permutive_response.into_body(),
+            UPSTREAM_SDK_MAX_RESPONSE_BYTES,
+            PERMUTIVE_INTEGRATION_ID,
+        )
+        .await
+        .change_context(Self::error("Failed to read Permutive SDK response body"))?;
         log::info!(
             "Successfully fetched Permutive SDK: {} bytes",
             sdk_body.len()
@@ -150,335 +164,99 @@ impl PermutiveIntegration {
 
         // TODO: Cache in KV store (future enhancement)
 
-        Ok(Response::from_status(StatusCode::OK)
-            .with_header(
+        http::Response::builder()
+            .status(StatusCode::OK)
+            .header(
                 header::CONTENT_TYPE,
                 "application/javascript; charset=utf-8",
             )
-            .with_header(
+            .header(
                 header::CACHE_CONTROL,
                 format!("public, max-age={}", self.config.cache_ttl_seconds),
             )
-            .with_header("X-Permutive-SDK-Proxy", "true")
-            .with_header("X-SDK-Source", &sdk_url)
-            .with_body(sdk_body))
+            .header("X-Permutive-SDK-Proxy", "true")
+            .header("X-SDK-Source", &sdk_url)
+            .body(EdgeBody::from(sdk_body))
+            .change_context(Self::error("Failed to build Permutive SDK response"))
     }
 
-    /// Handle API proxy - forward requests to api.permutive.com.
-    async fn handle_api_proxy(
+    async fn forward_proxy_request(
         &self,
-        _settings: &Settings,
-        mut req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let original_path = req.get_path();
-        let method = req.get_method();
+        services: &RuntimeServices,
+        req: http::Request<EdgeBody>,
+        route_prefix: &str,
+        upstream_base: &str,
+        route_name: &str,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let (parts, body) = req.into_parts();
+        let original_path = parts.uri.path().to_string();
+        let method = parts.method.clone();
 
         log::info!(
-            "Proxying Permutive API request: {} {}",
+            "Proxying {} request: {} {}",
+            route_name,
             method,
             original_path
         );
 
-        // Extract path after /integrations/permutive/api
-        let api_path = original_path
-            .strip_prefix("/integrations/permutive/api")
-            .ok_or_else(|| Self::error(format!("Invalid Permutive API path: {}", original_path)))?;
+        let upstream_path = original_path.strip_prefix(route_prefix).ok_or_else(|| {
+            Self::error(format!("Invalid {} path: {}", route_name, original_path))
+        })?;
 
-        // Build full target URL with query parameters
-        let query = req
-            .get_url()
+        let query = parts
+            .uri
             .query()
             .map(|q| format!("?{}", q))
             .unwrap_or_default();
-        let target_url = format!("{}{}{}", self.config.api_endpoint, api_path, query);
+        let target_url = format!("{}{}{}", upstream_base, upstream_path, query);
 
-        log::info!("Forwarding to Permutive API: {}", target_url);
+        log::info!("Forwarding {} to {}", route_name, target_url);
 
-        // Create new request
-        let mut target_req = Request::new(method.clone(), &target_url);
+        let request_body = if method == Method::POST {
+            let bytes =
+                collect_body_bounded(body, INTEGRATION_MAX_BODY_BYTES, PERMUTIVE_INTEGRATION_ID)
+                    .await?;
+            EdgeBody::from(bytes)
+        } else {
+            EdgeBody::empty()
+        };
 
-        // Copy headers
-        self.copy_request_headers(&req, &mut target_req);
-
-        // Copy body for POST/PUT/PATCH
-        if matches!(method, &Method::POST | &Method::PUT | &Method::PATCH) {
-            let body = req.take_body();
-            target_req.set_body(body);
-        }
-
-        // Get backend and forward
-        let backend_name = BackendConfig::from_url(&self.config.api_endpoint, true)
-            .change_context(Self::error("Failed to determine backend for API proxy"))?;
-
-        let response = target_req
-            .send(backend_name)
+        let mut target_req = http::Request::builder()
+            .method(method)
+            .uri(&target_url)
+            .body(request_body)
             .change_context(Self::error(format!(
-                "Failed to forward request to {}",
-                target_url
+                "Failed to build {} proxy request",
+                route_name
             )))?;
+        self.copy_request_headers(&parts.headers, target_req.headers_mut());
 
-        log::info!(
-            "Permutive API responded with status: {}",
-            response.get_status()
-        );
-
-        Ok(response)
-    }
-
-    /// Handle Secure Signals proxy - forward requests to secure-signals.permutive.app.
-    async fn handle_secure_signals_proxy(
-        &self,
-        _settings: &Settings,
-        mut req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let original_path = req.get_path();
-        let method = req.get_method();
-
-        log::info!(
-            "Proxying Permutive Secure Signals request: {} {}",
-            method,
-            original_path
-        );
-
-        // Extract path after /integrations/permutive/secure-signal
-        let signal_path = original_path
-            .strip_prefix("/integrations/permutive/secure-signal")
-            .ok_or_else(|| {
-                Self::error(format!(
-                    "Invalid Permutive Secure Signals path: {}",
-                    original_path
-                ))
-            })?;
-
-        // Build full target URL with query parameters
-        let query = req
-            .get_url()
-            .query()
-            .map(|q| format!("?{}", q))
-            .unwrap_or_default();
-        let target_url = format!(
-            "{}{}{}",
-            self.config.secure_signals_endpoint, signal_path, query
-        );
-
-        log::info!("Forwarding to Permutive Secure Signals: {}", target_url);
-
-        // Create new request
-        let mut target_req = Request::new(method.clone(), &target_url);
-
-        // Copy headers
-        self.copy_request_headers(&req, &mut target_req);
-
-        // Copy body for POST/PUT/PATCH
-        if matches!(method, &Method::POST | &Method::PUT | &Method::PATCH) {
-            let body = req.take_body();
-            target_req.set_body(body);
-        }
-
-        // Get backend and forward
-        let backend_name = BackendConfig::from_url(&self.config.secure_signals_endpoint, true)
-            .change_context(Self::error(
-                "Failed to determine backend for Secure Signals proxy",
+        let backend_name =
+            Self::backend_name_for_url(services, upstream_base).change_context(Self::error(
+                format!("Failed to determine backend for {} proxy", route_name),
             ))?;
 
-        let response = target_req
-            .send(backend_name)
+        let response = services
+            .http_client()
+            .send(PlatformHttpRequest::new(target_req, backend_name))
+            .await
             .change_context(Self::error(format!(
                 "Failed to forward request to {}",
                 target_url
-            )))?;
+            )))?
+            .response;
 
         log::info!(
-            "Permutive Secure Signals responded with status: {}",
-            response.get_status()
-        );
-
-        Ok(response)
-    }
-
-    /// Handle Events proxy - forward requests to events.permutive.app.
-    async fn handle_events_proxy(
-        &self,
-        _settings: &Settings,
-        mut req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let original_path = req.get_path();
-        let method = req.get_method();
-
-        log::info!(
-            "Proxying Permutive Events request: {} {}",
-            method,
-            original_path
-        );
-
-        // Extract path after /integrations/permutive/events
-        let events_path = original_path
-            .strip_prefix("/integrations/permutive/events")
-            .ok_or_else(|| {
-                Self::error(format!("Invalid Permutive Events path: {}", original_path))
-            })?;
-
-        // Build full target URL with query parameters
-        let query = req
-            .get_url()
-            .query()
-            .map(|q| format!("?{}", q))
-            .unwrap_or_default();
-        let target_url = format!("https://events.permutive.app{}{}", events_path, query);
-
-        log::info!("Forwarding to Permutive Events: {}", target_url);
-
-        // Create new request
-        let mut target_req = Request::new(method.clone(), &target_url);
-
-        // Copy headers
-        self.copy_request_headers(&req, &mut target_req);
-
-        // Copy body for POST/PUT/PATCH
-        if matches!(method, &Method::POST | &Method::PUT | &Method::PATCH) {
-            let body = req.take_body();
-            target_req.set_body(body);
-        }
-
-        // Get backend and forward
-        let backend_name = BackendConfig::from_url("https://events.permutive.app", true)
-            .change_context(Self::error("Failed to determine backend for Events proxy"))?;
-
-        let response = target_req
-            .send(backend_name)
-            .change_context(Self::error(format!(
-                "Failed to forward request to {}",
-                target_url
-            )))?;
-
-        log::info!(
-            "Permutive Events responded with status: {}",
-            response.get_status()
-        );
-
-        Ok(response)
-    }
-
-    /// Handle Sync proxy - forward requests to sync.permutive.com.
-    async fn handle_sync_proxy(
-        &self,
-        _settings: &Settings,
-        mut req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let original_path = req.get_path();
-        let method = req.get_method();
-
-        log::info!(
-            "Proxying Permutive Sync request: {} {}",
-            method,
-            original_path
-        );
-
-        // Extract path after /integrations/permutive/sync
-        let sync_path = original_path
-            .strip_prefix("/integrations/permutive/sync")
-            .ok_or_else(|| {
-                Self::error(format!("Invalid Permutive Sync path: {}", original_path))
-            })?;
-
-        // Build full target URL with query parameters
-        let query = req
-            .get_url()
-            .query()
-            .map(|q| format!("?{}", q))
-            .unwrap_or_default();
-        let target_url = format!("https://sync.permutive.com{}{}", sync_path, query);
-
-        log::info!("Forwarding to Permutive Sync: {}", target_url);
-
-        // Create new request
-        let mut target_req = Request::new(method.clone(), &target_url);
-
-        // Copy headers
-        self.copy_request_headers(&req, &mut target_req);
-
-        // Copy body for POST/PUT/PATCH
-        if matches!(method, &Method::POST | &Method::PUT | &Method::PATCH) {
-            let body = req.take_body();
-            target_req.set_body(body);
-        }
-
-        // Get backend and forward
-        let backend_name = BackendConfig::from_url("https://sync.permutive.com", true)
-            .change_context(Self::error("Failed to determine backend for Sync proxy"))?;
-
-        let response = target_req
-            .send(backend_name)
-            .change_context(Self::error(format!(
-                "Failed to forward request to {}",
-                target_url
-            )))?;
-
-        log::info!(
-            "Permutive Sync responded with status: {}",
-            response.get_status()
-        );
-
-        Ok(response)
-    }
-
-    /// Handle CDN proxy - forward requests to cdn.permutive.com.
-    async fn handle_cdn_proxy(
-        &self,
-        _settings: &Settings,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let original_path = req.get_path();
-        let method = req.get_method();
-
-        log::info!(
-            "Proxying Permutive CDN request: {} {}",
-            method,
-            original_path
-        );
-
-        // Extract path after /integrations/permutive/cdn
-        let cdn_path = original_path
-            .strip_prefix("/integrations/permutive/cdn")
-            .ok_or_else(|| Self::error(format!("Invalid Permutive CDN path: {}", original_path)))?;
-
-        // Build full target URL with query parameters
-        let query = req
-            .get_url()
-            .query()
-            .map(|q| format!("?{}", q))
-            .unwrap_or_default();
-        let target_url = format!("https://cdn.permutive.com{}{}", cdn_path, query);
-
-        log::info!("Forwarding to Permutive CDN: {}", target_url);
-
-        // Create new request
-        let mut target_req = Request::new(method.clone(), &target_url);
-
-        // Copy headers
-        self.copy_request_headers(&req, &mut target_req);
-
-        // Get backend and forward
-        let backend_name = BackendConfig::from_url("https://cdn.permutive.com", true)
-            .change_context(Self::error("Failed to determine backend for CDN proxy"))?;
-
-        let response = target_req
-            .send(backend_name)
-            .change_context(Self::error(format!(
-                "Failed to forward request to {}",
-                target_url
-            )))?;
-
-        log::info!(
-            "Permutive CDN responded with status: {}",
-            response.get_status()
+            "{} responded with status: {}",
+            route_name,
+            response.status()
         );
 
         Ok(response)
     }
 
     /// Copy relevant request headers for proxying.
-    fn copy_request_headers(&self, from: &Request, to: &mut Request) {
+    fn copy_request_headers(&self, from: &HeaderMap<HeaderValue>, to: &mut HeaderMap<HeaderValue>) {
         let headers_to_copy = [
             header::CONTENT_TYPE,
             header::ACCEPT,
@@ -489,13 +267,25 @@ impl PermutiveIntegration {
         ];
 
         for header_name in &headers_to_copy {
-            if let Some(value) = from.get_header(header_name) {
-                to.set_header(header_name, value);
+            if let Some(value) = from.get(header_name) {
+                to.insert(header_name, value.clone());
             }
         }
 
         // Copy any X-* custom headers, skipping TS-internal headers
-        compat::copy_fastly_custom_headers(from, to);
+        for (name, value) in from {
+            let name_str = name.as_str();
+            if name_str.starts_with("x-") && !INTERNAL_HEADERS.contains(&name_str) {
+                to.append(name.clone(), value.clone());
+            }
+        }
+    }
+
+    fn backend_name_for_url(
+        services: &RuntimeServices,
+        target_url: &str,
+    ) -> Result<String, Report<TrustedServerError>> {
+        ensure_integration_backend(services, target_url, PERMUTIVE_INTEGRATION_ID, None)
     }
 }
 
@@ -561,23 +351,58 @@ impl IntegrationProxy for PermutiveIntegration {
     async fn handle(
         &self,
         settings: &Settings,
-        _services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let path = req.get_path();
+        services: &RuntimeServices,
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let path = req.uri().path().to_string();
 
         if path.starts_with("/integrations/permutive/api/") {
-            self.handle_api_proxy(settings, req).await
+            self.forward_proxy_request(
+                services,
+                req,
+                "/integrations/permutive/api",
+                &self.config.api_endpoint,
+                "Permutive API",
+            )
+            .await
         } else if path.starts_with("/integrations/permutive/secure-signal/") {
-            self.handle_secure_signals_proxy(settings, req).await
+            self.forward_proxy_request(
+                services,
+                req,
+                "/integrations/permutive/secure-signal",
+                &self.config.secure_signals_endpoint,
+                "Permutive Secure Signals",
+            )
+            .await
         } else if path.starts_with("/integrations/permutive/events/") {
-            self.handle_events_proxy(settings, req).await
+            self.forward_proxy_request(
+                services,
+                req,
+                "/integrations/permutive/events",
+                "https://events.permutive.app",
+                "Permutive Events",
+            )
+            .await
         } else if path.starts_with("/integrations/permutive/sync/") {
-            self.handle_sync_proxy(settings, req).await
+            self.forward_proxy_request(
+                services,
+                req,
+                "/integrations/permutive/sync",
+                "https://sync.permutive.com",
+                "Permutive Sync",
+            )
+            .await
         } else if path.starts_with("/integrations/permutive/cdn/") {
-            self.handle_cdn_proxy(settings, req).await
+            self.forward_proxy_request(
+                services,
+                req,
+                "/integrations/permutive/cdn",
+                "https://cdn.permutive.com",
+                "Permutive CDN",
+            )
+            .await
         } else if path == "/integrations/permutive/sdk" {
-            self.handle_sdk_serving(settings, req).await
+            self.handle_sdk_serving(settings, services).await
         } else {
             Err(Report::new(Self::error(format!(
                 "Unknown Permutive route: {}",
@@ -641,7 +466,10 @@ fn default_rewrite_sdk() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
     use crate::test_support::tests::create_test_settings;
 
     #[test]
@@ -789,6 +617,45 @@ mod tests {
                 .iter()
                 .any(|r| r.path == "/integrations/permutive/sdk" && r.method == Method::GET),
             "Should register SDK endpoint"
+        );
+    }
+
+    #[test]
+    fn permutive_proxy_uses_platform_http_client() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let integration = PermutiveIntegration::new(PermutiveConfig {
+            enabled: true,
+            organization_id: "myorg".to_string(),
+            workspace_id: "workspace-123".to_string(),
+            project_id: String::new(),
+            api_endpoint: default_api_endpoint(),
+            secure_signals_endpoint: default_secure_signals_endpoint(),
+            cache_ttl_seconds: 3600,
+            rewrite_sdk: true,
+        });
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://publisher.example/integrations/permutive/api/v2.0/events")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let response = futures::executor::block_on(integration.handle(&settings, &services, req))
+            .expect("should proxy request");
+
+        assert_eq!(
+            response.status(),
+            http::StatusCode::OK,
+            "should return stubbed response"
+        );
+        assert_eq!(
+            stub.recorded_backend_names(),
+            vec!["stub-backend".to_string()],
+            "should route outbound request through PlatformHttpClient"
         );
     }
 }

--- a/crates/trusted-server-core/src/integrations/permutive.rs
+++ b/crates/trusted-server-core/src/integrations/permutive.rs
@@ -19,6 +19,7 @@ use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
 };
+use crate::platform::RuntimeServices;
 use crate::settings::{IntegrationConfig, Settings};
 
 const PERMUTIVE_INTEGRATION_ID: &str = "permutive";
@@ -560,6 +561,7 @@ impl IntegrationProxy for PermutiveIntegration {
     async fn handle(
         &self,
         settings: &Settings,
+        _services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path();

--- a/crates/trusted-server-core/src/integrations/prebid.rs
+++ b/crates/trusted-server-core/src/integrations/prebid.rs
@@ -30,6 +30,7 @@ use crate::openrtb::{
     OpenRtbRequest, PrebidExt, PrebidImpExt, Publisher, Regs, RegsExt, RequestExt, Site, ToExt,
     TrustedServerExt, User, UserExt,
 };
+use crate::platform::RuntimeServices;
 use crate::request_signing::{RequestSigner, SigningParams, SIGNING_VERSION};
 use crate::settings::{IntegrationConfig, Settings};
 
@@ -420,6 +421,7 @@ impl IntegrationProxy for PrebidIntegration {
     async fn handle(
         &self,
         _settings: &Settings,
+        _services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path().to_string();

--- a/crates/trusted-server-core/src/integrations/prebid.rs
+++ b/crates/trusted-server-core/src/integrations/prebid.rs
@@ -3,39 +3,42 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, Method, StatusCode, Url};
-use fastly::{Request, Response};
+use http::header::HeaderValue;
+use http::{header, Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
+use url::Url;
 use validator::Validate;
 
-use crate::auction::orchestrator::ERROR_TYPE_HTTP_STATUS;
 use crate::auction::provider::AuctionProvider;
 use crate::auction::types::{
     AuctionContext, AuctionRequest, AuctionResponse, Bid as AuctionBid, MediaType,
 };
 use crate::backend::BackendConfig;
-use crate::compat;
 use crate::consent_config::ConsentForwardingMode;
+use crate::cookies::{strip_cookies, CONSENT_COOKIE_NAMES};
 use crate::error::TrustedServerError;
 use crate::http_util::RequestInfo;
 use crate::integrations::{
-    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
-    IntegrationRegistration,
+    collect_response_bounded, ensure_integration_backend, AttributeRewriteAction,
+    IntegrationAttributeContext, IntegrationAttributeRewriter, IntegrationEndpoint,
+    IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy, IntegrationRegistration,
+    UPSTREAM_RTB_MAX_RESPONSE_BYTES,
 };
 use crate::openrtb::{
     to_openrtb_i32, Banner, ConsentedProvidersSettings, Device, Format, Geo, Imp, ImpExt,
     OpenRtbRequest, PrebidExt, PrebidImpExt, Publisher, Regs, RegsExt, RequestExt, Site, ToExt,
     TrustedServerExt, User, UserExt,
 };
-use crate::platform::RuntimeServices;
+use crate::platform::{
+    PlatformHttpRequest, PlatformPendingRequest, PlatformResponse, RuntimeServices,
+};
 use crate::request_signing::{RequestSigner, SigningParams, SIGNING_VERSION};
 use crate::settings::{IntegrationConfig, Settings};
 
 const PREBID_INTEGRATION_ID: &str = "prebid";
-const PREBID_REASON_EMPTY_RESPONSE: &str = "empty_response";
 const TRUSTED_SERVER_BIDDER: &str = "trustedServer";
 const BIDDER_PARAMS_KEY: &str = "bidderParams";
 const ZONE_KEY: &str = "zone";
@@ -43,14 +46,13 @@ const ZONE_KEY: &str = "zone";
 /// Default currency for `OpenRTB` bid floors and responses.
 const DEFAULT_CURRENCY: &str = "USD";
 
-/// Maximum number of characters from upstream failure payloads included in
-/// debug-facing `body_preview` metadata.
+#[cfg(test)]
 const PREBID_ERROR_BODY_PREVIEW_CHARS: usize = 1000;
 
-/// Maximum number of bytes processed when constructing debug-facing upstream
-/// failure previews.
+#[cfg(test)]
 const PREBID_ERROR_BODY_PREVIEW_BYTES: usize = PREBID_ERROR_BODY_PREVIEW_CHARS * 4;
 
+#[cfg(test)]
 fn prebid_body_preview(body: &[u8]) -> String {
     let bounded_body = &body[..body.len().min(PREBID_ERROR_BODY_PREVIEW_BYTES)];
 
@@ -335,16 +337,22 @@ impl PrebidIntegration {
         false
     }
 
-    fn handle_script_handler(&self) -> Result<Response, Report<TrustedServerError>> {
+    fn handle_script_handler(
+        &self,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
         let body = "// Script overridden by Trusted Server\n";
 
-        Ok(Response::from_status(StatusCode::OK)
-            .with_header(
+        http::Response::builder()
+            .status(StatusCode::OK)
+            .header(
                 header::CONTENT_TYPE,
                 "application/javascript; charset=utf-8",
             )
-            .with_header(header::CACHE_CONTROL, "public, max-age=31536000")
-            .with_body(body))
+            .header(header::CACHE_CONTROL, "public, max-age=31536000")
+            .body(EdgeBody::from(body))
+            .change_context(TrustedServerError::Prebid {
+                message: "Failed to build Prebid script handler response".to_string(),
+            })
     }
 }
 
@@ -422,15 +430,20 @@ impl IntegrationProxy for PrebidIntegration {
         &self,
         _settings: &Settings,
         _services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let path = req.get_path().to_string();
-        let method = req.get_method().clone();
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let path = req.uri().path().to_string();
+        let method = req.method().clone();
 
         match method {
             // Serve empty JS for matching script patterns
             Method::GET if self.matches_script_pattern(&path) => self.handle_script_handler(),
-            _ => Ok(Response::from_status(StatusCode::NOT_FOUND).with_body("Not Found")),
+            _ => http::Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(EdgeBody::from("Not Found"))
+                .change_context(TrustedServerError::Prebid {
+                    message: "Failed to build Prebid not found response".to_string(),
+                }),
         }
     }
 }
@@ -829,8 +842,8 @@ fn non_empty_override_object(
 /// stripped from the `Cookie` header since consent travels exclusively
 /// through the `OpenRTB` body.
 fn copy_request_headers(
-    from: &Request,
-    to: &mut Request,
+    from: &http::Request<EdgeBody>,
+    to: &mut http::Request<EdgeBody>,
     consent_forwarding: ConsentForwardingMode,
 ) {
     let headers_to_copy = [
@@ -841,12 +854,37 @@ fn copy_request_headers(
     ];
 
     for header_name in &headers_to_copy {
-        if let Some(value) = from.get_header(header_name) {
-            to.set_header(header_name, value);
+        if let Some(value) = from.headers().get(header_name) {
+            to.headers_mut().insert(header_name, value.clone());
         }
     }
 
-    compat::forward_fastly_cookie_header(from, to, consent_forwarding.strips_consent_cookies());
+    let Some(cookie_value) = from.headers().get(header::COOKIE) else {
+        return;
+    };
+
+    if !consent_forwarding.strips_consent_cookies() {
+        to.headers_mut()
+            .insert(header::COOKIE, cookie_value.clone());
+        return;
+    }
+
+    match cookie_value.to_str() {
+        Ok(value) => {
+            let stripped = strip_cookies(value, CONSENT_COOKIE_NAMES);
+            if stripped.is_empty() {
+                return;
+            }
+
+            if let Ok(cookie_header) = HeaderValue::from_str(&stripped) {
+                to.headers_mut().insert(header::COOKIE, cookie_header);
+            }
+        }
+        Err(_) => {
+            to.headers_mut()
+                .insert(header::COOKIE, cookie_value.clone());
+        }
+    }
 }
 
 /// Appends query parameters to a URL, handling both URLs with and without existing query strings.
@@ -896,7 +934,7 @@ impl PrebidAuctionProvider {
         request: &AuctionRequest,
         context: &AuctionContext<'_>,
         signer: Option<(&RequestSigner, String, &SigningParams)>,
-        _request_info: RequestInfo,
+        request_info: RequestInfo,
     ) -> OpenRtbRequest {
         let imps = request
             .slots
@@ -1026,17 +1064,24 @@ impl PrebidAuctionProvider {
         });
 
         // Extract DNT header and Accept-Language from the original request
-        let dnt = context.request.get_header_str("DNT").and_then(|v| {
-            if v.trim() == "1" {
-                Some(true)
-            } else {
-                None
-            }
-        });
+        let dnt = context
+            .request
+            .headers()
+            .get("DNT")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| {
+                if value.trim() == "1" {
+                    Some(true)
+                } else {
+                    None
+                }
+            });
 
         let language = context
             .request
-            .get_header_str(header::ACCEPT_LANGUAGE)
+            .headers()
+            .get(header::ACCEPT_LANGUAGE)
+            .and_then(|value| value.to_str().ok())
             .and_then(|v| {
                 // Extract the primary ISO-639 language tag (e.g., "en" from
                 // "en-US,en;q=0.9"). Strip the region subtag so bidders get a
@@ -1109,8 +1154,6 @@ impl PrebidAuctionProvider {
         let regs = Self::build_regs(consent_ctx);
 
         // Build ext object
-        let http_req = compat::from_fastly_headers_ref(context.request);
-        let request_info = RequestInfo::from_request(&http_req, &context.services.client_info);
         let (version, signature, kid, ts) = signer
             .map(|(s, sig, params)| {
                 (
@@ -1143,7 +1186,9 @@ impl PrebidAuctionProvider {
         // Extract Referer header for site.ref
         let referer = context
             .request
-            .get_header_str(header::REFERER)
+            .headers()
+            .get(header::REFERER)
+            .and_then(|value| value.to_str().ok())
             .map(std::string::ToString::to_string);
 
         let tmax = to_openrtb_i32(self.config.timeout_ms, "tmax", "request");
@@ -1391,100 +1436,21 @@ impl PrebidAuctionProvider {
     }
 }
 
-impl PrebidAuctionProvider {
-    fn parse_response_inner(
-        &self,
-        mut response: fastly::Response,
-        response_time_ms: u64,
-    ) -> Result<AuctionResponse, Report<TrustedServerError>> {
-        // Parse response
-        let status = response.get_status();
-        let body_bytes = response.take_body_bytes();
-
-        if !status.is_success() {
-            log::warn!(
-                "Prebid returned non-success status: {status}; {} bytes",
-                body_bytes.len()
-            );
-
-            let mut auction_response =
-                AuctionResponse::error(PREBID_INTEGRATION_ID, response_time_ms)
-                    .with_metadata("error_type", serde_json::json!(ERROR_TYPE_HTTP_STATUS))
-                    .with_metadata("http_status", serde_json::json!(status.as_u16()));
-            if self.config.debug {
-                let body_preview = prebid_body_preview(&body_bytes);
-                if !body_preview.is_empty() {
-                    log::debug!("Prebid non-success response body: {body_preview}");
-                    auction_response = auction_response
-                        .with_metadata("body_preview", serde_json::json!(body_preview));
-                }
-            }
-
-            return Ok(auction_response);
-        }
-
-        if body_bytes.is_empty() {
-            log::info!(
-                "Prebid returned successful empty response with status {status}; treating as no-bid"
-            );
-            return Ok(
-                AuctionResponse::no_bid(PREBID_INTEGRATION_ID, response_time_ms)
-                    .with_metadata("reason", serde_json::json!(PREBID_REASON_EMPTY_RESPONSE))
-                    .with_metadata("http_status", serde_json::json!(status.as_u16())),
-            );
-        }
-
-        let response_json: Json = match serde_json::from_slice(&body_bytes) {
-            Ok(response_json) => response_json,
-            Err(error) => {
-                log::warn!(
-                    "Prebid: failed to parse response JSON (status {status}, {} bytes): {error}",
-                    body_bytes.len()
-                );
-                return Err(Report::new(TrustedServerError::Prebid {
-                    message: "Failed to parse Prebid response JSON".to_string(),
-                }));
-            }
-        };
-
-        // Log the full response body when debug is enabled to surface
-        // ext.debug.httpcalls, resolvedrequest, bidstatus, errors, etc.
-        if self.config.debug && log::log_enabled!(log::Level::Trace) {
-            match serde_json::to_string_pretty(&response_json) {
-                Ok(json) => log::trace!("Prebid OpenRTB response:\n{json}"),
-                Err(e) => {
-                    log::warn!("Prebid: failed to serialize response for logging: {e}");
-                }
-            }
-        }
-
-        let mut auction_response = self.parse_openrtb_response(&response_json, response_time_ms);
-        self.enrich_response_metadata(&response_json, &mut auction_response);
-
-        log::info!(
-            "Prebid returned {} bids in {}ms",
-            auction_response.bids.len(),
-            response_time_ms
-        );
-
-        Ok(auction_response)
-    }
-}
-
+#[async_trait(?Send)]
 impl AuctionProvider for PrebidAuctionProvider {
     fn provider_name(&self) -> &'static str {
         PREBID_INTEGRATION_ID
     }
 
-    fn request_bids(
+    async fn request_bids(
         &self,
         request: &AuctionRequest,
         context: &AuctionContext<'_>,
-    ) -> Result<fastly::http::request::PendingRequest, Report<TrustedServerError>> {
+    ) -> Result<PlatformPendingRequest, Report<TrustedServerError>> {
         log::info!("Prebid: requesting bids for {} slots", request.slots.len());
 
-        let http_req = compat::from_fastly_headers_ref(context.request);
-        let request_info = RequestInfo::from_request(&http_req, &context.services.client_info);
+        let request_info =
+            RequestInfo::from_request(context.request, context.services.client_info());
 
         // Create signer and compute signature if request signing is enabled
         let signer_with_signature =
@@ -1540,44 +1506,103 @@ impl AuctionProvider for PrebidAuctionProvider {
         }
 
         // Create HTTP request
-        let mut pbs_req = Request::new(
-            Method::POST,
-            format!("{}/openrtb2/auction", self.config.server_url),
-        );
+        let mut pbs_req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!("{}/openrtb2/auction", self.config.server_url))
+            .body(EdgeBody::empty())
+            .change_context(TrustedServerError::Prebid {
+                message: "Failed to build Prebid request".to_string(),
+            })?;
         copy_request_headers(
             context.request,
             &mut pbs_req,
             self.config.consent_forwarding,
         );
 
-        pbs_req
-            .set_body_json(&openrtb)
-            .change_context(TrustedServerError::Prebid {
-                message: "Failed to set request body".to_string(),
-            })?;
+        let pbs_body = serde_json::to_vec(&openrtb).change_context(TrustedServerError::Prebid {
+            message: "Failed to serialize Prebid request body".to_string(),
+        })?;
+        pbs_req.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        *pbs_req.body_mut() = EdgeBody::from(pbs_body);
 
-        // Send request asynchronously with auction-scoped timeout
-        let backend_name = BackendConfig::from_url_with_first_byte_timeout(
+        let backend_name = ensure_integration_backend(
+            context.services,
             &self.config.server_url,
-            true,
-            Duration::from_millis(u64::from(context.timeout_ms)),
+            "prebid",
+            Some(Duration::from_millis(u64::from(context.timeout_ms))),
         )?;
-        let pending =
-            pbs_req
-                .send_async(backend_name)
-                .change_context(TrustedServerError::Prebid {
-                    message: "Failed to send async request to Prebid Server".to_string(),
-                })?;
+        let pending = context
+            .services
+            .http_client()
+            .send_async(PlatformHttpRequest::new(pbs_req, backend_name))
+            .await
+            .change_context(TrustedServerError::Prebid {
+                message: "Failed to send async request to Prebid Server".to_string(),
+            })?;
 
         Ok(pending)
     }
 
-    fn parse_response(
+    async fn parse_response(
         &self,
-        response: fastly::Response,
+        response: PlatformResponse,
         response_time_ms: u64,
     ) -> Result<AuctionResponse, Report<TrustedServerError>> {
-        self.parse_response_inner(response, response_time_ms)
+        let response = response.response;
+        let status = response.status();
+
+        // Parse response — collect_response_bounded caps memory from misbehaving providers.
+        let body_bytes = collect_response_bounded(
+            response.into_body(),
+            UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+            "prebid",
+        )
+        .await
+        .change_context(TrustedServerError::Prebid {
+            message: "Failed to read Prebid response body".to_string(),
+        })?;
+
+        if !status.is_success() {
+            log::warn!("Prebid returned non-success status: {}", status,);
+            if log::log_enabled!(log::Level::Trace) {
+                let body_preview = String::from_utf8_lossy(&body_bytes);
+                log::trace!(
+                    "Prebid error response body: {}",
+                    &body_preview[..body_preview.floor_char_boundary(1000)]
+                );
+            }
+            return Ok(AuctionResponse::error("prebid", response_time_ms));
+        }
+
+        let response_json: Json =
+            serde_json::from_slice(&body_bytes).change_context(TrustedServerError::Prebid {
+                message: "Failed to parse Prebid response".to_string(),
+            })?;
+
+        // Log the full response body when debug is enabled to surface
+        // ext.debug.httpcalls, resolvedrequest, bidstatus, errors, etc.
+        if self.config.debug && log::log_enabled!(log::Level::Trace) {
+            match serde_json::to_string_pretty(&response_json) {
+                Ok(json) => log::trace!("Prebid OpenRTB response:\n{json}"),
+                Err(e) => {
+                    log::warn!("Prebid: failed to serialize response for logging: {e}");
+                }
+            }
+        }
+
+        let mut auction_response = self.parse_openrtb_response(&response_json, response_time_ms);
+        self.enrich_response_metadata(&response_json, &mut auction_response);
+
+        log::info!(
+            "Prebid returned {} bids in {}ms",
+            auction_response.bids.len(),
+            response_time_ms
+        );
+
+        Ok(auction_response)
     }
 
     fn supports_media_type(&self, media_type: &MediaType) -> bool {
@@ -1645,22 +1670,25 @@ pub fn register_auction_provider(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::auction::test_support::create_test_auction_context as shared_test_auction_context;
     use crate::auction::types::{
         AdFormat, AdSlot, AuctionContext, AuctionRequest, DeviceInfo, PublisherInfo, UserInfo,
     };
+
     use crate::consent::ConsentContext;
     use crate::geo::GeoInfo;
     use crate::html_processor::{create_html_processor, HtmlProcessorConfig};
     use crate::integrations::{
         AttributeRewriteAction, IntegrationDocumentState, IntegrationRegistry,
     };
+    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
     use crate::settings::Settings;
     use crate::streaming_processor::{Compression, PipelineConfig, StreamingPipeline};
     use crate::test_support::tests::crate_test_settings_str;
-    use fastly::http::Method;
-    use fastly::Request;
+    use http::Method;
     use serde_json::json;
     use std::collections::HashMap;
     use std::io::Cursor;
@@ -1717,16 +1745,61 @@ mod tests {
         }
     }
 
+    fn build_test_request() -> http::Request<EdgeBody> {
+        http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://pub.example/auction")
+            .body(EdgeBody::empty())
+            .expect("should build request")
+    }
+
+    #[test]
+    fn prebid_provider_uses_platform_http_client_for_bid_request() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, br#"{"seatbid":[]}"#.to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = make_settings();
+        let provider = PrebidAuctionProvider::new(base_config());
+        let auction_request = create_test_auction_request();
+        let http_req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://publisher.example/auction")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+        let context = AuctionContext {
+            settings: &settings,
+            request: &http_req,
+            timeout_ms: 500,
+            provider_responses: None,
+            services: &services,
+        };
+
+        let pending =
+            futures::executor::block_on(provider.request_bids(&auction_request, &context))
+                .expect("should start request");
+
+        assert!(
+            pending.backend_name().is_some(),
+            "should preserve backend correlation"
+        );
+        assert_eq!(
+            stub.recorded_backend_names().len(),
+            1,
+            "should launch one upstream request through PlatformHttpClient"
+        );
+    }
+
     fn create_test_auction_context<'a>(
         settings: &'a Settings,
-        request: &'a Request,
+        request: &'a http::Request<EdgeBody>,
     ) -> AuctionContext<'a> {
         shared_test_auction_context(settings, request, 1000)
     }
 
     fn make_request_info(context: &AuctionContext<'_>) -> RequestInfo {
-        let http_req = compat::from_fastly_headers_ref(context.request);
-        RequestInfo::from_request(&http_req, &context.services.client_info)
+        RequestInfo::from_request(context.request, context.services.client_info())
     }
 
     fn config_from_settings(
@@ -1975,19 +2048,24 @@ server_url = "https://prebid.example"
             .handle_script_handler()
             .expect("should return response");
 
-        assert_eq!(response.get_status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let content_type = response
-            .get_header_str(header::CONTENT_TYPE)
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
             .expect("should have content-type");
         assert_eq!(content_type, "application/javascript; charset=utf-8");
 
         let cache_control = response
-            .get_header_str(header::CACHE_CONTROL)
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|value| value.to_str().ok())
             .expect("should have cache-control");
         assert!(cache_control.contains("max-age=31536000"));
 
-        let body = response.into_body_str();
+        let body = String::from_utf8(response.into_body().into_bytes().to_vec())
+            .expect("should parse script body as utf-8");
         assert!(body.contains("// Script overridden by Trusted Server"));
     }
 
@@ -2149,7 +2227,7 @@ server_url = "https://prebid.example"
         let provider = PrebidAuctionProvider::new(config);
         let auction_request = create_test_auction_request();
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2201,7 +2279,7 @@ server_url = "https://prebid.example"
         let provider = PrebidAuctionProvider::new(config);
         let auction_request = create_test_auction_request();
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2235,7 +2313,7 @@ server_url = "https://prebid.example"
             geo: None,
         });
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2267,7 +2345,7 @@ server_url = "https://prebid.example"
         let provider = PrebidAuctionProvider::new(base_config());
         let auction_request = create_test_auction_request();
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2322,7 +2400,7 @@ server_url = "https://prebid.example"
         auction_request.slots[0].floor_price = Some(1.5);
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2347,7 +2425,7 @@ server_url = "https://prebid.example"
         let auction_request = create_test_auction_request(); // floor_price is None
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2371,7 +2449,7 @@ server_url = "https://prebid.example"
         let auction_request = create_test_auction_request();
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2416,7 +2494,7 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2467,7 +2545,7 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2506,7 +2584,7 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2534,7 +2612,7 @@ server_url = "https://prebid.example"
         // No device/geo
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2557,7 +2635,7 @@ server_url = "https://prebid.example"
         let auction_request = create_test_auction_request(); // consent=None, no geo
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2583,7 +2661,7 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2803,8 +2881,10 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let mut request = Request::get("https://pub.example/auction");
-        request.set_header("DNT", "1");
+        let mut request = build_test_request();
+        request
+            .headers_mut()
+            .insert("DNT", http::header::HeaderValue::from_static("1"));
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2829,8 +2909,11 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let mut request = Request::get("https://pub.example/auction");
-        request.set_header("Accept-Language", "en-US,en;q=0.9,fr;q=0.8");
+        let mut request = build_test_request();
+        request.headers_mut().insert(
+            "Accept-Language",
+            http::header::HeaderValue::from_static("en-US,en;q=0.9,fr;q=0.8"),
+        );
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2859,8 +2942,11 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let mut request = Request::get("https://pub.example/auction");
-        request.set_header("Accept-Language", "");
+        let mut request = build_test_request();
+        request.headers_mut().insert(
+            "Accept-Language",
+            http::header::HeaderValue::from_static(""),
+        );
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2896,7 +2982,7 @@ server_url = "https://prebid.example"
         }];
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2932,7 +3018,7 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2965,7 +3051,7 @@ server_url = "https://prebid.example"
         let auction_request = create_test_auction_request();
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -2995,7 +3081,7 @@ server_url = "https://prebid.example"
         let auction_request = create_test_auction_request();
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -3022,7 +3108,7 @@ server_url = "https://prebid.example"
         });
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -3052,8 +3138,11 @@ server_url = "https://prebid.example"
         let auction_request = create_test_auction_request();
 
         let settings = make_settings();
-        let mut request = Request::get("https://pub.example/auction");
-        request.set_header("Referer", "https://google.com/search?q=test");
+        let mut request = build_test_request();
+        request.headers_mut().insert(
+            "Referer",
+            http::header::HeaderValue::from_static("https://google.com/search?q=test"),
+        );
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -3077,7 +3166,7 @@ server_url = "https://prebid.example"
         let auction_request = create_test_auction_request();
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -3123,7 +3212,7 @@ server_url = "https://prebid.example"
         ]);
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -3153,7 +3242,7 @@ server_url = "https://prebid.example"
         let auction_request = create_test_auction_request();
 
         let settings = make_settings();
-        let request = Request::get("https://pub.example/auction");
+        let request = build_test_request();
         let context = create_test_auction_context(&settings, &request);
 
         let openrtb = provider.to_openrtb(
@@ -3341,11 +3430,15 @@ server_url = "https://prebid.example"
         use crate::platform::test_support::noop_services;
         let provider = PrebidAuctionProvider::new(config);
         let settings = make_settings();
-        let fastly_req = Request::new(Method::POST, "https://example.com/auction");
+        let http_req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://example.com/auction")
+            .body(EdgeBody::empty())
+            .expect("should build request");
         let services = noop_services();
         let context = AuctionContext {
             settings: &settings,
-            request: &fastly_req,
+            request: &http_req,
             timeout_ms: 1000,
             provider_responses: None,
             services: &services,
@@ -3368,154 +3461,6 @@ server_url = "https://prebid.example"
     fn get_prebid_ext(req: &OpenRtbRequest) -> PrebidExt {
         let ext = req.ext.as_ref().expect("should have request ext");
         serde_json::from_value(ext["prebid"].clone()).expect("should deserialise ext.prebid")
-    }
-
-    #[test]
-    fn parse_response_non_success_returns_error_with_http_metadata() {
-        let provider = PrebidAuctionProvider::new(base_config());
-        let response = Response::from_status(StatusCode::BAD_REQUEST).with_body("invalid request");
-
-        let auction_response = provider
-            .parse_response(response, 58)
-            .expect("should convert non-success status to provider error");
-
-        assert_eq!(
-            auction_response.status,
-            crate::auction::types::BidStatus::Error,
-            "should mark non-success upstream responses as errors"
-        );
-        assert_eq!(
-            auction_response.metadata["error_type"],
-            json!("http_status"),
-            "should classify the error source"
-        );
-        assert_eq!(
-            auction_response.metadata["http_status"],
-            json!(400),
-            "should include upstream HTTP status"
-        );
-        assert!(
-            !auction_response.metadata.contains_key("body_preview"),
-            "should omit upstream body preview unless Prebid debug is enabled"
-        );
-    }
-
-    #[test]
-    fn parse_response_non_success_includes_body_preview_when_debug_enabled() {
-        let mut config = base_config();
-        config.debug = true;
-        let provider = PrebidAuctionProvider::new(config);
-        let body = "x".repeat(PREBID_ERROR_BODY_PREVIEW_CHARS + 100);
-        let response = Response::from_status(StatusCode::BAD_REQUEST).with_body(body);
-
-        let auction_response = provider
-            .parse_response(response, 58)
-            .expect("should convert non-success status to provider error");
-
-        let body_preview = auction_response.metadata["body_preview"]
-            .as_str()
-            .expect("should include upstream body preview in debug mode");
-        assert_eq!(
-            body_preview.chars().count(),
-            PREBID_ERROR_BODY_PREVIEW_CHARS,
-            "should cap debug upstream body preview"
-        );
-    }
-
-    #[test]
-    fn parse_response_invalid_json_returns_safe_client_error() {
-        let provider = PrebidAuctionProvider::new(base_config());
-        let response = Response::from_status(StatusCode::OK).with_body(r#"{"seatbid":["bid""#);
-
-        let error = provider
-            .parse_response(response, 42)
-            .expect_err("should return parse failure for invalid JSON");
-
-        let message = format!("{error}");
-        assert!(
-            message.contains("Failed to parse Prebid response JSON"),
-            "should include stable user-safe parse failure message"
-        );
-        assert!(
-            !message.contains("expected value"),
-            "should not leak serde parse details"
-        );
-        assert!(
-            !message.contains("bytes"),
-            "should not leak response length in the user-safe message"
-        );
-    }
-
-    #[test]
-    fn parse_response_no_content_returns_no_bid_with_reason() {
-        let provider = PrebidAuctionProvider::new(base_config());
-        let response = Response::from_status(StatusCode::NO_CONTENT);
-
-        let auction_response = provider
-            .parse_response(response, 42)
-            .expect("should convert no-content status to no-bid");
-
-        assert_eq!(
-            auction_response.status,
-            crate::auction::types::BidStatus::NoBid,
-            "should treat 204 as a no-bid response"
-        );
-        assert_eq!(
-            auction_response.metadata["reason"],
-            json!("empty_response"),
-            "should explain why the provider returned no bids"
-        );
-        assert_eq!(
-            auction_response.metadata["http_status"],
-            json!(204),
-            "should include upstream HTTP status"
-        );
-    }
-
-    #[test]
-    fn parse_response_ok_empty_body_returns_no_bid_with_reason() {
-        let provider = PrebidAuctionProvider::new(base_config());
-        let response = Response::from_status(StatusCode::OK);
-
-        let auction_response = provider
-            .parse_response(response, 17)
-            .expect("should convert empty successful response to no-bid");
-
-        assert_eq!(
-            auction_response.status,
-            crate::auction::types::BidStatus::NoBid,
-            "should treat empty 200 as a no-bid response"
-        );
-        assert_eq!(
-            auction_response.metadata["reason"],
-            json!("empty_response"),
-            "should explain why the provider returned no bids"
-        );
-        assert_eq!(
-            auction_response.metadata["http_status"],
-            json!(200),
-            "should include upstream HTTP status"
-        );
-    }
-
-    #[test]
-    fn parse_response_valid_json_without_bids_returns_no_bid() {
-        let provider = PrebidAuctionProvider::new(base_config());
-        let response = Response::from_status(StatusCode::OK).with_body(r#"{"seatbid":[]}"#);
-
-        let auction_response = provider
-            .parse_response(response, 23)
-            .expect("should parse valid no-bid JSON");
-
-        assert_eq!(
-            auction_response.status,
-            crate::auction::types::BidStatus::NoBid,
-            "should preserve valid JSON no-bid behavior"
-        );
-        assert!(
-            auction_response.metadata.is_empty(),
-            "should not add empty-response metadata for valid no-bid JSON"
-        );
     }
 
     // ========================================================================

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -259,8 +259,24 @@ pub trait IntegrationProxy: Send + Sync {
     /// Use this with the `namespaced_*` helper methods to automatically prefix routes.
     fn integration_name(&self) -> &'static str;
 
+    /// Returns the URL path prefix for this integration's proxy routes.
+    ///
+    /// Override this to provide a custom, customer-specific proxy path that is
+    /// harder for ad blockers to target. When not overridden, defaults to
+    /// `/integrations/{integration_name()}`.
+    ///
+    /// # Example
+    /// ```ignore
+    /// fn proxy_prefix(&self) -> String {
+    ///     "/my-custom-path".to_string()  // instead of /integrations/didomi
+    /// }
+    /// ```
+    fn proxy_prefix(&self) -> String {
+        format!("/integrations/{}", self.integration_name())
+    }
+
     /// Routes handled by this integration.
-    /// to automatically namespace routes under `/integrations/{integration_name()}/`,
+    /// to automatically namespace routes under the proxy prefix,
     /// or define routes manually for backwards compatibility.
     fn routes(&self) -> Vec<IntegrationEndpoint>;
 
@@ -273,62 +289,37 @@ pub trait IntegrationProxy: Send + Sync {
     ) -> Result<Response, Report<TrustedServerError>>;
 
     /// Helper to create a namespaced GET endpoint.
-    /// Automatically prefixes the path with `/integrations/{integration_name()}`.
-    ///
-    /// # Example
-    /// ```ignore
-    /// self.namespaced_get("/auction")  // becomes /integrations/my_integration/auction
-    /// ```
+    /// Automatically prefixes the path with the integration's `proxy_prefix()`.
     fn get(&self, path: &str) -> IntegrationEndpoint {
-        let full_path = format!("/integrations/{}{}", self.integration_name(), path);
+        let full_path = format!("{}{}", self.proxy_prefix(), path);
         IntegrationEndpoint::get(full_path)
     }
 
     /// Helper to create a namespaced POST endpoint.
-    /// Automatically prefixes the path with `/integrations/{integration_name()}`.
-    ///
-    /// # Example
-    /// ```ignore
-    /// self.post("/auction")  // becomes /integrations/my_integration/auction
-    /// ```
+    /// Automatically prefixes the path with the integration's `proxy_prefix()`.
     fn post(&self, path: &str) -> IntegrationEndpoint {
-        let full_path = format!("/integrations/{}{}", self.integration_name(), path);
+        let full_path = format!("{}{}", self.proxy_prefix(), path);
         IntegrationEndpoint::post(full_path)
     }
 
     /// Helper to create a namespaced PUT endpoint.
-    /// Automatically prefixes the path with `/integrations/{integration_name()}`.
-    ///
-    /// # Example
-    /// ```ignore
-    /// self.put("/users")  // becomes /integrations/my_integration/users
-    /// ```
+    /// Automatically prefixes the path with the integration's `proxy_prefix()`.
     fn put(&self, path: &str) -> IntegrationEndpoint {
-        let full_path = format!("/integrations/{}{}", self.integration_name(), path);
+        let full_path = format!("{}{}", self.proxy_prefix(), path);
         IntegrationEndpoint::put(full_path)
     }
 
     /// Helper to create a namespaced DELETE endpoint.
-    /// Automatically prefixes the path with `/integrations/{integration_name()}`.
-    ///
-    /// # Example
-    /// ```ignore
-    /// self.delete("/users/123")  // becomes /integrations/my_integration/users/123
-    /// ```
+    /// Automatically prefixes the path with the integration's `proxy_prefix()`.
     fn delete(&self, path: &str) -> IntegrationEndpoint {
-        let full_path = format!("/integrations/{}{}", self.integration_name(), path);
+        let full_path = format!("{}{}", self.proxy_prefix(), path);
         IntegrationEndpoint::delete(full_path)
     }
 
     /// Helper to create a namespaced PATCH endpoint.
-    /// Automatically prefixes the path with `/integrations/{integration_name()}`.
-    ///
-    /// # Example
-    /// ```ignore
-    /// self.patch("/settings")  // becomes /integrations/my_integration/settings
-    /// ```
+    /// Automatically prefixes the path with the integration's `proxy_prefix()`.
     fn patch(&self, path: &str) -> IntegrationEndpoint {
-        let full_path = format!("/integrations/{}{}", self.integration_name(), path);
+        let full_path = format!("{}{}", self.proxy_prefix(), path);
         IntegrationEndpoint::patch(full_path)
     }
 }

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -3,12 +3,11 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::Report;
-use fastly::http::Method;
-use fastly::{Request, Response};
+use http::{Method, Request, Response};
 use matchit::Router;
 
-use crate::compat;
 use crate::constants::HEADER_X_TS_EC;
 use crate::ec::kv::KvIdentityGraph;
 use crate::ec::EcContext;
@@ -285,8 +284,8 @@ pub trait IntegrationProxy: Send + Sync {
         &self,
         settings: &Settings,
         services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>>;
+        req: Request<EdgeBody>,
+    ) -> Result<Response<EdgeBody>, Report<TrustedServerError>>;
 
     /// Helper to create a namespaced GET endpoint.
     /// Automatically prefixes the path with the integration's `proxy_prefix()`.
@@ -551,7 +550,7 @@ pub struct ProxyDispatchInput<'a> {
     pub kv: Option<&'a KvIdentityGraph>,
     pub ec_context: &'a mut EcContext,
     pub services: &'a RuntimeServices,
-    pub req: Request,
+    pub req: Request<EdgeBody>,
 }
 
 /// In-memory registry of integrations discovered from settings.
@@ -675,7 +674,7 @@ impl IntegrationRegistry {
     pub async fn handle_proxy(
         &self,
         input: ProxyDispatchInput<'_>,
-    ) -> Option<Result<Response, Report<TrustedServerError>>> {
+    ) -> Option<Result<Response<EdgeBody>, Report<TrustedServerError>>> {
         let ProxyDispatchInput {
             method,
             path,
@@ -689,8 +688,7 @@ impl IntegrationRegistry {
             // Organic proxy handler: generate if needed (best effort).
             // Only generate for document navigations — subresource requests
             // may lack consent signals such as the Sec-GPC header.
-            let http_req = compat::from_fastly_headers_ref(&req);
-            if is_navigation_request(&http_req) {
+            if is_navigation_request(&req) {
                 if let Err(err) = ec_context.generate_if_needed(settings, kv) {
                     log::warn!("EC generation failed for integration proxy: {err:?}");
                 }
@@ -702,7 +700,7 @@ impl IntegrationRegistry {
             }
 
             // Remove any caller-supplied EC header rather than forwarding it.
-            req.remove_header(HEADER_X_TS_EC);
+            req.headers_mut().remove(HEADER_X_TS_EC.clone());
 
             Some(proxy.handle(settings, services, req).await)
         } else {
@@ -980,6 +978,9 @@ impl IntegrationRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::COOKIE_TS_EC;
+    use crate::platform::test_support::noop_services;
+    use http::{header, HeaderValue, StatusCode};
 
     // Mock integration proxy for testing
     struct MockProxy;
@@ -998,9 +999,9 @@ mod tests {
             &self,
             _settings: &Settings,
             _services: &RuntimeServices,
-            _req: Request,
-        ) -> Result<Response, Report<TrustedServerError>> {
-            Ok(Response::new())
+            _req: Request<EdgeBody>,
+        ) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+            Ok(Response::new(EdgeBody::empty()))
         }
     }
 
@@ -1013,6 +1014,33 @@ mod tests {
 
         fn post_process(&self, _html: &mut String, _ctx: &IntegrationHtmlContext<'_>) -> bool {
             false
+        }
+    }
+
+    struct EchoProxy;
+
+    #[async_trait(?Send)]
+    impl IntegrationProxy for EchoProxy {
+        fn integration_name(&self) -> &'static str {
+            "echo"
+        }
+
+        fn routes(&self) -> Vec<IntegrationEndpoint> {
+            vec![]
+        }
+
+        async fn handle(
+            &self,
+            _settings: &Settings,
+            _services: &RuntimeServices,
+            req: http::Request<EdgeBody>,
+        ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+            let response = http::Response::builder()
+                .status(http::StatusCode::OK)
+                .header("x-echo-path", req.uri().path())
+                .body(EdgeBody::empty())
+                .expect("should build echo response");
+            Ok(response)
         }
     }
 
@@ -1030,6 +1058,46 @@ mod tests {
         assert!(
             !processor.should_process("<html></html>", &ctx),
             "Default `should_process` should be false to avoid running post-processing unexpectedly"
+        );
+    }
+
+    #[test]
+    fn handle_proxy_passes_http_request_without_fastly_round_trip() {
+        let settings = create_test_settings();
+        let registry = IntegrationRegistry::from_routes(vec![(
+            http::Method::GET,
+            "/integrations/test/echo",
+            (Arc::new(EchoProxy) as Arc<dyn IntegrationProxy>, "echo"),
+        )]);
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://test.example.com/integrations/test/echo?x=1")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let mut ec_context =
+            EcContext::new_for_test(None, crate::consent::ConsentContext::default());
+        let response = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
+            method: &http::Method::GET,
+            path: "/integrations/test/echo",
+            settings: &settings,
+            kv: None,
+            ec_context: &mut ec_context,
+            services: &noop_services(),
+            req,
+        }))
+        .expect("should match route")
+        .expect("proxy should succeed");
+
+        assert_eq!(
+            response.status(),
+            http::StatusCode::OK,
+            "should preserve HTTP status"
+        );
+        assert_eq!(
+            response.headers()["x-echo-path"],
+            "/integrations/test/echo",
+            "should expose the HTTP request path to the proxy"
         );
     }
 
@@ -1253,7 +1321,6 @@ mod tests {
 
     // Tests for EC ID header on proxy responses
     use crate::test_support::tests::create_test_settings;
-    use fastly::http::header;
 
     /// Mock proxy that returns a simple 200 OK response
     struct EcTestProxy;
@@ -1281,15 +1348,17 @@ mod tests {
             &self,
             _settings: &Settings,
             _services: &RuntimeServices,
-            req: Request,
-        ) -> Result<Response, Report<TrustedServerError>> {
-            let mut response =
-                Response::from_status(fastly::http::StatusCode::OK).with_body("test response");
-
-            if let Some(ec) = req.get_header(HEADER_X_TS_EC) {
-                response.set_header("x-echo-ts-ec", ec);
+            req: Request<EdgeBody>,
+        ) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+            let mut response = Response::builder()
+                .status(StatusCode::OK)
+                .body(EdgeBody::from("test response"))
+                .expect("should build test response");
+            if let Some(ec) = req.headers().get(HEADER_X_TS_EC.clone()) {
+                response
+                    .headers_mut()
+                    .insert(http::HeaderName::from_static("x-echo-ts-ec"), ec.clone());
             }
-
             Ok(response)
         }
     }
@@ -1307,13 +1376,18 @@ mod tests {
         )];
         let registry = IntegrationRegistry::from_routes(routes);
 
-        let valid_ec_id = format!("{}.CkEc1", "a".repeat(64));
-        let mut req = Request::get("https://test-publisher.com/integrations/test/ec");
-        req.set_header(header::COOKIE, format!("ts-ec={valid_ec_id}"));
-        req.set_header("x-ts-ec", format!("{}.HdrEc1", "b".repeat(64)));
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("https://test-publisher.com/integrations/test/ec")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+        req.headers_mut().insert(
+            HEADER_X_TS_EC.clone(),
+            HeaderValue::from_static("some-ec-value"),
+        );
         let mut ec_context =
-            EcContext::read_from_request(&settings, &req).expect("should read EC context");
-        let services = crate::platform::test_support::noop_services();
+            EcContext::new_for_test(None, crate::consent::ConsentContext::default());
+        let services = noop_services();
 
         // Call handle_proxy (uses futures executor in test environment)
         let result = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
@@ -1334,7 +1408,7 @@ mod tests {
         let response = response.unwrap();
 
         assert!(
-            response.get_header("x-echo-ts-ec").is_none(),
+            response.headers().get("x-echo-ts-ec").is_none(),
             "should not have x-ts-ec header on integration request"
         );
     }
@@ -1352,10 +1426,18 @@ mod tests {
         )];
         let registry = IntegrationRegistry::from_routes(routes);
 
-        let mut req = Request::get("https://test-publisher.com/integrations/test/ec");
-        req.set_header(HEADER_X_TS_EC, "evil;injected");
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("https://test-publisher.com/integrations/test/ec")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+        req.headers_mut().insert(
+            HEADER_X_TS_EC.clone(),
+            HeaderValue::from_static("evil;injected"),
+        );
         let mut ec_context =
-            EcContext::read_from_request(&settings, &req).expect("should read EC context");
+            EcContext::new_for_test(None, crate::consent::ConsentContext::default());
+
         let services = crate::platform::test_support::noop_services();
 
         let result = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
@@ -1372,7 +1454,7 @@ mod tests {
         let response = result.expect("handler should succeed");
 
         assert!(
-            response.get_header("x-echo-ts-ec").is_none(),
+            response.headers().get("x-echo-ts-ec").is_none(),
             "should not reflect the tampered request header to the integration"
         );
     }
@@ -1388,13 +1470,23 @@ mod tests {
 
         let registry = IntegrationRegistry::from_routes(routes);
 
-        let mut req = Request::get("https://test.example.com/integrations/test/ec");
-        // Pre-existing cookie with valid EC ID format, but no geo data →
-        // Unknown jurisdiction → consent denied.
-        let valid_ec_id = format!("{}.AbCd12", "a".repeat(64));
-        req.set_header(header::COOKIE, format!("ts-ec={valid_ec_id}"));
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("https://test.example.com/integrations/test/ec")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+        req.headers_mut().insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!(
+                "{}={}",
+                COOKIE_TS_EC,
+                crate::test_support::tests::VALID_SYNTHETIC_ID
+            ))
+            .expect("should build Cookie header"),
+        );
         let mut ec_context =
-            EcContext::read_from_request(&settings, &req).expect("should read EC context");
+            EcContext::new_for_test(None, crate::consent::ConsentContext::default());
+
         let services = crate::platform::test_support::noop_services();
 
         let result = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
@@ -1411,7 +1503,7 @@ mod tests {
         let response = result.expect("proxy handle should succeed");
 
         assert!(
-            response.get_header("x-echo-ts-ec").is_none(),
+            response.headers().get("x-echo-ts-ec").is_none(),
             "should not set x-ts-ec on integration request"
         );
     }
@@ -1429,13 +1521,18 @@ mod tests {
         )];
         let registry = IntegrationRegistry::from_routes(routes);
 
-        let valid_ec_id = format!("{}.CkEc1", "a".repeat(64));
-        let mut req =
-            Request::post("https://test-publisher.com/integrations/test/ec").with_body("test body");
-        req.set_header(header::COOKIE, format!("ts-ec={valid_ec_id}"));
-        req.set_header("x-ts-ec", format!("{}.HdrEc1", "b".repeat(64)));
+        let mut req = Request::builder()
+            .method(Method::POST)
+            .uri("https://test-publisher.com/integrations/test/ec")
+            .body(EdgeBody::from("test body"))
+            .expect("should build POST request");
+        req.headers_mut().insert(
+            HEADER_X_TS_EC.clone(),
+            HeaderValue::from_static("some-ec-value"),
+        );
         let mut ec_context =
-            EcContext::read_from_request(&settings, &req).expect("should read EC context");
+            EcContext::new_for_test(None, crate::consent::ConsentContext::default());
+
         let services = crate::platform::test_support::noop_services();
 
         let result = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
@@ -1454,7 +1551,7 @@ mod tests {
 
         let response = response.unwrap();
         assert!(
-            response.get_header("x-echo-ts-ec").is_none(),
+            response.headers().get("x-echo-ts-ec").is_none(),
             "POST integration request should not include x-ts-ec"
         );
     }

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -14,6 +14,7 @@ use crate::ec::kv::KvIdentityGraph;
 use crate::ec::EcContext;
 use crate::error::TrustedServerError;
 use crate::http_util::is_navigation_request;
+use crate::platform::RuntimeServices;
 use crate::settings::Settings;
 
 /// Action returned by attribute rewriters to describe how the runtime should mutate the element.
@@ -245,6 +246,13 @@ impl IntegrationEndpoint {
 }
 
 /// Trait implemented by integration proxies that expose HTTP endpoints.
+///
+/// `Send + Sync` bounds are required so trait objects can be stored in
+/// `Arc<dyn IntegrationProxy>` and shared across the single-threaded WASM
+/// request context. The `?Send` on the async methods is intentional — see the
+/// `!Send` design rationale on [`crate::platform::PlatformPendingRequest`] for
+/// the full explanation. On wasm32 these bounds are compatible because the runtime is
+/// single-threaded.
 #[async_trait(?Send)]
 pub trait IntegrationProxy: Send + Sync {
     /// Integration identifier used for logging and optional URL namespace.
@@ -260,6 +268,7 @@ pub trait IntegrationProxy: Send + Sync {
     async fn handle(
         &self,
         settings: &Settings,
+        services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>>;
 
@@ -550,6 +559,7 @@ pub struct ProxyDispatchInput<'a> {
     pub settings: &'a Settings,
     pub kv: Option<&'a KvIdentityGraph>,
     pub ec_context: &'a mut EcContext,
+    pub services: &'a RuntimeServices,
     pub req: Request,
 }
 
@@ -681,6 +691,7 @@ impl IntegrationRegistry {
             settings,
             kv,
             ec_context,
+            services,
             mut req,
         } = input;
         if let Some((proxy, _)) = self.find_route(method, path) {
@@ -702,7 +713,7 @@ impl IntegrationRegistry {
             // Remove any caller-supplied EC header rather than forwarding it.
             req.remove_header(HEADER_X_TS_EC);
 
-            Some(proxy.handle(settings, req).await)
+            Some(proxy.handle(settings, services, req).await)
         } else {
             None
         }
@@ -995,6 +1006,7 @@ mod tests {
         async fn handle(
             &self,
             _settings: &Settings,
+            _services: &RuntimeServices,
             _req: Request,
         ) -> Result<Response, Report<TrustedServerError>> {
             Ok(Response::new())
@@ -1277,6 +1289,7 @@ mod tests {
         async fn handle(
             &self,
             _settings: &Settings,
+            _services: &RuntimeServices,
             req: Request,
         ) -> Result<Response, Report<TrustedServerError>> {
             let mut response =
@@ -1309,6 +1322,7 @@ mod tests {
         req.set_header("x-ts-ec", format!("{}.HdrEc1", "b".repeat(64)));
         let mut ec_context =
             EcContext::read_from_request(&settings, &req).expect("should read EC context");
+        let services = crate::platform::test_support::noop_services();
 
         // Call handle_proxy (uses futures executor in test environment)
         let result = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
@@ -1317,6 +1331,7 @@ mod tests {
             settings: &settings,
             kv: None,
             ec_context: &mut ec_context,
+            services: &services,
             req,
         }));
 
@@ -1350,6 +1365,7 @@ mod tests {
         req.set_header(HEADER_X_TS_EC, "evil;injected");
         let mut ec_context =
             EcContext::read_from_request(&settings, &req).expect("should read EC context");
+        let services = crate::platform::test_support::noop_services();
 
         let result = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
             method: &Method::GET,
@@ -1357,6 +1373,7 @@ mod tests {
             settings: &settings,
             kv: None,
             ec_context: &mut ec_context,
+            services: &services,
             req,
         }))
         .expect("should handle proxy request");
@@ -1387,6 +1404,7 @@ mod tests {
         req.set_header(header::COOKIE, format!("ts-ec={valid_ec_id}"));
         let mut ec_context =
             EcContext::read_from_request(&settings, &req).expect("should read EC context");
+        let services = crate::platform::test_support::noop_services();
 
         let result = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
             method: &Method::GET,
@@ -1394,6 +1412,7 @@ mod tests {
             settings: &settings,
             kv: None,
             ec_context: &mut ec_context,
+            services: &services,
             req,
         }))
         .expect("should handle proxy request");
@@ -1426,6 +1445,7 @@ mod tests {
         req.set_header("x-ts-ec", format!("{}.HdrEc1", "b".repeat(64)));
         let mut ec_context =
             EcContext::read_from_request(&settings, &req).expect("should read EC context");
+        let services = crate::platform::test_support::noop_services();
 
         let result = futures::executor::block_on(registry.handle_proxy(ProxyDispatchInput {
             method: &Method::POST,
@@ -1433,6 +1453,7 @@ mod tests {
             settings: &settings,
             kv: None,
             ec_context: &mut ec_context,
+            services: &services,
             req,
         }));
 

--- a/crates/trusted-server-core/src/integrations/sourcepoint.rs
+++ b/crates/trusted-server-core/src/integrations/sourcepoint.rs
@@ -22,9 +22,10 @@ use std::net::IpAddr;
 use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, Method, StatusCode};
-use fastly::{Request, Response};
+use http::header::{self, HeaderValue};
+use http::{Method, Request, Response, StatusCode};
 use regex::Regex;
 use serde::Deserialize;
 use url::Url;
@@ -33,11 +34,12 @@ use validator::{Validate, ValidationError};
 use crate::backend::BackendConfig;
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
-    IntegrationRegistration,
+    collect_body_bounded, collect_response_bounded, AttributeRewriteAction,
+    IntegrationAttributeContext, IntegrationAttributeRewriter, IntegrationEndpoint,
+    IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy, IntegrationRegistration,
+    INTEGRATION_MAX_BODY_BYTES,
 };
-use crate::platform::RuntimeServices;
+use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
 
 const SOURCEPOINT_INTEGRATION_ID: &str = "sourcepoint";
@@ -309,11 +311,13 @@ impl SourcepointIntegration {
     fn copy_headers(
         &self,
         client_ip: Option<IpAddr>,
-        original_req: &Request,
-        proxy_req: &mut Request,
+        original_req: &Request<EdgeBody>,
+        proxy_req: &mut Request<EdgeBody>,
     ) -> bool {
         if let Some(client_ip) = client_ip {
-            proxy_req.set_header("X-Forwarded-For", client_ip.to_string());
+            if let Ok(val) = HeaderValue::from_str(&client_ip.to_string()) {
+                proxy_req.headers_mut().insert("x-forwarded-for", val);
+            }
         }
 
         // Accept-Encoding is deliberately omitted here and handled in the
@@ -332,22 +336,27 @@ impl SourcepointIntegration {
             header::HeaderName::from_static("access-control-request-method"),
             header::HeaderName::from_static("access-control-request-headers"),
         ] {
-            if let Some(value) = original_req.get_header(&header_name) {
-                proxy_req.set_header(&header_name, value);
+            if let Some(value) = original_req.headers().get(&header_name) {
+                proxy_req.headers_mut().insert(header_name, value.clone());
             }
         }
 
         if let Some(filtered_cookie_header) = self.filtered_sourcepoint_cookie_header(original_req)
         {
-            proxy_req.set_header(header::COOKIE, &filtered_cookie_header);
+            if let Ok(val) = HeaderValue::from_str(&filtered_cookie_header) {
+                proxy_req.headers_mut().insert(header::COOKIE, val);
+            }
             return true;
         }
 
         false
     }
 
-    fn filtered_sourcepoint_cookie_header(&self, original_req: &Request) -> Option<String> {
-        let cookie_header = original_req.get_header(header::COOKIE)?;
+    fn filtered_sourcepoint_cookie_header(
+        &self,
+        original_req: &Request<EdgeBody>,
+    ) -> Option<String> {
+        let cookie_header = original_req.headers().get(header::COOKIE)?;
         let cookie_header = match cookie_header.to_str() {
             Ok(value) => value,
             Err(_) => {
@@ -381,35 +390,39 @@ impl SourcepointIntegration {
             || self.config.auth_cookie_name.as_deref() == Some(cookie_name)
     }
 
-    fn response_sets_cookie(response: &Response) -> bool {
-        response.get_header(header::SET_COOKIE).is_some()
+    fn response_sets_cookie(response: &Response<EdgeBody>) -> bool {
+        response.headers().contains_key(header::SET_COOKIE)
     }
 
-    fn apply_cookie_safety(response: &mut Response) -> bool {
+    fn apply_cookie_safety(response: &mut Response<EdgeBody>) -> bool {
         if Self::response_sets_cookie(response) {
-            response.set_header(header::CACHE_CONTROL, "private, no-store");
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("private, no-store"),
+            );
             return true;
         }
 
         false
     }
 
-    fn apply_cache_headers(&self, response: &mut Response, forwarded_cookies: bool) {
+    fn apply_cache_headers(&self, response: &mut Response<EdgeBody>, forwarded_cookies: bool) {
         if Self::apply_cookie_safety(response) {
             return;
         }
 
-        if response.get_header(header::CACHE_CONTROL).is_none()
-            && response.get_status().is_success()
+        if response.headers().get(header::CACHE_CONTROL).is_none() && response.status().is_success()
         {
-            if forwarded_cookies {
-                response.set_header(header::CACHE_CONTROL, "private, max-age=0");
+            let val = if forwarded_cookies {
+                HeaderValue::from_static("private, max-age=0")
             } else {
-                response.set_header(
-                    header::CACHE_CONTROL,
-                    format!("public, max-age={}", self.config.cache_ttl_seconds),
-                );
-            }
+                HeaderValue::from_str(&format!(
+                    "public, max-age={}",
+                    self.config.cache_ttl_seconds
+                ))
+                .unwrap_or(HeaderValue::from_static("public"))
+            };
+            response.headers_mut().insert(header::CACHE_CONTROL, val);
         }
     }
 
@@ -495,22 +508,29 @@ impl SourcepointIntegration {
     }
 
     /// Returns `true` when the response `Content-Type` looks like JavaScript.
-    fn is_javascript_response(response: &Response) -> bool {
+    fn is_javascript_response(response: &Response<EdgeBody>) -> bool {
         response
-            .get_header_str(header::CONTENT_TYPE)
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
             .is_some_and(|ct| ct.contains("javascript") || ct.contains("ecmascript"))
     }
 
-    fn remove_vary_accept_encoding(response: &mut Response) {
-        let Some(vary) = response.get_header_str(header::VARY) else {
-            return;
+    fn remove_vary_accept_encoding(response: &mut Response<EdgeBody>) {
+        let vary_owned = match response
+            .headers()
+            .get(header::VARY)
+            .and_then(|v| v.to_str().ok())
+        {
+            Some(v) => v.to_string(),
+            None => return,
         };
 
-        if vary.trim() == "*" {
+        if vary_owned.trim() == "*" {
             return;
         }
 
-        let kept = vary
+        let kept = vary_owned
             .split(',')
             .map(str::trim)
             .filter(|value| !value.eq_ignore_ascii_case("accept-encoding"))
@@ -519,15 +539,15 @@ impl SourcepointIntegration {
             .collect::<Vec<_>>();
 
         if kept.is_empty() {
-            response.remove_header(header::VARY);
-        } else {
-            response.set_header(header::VARY, kept.join(", "));
+            response.headers_mut().remove(header::VARY);
+        } else if let Ok(val) = HeaderValue::from_str(&kept.join(", ")) {
+            response.headers_mut().insert(header::VARY, val);
         }
     }
 
-    fn rewrite_javascript_response(&self, response: &mut Response, rewritten: String) {
-        response.remove_header(header::CONTENT_ENCODING);
-        response.remove_header(header::CONTENT_LENGTH);
+    fn rewrite_javascript_response(&self, response: &mut Response<EdgeBody>, rewritten: String) {
+        response.headers_mut().remove(header::CONTENT_ENCODING);
+        response.headers_mut().remove(header::CONTENT_LENGTH);
         Self::remove_vary_accept_encoding(response);
 
         if !Self::apply_cookie_safety(response) {
@@ -536,17 +556,19 @@ impl SourcepointIntegration {
             // regardless of what upstream sent. This intentionally diverges from the
             // passthrough path's `apply_cache_headers` (which only sets a default
             // when upstream omitted Cache-Control).
-            response.set_header(
-                header::CACHE_CONTROL,
-                format!("public, max-age={}", self.config.cache_ttl_seconds),
-            );
+            if let Ok(val) = HeaderValue::from_str(&format!(
+                "public, max-age={}",
+                self.config.cache_ttl_seconds
+            )) {
+                response.headers_mut().insert(header::CACHE_CONTROL, val);
+            }
         }
-        response.set_header(
+        response.headers_mut().insert(
             header::CONTENT_TYPE,
-            "application/javascript; charset=utf-8",
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
         );
 
-        response.set_body(rewritten);
+        *response.body_mut() = EdgeBody::from(rewritten.into_bytes());
     }
 }
 
@@ -642,64 +664,97 @@ impl IntegrationProxy for SourcepointIntegration {
     async fn handle(
         &self,
         _settings: &Settings,
-        _services: &RuntimeServices,
-        req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let path = req.get_path().to_string();
-        let method = req.get_method().clone();
+        services: &RuntimeServices,
+        req: Request<EdgeBody>,
+    ) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+        let path = req.uri().path().to_string();
+        let method = req.method().clone();
         let target_path = Self::strip_cdn_prefix(&path).ok_or_else(|| {
             Report::new(Self::error(format!("Unknown Sourcepoint route: {path}")))
         })?;
 
         let target_url = self
-            .build_target_url(target_path, req.get_query_str())
+            .build_target_url(target_path, req.uri().query())
             .change_context(Self::error("Failed to build Sourcepoint target URL"))?;
 
         log::info!("Sourcepoint: proxying {method} {path} → {target_url}");
 
-        let mut proxy_req = Request::new(req.get_method().clone(), &target_url);
-        let forwarded_cookies = self.copy_headers(req.get_client_ip_addr(), &req, &mut proxy_req);
+        let (req_parts, req_body) = req.into_parts();
+
+        let request_body = if method == Method::POST {
+            let bytes = collect_body_bounded(
+                req_body,
+                INTEGRATION_MAX_BODY_BYTES,
+                SOURCEPOINT_INTEGRATION_ID,
+            )
+            .await?;
+            EdgeBody::from(bytes)
+        } else {
+            EdgeBody::empty()
+        };
+
+        let mut proxy_req = http::Request::builder()
+            .method(method.clone())
+            .uri(&target_url)
+            .body(request_body)
+            .change_context(Self::error("Failed to build Sourcepoint proxy request"))?;
+
+        let source_req = http::Request::from_parts(req_parts, EdgeBody::empty());
+        let forwarded_cookies =
+            self.copy_headers(services.client_info.client_ip, &source_req, &mut proxy_req);
 
         // Request uncompressed content only for paths that are likely
         // JavaScript (the files we need to regex-rewrite).  All other CDN
         // responses (images, JSON API responses, CSS) keep the client's
         // original Accept-Encoding for efficiency.
         if self.config.rewrite_sdk && Self::is_likely_javascript_path(target_path) {
-            proxy_req.set_header(header::ACCEPT_ENCODING, "identity");
-        } else if let Some(ae) = req.get_header(header::ACCEPT_ENCODING) {
-            proxy_req.set_header(header::ACCEPT_ENCODING, ae);
+            proxy_req.headers_mut().insert(
+                header::ACCEPT_ENCODING,
+                HeaderValue::from_static("identity"),
+            );
+        } else if let Some(ae) = source_req.headers().get(header::ACCEPT_ENCODING) {
+            proxy_req
+                .headers_mut()
+                .insert(header::ACCEPT_ENCODING, ae.clone());
         }
 
-        if matches!(method, Method::POST) {
-            if let Some(content_type) = req.get_header(header::CONTENT_TYPE) {
-                proxy_req.set_header(header::CONTENT_TYPE, content_type);
+        if method == Method::POST {
+            if let Some(content_type) = source_req.headers().get(header::CONTENT_TYPE) {
+                proxy_req
+                    .headers_mut()
+                    .insert(header::CONTENT_TYPE, content_type.clone());
             }
-            proxy_req.set_body(req.into_body());
         }
 
         let backend_name = BackendConfig::from_url(&self.config.cdn_origin, true)
             .change_context(Self::error("Failed to configure Sourcepoint backend"))?;
 
-        let mut response = proxy_req
-            .send(&backend_name)
-            .change_context(Self::error("Sourcepoint upstream request failed"))?;
+        let mut response = services
+            .http_client()
+            .send(PlatformHttpRequest::new(proxy_req, backend_name))
+            .await
+            .change_context(Self::error("Sourcepoint upstream request failed"))?
+            .response;
 
         log::info!(
             "Sourcepoint: upstream responded with status {}",
-            response.get_status()
+            response.status()
         );
 
         // Rewrite Location headers on redirect responses so the browser
         // follows the redirect through the first-party proxy instead of
         // leaking the CDN origin to the client.
-        if response.get_status().is_redirection() {
+        if response.status().is_redirection() {
             if let Some(location) = response
-                .get_header(header::LOCATION)
+                .headers()
+                .get(header::LOCATION)
                 .and_then(|h| h.to_str().ok())
             {
                 if let Some(rewritten) = Self::rewrite_redirect_location(location, &target_url) {
                     log::info!("Sourcepoint: rewrote redirect Location to {rewritten}");
-                    response.set_header(header::LOCATION, &rewritten);
+                    if let Ok(val) = HeaderValue::from_str(&rewritten) {
+                        response.headers_mut().insert(header::LOCATION, val);
+                    }
                 }
             }
             // Redirects without Set-Cookie intentionally keep upstream cache
@@ -711,8 +766,8 @@ impl IntegrationProxy for SourcepointIntegration {
 
         // Rewrite CDN URLs inside JavaScript responses so that dynamically
         // loaded chunks and API calls route through the first-party proxy.
-        if matches!(method, Method::GET)
-            && response.get_status() == StatusCode::OK
+        if method == Method::GET
+            && response.status() == StatusCode::OK
             && self.config.rewrite_sdk
             && Self::is_javascript_response(&response)
         {
@@ -721,7 +776,8 @@ impl IntegrationProxy for SourcepointIntegration {
             // Guard against unexpectedly large responses to avoid unbounded
             // memory consumption during rewriting.
             let content_length = response
-                .get_header(header::CONTENT_LENGTH)
+                .headers()
+                .get(header::CONTENT_LENGTH)
                 .and_then(|v| v.to_str().ok())
                 .and_then(|s| s.parse::<u64>().ok());
 
@@ -746,7 +802,15 @@ impl IntegrationProxy for SourcepointIntegration {
                 Some(_) => {}
             }
 
-            let body_bytes = response.take_body_bytes();
+            let (resp_parts, resp_body) = response.into_parts();
+            let body_bytes = collect_response_bounded(
+                resp_body,
+                MAX_REWRITE_BODY_SIZE as usize,
+                SOURCEPOINT_INTEGRATION_ID,
+            )
+            .await?;
+            let mut response = http::Response::from_parts(resp_parts, EdgeBody::empty());
+
             let body = match String::from_utf8(body_bytes) {
                 Ok(text) => text,
                 Err(err) => {
@@ -755,7 +819,7 @@ impl IntegrationProxy for SourcepointIntegration {
                          at byte offset {}, passing through unmodified",
                         err.utf8_error().valid_up_to()
                     );
-                    response.set_body(err.into_bytes());
+                    *response.body_mut() = EdgeBody::from(err.into_bytes());
                     self.apply_cache_headers(&mut response, forwarded_cookies);
                     return Ok(response);
                 }
@@ -870,7 +934,6 @@ mod tests {
     use super::*;
     use crate::integrations::{IntegrationDocumentState, IntegrationRegistry};
     use crate::test_support::tests::create_test_settings;
-    use fastly::http::Method;
     use serde_json::json;
 
     fn config(enabled: bool) -> SourcepointConfig {
@@ -1341,11 +1404,69 @@ mod tests {
         );
     }
 
+    fn make_req(method: Method, url: &str) -> Request<EdgeBody> {
+        http::Request::builder()
+            .method(method)
+            .uri(url)
+            .body(EdgeBody::empty())
+            .expect("should build test request")
+    }
+
+    fn make_resp_with_status(status: StatusCode) -> Response<EdgeBody> {
+        http::Response::builder()
+            .status(status)
+            .body(EdgeBody::empty())
+            .expect("should build test response")
+    }
+
+    fn get_header_str(
+        resp: &Response<EdgeBody>,
+        name: impl http::header::AsHeaderName,
+    ) -> Option<&str> {
+        resp.headers().get(name).and_then(|v| v.to_str().ok())
+    }
+
+    fn get_req_header_str(
+        req: &Request<EdgeBody>,
+        name: impl http::header::AsHeaderName,
+    ) -> Option<&str> {
+        req.headers().get(name).and_then(|v| v.to_str().ok())
+    }
+
+    fn set_header(
+        resp: &mut Response<EdgeBody>,
+        name: impl http::header::IntoHeaderName,
+        value: &str,
+    ) {
+        resp.headers_mut().insert(
+            name,
+            HeaderValue::from_str(value).expect("should build header value"),
+        );
+    }
+
+    fn set_req_header(
+        req: &mut Request<EdgeBody>,
+        name: impl http::header::IntoHeaderName,
+        value: &str,
+    ) {
+        req.headers_mut().insert(
+            name,
+            HeaderValue::from_str(value).expect("should build header value"),
+        );
+    }
+
+    fn take_body_bytes(resp: Response<EdgeBody>) -> Vec<u8> {
+        match resp.into_body() {
+            EdgeBody::Once(b) => b.to_vec(),
+            EdgeBody::Stream(_) => vec![],
+        }
+    }
+
     #[test]
     fn copy_headers_sets_x_forwarded_for_from_runtime_client_ip() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let original_req = Request::new(Method::GET, "https://publisher.example.com/sourcepoint");
-        let mut proxy_req = Request::new(Method::GET, "https://cdn.privacy-mgmt.com/wrapper.js");
+        let original_req = make_req(Method::GET, "https://publisher.example.com/sourcepoint");
+        let mut proxy_req = make_req(Method::GET, "https://cdn.privacy-mgmt.com/wrapper.js");
         let client_ip = "203.0.113.10".parse().expect("should parse test IP");
 
         let forwarded_cookies =
@@ -1356,7 +1477,7 @@ mod tests {
             "should report no forwarded cookies when request has none"
         );
         assert_eq!(
-            proxy_req.get_header_str("X-Forwarded-For"),
+            get_req_header_str(&proxy_req, "x-forwarded-for"),
             Some("203.0.113.10"),
             "should forward platform-provided client IP"
         );
@@ -1366,21 +1487,24 @@ mod tests {
     fn copy_headers_forwards_preflight_headers() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
         let mut original_req =
-            Request::new(Method::OPTIONS, "https://publisher.example.com/sourcepoint");
-        original_req.set_header("Access-Control-Request-Method", "POST");
-        original_req.set_header("Access-Control-Request-Headers", "Content-Type, X-Test");
-        let mut proxy_req =
-            Request::new(Method::OPTIONS, "https://cdn.privacy-mgmt.com/wrapper.js");
+            make_req(Method::OPTIONS, "https://publisher.example.com/sourcepoint");
+        set_req_header(&mut original_req, "access-control-request-method", "POST");
+        set_req_header(
+            &mut original_req,
+            "access-control-request-headers",
+            "Content-Type, X-Test",
+        );
+        let mut proxy_req = make_req(Method::OPTIONS, "https://cdn.privacy-mgmt.com/wrapper.js");
 
         integration.copy_headers(None, &original_req, &mut proxy_req);
 
         assert_eq!(
-            proxy_req.get_header_str("Access-Control-Request-Method"),
+            get_req_header_str(&proxy_req, "access-control-request-method"),
             Some("POST"),
             "should forward requested preflight method"
         );
         assert_eq!(
-            proxy_req.get_header_str("Access-Control-Request-Headers"),
+            get_req_header_str(&proxy_req, "access-control-request-headers"),
             Some("Content-Type, X-Test"),
             "should forward requested preflight headers"
         );
@@ -1389,8 +1513,9 @@ mod tests {
     #[test]
     fn forwards_only_allowlisted_sourcepoint_cookies() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let mut req = Request::new(Method::GET, "https://publisher.example.com/sourcepoint");
-        req.set_header(
+        let mut req = make_req(Method::GET, "https://publisher.example.com/sourcepoint");
+        set_req_header(
+            &mut req,
             header::COOKIE,
             "consentUUID=uuid123; session_id=secret; euconsent-v2=tcf; _sp_su=1; theme=dark",
         );
@@ -1409,8 +1534,9 @@ mod tests {
         let mut cfg = config(true);
         cfg.auth_cookie_name = Some("sp_auth".to_string());
         let integration = SourcepointIntegration::new(Arc::new(cfg));
-        let mut req = Request::new(Method::GET, "https://publisher.example.com/sourcepoint");
-        req.set_header(
+        let mut req = make_req(Method::GET, "https://publisher.example.com/sourcepoint");
+        set_req_header(
+            &mut req,
             header::COOKIE,
             "sp_auth=token123; session_id=secret; consentUUID=uuid123",
         );
@@ -1427,8 +1553,8 @@ mod tests {
     #[test]
     fn drops_unrelated_publisher_cookies_from_upstream_request() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let mut req = Request::new(Method::GET, "https://publisher.example.com/sourcepoint");
-        req.set_header(header::COOKIE, "session_id=secret; theme=dark");
+        let mut req = make_req(Method::GET, "https://publisher.example.com/sourcepoint");
+        set_req_header(&mut req, header::COOKIE, "session_id=secret; theme=dark");
 
         assert_eq!(
             integration.filtered_sourcepoint_cookie_header(&req),
@@ -1440,14 +1566,18 @@ mod tests {
     #[test]
     fn apply_cache_headers_uses_private_no_store_for_cookie_setting_responses() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let mut response = Response::from_status(StatusCode::OK);
-        response.set_header(header::SET_COOKIE, "consentUUID=uuid123; Path=/");
-        response.set_header(header::CACHE_CONTROL, "public, max-age=3600");
+        let mut response = make_resp_with_status(StatusCode::OK);
+        set_header(
+            &mut response,
+            header::SET_COOKIE,
+            "consentUUID=uuid123; Path=/",
+        );
+        set_header(&mut response, header::CACHE_CONTROL, "public, max-age=3600");
 
         integration.apply_cache_headers(&mut response, false);
 
         assert_eq!(
-            response.get_header_str(header::CACHE_CONTROL),
+            get_header_str(&response, header::CACHE_CONTROL),
             Some("private, no-store"),
             "should prevent public caching for cookie-setting responses"
         );
@@ -1456,12 +1586,12 @@ mod tests {
     #[test]
     fn apply_cache_headers_uses_private_policy_when_cookies_were_forwarded() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let mut response = Response::from_status(StatusCode::OK);
+        let mut response = make_resp_with_status(StatusCode::OK);
 
         integration.apply_cache_headers(&mut response, true);
 
         assert_eq!(
-            response.get_header_str(header::CACHE_CONTROL),
+            get_header_str(&response, header::CACHE_CONTROL),
             Some("private, max-age=0"),
             "should not publicly cache responses that may vary by forwarded Cookie"
         );
@@ -1470,13 +1600,13 @@ mod tests {
     #[test]
     fn apply_cache_headers_uses_public_default_without_forwarded_cookies() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let mut response = Response::from_status(StatusCode::OK);
+        let mut response = make_resp_with_status(StatusCode::OK);
 
         integration.apply_cache_headers(&mut response, false);
 
         let expected_cache_control = format!("public, max-age={}", default_cache_ttl());
         assert_eq!(
-            response.get_header_str(header::CACHE_CONTROL),
+            get_header_str(&response, header::CACHE_CONTROL),
             Some(expected_cache_control.as_str()),
             "should keep public default caching for non-personalized responses"
         );
@@ -1485,36 +1615,40 @@ mod tests {
     #[test]
     fn rewrite_javascript_response_preserves_headers() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let mut response = Response::from_status(StatusCode::OK);
+        let mut response = make_resp_with_status(StatusCode::OK);
 
-        response.set_header(header::VARY, "Accept-Encoding, Origin");
-        response.set_header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "https://example.com");
-        response.set_header(header::CONTENT_ENCODING, "gzip");
-        response.set_header(header::CONTENT_LENGTH, "4");
-        response.set_header(header::CACHE_CONTROL, "no-store");
+        set_header(&mut response, header::VARY, "Accept-Encoding, Origin");
+        set_header(
+            &mut response,
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            "https://example.com",
+        );
+        set_header(&mut response, header::CONTENT_ENCODING, "gzip");
+        set_header(&mut response, header::CONTENT_LENGTH, "4");
+        set_header(&mut response, header::CACHE_CONTROL, "no-store");
+        *response.body_mut() = EdgeBody::from(b"payload".to_vec());
 
-        response.set_body("payload");
         integration.rewrite_javascript_response(&mut response, "rewritten".to_string());
 
-        assert_eq!(response.get_status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            response.get_header_str(header::CONTENT_TYPE),
+            get_header_str(&response, header::CONTENT_TYPE),
             Some("application/javascript; charset=utf-8")
         );
         let expected_cache_control = format!("public, max-age={}", default_cache_ttl());
         assert_eq!(
-            response.get_header_str(header::CACHE_CONTROL),
+            get_header_str(&response, header::CACHE_CONTROL),
             Some(expected_cache_control.as_str())
         );
-        assert_eq!(response.get_header_str(header::VARY), Some("Origin"));
+        assert_eq!(get_header_str(&response, header::VARY), Some("Origin"));
         assert_eq!(
-            response.get_header_str(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            get_header_str(&response, header::ACCESS_CONTROL_ALLOW_ORIGIN),
             Some("https://example.com")
         );
-        assert!(response.get_header(header::CONTENT_ENCODING).is_none());
-        assert!(response.get_header(header::CONTENT_LENGTH).is_none());
+        assert!(response.headers().get(header::CONTENT_ENCODING).is_none());
+        assert!(response.headers().get(header::CONTENT_LENGTH).is_none());
 
-        let body = response.take_body_bytes();
+        let body = take_body_bytes(response);
         assert_eq!(
             String::from_utf8(body).expect("should decode rewritten JavaScript response"),
             "rewritten"
@@ -1524,20 +1658,24 @@ mod tests {
     #[test]
     fn rewrite_javascript_response_uses_private_no_store_for_cookie_setting_responses() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let mut response = Response::from_status(StatusCode::OK);
-        response.set_header(header::SET_COOKIE, "consentUUID=uuid123; Path=/");
-        response.set_header(header::CACHE_CONTROL, "public, max-age=3600");
-        response.set_body("payload");
+        let mut response = make_resp_with_status(StatusCode::OK);
+        set_header(
+            &mut response,
+            header::SET_COOKIE,
+            "consentUUID=uuid123; Path=/",
+        );
+        set_header(&mut response, header::CACHE_CONTROL, "public, max-age=3600");
+        *response.body_mut() = EdgeBody::from(b"payload".to_vec());
 
         integration.rewrite_javascript_response(&mut response, "rewritten".to_string());
 
         assert_eq!(
-            response.get_header_str(header::CACHE_CONTROL),
+            get_header_str(&response, header::CACHE_CONTROL),
             Some("private, no-store"),
             "should avoid public caching when rewritten response still sets cookies"
         );
         assert_eq!(
-            response.get_header_str(header::CONTENT_TYPE),
+            get_header_str(&response, header::CONTENT_TYPE),
             Some("application/javascript; charset=utf-8")
         );
     }
@@ -1545,14 +1683,14 @@ mod tests {
     #[test]
     fn rewrite_javascript_response_removes_exact_accept_encoding_vary() {
         let integration = SourcepointIntegration::new(Arc::new(config(true)));
-        let mut response = Response::from_status(StatusCode::OK);
-        response.set_header(header::VARY, "Accept-Encoding");
-        response.set_body("payload");
+        let mut response = make_resp_with_status(StatusCode::OK);
+        set_header(&mut response, header::VARY, "Accept-Encoding");
+        *response.body_mut() = EdgeBody::from(b"payload".to_vec());
 
         integration.rewrite_javascript_response(&mut response, "rewritten".to_string());
 
         assert!(
-            response.get_header(header::VARY).is_none(),
+            response.headers().get(header::VARY).is_none(),
             "should remove stale Vary: Accept-Encoding after stripping content encoding"
         );
     }

--- a/crates/trusted-server-core/src/integrations/sourcepoint.rs
+++ b/crates/trusted-server-core/src/integrations/sourcepoint.rs
@@ -37,6 +37,7 @@ use crate::integrations::{
     IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
     IntegrationRegistration,
 };
+use crate::platform::RuntimeServices;
 use crate::settings::{IntegrationConfig, Settings};
 
 const SOURCEPOINT_INTEGRATION_ID: &str = "sourcepoint";
@@ -641,6 +642,7 @@ impl IntegrationProxy for SourcepointIntegration {
     async fn handle(
         &self,
         _settings: &Settings,
+        _services: &RuntimeServices,
         req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let path = req.get_path().to_string();

--- a/crates/trusted-server-core/src/integrations/testlight.rs
+++ b/crates/trusted-server-core/src/integrations/testlight.rs
@@ -14,6 +14,7 @@ use crate::integrations::{
     AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
     IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
 };
+use crate::platform::RuntimeServices;
 use crate::proxy::{proxy_request, ProxyRequestConfig};
 use crate::settings::{IntegrationConfig, Settings};
 use crate::tsjs;
@@ -140,6 +141,7 @@ impl IntegrationProxy for TestlightIntegration {
     async fn handle(
         &self,
         settings: &Settings,
+        services: &RuntimeServices,
         mut req: Request,
     ) -> Result<Response, Report<TrustedServerError>> {
         let mut payload = serde_json::from_slice::<TestlightRequestBody>(&req.take_body_bytes())
@@ -172,7 +174,7 @@ impl IntegrationProxy for TestlightIntegration {
             HeaderValue::from_static("application/json"),
         ));
 
-        let mut response = proxy_request(settings, req, proxy_config)
+        let mut response = proxy_request(settings, req, proxy_config, services)
             .await
             .change_context(Self::error("Failed to contact upstream integration"))?;
 

--- a/crates/trusted-server-core/src/integrations/testlight.rs
+++ b/crates/trusted-server-core/src/integrations/testlight.rs
@@ -1,18 +1,21 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, HeaderValue};
-use fastly::{Request, Response};
+use http::header::{self, HeaderValue};
+use http::Response;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use validator::Validate;
 
-use crate::ec::get_ec_id;
+use crate::edge_cookie::get_ec_id;
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
+    collect_body_bounded, collect_response_bounded, AttributeRewriteAction,
+    IntegrationAttributeContext, IntegrationAttributeRewriter, IntegrationEndpoint,
+    IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
+    UPSTREAM_RTB_MAX_RESPONSE_BYTES,
 };
 use crate::platform::RuntimeServices;
 use crate::proxy::{proxy_request, ProxyRequestConfig};
@@ -43,7 +46,7 @@ impl IntegrationConfig for TestlightConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Validate)]
+#[derive(Debug, Default, Deserialize, Serialize, Validate)]
 struct TestlightRequestBody {
     #[validate(nested)]
     #[serde(default)]
@@ -73,7 +76,7 @@ struct TestlightImp {
     extra: Map<String, Value>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 struct TestlightResponseBody {
     #[serde(flatten)]
     fields: Map<String, Value>,
@@ -93,6 +96,38 @@ impl TestlightIntegration {
             integration: TESTLIGHT_INTEGRATION_ID.to_string(),
             message: message.into(),
         }
+    }
+
+    fn rewrite_request_body(
+        payload_bytes: &[u8],
+        synthetic_id: &str,
+    ) -> Result<Vec<u8>, Report<TrustedServerError>> {
+        let mut payload = serde_json::from_slice::<TestlightRequestBody>(payload_bytes)
+            .change_context(Self::error("Failed to parse request body"))?;
+        payload
+            .validate()
+            .map_err(|err| Report::new(Self::error(format!("Invalid request payload: {err}"))))?;
+
+        payload.user.id = Some(synthetic_id.to_string());
+
+        serde_json::to_vec(&payload).change_context(Self::error("Failed to serialize request body"))
+    }
+
+    fn rebuild_response(
+        mut parts: http::response::Parts,
+        body_bytes: Vec<u8>,
+        json_content_type: bool,
+    ) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+        parts.headers.remove(header::CONTENT_LENGTH);
+
+        if json_content_type {
+            parts.headers.insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+        }
+
+        Ok(Response::from_parts(parts, EdgeBody::from(body_bytes)))
     }
 }
 
@@ -142,28 +177,25 @@ impl IntegrationProxy for TestlightIntegration {
         &self,
         settings: &Settings,
         services: &RuntimeServices,
-        mut req: Request,
-    ) -> Result<Response, Report<TrustedServerError>> {
-        let mut payload = serde_json::from_slice::<TestlightRequestBody>(&req.take_body_bytes())
-            .change_context(Self::error("Failed to parse request body"))?;
-        payload
-            .validate()
-            .map_err(|err| Report::new(Self::error(format!("Invalid request payload: {err}"))))?;
+        req: http::Request<EdgeBody>,
+    ) -> Result<http::Response<EdgeBody>, Report<TrustedServerError>> {
+        let (parts, body) = req.into_parts();
+        let payload_bytes =
+            collect_body_bounded(body, INTEGRATION_MAX_BODY_BYTES, TESTLIGHT_INTEGRATION_ID)
+                .await?;
+        let req = http::Request::from_parts(parts, EdgeBody::empty());
 
-        // Read EC ID from header (set by registry) or cookie
+        // Read EC ID from the ts-ec cookie forwarded by the client.
+        // The registry strips x-ts-ec before dispatching, so only the cookie is available here.
         let ec_id = get_ec_id(&req)
             .change_context(Self::error("Failed to read EC ID"))?
             .ok_or_else(|| {
                 Report::new(Self::error(
-                    "EC ID not found in request header or cookie — \
-                     check that the integration registry propagated it",
+                    "EC ID not found in ts-ec cookie — the client must carry a valid EC cookie",
                 ))
             })?;
 
-        payload.user.id = Some(ec_id);
-
-        let payload_bytes = serde_json::to_vec(&payload)
-            .change_context(Self::error("Failed to serialize request body"))?;
+        let payload_bytes = Self::rewrite_request_body(&payload_bytes, &ec_id)?;
 
         let mut proxy_config = ProxyRequestConfig::new(&self.config.endpoint);
         proxy_config.forward_ec_id = false;
@@ -174,25 +206,29 @@ impl IntegrationProxy for TestlightIntegration {
             HeaderValue::from_static("application/json"),
         ));
 
-        let mut response = proxy_request(settings, req, proxy_config, services)
+        let response = proxy_request(settings, req, proxy_config, services)
             .await
             .change_context(Self::error("Failed to contact upstream integration"))?;
+        let (parts, body) = response.into_parts();
 
         // Attempt to parse response into structured form for logging/future transforms.
-        let response_body = response.take_body_bytes();
+        let response_body = collect_response_bounded(
+            body,
+            UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+            TESTLIGHT_INTEGRATION_ID,
+        )
+        .await?;
         match serde_json::from_slice::<TestlightResponseBody>(&response_body) {
             Ok(body) => {
-                response
-                    .set_body_json(&body)
+                let response_body = serde_json::to_vec(&body)
                     .change_context(Self::error("Failed to serialize integration response body"))?;
+                Self::rebuild_response(parts, response_body, true)
             }
             Err(_) => {
                 // Preserve original body if the integration responded with non-JSON content.
-                response.set_body(response_body);
+                Self::rebuild_response(parts, response_body, false)
             }
         }
-
-        Ok(response)
     }
 }
 
@@ -238,28 +274,15 @@ fn default_enabled() -> bool {
     false
 }
 
-impl Default for TestlightRequestBody {
-    fn default() -> Self {
-        Self {
-            user: TestlightUserSection::default(),
-            imp: Vec::new(),
-            extra: Map::new(),
-        }
-    }
-}
-
-impl Default for TestlightResponseBody {
-    fn default() -> Self {
-        Self { fields: Map::new() }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_support::tests::create_test_settings, tsjs};
-    use fastly::http::Method;
+    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
+    use crate::test_support::tests::{create_test_settings, VALID_SYNTHETIC_ID};
+    use crate::tsjs;
+    use http::Method;
     use serde_json::json;
+    use std::sync::Arc;
 
     #[test]
     fn build_requires_config() {
@@ -349,6 +372,97 @@ mod tests {
             routes.iter().any(|route| route.method == Method::POST
                 && route.path == "/integrations/testlight/auction"),
             "Integration should register POST /integrations/testlight/auction"
+        );
+    }
+
+    #[test]
+    fn rewrite_request_body_injects_synthetic_id_without_fastly_types() {
+        let payload = br#"{"imp":[{"id":"slot-1"}]}"#;
+
+        let rewritten = TestlightIntegration::rewrite_request_body(payload, "abc123.XyZ789")
+            .expect("should rewrite Testlight payload");
+        let rewritten_json: serde_json::Value =
+            serde_json::from_slice(&rewritten).expect("should parse rewritten payload");
+
+        assert_eq!(
+            rewritten_json["user"]["id"], "abc123.XyZ789",
+            "should inject the synthetic ID into the Testlight user payload"
+        );
+    }
+
+    #[test]
+    fn rebuild_response_drops_stale_content_length_when_body_changes() {
+        let response = http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header(header::CONTENT_LENGTH, "99")
+            .body(EdgeBody::from(br#"{ "ok" : true }"#.to_vec()))
+            .expect("should build Testlight response");
+        let (parts, _) = response.into_parts();
+
+        let rebuilt =
+            TestlightIntegration::rebuild_response(parts, br#"{"ok":true}"#.to_vec(), true)
+                .expect("should rebuild Testlight response");
+
+        assert!(
+            rebuilt.headers().get(header::CONTENT_LENGTH).is_none(),
+            "should drop stale Content-Length when rebuilding the response body"
+        );
+        assert_eq!(
+            rebuilt
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json"),
+            "should normalize JSON responses to application/json"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_uses_platform_http_client_with_http_request() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, br#"{"ok":true}"#.to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let integration = TestlightIntegration::new(TestlightConfig {
+            enabled: true,
+            endpoint: "https://example.com/openrtb".to_string(),
+            timeout_ms: 1000,
+            shim_src: tsjs::tsjs_unified_script_src(),
+            rewrite_scripts: true,
+        });
+        let mut req = http::Request::builder()
+            .method(Method::POST)
+            .uri("https://edge.example.com/integrations/testlight/auction")
+            .body(EdgeBody::from(br#"{"imp":[{"id":"slot-1"}]}"#.to_vec()))
+            .expect("should build request");
+        req.headers_mut().insert(
+            crate::constants::HEADER_X_TS_EC.clone(),
+            http::HeaderValue::from_static(VALID_SYNTHETIC_ID),
+        );
+
+        let response = integration
+            .handle(&settings, &services, req)
+            .await
+            .expect("should proxy Testlight request");
+
+        assert_eq!(
+            response.status(),
+            http::StatusCode::OK,
+            "should return stubbed upstream status"
+        );
+        assert_eq!(
+            stub.recorded_backend_names(),
+            vec!["stub-backend".to_string()],
+            "should route outbound request through PlatformHttpClient"
+        );
+        let response_json: serde_json::Value =
+            serde_json::from_slice(&response.into_body().into_bytes())
+                .expect("should parse JSON response");
+        assert_eq!(
+            response_json["ok"], true,
+            "should preserve the upstream JSON response body"
         );
     }
 }

--- a/crates/trusted-server-core/src/lib.rs
+++ b/crates/trusted-server-core/src/lib.rs
@@ -12,13 +12,11 @@
 //! - [`consent`]: Consent signal extraction and logging
 //! - [`geo`]: Geographic location utilities and DMA code extraction
 //! - [`models`]: Data models for ad serving and callbacks
-//! - [`prebid`]: Prebid integration and real-time bidding support
-//! - [`privacy`]: Privacy utilities and helpers
+//! - [`integrations::prebid`]: Prebid integration and real-time bidding support
 //! - [`settings`]: Configuration management and validation
 //! - [`streaming_replacer`]: Streaming URL replacement for large responses
 //! - [`ec`]: Edge Cookie (EC) identity subsystem — ID generation, consent gating, lifecycle
 //! - [`test_support`]: Testing utilities and mocks
-//! - [`why`]: Debugging and introspection utilities
 
 #![cfg_attr(
     test,
@@ -31,6 +29,7 @@
     )
 )]
 
+pub(crate) mod asset_image_optimizer;
 pub mod auction;
 pub mod auction_config_types;
 pub mod auth;
@@ -45,6 +44,7 @@ pub mod creative;
 pub mod ec;
 pub mod error;
 pub mod geo;
+pub(crate) mod host_header;
 pub(crate) mod host_rewrite;
 pub mod html_processor;
 pub mod http_util;
@@ -57,6 +57,7 @@ pub mod publisher;
 pub mod redacted;
 pub mod request_signing;
 pub mod rsc_flight;
+pub(crate) mod s3_sigv4;
 pub mod settings;
 pub mod settings_data;
 pub mod storage;

--- a/crates/trusted-server-core/src/lib.rs
+++ b/crates/trusted-server-core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod constants;
 pub mod cookies;
 pub mod creative;
 pub mod ec;
+pub(crate) mod edge_cookie;
 pub mod error;
 pub mod geo;
 pub(crate) mod host_header;

--- a/crates/trusted-server-core/src/migration_guards.rs
+++ b/crates/trusted-server-core/src/migration_guards.rs
@@ -23,32 +23,38 @@ fn strip_line_comments(source: &str) -> String {
 }
 
 #[test]
-fn migrated_utility_modules_do_not_depend_on_fastly_request_response_types() {
+fn migrated_utility_and_handler_modules_do_not_depend_on_fastly_request_response_types() {
     let sources = [
         ("auth.rs", include_str!("auth.rs")),
         ("cookies.rs", include_str!("cookies.rs")),
         ("http_util.rs", include_str!("http_util.rs")),
+        ("geo.rs", include_str!("geo.rs")),
+        ("publisher.rs", include_str!("publisher.rs")),
+        ("proxy.rs", include_str!("proxy.rs")),
+        ("auction/formats.rs", include_str!("auction/formats.rs")),
+        ("auction/endpoints.rs", include_str!("auction/endpoints.rs")),
+        (
+            "request_signing/endpoints.rs",
+            include_str!("request_signing/endpoints.rs"),
+        ),
         (
             "consent/extraction.rs",
             include_str!("consent/extraction.rs"),
         ),
         ("consent/mod.rs", include_str!("consent/mod.rs")),
     ];
-    let banned_patterns = [
-        "fastly::Request",
-        "fastly::Response",
-        "fastly::http::Method",
-        "fastly::http::StatusCode",
-        "fastly::mime::APPLICATION_JSON",
-    ];
+    // Word-boundary regex prevents false positives from doc comments or string
+    // literals that merely mention Fastly type names without importing them.
+    let banned = regex::Regex::new(
+        r"\bfastly::(Request|Response|http::(Method|StatusCode)|mime::APPLICATION_JSON)\b",
+    )
+    .expect("should compile migration guard regex");
 
     for (path, source) in sources {
         let uncommented = strip_line_comments(source);
-        for banned in banned_patterns {
-            assert!(
-                !uncommented.contains(banned),
-                "{path} should not reference `{banned}` after PR11 migration"
-            );
-        }
+        assert!(
+            !banned.is_match(&uncommented),
+            "{path} should not reference fastly Request/Response types after PR11 migration"
+        );
     }
 }

--- a/crates/trusted-server-core/src/platform/http.rs
+++ b/crates/trusted-server-core/src/platform/http.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use edgezero_core::http::{Request as EdgeRequest, Response as EdgeResponse};
 use error_stack::Report;
 
+use super::image_optimizer::PlatformImageOptimizerOptions;
 use super::PlatformError;
 
 /// Outbound HTTP request paired with a pre-resolved backend name.
@@ -17,6 +18,16 @@ pub struct PlatformHttpRequest {
     pub request: EdgeRequest,
     /// Backend name resolved ahead of time via `PlatformBackend`.
     pub backend_name: String,
+    /// Optional Image Optimizer metadata for platforms that support it.
+    ///
+    /// Adapters that cannot attach this metadata to their send path should
+    /// return an error rather than silently dropping transformations.
+    pub image_optimizer: Option<PlatformImageOptimizerOptions>,
+    /// Whether the response body should stay streaming in the platform response.
+    ///
+    /// Adapters that cannot preserve streaming response bodies should return an
+    /// error rather than silently buffering large asset responses.
+    pub stream_response: bool,
 }
 
 impl PlatformHttpRequest {
@@ -26,7 +37,30 @@ impl PlatformHttpRequest {
         Self {
             request,
             backend_name: backend_name.into(),
+            image_optimizer: None,
+            stream_response: false,
         }
+    }
+
+    /// Attach Image Optimizer metadata to the request.
+    ///
+    /// The current Fastly adapter supports this on [`PlatformHttpClient::send`]
+    /// and rejects it on [`PlatformHttpClient::send_async`] because Fastly IO is
+    /// not available through the fan-out helper path.
+    #[must_use]
+    pub fn with_image_optimizer(mut self, options: PlatformImageOptimizerOptions) -> Self {
+        self.image_optimizer = Some(options);
+        self
+    }
+
+    /// Preserve the upstream response body as a stream when the adapter supports it.
+    ///
+    /// Asset routes use this to avoid materializing large image/static responses
+    /// into WASM memory before returning them to the client.
+    #[must_use]
+    pub fn with_stream_response(mut self) -> Self {
+        self.stream_response = true;
+        self
     }
 }
 

--- a/crates/trusted-server-core/src/platform/http.rs
+++ b/crates/trusted-server-core/src/platform/http.rs
@@ -179,7 +179,16 @@ pub struct PlatformSelectResult {
     /// Completed response, or the error returned by the ready request.
     pub ready: Result<PlatformResponse, Report<PlatformError>>,
     /// Requests still in flight after the ready result is removed.
+    ///
+    /// Note: entries in this list may have `backend_name == None` on some
+    /// adapters (e.g., Fastly), because the adapter cannot preserve input
+    /// identifiers across the platform `select()` call. Orchestrators must
+    /// not rely on `backend_name()` being set on remaining entries.
     pub remaining: Vec<PlatformPendingRequest>,
+    /// Backend name of the request that became ready with an error, when
+    /// `ready` is `Err`. `None` on the success path and when the adapter
+    /// cannot identify the failed backend.
+    pub failed_backend_name: Option<String>,
 }
 
 /// Outbound HTTP client abstraction.

--- a/crates/trusted-server-core/src/platform/image_optimizer.rs
+++ b/crates/trusted-server-core/src/platform/image_optimizer.rs
@@ -1,0 +1,181 @@
+//! Platform-neutral Image Optimizer request metadata.
+//!
+//! These DTOs describe the closed image transformation set that Trusted Server
+//! attaches to an outbound asset proxy request. They intentionally avoid Fastly
+//! SDK types so the profile-table logic can stay in core while the Fastly
+//! adapter remains responsible for translating metadata into
+//! `fastly::image_optimizer::ImageOptimizerOptions`.
+//!
+//! Unsupported adapters should reject requests carrying this metadata rather
+//! than silently dropping transformations.
+
+/// Platform-neutral Image Optimizer processing region.
+///
+/// These variants mirror the regions currently exposed by the Fastly SDK while
+/// keeping config validation in core independent from adapter-specific types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformImageOptimizerRegion {
+    /// Apply image optimization in the eastern United States.
+    UsEast,
+    /// Apply image optimization in the central United States.
+    UsCentral,
+    /// Apply image optimization in the western United States.
+    UsWest,
+    /// Apply image optimization in central Europe.
+    EuCentral,
+    /// Apply image optimization in western Europe.
+    EuWest,
+    /// Apply image optimization in Asia.
+    Asia,
+    /// Apply image optimization in Australia.
+    Australia,
+}
+
+impl PlatformImageOptimizerRegion {
+    /// Parse a configured region string into a supported Image Optimizer region.
+    #[must_use]
+    pub fn parse(region: &str) -> Option<Self> {
+        match region
+            .trim()
+            .to_ascii_lowercase()
+            .replace('-', "_")
+            .as_str()
+        {
+            "us_east" | "us_east_1" => Some(Self::UsEast),
+            "us_central" | "us_central_1" => Some(Self::UsCentral),
+            "us_west" | "us_west_1" | "us_west_2" => Some(Self::UsWest),
+            "eu_central" | "eu_central_1" => Some(Self::EuCentral),
+            "eu_west" | "eu_west_1" => Some(Self::EuWest),
+            "asia" => Some(Self::Asia),
+            "australia" => Some(Self::Australia),
+            _ => None,
+        }
+    }
+}
+
+/// Platform-neutral Image Optimizer options for an upstream request.
+///
+/// Core code stores only a closed transformation set here. The Fastly adapter is
+/// responsible for translating these values to SDK-specific
+/// `ImageOptimizerOptions`, while adapters without Image Optimizer support
+/// should reject requests carrying this metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlatformImageOptimizerOptions {
+    /// Image Optimizer processing region understood by the target adapter.
+    pub region: String,
+    /// Whether non-IO query parameters should be preserved on the origin request.
+    pub preserve_query_string_on_origin_request: bool,
+    /// Transformation parameters to apply.
+    pub params: PlatformImageOptimizerParams,
+}
+
+impl PlatformImageOptimizerOptions {
+    /// Create Image Optimizer options for the given region and params.
+    #[must_use]
+    pub fn new(region: impl Into<String>, params: PlatformImageOptimizerParams) -> Self {
+        Self {
+            region: region.into(),
+            preserve_query_string_on_origin_request: false,
+            params,
+        }
+    }
+
+    /// Preserve non-IO query parameters on the origin request.
+    ///
+    /// Asset routes with profile-table IO reject arbitrary query preservation by
+    /// default because client query parameters can otherwise become additional
+    /// Image Optimizer inputs.
+    #[must_use]
+    pub fn with_preserve_query_string_on_origin_request(mut self, preserve: bool) -> Self {
+        self.preserve_query_string_on_origin_request = preserve;
+        self
+    }
+}
+
+/// Platform-neutral subset of image transformation parameters.
+///
+/// This intentionally mirrors only the parameters accepted by asset-route
+/// profile tables: format, quality, resize filter, dimensions, and crop. Client
+/// query strings are converted into this closed set before the request reaches a
+/// platform adapter.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PlatformImageOptimizerParams {
+    /// Output format such as `auto` or `webp`.
+    pub format: Option<String>,
+    /// Output quality from 0 to 100.
+    pub quality: Option<u32>,
+    /// Resize filter such as `bicubic`.
+    pub resize_filter: Option<String>,
+    /// Output width in pixels.
+    pub width: Option<u32>,
+    /// Output height in pixels.
+    pub height: Option<u32>,
+    /// Crop transformation.
+    pub crop: Option<PlatformImageOptimizerCrop>,
+}
+
+impl PlatformImageOptimizerParams {
+    /// Merge another param set into this one, with `other` taking precedence.
+    pub fn merge_from(&mut self, other: Self) {
+        if other.format.is_some() {
+            self.format = other.format;
+        }
+        if other.quality.is_some() {
+            self.quality = other.quality;
+        }
+        if other.resize_filter.is_some() {
+            self.resize_filter = other.resize_filter;
+        }
+        if other.width.is_some() {
+            self.width = other.width;
+        }
+        if other.height.is_some() {
+            self.height = other.height;
+        }
+        if other.crop.is_some() {
+            self.crop = other.crop;
+        }
+    }
+}
+
+/// Platform-neutral crop transformation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlatformImageOptimizerCrop {
+    /// Aspect-ratio width component.
+    pub width: u32,
+    /// Aspect-ratio height component.
+    pub height: u32,
+    /// Optional crop focus mode.
+    pub mode: Option<PlatformImageOptimizerCropMode>,
+    /// Optional x-axis crop offset bucket.
+    pub offset_x: Option<u32>,
+    /// Optional y-axis crop offset bucket.
+    pub offset_y: Option<u32>,
+}
+
+impl PlatformImageOptimizerCrop {
+    /// Create a bare aspect-ratio crop.
+    #[must_use]
+    pub fn aspect_ratio(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            mode: None,
+            offset_x: None,
+            offset_y: None,
+        }
+    }
+
+    /// Returns true when no focus mode or explicit offsets have been applied.
+    #[must_use]
+    pub fn is_bare_aspect_ratio(&self) -> bool {
+        self.mode.is_none() && self.offset_x.is_none() && self.offset_y.is_none()
+    }
+}
+
+/// Platform-neutral crop focus mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformImageOptimizerCropMode {
+    /// Use Fastly IO smart crop mode.
+    Smart,
+}

--- a/crates/trusted-server-core/src/platform/mod.rs
+++ b/crates/trusted-server-core/src/platform/mod.rs
@@ -33,6 +33,7 @@
 
 mod error;
 mod http;
+mod image_optimizer;
 mod kv;
 #[cfg(test)]
 pub(crate) mod test_support;
@@ -44,6 +45,10 @@ pub use error::PlatformError;
 pub use http::{
     PlatformHttpClient, PlatformHttpRequest, PlatformPendingRequest, PlatformResponse,
     PlatformSelectResult,
+};
+pub use image_optimizer::{
+    PlatformImageOptimizerCrop, PlatformImageOptimizerCropMode, PlatformImageOptimizerOptions,
+    PlatformImageOptimizerParams, PlatformImageOptimizerRegion,
 };
 pub use kv::UnavailableKvStore;
 pub use traits::{PlatformBackend, PlatformConfigStore, PlatformGeo, PlatformSecretStore};

--- a/crates/trusted-server-core/src/platform/test_support.rs
+++ b/crates/trusted-server-core/src/platform/test_support.rs
@@ -9,8 +9,9 @@ use rand::rngs::OsRng;
 
 use super::{
     ClientInfo, GeoInfo, PlatformBackend, PlatformBackendSpec, PlatformConfigStore, PlatformError,
-    PlatformGeo, PlatformHttpClient, PlatformHttpRequest, PlatformPendingRequest, PlatformResponse,
-    PlatformSecretStore, PlatformSelectResult, RuntimeServices, StoreId, StoreName,
+    PlatformGeo, PlatformHttpClient, PlatformHttpRequest, PlatformImageOptimizerOptions,
+    PlatformImageOptimizerParams, PlatformPendingRequest, PlatformResponse, PlatformSecretStore,
+    PlatformSelectResult, RuntimeServices, StoreId, StoreName,
 };
 use crate::request_signing::{JWKS_STORE_NAME, SIGNING_STORE_NAME};
 
@@ -201,7 +202,7 @@ struct StubPendingResponse {
 /// Test stub for [`PlatformHttpClient`] that records call backend names and
 /// returns pre-queued canned responses for `send`, `send_async`, and `select`.
 ///
-/// Responses are stored as `(status_code, body_bytes)` to remain [`Send`].
+/// Responses are stored as status/body/header parts to remain [`Send`].
 /// [`PlatformResponse`] contains [`edgezero_core::body::Body`] which wraps a
 /// `LocalBoxStream` that is `!Send`, so it cannot be stored directly in a
 /// `Mutex` field.
@@ -212,10 +213,19 @@ struct StubPendingResponse {
 /// sites.
 pub(crate) struct StubHttpClient {
     calls: Mutex<Vec<String>>,
-    // (status_code, body_bytes) — kept Send by avoiding Body::Stream
-    responses: Mutex<VecDeque<(u16, Vec<u8>)>>,
+    responses: Mutex<VecDeque<StubHttpResponse>>,
     // Headers captured per send call, stored as (name, value) string pairs.
     request_headers: Mutex<Vec<Vec<(String, String)>>>,
+    image_optimizer_options: Mutex<Vec<Option<PlatformImageOptimizerOptions>>>,
+    stream_response_flags: Mutex<Vec<bool>>,
+    request_methods: Mutex<Vec<String>>,
+    request_uris: Mutex<Vec<String>>,
+}
+
+struct StubHttpResponse {
+    status: u16,
+    body: Vec<u8>,
+    headers: Vec<(String, String)>,
 }
 
 impl StubHttpClient {
@@ -224,20 +234,84 @@ impl StubHttpClient {
             calls: Mutex::new(Vec::new()),
             responses: Mutex::new(VecDeque::new()),
             request_headers: Mutex::new(Vec::new()),
+            image_optimizer_options: Mutex::new(Vec::new()),
+            stream_response_flags: Mutex::new(Vec::new()),
+            request_methods: Mutex::new(Vec::new()),
+            request_uris: Mutex::new(Vec::new()),
         }
     }
 
     /// Queue a canned response by status code and body bytes.
     pub fn push_response(&self, status: u16, body: Vec<u8>) {
+        self.push_response_with_headers(status, body, Vec::<(String, String)>::new());
+    }
+
+    /// Queue a canned response with headers.
+    pub fn push_response_with_headers(
+        &self,
+        status: u16,
+        body: Vec<u8>,
+        headers: Vec<(impl Into<String>, impl Into<String>)>,
+    ) {
+        let headers = headers
+            .into_iter()
+            .map(|(name, value)| (name.into(), value.into()))
+            .collect();
         self.responses
             .lock()
             .expect("should lock responses")
-            .push_back((status, body));
+            .push_back(StubHttpResponse {
+                status,
+                body,
+                headers,
+            });
     }
 
     /// Return backend names recorded across all `send` calls, in order.
     pub fn recorded_backend_names(&self) -> Vec<String> {
         self.calls.lock().expect("should lock calls").clone()
+    }
+
+    /// Return the request headers captured per `send` call, in order.
+    ///
+    /// Each entry is the set of `(name, value)` pairs from one call.
+    pub fn recorded_request_headers(&self) -> Vec<Vec<(String, String)>> {
+        self.request_headers
+            .lock()
+            .expect("should lock request_headers")
+            .clone()
+    }
+
+    /// Return Image Optimizer metadata captured per `send` call, in order.
+    pub fn recorded_image_optimizer_options(&self) -> Vec<Option<PlatformImageOptimizerOptions>> {
+        self.image_optimizer_options
+            .lock()
+            .expect("should lock image optimizer options")
+            .clone()
+    }
+
+    /// Return streaming-response flags captured per `send` call, in order.
+    pub fn recorded_stream_response_flags(&self) -> Vec<bool> {
+        self.stream_response_flags
+            .lock()
+            .expect("should lock stream response flags")
+            .clone()
+    }
+
+    /// Return request methods captured per `send` call, in order.
+    pub fn recorded_request_methods(&self) -> Vec<String> {
+        self.request_methods
+            .lock()
+            .expect("should lock request methods")
+            .clone()
+    }
+
+    /// Return request URIs captured per `send` call, in order.
+    pub fn recorded_request_uris(&self) -> Vec<String> {
+        self.request_uris
+            .lock()
+            .expect("should lock request URIs")
+            .clone()
     }
 }
 
@@ -252,6 +326,23 @@ impl PlatformHttpClient for StubHttpClient {
             .lock()
             .expect("should lock calls")
             .push(request.backend_name.clone());
+
+        self.image_optimizer_options
+            .lock()
+            .expect("should lock image optimizer options")
+            .push(request.image_optimizer.clone());
+        self.stream_response_flags
+            .lock()
+            .expect("should lock stream response flags")
+            .push(request.stream_response);
+        self.request_methods
+            .lock()
+            .expect("should lock request methods")
+            .push(request.request.method().to_string());
+        self.request_uris
+            .lock()
+            .expect("should lock request URIs")
+            .push(request.request.uri().to_string());
 
         let headers: Vec<(String, String)> = request
             .request
@@ -269,16 +360,19 @@ impl PlatformHttpClient for StubHttpClient {
             .expect("should lock request_headers")
             .push(headers);
 
-        let (status, body_bytes) = self
+        let response = self
             .responses
             .lock()
             .expect("should lock responses")
             .pop_front()
             .ok_or_else(|| Report::new(PlatformError::HttpClient))?;
 
-        let edge_response = edgezero_core::http::response_builder()
-            .status(status)
-            .body(edgezero_core::body::Body::from(body_bytes))
+        let mut builder = edgezero_core::http::response_builder().status(response.status);
+        for (name, value) in response.headers {
+            builder = builder.header(name, value);
+        }
+        let edge_response = builder
+            .body(edgezero_core::body::Body::from(response.body))
             .change_context(PlatformError::HttpClient)?;
 
         Ok(PlatformResponse::new(edge_response))
@@ -288,13 +382,22 @@ impl PlatformHttpClient for StubHttpClient {
         &self,
         request: PlatformHttpRequest,
     ) -> Result<PlatformPendingRequest, Report<PlatformError>> {
+        if request.image_optimizer.is_some() {
+            return Err(Report::new(PlatformError::HttpClient)
+                .attach("Image Optimizer is not supported with StubHttpClient send_async"));
+        }
+        if request.stream_response {
+            return Err(Report::new(PlatformError::HttpClient)
+                .attach("streaming responses are not supported with StubHttpClient send_async"));
+        }
+
         let backend_name = request.backend_name.clone();
         self.calls
             .lock()
             .expect("should lock calls")
             .push(backend_name.clone());
 
-        let (status, body_bytes) = self
+        let response = self
             .responses
             .lock()
             .expect("should lock responses")
@@ -303,8 +406,8 @@ impl PlatformHttpClient for StubHttpClient {
 
         let pending = StubPendingResponse {
             backend_name: backend_name.clone(),
-            status,
-            body: body_bytes,
+            status: response.status,
+            body: response.body,
         };
         Ok(PlatformPendingRequest::new(pending).with_backend_name(backend_name))
     }
@@ -437,6 +540,35 @@ pub(crate) fn noop_services_with_client_ip(ip: IpAddr) -> RuntimeServices {
         .build()
 }
 
+/// Build a [`RuntimeServices`] with a [`StubBackend`] and the given HTTP client.
+///
+/// Useful for tests that need to verify `services.http_client()` call sites.
+pub(crate) fn build_services_with_http_client(
+    http_client: Arc<dyn PlatformHttpClient>,
+) -> RuntimeServices {
+    build_services_with_secret_and_http_client(NoopSecretStore, http_client)
+}
+
+/// Build a [`RuntimeServices`] with a custom secret store, [`StubBackend`], and HTTP client.
+pub(crate) fn build_services_with_secret_and_http_client(
+    secret_store: impl PlatformSecretStore + 'static,
+    http_client: Arc<dyn PlatformHttpClient>,
+) -> RuntimeServices {
+    RuntimeServices::builder()
+        .config_store(Arc::new(NoopConfigStore))
+        .secret_store(Arc::new(secret_store))
+        .kv_store(Arc::new(edgezero_core::key_value_store::NoopKvStore))
+        .backend(Arc::new(StubBackend))
+        .http_client(http_client)
+        .geo(Arc::new(NoopGeo))
+        .client_info(ClientInfo {
+            client_ip: None,
+            tls_protocol: None,
+            tls_cipher: None,
+        })
+        .build()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::backend::DEFAULT_FIRST_BYTE_TIMEOUT;
@@ -551,6 +683,53 @@ mod tests {
             names,
             vec!["backend-a", "backend-b"],
             "should record both send_async calls in order"
+        );
+    }
+
+    #[test]
+    fn stub_http_client_send_async_rejects_image_optimizer_metadata() {
+        let stub = StubHttpClient::new();
+        let req = PlatformHttpRequest::new(
+            request_builder()
+                .method("GET")
+                .uri("https://example.com/image.jpg")
+                .body(Body::empty())
+                .expect("should build request"),
+            "stub-backend",
+        )
+        .with_image_optimizer(PlatformImageOptimizerOptions::new(
+            "us_east",
+            PlatformImageOptimizerParams::default(),
+        ));
+
+        let err = futures::executor::block_on(stub.send_async(req))
+            .expect_err("should reject async Image Optimizer metadata");
+
+        assert!(
+            format!("{err:?}").contains("Image Optimizer"),
+            "should explain unsupported async IO path: {err:?}"
+        );
+    }
+
+    #[test]
+    fn stub_http_client_send_async_rejects_stream_response() {
+        let stub = StubHttpClient::new();
+        let req = PlatformHttpRequest::new(
+            request_builder()
+                .method("GET")
+                .uri("https://example.com/image.jpg")
+                .body(Body::empty())
+                .expect("should build request"),
+            "stub-backend",
+        )
+        .with_stream_response();
+
+        let err = futures::executor::block_on(stub.send_async(req))
+            .expect_err("should reject async streaming-response requests");
+
+        assert!(
+            format!("{err:?}").contains("streaming responses"),
+            "should explain unsupported async streaming-response path: {err:?}"
         );
     }
 

--- a/crates/trusted-server-core/src/platform/test_support.rs
+++ b/crates/trusted-server-core/src/platform/test_support.rs
@@ -216,6 +216,8 @@ pub(crate) struct StubHttpClient {
     responses: Mutex<VecDeque<StubHttpResponse>>,
     // Headers captured per send call, stored as (name, value) string pairs.
     request_headers: Mutex<Vec<Vec<(String, String)>>>,
+    // Queued select() errors — each pop makes the next select() return ready: Err.
+    select_errors: Mutex<VecDeque<()>>,
     image_optimizer_options: Mutex<Vec<Option<PlatformImageOptimizerOptions>>>,
     stream_response_flags: Mutex<Vec<bool>>,
     request_methods: Mutex<Vec<String>>,
@@ -234,6 +236,7 @@ impl StubHttpClient {
             calls: Mutex::new(Vec::new()),
             responses: Mutex::new(VecDeque::new()),
             request_headers: Mutex::new(Vec::new()),
+            select_errors: Mutex::new(VecDeque::new()),
             image_optimizer_options: Mutex::new(Vec::new()),
             stream_response_flags: Mutex::new(Vec::new()),
             request_methods: Mutex::new(Vec::new()),
@@ -265,6 +268,16 @@ impl StubHttpClient {
                 body,
                 headers,
             });
+    }
+
+    /// Inject a `select()` error: the next call to `select()` will return
+    /// `ready: Err(...)` with the failed request's backend name in
+    /// `failed_backend_name`. The corresponding queued response is consumed.
+    pub fn push_select_error(&self) {
+        self.select_errors
+            .lock()
+            .expect("should lock select_errors")
+            .push_back(());
     }
 
     /// Return backend names recorded across all `send` calls, in order.
@@ -397,6 +410,22 @@ impl PlatformHttpClient for StubHttpClient {
             .expect("should lock calls")
             .push(backend_name.clone());
 
+        let headers: Vec<(String, String)> = request
+            .request
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|v| (name.as_str().to_string(), v.to_string()))
+            })
+            .collect();
+        self.request_headers
+            .lock()
+            .expect("should lock request_headers")
+            .push(headers);
+
         let response = self
             .responses
             .lock()
@@ -435,16 +464,47 @@ impl PlatformHttpClient for StubHttpClient {
                     .attach("unexpected inner type in StubHttpClient::select")
             })?;
 
+        let ready_backend_name = stub.backend_name.clone();
+
+        // Strip backend names from remaining to match Fastly production behavior:
+        // Fastly's select() rebuilds remaining with PlatformPendingRequest::new()
+        // (no backend_name) — orchestrators must not rely on names being set.
+        let remaining: Vec<PlatformPendingRequest> = pending_requests
+            .into_iter()
+            .map(|r| match r.downcast::<StubPendingResponse>() {
+                Ok(inner) => PlatformPendingRequest::new(inner),
+                Err(r) => r,
+            })
+            .collect();
+
+        let should_error = self
+            .select_errors
+            .lock()
+            .expect("should lock select_errors")
+            .pop_front()
+            .is_some();
+
+        if should_error {
+            return Ok(PlatformSelectResult {
+                ready: Err(Report::new(PlatformError::HttpClient).attach(format!(
+                    "injected select error for backend '{ready_backend_name}'"
+                ))),
+                remaining,
+                failed_backend_name: Some(ready_backend_name),
+            });
+        }
+
         let edge_response = edgezero_core::http::response_builder()
             .status(stub.status)
             .body(edgezero_core::body::Body::from(stub.body))
             .change_context(PlatformError::HttpClient)?;
 
-        let ready = Ok(PlatformResponse::new(edge_response).with_backend_name(stub.backend_name));
+        let ready = Ok(PlatformResponse::new(edge_response).with_backend_name(ready_backend_name));
 
         Ok(PlatformSelectResult {
             ready,
-            remaining: pending_requests,
+            remaining,
+            failed_backend_name: None,
         })
     }
 }
@@ -524,6 +584,19 @@ pub(crate) fn noop_services() -> RuntimeServices {
     build_services_with_config(NoopConfigStore)
 }
 
+/// Build a [`RuntimeServices`] with a caller-supplied HTTP client and a [`StubBackend`].
+///
+/// Uses [`StubBackend`] (always returns `Ok("stub-backend")`) rather than
+/// [`NoopBackend`] (always returns `Err(Unsupported)`) so that handlers which
+/// both make HTTP calls and resolve backends don't need two separate service
+/// setups.  If your test must verify that a missing backend returns an error,
+/// use [`noop_services`] directly.
+pub(crate) fn build_services_with_http_client(
+    http_client: Arc<dyn PlatformHttpClient>,
+) -> RuntimeServices {
+    build_services_with_secret_and_http_client(NoopSecretStore, http_client)
+}
+
 pub(crate) fn noop_services_with_client_ip(ip: IpAddr) -> RuntimeServices {
     RuntimeServices::builder()
         .config_store(Arc::new(NoopConfigStore))
@@ -538,15 +611,6 @@ pub(crate) fn noop_services_with_client_ip(ip: IpAddr) -> RuntimeServices {
             tls_cipher: None,
         })
         .build()
-}
-
-/// Build a [`RuntimeServices`] with a [`StubBackend`] and the given HTTP client.
-///
-/// Useful for tests that need to verify `services.http_client()` call sites.
-pub(crate) fn build_services_with_http_client(
-    http_client: Arc<dyn PlatformHttpClient>,
-) -> RuntimeServices {
-    build_services_with_secret_and_http_client(NoopSecretStore, http_client)
 }
 
 /// Build a [`RuntimeServices`] with a custom secret store, [`StubBackend`], and HTTP client.
@@ -674,8 +738,8 @@ mod tests {
         );
         assert_eq!(
             result.remaining[0].backend_name(),
-            Some("backend-b"),
-            "should preserve backend name on remaining request"
+            None,
+            "should strip backend name from remaining (matches Fastly production behavior)"
         );
 
         let names = stub.recorded_backend_names();

--- a/crates/trusted-server-core/src/proxy.rs
+++ b/crates/trusted-server-core/src/proxy.rs
@@ -1,8 +1,15 @@
+use crate::backend::DEFAULT_FIRST_BYTE_TIMEOUT;
 use crate::http_util::{compute_encrypted_sha256_token, ct_str_eq};
+use edgezero_core::body::Body as EdgeBody;
+use edgezero_core::http::{request_builder as edge_request_builder, Uri as EdgeUri};
 use error_stack::{Report, ResultExt};
 use fastly::http::{header, HeaderValue, Method, StatusCode};
 use fastly::{Request, Response};
+use futures::StreamExt as _;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::constants::{
@@ -12,11 +19,257 @@ use crate::constants::{
 use crate::creative::{CreativeCssProcessor, CreativeHtmlProcessor};
 use crate::ec::get_ec_id;
 use crate::error::TrustedServerError;
-use crate::settings::Settings;
+use crate::platform::{
+    PlatformBackendSpec, PlatformHttpRequest, PlatformResponse, RuntimeServices, StoreName,
+};
+use crate::redacted::Redacted;
+use crate::s3_sigv4::{self, S3Credentials};
+use crate::settings::{
+    AssetOriginAuth, OriginQueryPolicy, ProxyAssetRoute, S3SigV4AuthConfig, Settings,
+};
 use crate::streaming_processor::{Compression, PipelineConfig, StreamProcessor, StreamingPipeline};
 
 /// Chunk size used for streaming content through the rewrite pipeline.
 const STREAMING_CHUNK_SIZE: usize = 8192;
+
+/// Headers copied from the original client request to the upstream proxy request
+/// when `copy_request_headers` is enabled.
+///
+/// `Accept-Encoding` is also overridden in the same code path, but with a fixed
+/// value ([`SUPPORTED_ENCODINGS`]) rather than forwarding the client's preference.
+/// Both forwarded headers and the Accept-Encoding override are applied together in
+/// the `copy_request_headers` branch of the proxy request builder.
+const PROXY_FORWARD_HEADERS: [header::HeaderName; 5] = [
+    HEADER_USER_AGENT,
+    HEADER_ACCEPT,
+    HEADER_ACCEPT_LANGUAGE,
+    HEADER_REFERER,
+    HEADER_X_FORWARDED_FOR,
+];
+
+/// Curated request headers preserved for asset proxying.
+///
+/// Unlike the HTML publisher fallback, asset requests need cache validation and
+/// byte-range semantics to keep 304/206 responses working for browsers.
+/// Client-supplied forwarding headers are stripped at the edge and are not
+/// reconstructed here, so asset origins see Trusted Server as the client.
+const ASSET_PROXY_FORWARD_HEADERS: [header::HeaderName; 11] = [
+    HEADER_USER_AGENT,
+    HEADER_ACCEPT,
+    HEADER_ACCEPT_ENCODING,
+    HEADER_ACCEPT_LANGUAGE,
+    HEADER_REFERER,
+    header::IF_NONE_MATCH,
+    header::IF_MODIFIED_SINCE,
+    header::IF_MATCH,
+    header::IF_UNMODIFIED_SINCE,
+    header::RANGE,
+    header::IF_RANGE,
+];
+
+const ASSET_PROXY_STRIP_RESPONSE_HEADERS: [&str; 3] =
+    ["set-cookie", "strict-transport-security", "clear-site-data"];
+
+/// Cache-control value used when asset proxy responses must not be stored.
+pub const ASSET_NO_STORE_PRIVATE_CACHE_CONTROL: &str = "no-store, private";
+
+/// Cache policy metadata emitted by the asset proxy handler.
+///
+/// The Fastly router finalizes standard response headers after the asset handler
+/// returns. This typed policy lets the router reapply protected cache directives
+/// without depending on an exact header string set by the handler.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AssetProxyCachePolicy {
+    /// Leave origin/cache-control headers under normal response finalization.
+    OriginControlled,
+    /// Reapply `Cache-Control: no-store, private` after standard finalization.
+    NoStorePrivate,
+}
+
+impl AssetProxyCachePolicy {
+    /// Apply protected cache headers after route-level response finalization.
+    pub fn apply_after_route_finalization(self, response: &mut Response) {
+        if self == Self::NoStorePrivate {
+            apply_no_store_cache_control(response);
+        }
+    }
+}
+
+/// Asset proxy response plus metadata needed by the outer router.
+pub struct AssetProxyResponse {
+    response: Response,
+    stream_body: Option<EdgeBody>,
+    cache_policy: AssetProxyCachePolicy,
+}
+
+impl AssetProxyResponse {
+    fn new(
+        response: Response,
+        stream_body: Option<EdgeBody>,
+        cache_policy: AssetProxyCachePolicy,
+    ) -> Self {
+        Self {
+            response,
+            stream_body,
+            cache_policy,
+        }
+    }
+
+    fn origin_controlled(response: Response) -> Self {
+        Self::new(response, None, AssetProxyCachePolicy::OriginControlled)
+    }
+
+    fn origin_controlled_stream(response: Response, stream_body: EdgeBody) -> Self {
+        Self::new(
+            response,
+            Some(stream_body),
+            AssetProxyCachePolicy::OriginControlled,
+        )
+    }
+
+    fn no_store_private(response: Response) -> Self {
+        Self::new(response, None, AssetProxyCachePolicy::NoStorePrivate)
+    }
+
+    fn response(&self) -> &Response {
+        &self.response
+    }
+
+    fn response_mut(&mut self) -> &mut Response {
+        &mut self.response
+    }
+
+    fn apply_no_store_private_policy(&mut self) {
+        self.cache_policy = AssetProxyCachePolicy::NoStorePrivate;
+        apply_no_store_cache_control(&mut self.response);
+    }
+
+    /// Return cache policy metadata for router finalization.
+    #[must_use]
+    pub fn cache_policy(&self) -> AssetProxyCachePolicy {
+        self.cache_policy
+    }
+
+    /// Consume this wrapper and return a buffered Fastly response.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrustedServerError::Proxy`] when the response carries a
+    /// streaming body. Use [`Self::into_response_and_body`] when the caller
+    /// needs to handle both buffered and streaming asset responses.
+    pub fn into_response(self) -> Result<Response, Report<TrustedServerError>> {
+        if self.stream_body.is_some() {
+            return Err(Report::new(TrustedServerError::Proxy {
+                message: "streaming asset response cannot be converted into a buffered response"
+                    .to_string(),
+            }));
+        }
+
+        Ok(self.response)
+    }
+
+    /// Consume this wrapper and return the response headers plus optional stream body.
+    #[must_use]
+    pub fn into_response_and_body(self) -> (Response, Option<EdgeBody>) {
+        (self.response, self.stream_body)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct S3CredentialsCacheKey {
+    secret_store: String,
+    access_key_id: String,
+    secret_access_key: String,
+    session_token: Option<String>,
+}
+
+static S3_CREDENTIALS_CACHE: LazyLock<Mutex<HashMap<S3CredentialsCacheKey, Arc<S3Credentials>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Convert a platform-neutral response into a [`fastly::Response`] for downstream processing.
+///
+/// Shared with `auction/orchestrator.rs`. Both files will migrate off `fastly::Response`
+/// entirely in Phase 2, at which point this conversion helper will be removed.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError::Proxy`] when `platform_resp` carries a
+/// streaming body, which this Fastly-only conversion path cannot materialize.
+pub(crate) fn platform_response_to_fastly(
+    platform_resp: PlatformResponse,
+) -> Result<Response, Report<TrustedServerError>> {
+    let (parts, body) = platform_resp.response.into_parts();
+    let body_bytes = match body {
+        EdgeBody::Once(bytes) => bytes.to_vec(),
+        EdgeBody::Stream(_) => {
+            return Err(Report::new(TrustedServerError::Proxy {
+                message: "streaming platform response body is not supported by Fastly response conversion"
+                    .to_string(),
+            }));
+        }
+    };
+    let mut resp = Response::from_status(parts.status.as_u16());
+    for (name, value) in parts.headers.iter() {
+        resp.append_header(name.as_str(), value.as_bytes());
+    }
+    resp.set_body(body_bytes);
+    Ok(resp)
+}
+
+fn platform_response_to_fastly_asset(platform_resp: PlatformResponse) -> AssetProxyResponse {
+    let (parts, body) = platform_resp.response.into_parts();
+    let mut resp = Response::from_status(parts.status.as_u16());
+    for (name, value) in parts.headers.iter() {
+        resp.append_header(name.as_str(), value.as_bytes());
+    }
+
+    match body {
+        EdgeBody::Once(bytes) => {
+            resp.set_body(bytes.to_vec());
+            AssetProxyResponse::origin_controlled(resp)
+        }
+        stream_body @ EdgeBody::Stream(_) => {
+            AssetProxyResponse::origin_controlled_stream(resp, stream_body)
+        }
+    }
+}
+
+/// Stream an asset response body directly to a writable client stream.
+///
+/// # Errors
+///
+/// Returns an error if the platform stream yields an error or if writing a
+/// chunk to the client stream fails.
+pub async fn stream_asset_body<W: Write>(
+    body: EdgeBody,
+    output: &mut W,
+) -> Result<(), Report<TrustedServerError>> {
+    match body {
+        EdgeBody::Once(bytes) => {
+            output
+                .write_all(bytes.as_ref())
+                .change_context(TrustedServerError::Proxy {
+                    message: "failed to write buffered asset response body".to_string(),
+                })?;
+        }
+        EdgeBody::Stream(mut stream) => {
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.map_err(|err| {
+                    Report::new(TrustedServerError::Proxy {
+                        message: format!("streaming platform response body failed: {err}"),
+                    })
+                })?;
+                output
+                    .write_all(chunk.as_ref())
+                    .change_context(TrustedServerError::Proxy {
+                        message: "failed to write streaming asset response body".to_string(),
+                    })?;
+            }
+        }
+    }
+
+    Ok(())
+}
 
 #[derive(Deserialize)]
 struct ProxySignReq {
@@ -105,23 +358,6 @@ impl<'a> ProxyRequestConfig<'a> {
 /// Encodings we support decompressing in `finalize_proxied_response`.
 /// We override the client's Accept-Encoding to only advertise these.
 const SUPPORTED_ENCODINGS: &str = "gzip, deflate, br";
-
-/// Copy a curated set of request headers to a proxied request.
-fn copy_proxy_forward_headers(src: &Request, dst: &mut Request) {
-    for header_name in [
-        HEADER_USER_AGENT,
-        HEADER_ACCEPT,
-        HEADER_ACCEPT_LANGUAGE,
-        HEADER_REFERER,
-        HEADER_X_FORWARDED_FOR,
-    ] {
-        if let Some(v) = src.get_header(&header_name) {
-            dst.set_header(&header_name, v);
-        }
-    }
-    // Only advertise encodings we can decompress (excludes zstd, etc.)
-    dst.set_header(HEADER_ACCEPT_ENCODING, SUPPORTED_ENCODINGS);
-}
 
 /// Rebuild a response with a new body, preserving headers except Content-Length.
 /// If `preserve_encoding` is true, the Content-Encoding header is kept (for compressed responses).
@@ -397,9 +633,15 @@ fn finalize_response(
     }
 }
 
+/// Bundles per-request header configuration and [`RuntimeServices`] for the proxy redirect loop.
 struct ProxyRequestHeaders<'a> {
     additional_headers: &'a [(header::HeaderName, HeaderValue)],
     copy_request_headers: bool,
+    services: &'a RuntimeServices,
+    /// Domains permitted for the initial request and any redirects.
+    ///
+    /// Empty slice means open mode (all hosts allowed). Populated by first-party
+    /// handlers; integration proxies leave it empty.
     allowed_domains: &'a [String],
 }
 
@@ -417,6 +659,7 @@ pub async fn proxy_request(
     settings: &Settings,
     req: Request,
     config: ProxyRequestConfig<'_>,
+    services: &RuntimeServices,
 ) -> Result<Response, Report<TrustedServerError>> {
     let ProxyRequestConfig {
         target_url,
@@ -448,11 +691,428 @@ pub async fn proxy_request(
         ProxyRequestHeaders {
             additional_headers: &headers,
             copy_request_headers,
+            services,
             allowed_domains,
         },
         stream_passthrough,
     )
     .await
+}
+
+fn default_port_for_scheme(scheme: &str) -> Option<u16> {
+    match scheme {
+        "http" => Some(80),
+        "https" => Some(443),
+        _ => None,
+    }
+}
+
+fn build_asset_proxy_target_url(
+    route: &ProxyAssetRoute,
+    path: &str,
+    query: &str,
+) -> Result<url::Url, Report<TrustedServerError>> {
+    let mut target_url =
+        url::Url::parse(&route.origin_url).change_context(TrustedServerError::Proxy {
+            message: format!("Invalid asset origin_url: {}", route.origin_url),
+        })?;
+
+    let scheme = target_url.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(Report::new(TrustedServerError::Proxy {
+            message: format!("Unsupported asset origin_url scheme: {scheme}"),
+        }));
+    }
+
+    if target_url.host_str().is_none() {
+        return Err(Report::new(TrustedServerError::Proxy {
+            message: "Missing host in asset origin_url".to_string(),
+        }));
+    }
+
+    let target_path = route.target_path_for(path)?;
+    target_url.set_path(&target_path);
+    if query.is_empty() {
+        target_url.set_query(None);
+    } else {
+        target_url.set_query(Some(query));
+    }
+
+    Ok(target_url)
+}
+
+fn asset_path_skips_image_optimizer(target_url: &url::Url) -> bool {
+    let lower_path = target_url.path().to_ascii_lowercase();
+    lower_path.ends_with(".svg") || lower_path.ends_with(".svgz")
+}
+
+fn asset_origin_host_header(
+    target_url: &url::Url,
+) -> Result<HeaderValue, Report<TrustedServerError>> {
+    let scheme = target_url.scheme();
+    let host = target_url.host_str().ok_or_else(|| {
+        Report::new(TrustedServerError::Proxy {
+            message: "Missing host in asset target URL".to_string(),
+        })
+    })?;
+    let resolved_port = target_url.port_or_known_default().ok_or_else(|| {
+        Report::new(TrustedServerError::Proxy {
+            message: format!("Unsupported asset target URL scheme: {scheme}"),
+        })
+    })?;
+    let host_header = if Some(resolved_port) == default_port_for_scheme(scheme) {
+        host.to_string()
+    } else {
+        format!("{host}:{resolved_port}")
+    };
+
+    HeaderValue::from_str(&host_header).change_context(TrustedServerError::InvalidHeaderValue {
+        message: format!("invalid asset Host header value: {host_header}"),
+    })
+}
+
+fn s3_credentials_cache_key(config: &S3SigV4AuthConfig) -> S3CredentialsCacheKey {
+    S3CredentialsCacheKey {
+        secret_store: config.secret_store.clone(),
+        access_key_id: config.access_key_id.clone(),
+        secret_access_key: config.secret_access_key.clone(),
+        session_token: config.session_token.clone(),
+    }
+}
+
+fn load_s3_credentials(
+    services: &RuntimeServices,
+    config: &S3SigV4AuthConfig,
+) -> Result<Arc<S3Credentials>, Report<TrustedServerError>> {
+    let cache_key = s3_credentials_cache_key(config);
+    if let Some(credentials) = S3_CREDENTIALS_CACHE
+        .lock()
+        .expect("should lock S3 credentials cache")
+        .get(&cache_key)
+        .cloned()
+    {
+        return Ok(credentials);
+    }
+
+    let store_name = StoreName::from(config.secret_store.as_str());
+    let access_key_id = services
+        .secret_store()
+        .get_string(&store_name, &config.access_key_id)
+        .change_context(TrustedServerError::Proxy {
+            message: "failed to read S3 access key ID from secret store".to_string(),
+        })?;
+    let secret_access_key = services
+        .secret_store()
+        .get_string(&store_name, &config.secret_access_key)
+        .change_context(TrustedServerError::Proxy {
+            message: "failed to read S3 secret access key from secret store".to_string(),
+        })?;
+    let session_token = config
+        .session_token
+        .as_deref()
+        .map(|key| {
+            services
+                .secret_store()
+                .get_string(&store_name, key)
+                .change_context(TrustedServerError::Proxy {
+                    message: "failed to read S3 session token from secret store".to_string(),
+                })
+        })
+        .transpose()?;
+    let credentials = Arc::new(S3Credentials {
+        access_key_id,
+        secret_access_key: Redacted::new(secret_access_key),
+        session_token: session_token.map(Redacted::new),
+    });
+
+    let mut cache = S3_CREDENTIALS_CACHE
+        .lock()
+        .expect("should lock S3 credentials cache");
+    Ok(Arc::clone(cache.entry(cache_key).or_insert(credentials)))
+}
+
+#[cfg(test)]
+fn clear_s3_credentials_cache_for_tests() {
+    S3_CREDENTIALS_CACHE
+        .lock()
+        .expect("should lock S3 credentials cache")
+        .clear();
+}
+
+fn apply_asset_origin_auth(
+    services: &RuntimeServices,
+    method: &Method,
+    target_url: &url::Url,
+    headers: &mut http::HeaderMap,
+    auth: &AssetOriginAuth,
+) -> Result<(), Report<TrustedServerError>> {
+    match auth {
+        AssetOriginAuth::S3SigV4(config) => {
+            let credentials = load_s3_credentials(services, config)?;
+            s3_sigv4::sign_headers(
+                method,
+                target_url,
+                headers,
+                &config.region,
+                credentials.as_ref(),
+                SystemTime::now(),
+            )
+        }
+    }
+}
+
+fn build_asset_platform_request(
+    method: &Method,
+    target_url: &url::Url,
+    outbound_headers: &http::HeaderMap,
+    backend_name: &str,
+) -> Result<PlatformHttpRequest, Report<TrustedServerError>> {
+    let mut builder = edge_request_builder().method(method.clone()).uri(
+        target_url
+            .as_str()
+            .parse::<EdgeUri>()
+            .change_context(TrustedServerError::Proxy {
+                message: "invalid asset target URL".to_string(),
+            })?,
+    );
+
+    for (name, value) in outbound_headers {
+        builder = builder.header(name, value);
+    }
+
+    let edge_req =
+        builder
+            .body(EdgeBody::from(Vec::new()))
+            .change_context(TrustedServerError::Proxy {
+                message: "failed to build asset proxy request".to_string(),
+            })?;
+
+    Ok(PlatformHttpRequest::new(edge_req, backend_name))
+}
+
+async fn send_asset_origin_request(
+    services: &RuntimeServices,
+    backend_name: &str,
+    method: &Method,
+    target_url: &url::Url,
+    outbound_headers: &http::HeaderMap,
+    stream_response: bool,
+) -> Result<AssetProxyResponse, Report<TrustedServerError>> {
+    let mut platform_req =
+        build_asset_platform_request(method, target_url, outbound_headers, backend_name)?;
+    if stream_response {
+        platform_req = platform_req.with_stream_response();
+    }
+    let platform_resp = services
+        .http_client()
+        .send(platform_req)
+        .await
+        .change_context(TrustedServerError::Proxy {
+            message: "Failed to proxy asset request".to_string(),
+        })?;
+
+    if stream_response {
+        Ok(platform_response_to_fastly_asset(platform_resp))
+    } else {
+        platform_response_to_fastly(platform_resp).map(AssetProxyResponse::origin_controlled)
+    }
+}
+
+fn strip_asset_proxy_response_headers(response: &mut Response) {
+    // Asset origins must not be able to mutate publisher-domain browser state
+    // or security policy through this proxy path.
+    for header_name in ASSET_PROXY_STRIP_RESPONSE_HEADERS {
+        response.remove_header(header_name);
+    }
+}
+
+fn apply_no_store_cache_control(response: &mut Response) {
+    response.set_header(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(ASSET_NO_STORE_PRIVATE_CACHE_CONTROL),
+    );
+}
+
+fn should_preflight_s3(
+    route: &ProxyAssetRoute,
+    image_optimizer_enabled: bool,
+    request_method: &Method,
+) -> bool {
+    image_optimizer_enabled
+        && matches!(route.auth.as_ref(), Some(AssetOriginAuth::S3SigV4(_)))
+        && (request_method == Method::GET || request_method == Method::HEAD)
+}
+
+async fn preflight_s3_origin_for_image_optimizer(
+    services: &RuntimeServices,
+    route: &ProxyAssetRoute,
+    target_url: &url::Url,
+    request_method: &Method,
+    unsigned_headers: &http::HeaderMap,
+    backend_name: &str,
+) -> Result<Option<AssetProxyResponse>, Report<TrustedServerError>> {
+    let Some(auth @ AssetOriginAuth::S3SigV4(_)) = route.auth.as_ref() else {
+        return Ok(None);
+    };
+
+    // Fastly Image Optimizer can mask or transform S3 origin errors. A signed
+    // HEAD preflight lets missing or unauthorized objects return raw S3 errors
+    // without invoking IO on the failure path.
+    let mut head_headers = unsigned_headers.clone();
+    apply_asset_origin_auth(services, &Method::HEAD, target_url, &mut head_headers, auth)?;
+    let head_response = send_asset_origin_request(
+        services,
+        backend_name,
+        &Method::HEAD,
+        target_url,
+        &head_headers,
+        false,
+    )
+    .await?;
+    let head_status = head_response.response().get_status();
+    if head_status.is_success() || head_status == StatusCode::NOT_MODIFIED {
+        return Ok(None);
+    }
+
+    if request_method == Method::HEAD {
+        let mut response = head_response.into_response()?;
+        strip_asset_proxy_response_headers(&mut response);
+        apply_no_store_cache_control(&mut response);
+        return Ok(Some(AssetProxyResponse::no_store_private(response)));
+    }
+
+    let mut get_headers = unsigned_headers.clone();
+    apply_asset_origin_auth(services, &Method::GET, target_url, &mut get_headers, auth)?;
+    let mut response = send_asset_origin_request(
+        services,
+        backend_name,
+        &Method::GET,
+        target_url,
+        &get_headers,
+        true,
+    )
+    .await?;
+    strip_asset_proxy_response_headers(response.response_mut());
+    response.apply_no_store_private_policy();
+
+    Ok(Some(response))
+}
+
+/// Proxy a configured first-party asset path to its matched asset origin.
+///
+/// This is a lean raw pass-through path: it preserves status/body/headers,
+/// does not follow redirects, and bypasses publisher-page processing. The flow
+/// is path rewrite, profile-table Image Optimizer metadata extraction, optional
+/// origin query stripping, optional origin authentication, then platform send.
+///
+/// The origin query policy is applied before S3 signing so the signature covers
+/// the exact URL sent to the asset origin. Image Optimizer metadata remains
+/// separate from the origin URL and is translated by the platform adapter.
+///
+/// # Errors
+///
+/// Returns an error if the configured origin URL is invalid, backend
+/// registration fails, S3 credentials cannot be read, signing fails, image
+/// optimizer metadata cannot be built, or the upstream request cannot be sent.
+pub async fn handle_asset_proxy_request(
+    settings: &Settings,
+    services: &RuntimeServices,
+    req: Request,
+    route: &ProxyAssetRoute,
+) -> Result<AssetProxyResponse, Report<TrustedServerError>> {
+    let incoming_query = req.get_query_str().unwrap_or("");
+    let mut target_url = build_asset_proxy_target_url(route, req.get_path(), incoming_query)?;
+    let skip_image_optimizer = asset_path_skips_image_optimizer(&target_url);
+    let image_optimizer = if skip_image_optimizer {
+        log::debug!(
+            "Skipping Image Optimizer for unsupported SVG asset path: {}",
+            target_url.path()
+        );
+        None
+    } else {
+        crate::asset_image_optimizer::options_for_asset_request(settings, route, incoming_query)?
+    };
+
+    if route.origin_query_policy() == OriginQueryPolicy::Strip {
+        target_url.set_query(None);
+    }
+
+    let scheme = target_url.scheme();
+    let host = target_url.host_str().ok_or_else(|| {
+        Report::new(TrustedServerError::Proxy {
+            message: "Missing host in asset target URL".to_string(),
+        })
+    })?;
+
+    let backend_name = services
+        .backend()
+        .ensure(&PlatformBackendSpec {
+            scheme: scheme.to_string(),
+            host: host.to_string(),
+            port: target_url.port(),
+            certificate_check: settings.proxy.certificate_check,
+            first_byte_timeout: DEFAULT_FIRST_BYTE_TIMEOUT,
+        })
+        .change_context(TrustedServerError::Proxy {
+            message: "asset backend registration failed".to_string(),
+        })?;
+
+    let mut outbound_headers = http::HeaderMap::new();
+    for header_name in ASSET_PROXY_FORWARD_HEADERS {
+        if let Some(value) = req.get_header(&header_name) {
+            outbound_headers.insert(header_name, value.clone());
+        }
+    }
+    outbound_headers.insert(header::HOST, asset_origin_host_header(&target_url)?);
+
+    if should_preflight_s3(route, image_optimizer.is_some(), req.get_method()) {
+        if let Some(response) = preflight_s3_origin_for_image_optimizer(
+            services,
+            route,
+            &target_url,
+            req.get_method(),
+            &outbound_headers,
+            &backend_name,
+        )
+        .await?
+        {
+            return Ok(response);
+        }
+    }
+
+    if let Some(auth) = &route.auth {
+        apply_asset_origin_auth(
+            services,
+            req.get_method(),
+            &target_url,
+            &mut outbound_headers,
+            auth,
+        )?;
+    }
+
+    let mut platform_req = build_asset_platform_request(
+        req.get_method(),
+        &target_url,
+        &outbound_headers,
+        &backend_name,
+    )?;
+    if let Some(image_optimizer) = image_optimizer {
+        platform_req = platform_req.with_image_optimizer(image_optimizer);
+    }
+    platform_req = platform_req.with_stream_response();
+
+    let platform_resp = services
+        .http_client()
+        .send(platform_req)
+        .await
+        .change_context(TrustedServerError::Proxy {
+            message: "Failed to proxy asset request".to_string(),
+        })?;
+
+    let mut response = platform_response_to_fastly_asset(platform_resp);
+    strip_asset_proxy_response_headers(response.response_mut());
+
+    Ok(response)
 }
 
 /// Upserts the `ts-ec` query parameter on a URL, replacing any existing value.
@@ -570,28 +1230,67 @@ async fn proxy_with_redirects(
             }));
         }
 
-        let backend_name = crate::backend::BackendConfig::new(&scheme, host)
-            .port(parsed_url.port())
-            .certificate_check(settings.proxy.certificate_check)
-            .ensure()?;
+        let backend_name = request_headers
+            .services
+            .backend()
+            .ensure(&PlatformBackendSpec {
+                scheme: scheme.clone(),
+                host: host.to_string(),
+                port: parsed_url.port(),
+                certificate_check: settings.proxy.certificate_check,
+                first_byte_timeout: DEFAULT_FIRST_BYTE_TIMEOUT,
+            })
+            .change_context(TrustedServerError::Proxy {
+                message: "backend registration failed".to_string(),
+            })?;
 
-        let mut proxy_req = Request::new(current_method.clone(), &current_url);
+        let mut builder = edge_request_builder().method(current_method.clone()).uri(
+            current_url
+                .parse::<EdgeUri>()
+                .change_context(TrustedServerError::Proxy {
+                    message: "invalid url".to_string(),
+                })?,
+        );
+
+        // Collect outbound headers using insert-semantics so additional_headers override any
+        // header set by copy_request_headers, matching the old set_header() replace behavior.
+        let mut outbound_headers = http::HeaderMap::new();
         if request_headers.copy_request_headers {
-            copy_proxy_forward_headers(req, &mut proxy_req);
+            for header_name in PROXY_FORWARD_HEADERS {
+                if let Some(v) = req.get_header(&header_name) {
+                    outbound_headers.insert(header_name, v.clone());
+                }
+            }
+            outbound_headers.insert(
+                HEADER_ACCEPT_ENCODING,
+                HeaderValue::from_static(SUPPORTED_ENCODINGS),
+            );
         }
-        if let Some(body_bytes) = body {
-            proxy_req.set_body(body_bytes.to_vec());
-        }
-
         for (name, value) in request_headers.additional_headers {
-            proxy_req.set_header(name.clone(), value.clone());
+            // insert() replaces any existing value, matching set_header() semantics.
+            outbound_headers.insert(name.clone(), value.clone());
         }
+        for (name, value) in &outbound_headers {
+            builder = builder.header(name, value);
+        }
+        let body_bytes = body.map(<[u8]>::to_vec).unwrap_or_default();
+        let edge_req =
+            builder
+                .body(EdgeBody::from(body_bytes))
+                .change_context(TrustedServerError::Proxy {
+                    message: "failed to build proxy request".to_string(),
+                })?;
 
-        let beresp = proxy_req
-            .send(&backend_name)
+        let platform_resp = request_headers
+            .services
+            .http_client()
+            .send(PlatformHttpRequest::new(edge_req, backend_name))
+            .await
             .change_context(TrustedServerError::Proxy {
                 message: "Failed to proxy".to_string(),
             })?;
+
+        let beresp = platform_response_to_fastly(platform_resp)?;
 
         if !follow_redirects {
             return finalize_response(settings, req, &current_url, beresp, stream_passthrough);
@@ -694,6 +1393,7 @@ async fn proxy_with_redirects(
 /// Returns an error if the signed target cannot be reconstructed or validation fails.
 pub async fn handle_first_party_proxy(
     settings: &Settings,
+    services: &RuntimeServices,
     req: Request,
 ) -> Result<Response, Report<TrustedServerError>> {
     // Parse, reconstruct, and validate the signed target URL
@@ -713,6 +1413,7 @@ pub async fn handle_first_party_proxy(
             stream_passthrough: false,
             allowed_domains: &settings.proxy.allowed_domains,
         },
+        services,
     )
     .await
 }
@@ -729,6 +1430,7 @@ pub async fn handle_first_party_proxy(
 /// Returns an error if the signed target cannot be reconstructed or validation fails.
 pub async fn handle_first_party_click(
     settings: &Settings,
+    _services: &RuntimeServices,
     req: Request,
 ) -> Result<Response, Report<TrustedServerError>> {
     let SignedTarget {
@@ -795,6 +1497,7 @@ pub async fn handle_first_party_click(
 /// Returns an error if JSON parsing fails, the URL cannot be parsed, or the URL uses an unsupported scheme.
 pub async fn handle_first_party_proxy_sign(
     settings: &Settings,
+    _services: &RuntimeServices,
     mut req: Request,
 ) -> Result<Response, Report<TrustedServerError>> {
     let method = req.get_method().clone();
@@ -902,6 +1605,7 @@ struct ProxyRebuildResp {
 /// Returns an error if JSON parsing fails, the URL is invalid, or the request body cannot be read.
 pub async fn handle_first_party_proxy_rebuild(
     settings: &Settings,
+    _services: &RuntimeServices,
     mut req: Request,
 ) -> Result<Response, Report<TrustedServerError>> {
     let method = req.get_method().clone();
@@ -1164,32 +1868,151 @@ fn reconstruct_and_validate_signed_target(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
     use super::{
-        copy_proxy_forward_headers, handle_first_party_click, handle_first_party_proxy,
-        handle_first_party_proxy_rebuild, handle_first_party_proxy_sign, is_host_allowed,
-        rebuild_response_with_body, reconstruct_and_validate_signed_target, redirect_is_permitted,
-        ProxyRequestConfig, SUPPORTED_ENCODINGS,
+        asset_origin_host_header, asset_path_skips_image_optimizer, build_asset_proxy_target_url,
+        clear_s3_credentials_cache_for_tests, handle_asset_proxy_request, handle_first_party_click,
+        handle_first_party_proxy, handle_first_party_proxy_rebuild, handle_first_party_proxy_sign,
+        is_host_allowed, proxy_request, rebuild_response_with_body,
+        reconstruct_and_validate_signed_target, redirect_is_permitted, stream_asset_body,
+        AssetProxyCachePolicy, ProxyRequestConfig, SUPPORTED_ENCODINGS,
     };
+    use crate::constants::{HEADER_ACCEPT, HEADER_X_FORWARDED_FOR};
+    use crate::creative;
     use crate::error::{IntoHttpResponse, TrustedServerError};
-    use crate::test_support::tests::create_test_settings;
-    use crate::{
-        constants::{
-            HEADER_ACCEPT, HEADER_ACCEPT_ENCODING, HEADER_ACCEPT_LANGUAGE, HEADER_REFERER,
-            HEADER_USER_AGENT, HEADER_X_FORWARDED_FOR,
-        },
-        creative,
+    use crate::platform::test_support::{
+        build_services_with_http_client, build_services_with_secret_and_http_client, noop_services,
+        HashMapSecretStore, StubHttpClient,
     };
+    use crate::platform::{
+        PlatformError, PlatformHttpClient, PlatformHttpRequest, PlatformPendingRequest,
+        PlatformResponse, PlatformSecretStore, PlatformSelectResult, StoreId, StoreName,
+    };
+    use crate::settings::{
+        AssetImageOptimizerConfig, AssetOriginAuth, ImageOptimizerAspectRatioConfig,
+        ImageOptimizerCropOffsetsConfig, ImageOptimizerProfileSet, ImageOptimizerSettings,
+        OriginQueryPolicy, ProxyAssetRoute, S3SigV4AuthConfig, UnknownProfilePolicy,
+    };
+    use crate::test_support::tests::create_test_settings;
+    use bytes::Bytes;
+    use edgezero_core::body::Body as EdgeBody;
+    use edgezero_core::http::response_builder as edge_response_builder;
     use error_stack::Report;
     use fastly::http::{header, HeaderValue, Method, StatusCode};
     use fastly::{Request, Response};
+
+    /// Test double that always returns a streaming (non-buffered) response body.
+    ///
+    /// Used to exercise both the asset streaming success path and the
+    /// `Body::Stream` error path in `platform_response_to_fastly`, which cannot
+    /// materialise a streaming body into a `fastly::Response`. Only `send` is
+    /// implemented; `send_async` and `select` return `PlatformError::Unsupported`.
+    struct StreamingResponseHttpClient;
+
+    #[async_trait::async_trait(?Send)]
+    impl PlatformHttpClient for StreamingResponseHttpClient {
+        async fn send(
+            &self,
+            _request: PlatformHttpRequest,
+        ) -> Result<PlatformResponse, Report<PlatformError>> {
+            let edge_response = edge_response_builder()
+                .status(StatusCode::OK)
+                .header(header::SET_COOKIE.as_str(), "asset=1; Path=/; Secure")
+                .header(header::SET_COOKIE.as_str(), "other=2; Path=/; Secure")
+                .header(
+                    header::STRICT_TRANSPORT_SECURITY.as_str(),
+                    "max-age=31536000; includeSubDomains; preload",
+                )
+                .header("clear-site-data", "\"*\"")
+                .header(header::ETAG.as_str(), "\"stream-etag\"")
+                .body(EdgeBody::stream(futures::stream::iter(vec![
+                    Bytes::from_static(b"chunk"),
+                ])))
+                .expect("should build streaming test response");
+
+            Ok(PlatformResponse::new(edge_response).with_backend_name("stub-backend"))
+        }
+
+        async fn send_async(
+            &self,
+            _request: PlatformHttpRequest,
+        ) -> Result<PlatformPendingRequest, Report<PlatformError>> {
+            Err(Report::new(PlatformError::Unsupported))
+        }
+
+        async fn select(
+            &self,
+            _pending_requests: Vec<PlatformPendingRequest>,
+        ) -> Result<PlatformSelectResult, Report<PlatformError>> {
+            Err(Report::new(PlatformError::Unsupported))
+        }
+    }
+
+    #[derive(Clone)]
+    struct CountingSecretStore {
+        data: Arc<HashMap<String, Vec<u8>>>,
+        reads: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl CountingSecretStore {
+        fn new(data: HashMap<String, Vec<u8>>) -> Self {
+            Self {
+                data: Arc::new(data),
+                reads: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn read_count(&self, key: &str) -> usize {
+            self.reads
+                .lock()
+                .expect("should lock counting secret-store reads")
+                .iter()
+                .filter(|read_key| read_key.as_str() == key)
+                .count()
+        }
+    }
+
+    impl PlatformSecretStore for CountingSecretStore {
+        fn get_bytes(
+            &self,
+            _store_name: &StoreName,
+            key: &str,
+        ) -> Result<Vec<u8>, Report<PlatformError>> {
+            self.reads
+                .lock()
+                .expect("should lock counting secret-store reads")
+                .push(key.to_string());
+            self.data
+                .get(key)
+                .cloned()
+                .ok_or_else(|| Report::new(PlatformError::SecretStore))
+        }
+
+        fn create(
+            &self,
+            _store_id: &StoreId,
+            _name: &str,
+            _value: &str,
+        ) -> Result<(), Report<PlatformError>> {
+            Err(Report::new(PlatformError::Unsupported))
+        }
+
+        fn delete(&self, _store_id: &StoreId, _name: &str) -> Result<(), Report<PlatformError>> {
+            Err(Report::new(PlatformError::Unsupported))
+        }
+    }
 
     #[tokio::test]
     async fn proxy_missing_param_returns_400() {
         let settings = create_test_settings();
         let req = Request::new(Method::GET, "https://example.com/first-party/proxy");
-        let err: Report<TrustedServerError> = handle_first_party_proxy(&settings, req)
-            .await
-            .expect_err("expected error");
+        let err: Report<TrustedServerError> =
+            handle_first_party_proxy(&settings, &noop_services(), req)
+                .await
+                .expect_err("expected error");
         assert_eq!(err.current_context().status_code(), StatusCode::BAD_GATEWAY);
     }
 
@@ -1201,9 +2024,10 @@ mod tests {
             Method::GET,
             "https://example.com/first-party/proxy?tsurl=https%3A%2F%2Fcdn.example%2Fa.png",
         );
-        let err: Report<TrustedServerError> = handle_first_party_proxy(&settings, req)
-            .await
-            .expect_err("expected error");
+        let err: Report<TrustedServerError> =
+            handle_first_party_proxy(&settings, &noop_services(), req)
+                .await
+                .expect_err("expected error");
         assert_eq!(err.current_context().status_code(), StatusCode::BAD_GATEWAY);
     }
 
@@ -1215,7 +2039,7 @@ mod tests {
         });
         let mut req = Request::new(Method::POST, "https://edge.example/first-party/sign");
         req.set_body(body.to_string());
-        let mut resp = handle_first_party_proxy_sign(&settings, req)
+        let mut resp = handle_first_party_proxy_sign(&settings, &noop_services(), req)
             .await
             .expect("sign ok");
         assert_eq!(resp.get_status(), StatusCode::OK);
@@ -1237,9 +2061,10 @@ mod tests {
         });
         let mut req = Request::new(Method::POST, "https://edge.example/first-party/sign");
         req.set_body(body.to_string());
-        let err: Report<TrustedServerError> = handle_first_party_proxy_sign(&settings, req)
-            .await
-            .expect_err("expected error");
+        let err: Report<TrustedServerError> =
+            handle_first_party_proxy_sign(&settings, &noop_services(), req)
+                .await
+                .expect_err("expected error");
         assert_eq!(err.current_context().status_code(), StatusCode::BAD_GATEWAY);
     }
 
@@ -1251,7 +2076,7 @@ mod tests {
         });
         let mut req = Request::new(Method::POST, "https://edge.example/first-party/sign");
         req.set_body(body.to_string());
-        let mut resp = handle_first_party_proxy_sign(&settings, req)
+        let mut resp = handle_first_party_proxy_sign(&settings, &noop_services(), req)
             .await
             .expect("should sign URL with non-standard port");
         assert_eq!(
@@ -1358,9 +2183,10 @@ mod tests {
     async fn click_missing_params_returns_400() {
         let settings = create_test_settings();
         let req = Request::new(Method::GET, "https://edge.example/first-party/click");
-        let err: Report<TrustedServerError> = handle_first_party_click(&settings, req)
-            .await
-            .expect_err("expected error");
+        let err: Report<TrustedServerError> =
+            handle_first_party_click(&settings, &noop_services(), req)
+                .await
+                .expect_err("expected error");
         assert_eq!(err.current_context().status_code(), StatusCode::BAD_GATEWAY);
     }
 
@@ -1380,7 +2206,7 @@ mod tests {
                 sig
             ),
         );
-        let resp = handle_first_party_click(&settings, req)
+        let resp = handle_first_party_click(&settings, &noop_services(), req)
             .await
             .expect("should redirect");
         assert_eq!(resp.get_status(), StatusCode::FOUND);
@@ -1410,7 +2236,7 @@ mod tests {
         let valid_ec_id = format!("{}.AbCd12", "a".repeat(64));
         req.set_header(header::COOKIE, format!("ts-ec={valid_ec_id}"));
 
-        let resp = handle_first_party_click(&settings, req)
+        let resp = handle_first_party_click(&settings, &noop_services(), req)
             .await
             .expect("should redirect");
 
@@ -1443,7 +2269,7 @@ mod tests {
             "https://edge.example/first-party/proxy-rebuild",
         );
         req.set_body(serde_json::to_string(&body).expect("test JSON should serialize"));
-        let mut resp = handle_first_party_proxy_rebuild(&settings, req)
+        let mut resp = handle_first_party_proxy_rebuild(&settings, &noop_services(), req)
             .await
             .expect("rebuild ok");
         assert_eq!(resp.get_status(), StatusCode::OK);
@@ -1521,9 +2347,10 @@ mod tests {
         // Build a first-party proxy URL with a token for the unsupported scheme
         let first_party = creative::build_proxy_url(&settings, clear);
         let req = Request::new(Method::GET, format!("https://edge.example{}", first_party));
-        let err: Report<TrustedServerError> = handle_first_party_proxy(&settings, req)
-            .await
-            .expect_err("expected error");
+        let err: Report<TrustedServerError> =
+            handle_first_party_proxy(&settings, &noop_services(), req)
+                .await
+                .expect_err("expected error");
         assert_eq!(err.current_context().status_code(), StatusCode::BAD_GATEWAY);
     }
 
@@ -1541,68 +2368,11 @@ mod tests {
             sig
         );
         let req = Request::new(Method::GET, &url);
-        let err: Report<TrustedServerError> = handle_first_party_proxy(&settings, req)
-            .await
-            .expect_err("expected error");
+        let err: Report<TrustedServerError> =
+            handle_first_party_proxy(&settings, &noop_services(), req)
+                .await
+                .expect_err("expected error");
         assert_eq!(err.current_context().status_code(), StatusCode::BAD_GATEWAY);
-    }
-
-    #[test]
-    fn header_copy_copies_curated_set() {
-        let mut src = Request::new(Method::GET, "https://edge.example/first-party/proxy");
-        src.set_header(HEADER_USER_AGENT, "UA/1.0");
-        src.set_header(HEADER_ACCEPT, "image/*");
-        src.set_header(HEADER_ACCEPT_LANGUAGE, "en-US");
-        src.set_header(HEADER_ACCEPT_ENCODING, "gzip");
-        src.set_header(HEADER_REFERER, "https://pub.example/page");
-        src.set_header(HEADER_X_FORWARDED_FOR, "203.0.113.1");
-
-        let mut dst = Request::new(Method::GET, "https://cdn.example/a.png");
-        copy_proxy_forward_headers(&src, &mut dst);
-
-        assert_eq!(
-            dst.get_header(HEADER_USER_AGENT)
-                .expect("User-Agent header should be copied")
-                .to_str()
-                .expect("User-Agent should be valid UTF-8"),
-            "UA/1.0"
-        );
-        assert_eq!(
-            dst.get_header(HEADER_ACCEPT)
-                .expect("Accept header should be copied")
-                .to_str()
-                .expect("Accept should be valid UTF-8"),
-            "image/*"
-        );
-        assert_eq!(
-            dst.get_header(HEADER_ACCEPT_LANGUAGE)
-                .expect("Accept-Language header should be copied")
-                .to_str()
-                .expect("Accept-Language should be valid UTF-8"),
-            "en-US"
-        );
-        // Accept-Encoding is overridden to only include supported encodings
-        assert_eq!(
-            dst.get_header(HEADER_ACCEPT_ENCODING)
-                .expect("Accept-Encoding header should be set")
-                .to_str()
-                .expect("Accept-Encoding should be valid UTF-8"),
-            SUPPORTED_ENCODINGS
-        );
-        assert_eq!(
-            dst.get_header(HEADER_REFERER)
-                .expect("Referer header should be copied")
-                .to_str()
-                .expect("Referer should be valid UTF-8"),
-            "https://pub.example/page"
-        );
-        assert_eq!(
-            dst.get_header(HEADER_X_FORWARDED_FOR)
-                .expect("X-Forwarded-For header should be copied")
-                .to_str()
-                .expect("X-Forwarded-For should be valid UTF-8"),
-            "203.0.113.1"
-        );
     }
 
     #[tokio::test]
@@ -1611,7 +2381,7 @@ mod tests {
         let clear = "https://cdn.example/landing.html?x=1";
         let first_party = creative::build_click_url(&settings, clear);
         let req = Request::new(Method::GET, format!("https://edge.example{}", first_party));
-        let resp = handle_first_party_click(&settings, req)
+        let resp = handle_first_party_click(&settings, &noop_services(), req)
             .await
             .expect("should redirect");
         assert_eq!(resp.get_status(), StatusCode::FOUND);
@@ -1950,6 +2720,1096 @@ mod tests {
         );
     }
 
+    // --- Platform HTTP client integration ---
+
+    #[tokio::test]
+    async fn proxy_request_calls_platform_http_client_send() {
+        use crate::platform::test_support::StubHttpClient;
+
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let req = Request::new(Method::GET, "https://example.com/");
+
+        let result = proxy_request(
+            &settings,
+            req,
+            ProxyRequestConfig {
+                target_url: "https://example.com/resource",
+                follow_redirects: false,
+                forward_ec_id: false,
+                body: None,
+                headers: Vec::new(),
+                copy_request_headers: false,
+                stream_passthrough: false,
+                allowed_domains: &[],
+            },
+            &services,
+        )
+        .await;
+
+        assert!(result.is_ok(), "should proxy successfully");
+        let calls = stub.recorded_backend_names();
+        assert_eq!(calls.len(), 1, "should call send exactly once");
+        assert_eq!(
+            calls[0], "stub-backend",
+            "should use backend name from StubBackend"
+        );
+    }
+
+    #[tokio::test]
+    async fn proxy_request_forwards_curated_headers_when_copy_request_headers_is_true() {
+        use crate::platform::test_support::StubHttpClient;
+
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let mut req = Request::new(Method::GET, "https://example.com/");
+        req.set_header(header::USER_AGENT, "test-agent/1.0");
+        req.set_header(header::ACCEPT, "text/html");
+        req.set_header(header::ACCEPT_LANGUAGE, "en-US");
+
+        let result = proxy_request(
+            &settings,
+            req,
+            ProxyRequestConfig {
+                target_url: "https://example.com/resource",
+                follow_redirects: false,
+                forward_ec_id: false,
+                body: None,
+                headers: Vec::new(),
+                copy_request_headers: true,
+                stream_passthrough: false,
+                allowed_domains: &[],
+            },
+            &services,
+        )
+        .await;
+
+        assert!(result.is_ok(), "should proxy successfully");
+        let all_headers = stub.recorded_request_headers();
+        assert_eq!(all_headers.len(), 1, "should have captured one request");
+        let sent = &all_headers[0];
+
+        let header_value = |name: &str| -> Option<String> {
+            sent.iter().find(|(n, _)| n == name).map(|(_, v)| v.clone())
+        };
+
+        assert_eq!(
+            header_value("user-agent").as_deref(),
+            Some("test-agent/1.0"),
+            "should forward User-Agent"
+        );
+        assert_eq!(
+            header_value("accept").as_deref(),
+            Some("text/html"),
+            "should forward Accept"
+        );
+        assert_eq!(
+            header_value("accept-language").as_deref(),
+            Some("en-US"),
+            "should forward Accept-Language"
+        );
+        assert_eq!(
+            header_value("accept-encoding").as_deref(),
+            Some(SUPPORTED_ENCODINGS),
+            "should override Accept-Encoding with supported encodings"
+        );
+    }
+
+    #[test]
+    fn build_asset_proxy_target_url_preserves_path_and_query() {
+        let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
+        let target_url =
+            build_asset_proxy_target_url(&route, "/.images/foo.jpg", "auto=webp&width=800")
+                .expect("should build asset target URL");
+
+        assert_eq!(
+            target_url.as_str(),
+            "https://assets.example.com/.images/foo.jpg?auto=webp&width=800",
+            "should preserve the incoming path and query exactly"
+        );
+    }
+
+    #[test]
+    fn build_asset_proxy_target_url_applies_cdn_style_rewrite() {
+        let mut route = ProxyAssetRoute::new("/.image/", "https://assets-cdn.example.com");
+        route.path_pattern = Some(r"^/\.image/(.*)/[^/]+\.([^/.]+)$".to_string());
+        route.target_path = Some("/image/upload/$1.$2".to_string());
+        let target_url = build_asset_proxy_target_url(
+            &route,
+            "/.image/c_fit,w_1440/MjA/example.jpg",
+            "auto=webp",
+        )
+        .expect("should build rewritten asset target URL");
+
+        assert_eq!(
+            target_url.as_str(),
+            "https://assets-cdn.example.com/image/upload/c_fit,w_1440/MjA.jpg?auto=webp",
+            "should rewrite the path generically while preserving query parameters"
+        );
+    }
+
+    #[test]
+    fn build_asset_proxy_target_url_applies_static_prefix_rewrite() {
+        let mut route = ProxyAssetRoute::new("/_next/static/", "https://static-assets.example.com");
+        route.path_pattern = Some(r"^(.*)$".to_string());
+        route.target_path = Some("/_network$1".to_string());
+        let target_url = build_asset_proxy_target_url(&route, "/_next/static/chunks/app.js", "")
+            .expect("should build rewritten static asset target URL");
+
+        assert_eq!(
+            target_url.as_str(),
+            "https://static-assets.example.com/_network/_next/static/chunks/app.js",
+            "should prepend the configured upstream path prefix"
+        );
+    }
+
+    #[test]
+    fn build_asset_proxy_target_url_errors_when_rewrite_pattern_misses() {
+        let mut route = ProxyAssetRoute::new("/.image/", "https://assets.example.com");
+        route.path_pattern = Some(r"^/\.image/(.*)\.jpg$".to_string());
+        route.target_path = Some("/image/upload/$1.jpg".to_string());
+        let err = build_asset_proxy_target_url(&route, "/.image/foo.png", "")
+            .expect_err("should reject paths that do not match the configured rewrite");
+
+        assert!(
+            format!("{err:?}").contains("did not match path_pattern"),
+            "should explain the rewrite miss: {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_asset_proxy_target_url_errors_when_rewrite_omits_leading_slash() {
+        let mut route = ProxyAssetRoute::new("/assets/", "https://assets.example.com");
+        route.path_pattern = Some(r"^/assets/(.*)$".to_string());
+        route.target_path = Some("$1".to_string());
+        let err = build_asset_proxy_target_url(&route, "/assets/app.js", "")
+            .expect_err("should reject rewritten paths without a leading slash");
+
+        assert!(
+            format!("{err:?}").contains("must start with '/'"),
+            "should explain the invalid rewritten path: {err:?}"
+        );
+    }
+
+    #[test]
+    fn asset_path_skips_image_optimizer_for_svg_extensions() {
+        for url in [
+            "https://assets.example.com/.images/logo.svg",
+            "https://assets.example.com/.images/LOGO.SVG",
+            "https://assets.example.com/.images/icon.svgz",
+        ] {
+            let target_url = url::Url::parse(url).expect("should parse target URL");
+            assert!(
+                asset_path_skips_image_optimizer(&target_url),
+                "should skip Image Optimizer for {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn asset_path_uses_image_optimizer_for_raster_extensions() {
+        for url in [
+            "https://assets.example.com/.images/photo.jpg",
+            "https://assets.example.com/.images/photo.png",
+            "https://assets.example.com/.images/photo.webp",
+        ] {
+            let target_url = url::Url::parse(url).expect("should parse target URL");
+            assert!(
+                !asset_path_skips_image_optimizer(&target_url),
+                "should allow Image Optimizer for {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn asset_origin_host_header_omits_standard_port() {
+        let target_url = url::Url::parse("https://assets.example.com/.images/foo.jpg")
+            .expect("should parse URL");
+        let host = asset_origin_host_header(&target_url).expect("should compute Host header");
+        assert_eq!(
+            host.to_str().expect("should serialize Host header"),
+            "assets.example.com",
+            "should omit standard HTTPS port from Host header"
+        );
+    }
+
+    #[test]
+    fn asset_origin_host_header_includes_non_standard_port() {
+        let target_url = url::Url::parse("https://assets.example.com:8443/.images/foo.jpg")
+            .expect("should parse URL");
+        let host = asset_origin_host_header(&target_url).expect("should compute Host header");
+        assert_eq!(
+            host.to_str().expect("should serialize Host header"),
+            "assets.example.com:8443",
+            "should include non-standard port in Host header"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_forwards_asset_headers_and_host() {
+        use crate::platform::test_support::StubHttpClient;
+
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let mut req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/foo.jpg?auto=webp",
+        );
+        req.set_header(header::USER_AGENT, "asset-agent/1.0");
+        req.set_header(header::ACCEPT, "image/avif,image/webp,image/*,*/*;q=0.8");
+        req.set_header(header::ACCEPT_ENCODING, "gzip, br");
+        req.set_header(header::ACCEPT_LANGUAGE, "en-US");
+        req.set_header(header::REFERER, "https://www.example.com/article");
+        req.set_header(header::IF_NONE_MATCH, "\"asset-etag\"");
+        req.set_header(header::IF_MODIFIED_SINCE, "Thu, 13 Mar 2025 08:00:00 GMT");
+        req.set_header(header::IF_MATCH, "\"asset-precondition\"");
+        req.set_header(header::IF_UNMODIFIED_SINCE, "Thu, 13 Mar 2025 09:00:00 GMT");
+        req.set_header(header::RANGE, "bytes=0-1023");
+        req.set_header(header::IF_RANGE, "\"asset-range\"");
+        req.set_header(HEADER_X_FORWARDED_FOR, "198.51.100.10");
+        req.set_header(header::HeaderName::from_static("x-custom-test"), "drop-me");
+
+        let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com:8443");
+        let response = handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy asset request")
+            .into_response()
+            .expect("should return buffered asset response");
+        assert_eq!(response.get_status(), StatusCode::OK);
+
+        let all_headers = stub.recorded_request_headers();
+        assert_eq!(all_headers.len(), 1, "should have captured one request");
+        let sent = &all_headers[0];
+        let header_value = |name: &str| -> Option<String> {
+            sent.iter().find(|(n, _)| n == name).map(|(_, v)| v.clone())
+        };
+
+        assert_eq!(
+            header_value("user-agent").as_deref(),
+            Some("asset-agent/1.0"),
+            "should forward User-Agent"
+        );
+        assert_eq!(
+            header_value("accept-encoding").as_deref(),
+            Some("gzip, br"),
+            "should preserve the incoming Accept-Encoding"
+        );
+        assert_eq!(
+            header_value("if-none-match").as_deref(),
+            Some("\"asset-etag\""),
+            "should forward conditional ETag validation headers"
+        );
+        assert_eq!(
+            header_value("if-modified-since").as_deref(),
+            Some("Thu, 13 Mar 2025 08:00:00 GMT"),
+            "should forward conditional date validation headers"
+        );
+        assert_eq!(
+            header_value("if-match").as_deref(),
+            Some("\"asset-precondition\""),
+            "should forward precondition headers"
+        );
+        assert_eq!(
+            header_value("if-unmodified-since").as_deref(),
+            Some("Thu, 13 Mar 2025 09:00:00 GMT"),
+            "should forward date precondition headers"
+        );
+        assert_eq!(
+            header_value("range").as_deref(),
+            Some("bytes=0-1023"),
+            "should forward byte-range requests"
+        );
+        assert_eq!(
+            header_value("if-range").as_deref(),
+            Some("\"asset-range\""),
+            "should forward range validators"
+        );
+        assert_eq!(
+            header_value("host").as_deref(),
+            Some("assets.example.com:8443"),
+            "should override Host to the asset origin host"
+        );
+        assert!(
+            header_value("x-forwarded-for").is_none(),
+            "should not forward client-supplied X-Forwarded-For"
+        );
+        assert!(
+            header_value("x-custom-test").is_none(),
+            "should not forward unrelated custom headers"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_strips_unsafe_response_headers() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response_with_headers(
+            200,
+            Vec::new(),
+            vec![
+                (header::SET_COOKIE.as_str(), "asset=1; Path=/; Secure"),
+                (header::SET_COOKIE.as_str(), "other=2; Path=/; Secure"),
+                (
+                    header::STRICT_TRANSPORT_SECURITY.as_str(),
+                    "max-age=31536000; includeSubDomains; preload",
+                ),
+                ("clear-site-data", "\"*\""),
+                (header::ETAG.as_str(), "\"asset-etag\""),
+            ],
+        );
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let req = Request::new(Method::GET, "https://www.example.com/.images/foo.jpg");
+
+        let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
+        let response = handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy asset request")
+            .into_response()
+            .expect("should return buffered asset response");
+
+        assert!(
+            response.get_header(header::SET_COOKIE).is_none(),
+            "should strip upstream Set-Cookie headers from asset responses"
+        );
+        assert!(
+            response
+                .get_header(header::STRICT_TRANSPORT_SECURITY)
+                .is_none(),
+            "should strip upstream HSTS headers from asset responses"
+        );
+        assert!(
+            response.get_header("clear-site-data").is_none(),
+            "should strip upstream Clear-Site-Data headers from asset responses"
+        );
+        assert_eq!(
+            response.get_header_str(header::ETAG),
+            Some("\"asset-etag\""),
+            "should preserve safe cache validator headers on asset responses"
+        );
+    }
+
+    fn test_profile_set() -> ImageOptimizerProfileSet {
+        let mut profiles = HashMap::new();
+        profiles.insert("default".to_string(), "width=1920".to_string());
+        profiles.insert("medium".to_string(), "format=auto&width=828".to_string());
+        ImageOptimizerProfileSet {
+            base_params: "quality=70&resize-filter=bicubic".to_string(),
+            default_profile: "default".to_string(),
+            unknown_profile: Default::default(),
+            profile_param: "profile".to_string(),
+            aspect_ratio_param: "ar".to_string(),
+            debug_param: "_io_debug".to_string(),
+            profiles,
+            aspect_ratios: Some(ImageOptimizerAspectRatioConfig {
+                allowed: vec!["1-1".to_string()],
+                profiles: vec!["medium".to_string()],
+            }),
+            crop_offsets: Some(ImageOptimizerCropOffsetsConfig {
+                enabled: true,
+                x_param: "x".to_string(),
+                y_param: "y".to_string(),
+                buckets: vec![10, 30, 50, 70, 90],
+                default: 50,
+                when_missing: Default::default(),
+            }),
+        }
+    }
+
+    fn test_s3_secrets() -> HashMap<String, Vec<u8>> {
+        HashMap::from([
+            (
+                "access_key_id".to_string(),
+                b"AKIAIOSFODNN7EXAMPLE".to_vec(),
+            ),
+            (
+                "secret_access_key".to_string(),
+                b"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_vec(),
+            ),
+        ])
+    }
+
+    fn test_s3_image_optimizer_route() -> ProxyAssetRoute {
+        let mut route = ProxyAssetRoute::new(
+            "/.images/",
+            "https://examplebucket.s3.us-east-1.amazonaws.com",
+        );
+        route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
+            region: "us-east-1".to_string(),
+            secret_store: "s3-auth".to_string(),
+            access_key_id: "access_key_id".to_string(),
+            secret_access_key: "secret_access_key".to_string(),
+            session_token: None,
+            origin_query: None,
+        }));
+        route.image_optimizer = Some(AssetImageOptimizerConfig {
+            enabled: true,
+            region: "us_east".to_string(),
+            profile_set: "default_images".to_string(),
+            origin_query: None,
+        });
+        route
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_signs_s3_and_strips_transform_query() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "access_key_id".to_string(),
+            b"AKIAIOSFODNN7EXAMPLE".to_vec(),
+        );
+        secrets.insert(
+            "secret_access_key".to_string(),
+            b"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_vec(),
+        );
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(secrets),
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
+        );
+        let settings = create_test_settings();
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/foo.jpg?profile=medium&ar=1-1",
+        );
+        let mut route = ProxyAssetRoute::new(
+            "/.images/",
+            "https://examplebucket.s3.us-east-1.amazonaws.com",
+        );
+        route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
+            region: "us-east-1".to_string(),
+            secret_store: "s3-auth".to_string(),
+            access_key_id: "access_key_id".to_string(),
+            secret_access_key: "secret_access_key".to_string(),
+            session_token: None,
+            origin_query: Some(OriginQueryPolicy::Strip),
+        }));
+
+        handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy signed S3 asset request");
+
+        let uris = stub.recorded_request_uris();
+        assert_eq!(
+            uris,
+            vec!["https://examplebucket.s3.us-east-1.amazonaws.com/.images/foo.jpg"],
+            "should strip transform query before signing and sending to S3"
+        );
+        let headers = stub.recorded_request_headers();
+        let sent = &headers[0];
+        let header_value = |name: &str| -> Option<String> {
+            sent.iter().find(|(n, _)| n == name).map(|(_, v)| v.clone())
+        };
+        assert_eq!(
+            header_value("host").as_deref(),
+            Some("examplebucket.s3.us-east-1.amazonaws.com"),
+            "should sign for the S3 origin host"
+        );
+        assert!(
+            header_value("authorization")
+                .as_deref()
+                .is_some_and(|value| value.starts_with("AWS4-HMAC-SHA256 Credential=")),
+            "should add a SigV4 Authorization header"
+        );
+        assert_eq!(
+            header_value("x-amz-content-sha256").as_deref(),
+            Some("UNSIGNED-PAYLOAD"),
+            "should use unsigned payload for read-only asset requests"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_caches_s3_credentials_for_repeated_signing() {
+        clear_s3_credentials_cache_for_tests();
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, Vec::new());
+        stub.push_response(200, b"optimized".to_vec());
+        let secret_store = CountingSecretStore::new(HashMap::from([
+            (
+                "cache_access_key_id".to_string(),
+                b"AKIAIOSFODNN7EXAMPLE".to_vec(),
+            ),
+            (
+                "cache_secret_access_key".to_string(),
+                b"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_vec(),
+            ),
+            ("cache_session_token".to_string(), b"session-token".to_vec()),
+        ]));
+        let observed_secret_store = secret_store.clone();
+        let services = build_services_with_secret_and_http_client(
+            secret_store,
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
+        );
+        let mut settings = create_test_settings();
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
+        };
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/foo.jpg?profile=medium",
+        );
+        let mut route = test_s3_image_optimizer_route();
+        route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
+            region: "us-east-1".to_string(),
+            secret_store: "s3-auth-cache".to_string(),
+            access_key_id: "cache_access_key_id".to_string(),
+            secret_access_key: "cache_secret_access_key".to_string(),
+            session_token: Some("cache_session_token".to_string()),
+            origin_query: None,
+        }));
+
+        handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy optimized S3 asset request");
+
+        assert_eq!(
+            stub.recorded_request_methods(),
+            vec!["HEAD", "GET"],
+            "should sign both the S3 preflight and final request"
+        );
+        assert_eq!(
+            observed_secret_store.read_count("cache_access_key_id"),
+            1,
+            "should read S3 access key ID once despite repeated signing"
+        );
+        assert_eq!(
+            observed_secret_store.read_count("cache_secret_access_key"),
+            1,
+            "should read S3 secret access key once despite repeated signing"
+        );
+        assert_eq!(
+            observed_secret_store.read_count("cache_session_token"),
+            1,
+            "should read S3 session token once despite repeated signing"
+        );
+        let headers = stub.recorded_request_headers();
+        assert!(
+            headers.iter().all(|sent| sent
+                .iter()
+                .any(|(name, value)| name == "x-amz-security-token" && value == "session-token")),
+            "should sign both requests with the cached session token"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_attaches_image_optimizer_metadata() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let mut settings = create_test_settings();
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
+        };
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/foo.jpg?profile=medium&ar=1-1&x=71&y=bad",
+        );
+        let mut route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
+        route.image_optimizer = Some(AssetImageOptimizerConfig {
+            enabled: true,
+            region: "us_east".to_string(),
+            profile_set: "default_images".to_string(),
+            origin_query: None,
+        });
+
+        handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy optimized asset request");
+
+        let uris = stub.recorded_request_uris();
+        assert_eq!(
+            uris,
+            vec!["https://assets.example.com/.images/foo.jpg"],
+            "should strip profile-table query from the origin request by default"
+        );
+        assert_eq!(
+            stub.recorded_stream_response_flags(),
+            vec![true],
+            "final asset responses should stay streaming"
+        );
+        let options = stub.recorded_image_optimizer_options();
+        let options = options[0]
+            .as_ref()
+            .expect("should attach image optimizer metadata");
+        assert_eq!(options.region, "us_east");
+        assert!(!options.preserve_query_string_on_origin_request);
+        assert_eq!(options.params.quality, Some(70));
+        assert_eq!(options.params.resize_filter.as_deref(), Some("bicubic"));
+        assert_eq!(options.params.format.as_deref(), Some("auto"));
+        assert_eq!(options.params.width, Some(828));
+        let crop = options.params.crop.as_ref().expect("should set crop");
+        assert_eq!((crop.width, crop.height), (1, 1));
+        assert_eq!((crop.offset_x, crop.offset_y), (Some(70), Some(50)));
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_skips_image_optimizer_for_svg_assets() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let mut settings = create_test_settings();
+        let mut profile_set = test_profile_set();
+        profile_set.unknown_profile = UnknownProfilePolicy::Reject;
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: HashMap::from([("default_images".to_string(), profile_set)]),
+        };
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/logo.SVG?profile=unknown&ar=1-1",
+        );
+        let mut route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
+        route.image_optimizer = Some(AssetImageOptimizerConfig {
+            enabled: true,
+            region: "us_east".to_string(),
+            profile_set: "default_images".to_string(),
+            origin_query: None,
+        });
+
+        handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy SVG asset without Image Optimizer profile parsing");
+
+        assert_eq!(
+            stub.recorded_request_uris(),
+            vec!["https://assets.example.com/.images/logo.SVG"],
+            "should still strip profile-table query from SVG origin requests"
+        );
+        assert_eq!(
+            stub.recorded_image_optimizer_options(),
+            vec![None],
+            "SVG assets should bypass Image Optimizer metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_skips_image_optimizer_for_rewritten_svg_assets() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let mut settings = create_test_settings();
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
+        };
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.image/options/id/logo.svg?profile=medium",
+        );
+        let mut route = ProxyAssetRoute::new("/.image/", "https://assets.example.com");
+        route.path_pattern = Some(r"^/\.image/(.*)/[^/]+\.([^/.]+)$".to_string());
+        route.target_path = Some("/image/upload/$1.$2".to_string());
+        route.image_optimizer = Some(AssetImageOptimizerConfig {
+            enabled: true,
+            region: "us_east".to_string(),
+            profile_set: "default_images".to_string(),
+            origin_query: None,
+        });
+
+        handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy rewritten SVG asset without Image Optimizer metadata");
+
+        assert_eq!(
+            stub.recorded_request_uris(),
+            vec!["https://assets.example.com/image/upload/options/id.svg"],
+            "should detect SVG after route path rewriting"
+        );
+        assert_eq!(
+            stub.recorded_image_optimizer_options(),
+            vec![None],
+            "rewritten SVG assets should bypass Image Optimizer metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_skips_s3_preflight_for_svg_image_optimizer_routes() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"raw-svg".to_vec());
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(test_s3_secrets()),
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
+        );
+        let settings = create_test_settings();
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/logo.svg?profile=medium",
+        );
+        let route = test_s3_image_optimizer_route();
+
+        let mut response = handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy raw SVG asset through S3 route")
+            .into_response()
+            .expect("should return buffered asset response");
+
+        assert_eq!(response.take_body_str(), "raw-svg");
+        assert_eq!(
+            stub.recorded_request_methods(),
+            vec!["GET"],
+            "SVG IO bypass should not add an S3 preflight"
+        );
+        assert_eq!(
+            stub.recorded_request_uris(),
+            vec!["https://examplebucket.s3.us-east-1.amazonaws.com/.images/logo.svg"],
+            "SVG IO bypass should still strip the transform query"
+        );
+        assert_eq!(
+            stub.recorded_image_optimizer_options(),
+            vec![None],
+            "SVG IO bypass should not attach Image Optimizer metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_preflights_s3_before_image_optimizer() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, Vec::new());
+        stub.push_response(200, b"optimized".to_vec());
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(test_s3_secrets()),
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
+        );
+        let mut settings = create_test_settings();
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
+        };
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/foo.jpg?profile=medium",
+        );
+        let route = test_s3_image_optimizer_route();
+
+        let mut response = handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy optimized S3 asset request")
+            .into_response()
+            .expect("should return buffered asset response");
+
+        assert_eq!(response.get_status(), StatusCode::OK);
+        assert_eq!(response.take_body_str(), "optimized");
+        assert_eq!(
+            stub.recorded_request_methods(),
+            vec!["HEAD", "GET"],
+            "should preflight S3 with HEAD before the optimized GET"
+        );
+        assert_eq!(
+            stub.recorded_request_uris(),
+            vec![
+                "https://examplebucket.s3.us-east-1.amazonaws.com/.images/foo.jpg",
+                "https://examplebucket.s3.us-east-1.amazonaws.com/.images/foo.jpg",
+            ],
+            "should strip transform query from both S3 requests"
+        );
+        assert_eq!(
+            stub.recorded_stream_response_flags(),
+            vec![false, true],
+            "S3 HEAD preflight stays non-streaming, final asset GET stays streaming"
+        );
+        let options = stub.recorded_image_optimizer_options();
+        assert_eq!(options.len(), 2, "should send two origin requests");
+        assert!(
+            options[0].is_none(),
+            "preflight should not attach IO metadata"
+        );
+        assert!(
+            options[1].is_some(),
+            "final asset request should attach IO metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_returns_raw_s3_error_before_image_optimizer() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(404, Vec::new());
+        stub.push_response_with_headers(
+            404,
+            br#"<Error><Code>NoSuchKey</Code><Key>image/upload/missing.jpg</Key></Error>"#.to_vec(),
+            vec![
+                (header::CONTENT_TYPE.as_str(), "application/xml"),
+                (header::CACHE_CONTROL.as_str(), "public, max-age=3600"),
+                (header::SET_COOKIE.as_str(), "asset=1; Path=/"),
+            ],
+        );
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(test_s3_secrets()),
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
+        );
+        let mut settings = create_test_settings();
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
+        };
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/missing.jpg?profile=medium",
+        );
+        let route = test_s3_image_optimizer_route();
+
+        let asset_response = handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should return raw S3 error response");
+        assert_eq!(
+            asset_response.cache_policy(),
+            AssetProxyCachePolicy::NoStorePrivate,
+            "should carry a typed no-store policy for router finalization"
+        );
+        let mut response = asset_response
+            .into_response()
+            .expect("should return buffered asset response");
+
+        assert_eq!(response.get_status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response.get_header_str(header::CACHE_CONTROL),
+            Some("no-store, private"),
+            "S3 origin errors should not be cached"
+        );
+        assert!(
+            response.get_header(header::SET_COOKIE).is_none(),
+            "raw S3 error should still strip unsafe response headers"
+        );
+        let body = response.take_body_str();
+        assert!(body.contains("NoSuchKey"), "should return S3 error body");
+        assert!(
+            body.contains("image/upload/missing.jpg"),
+            "should expose the missing S3 key"
+        );
+        assert_eq!(
+            stub.recorded_request_methods(),
+            vec!["HEAD", "GET"],
+            "should fetch S3 error body after failed HEAD preflight"
+        );
+        assert_eq!(
+            stub.recorded_stream_response_flags(),
+            vec![false, true],
+            "S3 HEAD preflight stays non-streaming, error-body GET stays streaming"
+        );
+        let options = stub.recorded_image_optimizer_options();
+        assert_eq!(
+            options,
+            vec![None, None],
+            "should not invoke IO for S3 errors"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_does_not_preflight_when_io_disabled() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"raw".to_vec());
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(test_s3_secrets()),
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
+        );
+        let mut settings = create_test_settings();
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
+        };
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/foo.jpg?profile=medium&_io_debug=1",
+        );
+        let route = test_s3_image_optimizer_route();
+
+        let mut response = handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy debug S3 asset request")
+            .into_response()
+            .expect("should return buffered asset response");
+
+        assert_eq!(response.take_body_str(), "raw");
+        assert_eq!(
+            stub.recorded_request_methods(),
+            vec!["GET"],
+            "disabled IO should not add S3 preflight"
+        );
+        assert_eq!(
+            stub.recorded_image_optimizer_options(),
+            vec![None],
+            "debug query param should disable image optimizer metadata"
+        );
+        assert_eq!(
+            stub.recorded_stream_response_flags(),
+            vec![true],
+            "debug asset responses should still stay streaming"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_debug_param_disables_image_optimizer() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let mut settings = create_test_settings();
+        settings.image_optimizer = ImageOptimizerSettings {
+            profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
+        };
+        let req = Request::new(
+            Method::GET,
+            "https://www.example.com/.images/foo.jpg?profile=medium&_io_debug=1",
+        );
+        let mut route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
+        route.image_optimizer = Some(AssetImageOptimizerConfig {
+            enabled: true,
+            region: "us_east".to_string(),
+            profile_set: "default_images".to_string(),
+            origin_query: None,
+        });
+
+        handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy debug asset request");
+
+        let options = stub.recorded_image_optimizer_options();
+        assert!(
+            options[0].is_none(),
+            "debug query param should disable image optimizer metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_asset_proxy_request_accepts_streaming_platform_response_body() {
+        let services = build_services_with_http_client(
+            Arc::new(StreamingResponseHttpClient) as Arc<dyn PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let req = Request::new(Method::GET, "https://www.example.com/.images/foo.jpg");
+        let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
+
+        let (response, stream_body) = handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy a streaming asset response")
+            .into_response_and_body();
+        assert_eq!(response.get_status(), StatusCode::OK);
+        assert!(
+            response.get_header(header::SET_COOKIE).is_none(),
+            "should strip upstream Set-Cookie headers from streaming asset responses"
+        );
+        assert!(
+            response
+                .get_header(header::STRICT_TRANSPORT_SECURITY)
+                .is_none(),
+            "should strip upstream HSTS headers from streaming asset responses"
+        );
+        assert!(
+            response.get_header("clear-site-data").is_none(),
+            "should strip upstream Clear-Site-Data headers from streaming asset responses"
+        );
+        assert_eq!(
+            response.get_header_str(header::ETAG),
+            Some("\"stream-etag\""),
+            "should preserve safe cache validator headers on streaming asset responses"
+        );
+
+        let mut output = Vec::new();
+        stream_asset_body(
+            stream_body.expect("should preserve asset body as a stream"),
+            &mut output,
+        )
+        .await
+        .expect("should stream asset body");
+
+        assert_eq!(output, b"chunk");
+    }
+
+    #[tokio::test]
+    async fn stream_asset_body_reports_mid_stream_origin_errors() {
+        let body = EdgeBody::from_stream(futures::stream::iter(vec![
+            Ok::<Bytes, io::Error>(Bytes::from_static(b"partial")),
+            Err(io::Error::other("origin stream failed")),
+        ]));
+        let mut output = Vec::new();
+
+        let err = stream_asset_body(body, &mut output)
+            .await
+            .expect_err("should report mid-stream origin errors");
+
+        assert_eq!(
+            output, b"partial",
+            "should only write chunks received before the stream error"
+        );
+        assert!(
+            format!("{err:?}").contains("streaming platform response body failed"),
+            "should describe the streaming failure: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn asset_proxy_response_into_response_rejects_stream_body() {
+        let services = build_services_with_http_client(
+            Arc::new(StreamingResponseHttpClient) as Arc<dyn PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let req = Request::new(Method::GET, "https://www.example.com/.images/foo.jpg");
+        let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
+        let asset_response = handle_asset_proxy_request(&settings, &services, req, &route)
+            .await
+            .expect("should proxy a streaming asset response");
+
+        let err = asset_response
+            .into_response()
+            .expect_err("streaming asset responses should require explicit stream handling");
+        assert!(
+            format!("{err:?}").contains("streaming asset response cannot be converted"),
+            "should describe the buffered conversion failure: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn proxy_request_returns_error_for_streaming_platform_response_body() {
+        let services = build_services_with_http_client(
+            Arc::new(StreamingResponseHttpClient) as Arc<dyn PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let req = Request::new(Method::GET, "https://example.com/");
+
+        let err = proxy_request(
+            &settings,
+            req,
+            ProxyRequestConfig {
+                target_url: "https://example.com/resource",
+                follow_redirects: false,
+                forward_ec_id: false,
+                body: None,
+                headers: Vec::new(),
+                copy_request_headers: false,
+                stream_passthrough: false,
+                allowed_domains: &[],
+            },
+            &services,
+        )
+        .await
+        .expect_err("should reject streaming platform responses");
+
+        assert_eq!(
+            err.current_context().status_code(),
+            StatusCode::BAD_GATEWAY,
+            "should surface a proxy failure instead of truncating the body"
+        );
+        assert!(
+            format!("{err:?}").contains("streaming platform response body"),
+            "should describe the unsupported streaming body: {err:?}"
+        );
+    }
+
     // --- is_host_allowed ---
 
     #[test]
@@ -2187,7 +4047,7 @@ mod tests {
             token,
         );
         let req = Request::new(Method::GET, url);
-        let err = handle_first_party_proxy(&settings, req)
+        let err = handle_first_party_proxy(&settings, &noop_services(), req)
             .await
             .expect_err("should block initial target not in allowlist");
         assert_eq!(

--- a/crates/trusted-server-core/src/proxy.rs
+++ b/crates/trusted-server-core/src/proxy.rs
@@ -1,14 +1,13 @@
 use crate::backend::DEFAULT_FIRST_BYTE_TIMEOUT;
-use crate::http_util::{compute_encrypted_sha256_token, ct_str_eq};
+use crate::http_util::{compute_encrypted_sha256_token, ct_str_eq, enforce_max_body_size};
 use edgezero_core::body::Body as EdgeBody;
 use edgezero_core::http::{request_builder as edge_request_builder, Uri as EdgeUri};
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, HeaderValue, Method, StatusCode};
-use fastly::{Request, Response};
 use futures::StreamExt as _;
+use http::{header, HeaderValue, Method, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::Write;
+use std::io::{Cursor, Write};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -17,7 +16,7 @@ use crate::constants::{
     HEADER_USER_AGENT, HEADER_X_FORWARDED_FOR,
 };
 use crate::creative::{CreativeCssProcessor, CreativeHtmlProcessor};
-use crate::ec::get_ec_id;
+use crate::edge_cookie::get_ec_id;
 use crate::error::TrustedServerError;
 use crate::platform::{
     PlatformBackendSpec, PlatformHttpRequest, PlatformResponse, RuntimeServices, StoreName,
@@ -31,6 +30,13 @@ use crate::streaming_processor::{Compression, PipelineConfig, StreamProcessor, S
 
 /// Chunk size used for streaming content through the rewrite pipeline.
 const STREAMING_CHUNK_SIZE: usize = 8192;
+
+const SIGN_MAX_BODY_BYTES: usize = 65536;
+const REBUILD_MAX_BODY_BYTES: usize = 65536;
+
+fn body_as_reader(body: EdgeBody) -> Cursor<bytes::Bytes> {
+    Cursor::new(body.into_bytes())
+}
 
 /// Headers copied from the original client request to the upstream proxy request
 /// when `copy_request_headers` is enabled.
@@ -88,7 +94,7 @@ pub enum AssetProxyCachePolicy {
 
 impl AssetProxyCachePolicy {
     /// Apply protected cache headers after route-level response finalization.
-    pub fn apply_after_route_finalization(self, response: &mut Response) {
+    pub fn apply_after_route_finalization(self, response: &mut Response<EdgeBody>) {
         if self == Self::NoStorePrivate {
             apply_no_store_cache_control(response);
         }
@@ -97,14 +103,14 @@ impl AssetProxyCachePolicy {
 
 /// Asset proxy response plus metadata needed by the outer router.
 pub struct AssetProxyResponse {
-    response: Response,
+    response: Response<EdgeBody>,
     stream_body: Option<EdgeBody>,
     cache_policy: AssetProxyCachePolicy,
 }
 
 impl AssetProxyResponse {
     fn new(
-        response: Response,
+        response: Response<EdgeBody>,
         stream_body: Option<EdgeBody>,
         cache_policy: AssetProxyCachePolicy,
     ) -> Self {
@@ -115,11 +121,11 @@ impl AssetProxyResponse {
         }
     }
 
-    fn origin_controlled(response: Response) -> Self {
+    fn origin_controlled(response: Response<EdgeBody>) -> Self {
         Self::new(response, None, AssetProxyCachePolicy::OriginControlled)
     }
 
-    fn origin_controlled_stream(response: Response, stream_body: EdgeBody) -> Self {
+    fn origin_controlled_stream(response: Response<EdgeBody>, stream_body: EdgeBody) -> Self {
         Self::new(
             response,
             Some(stream_body),
@@ -127,15 +133,15 @@ impl AssetProxyResponse {
         )
     }
 
-    fn no_store_private(response: Response) -> Self {
+    fn no_store_private(response: Response<EdgeBody>) -> Self {
         Self::new(response, None, AssetProxyCachePolicy::NoStorePrivate)
     }
 
-    fn response(&self) -> &Response {
+    fn response(&self) -> &Response<EdgeBody> {
         &self.response
     }
 
-    fn response_mut(&mut self) -> &mut Response {
+    fn response_mut(&mut self) -> &mut Response<EdgeBody> {
         &mut self.response
     }
 
@@ -157,7 +163,7 @@ impl AssetProxyResponse {
     /// Returns [`TrustedServerError::Proxy`] when the response carries a
     /// streaming body. Use [`Self::into_response_and_body`] when the caller
     /// needs to handle both buffered and streaming asset responses.
-    pub fn into_response(self) -> Result<Response, Report<TrustedServerError>> {
+    pub fn into_response(self) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
         if self.stream_body.is_some() {
             return Err(Report::new(TrustedServerError::Proxy {
                 message: "streaming asset response cannot be converted into a buffered response"
@@ -170,7 +176,7 @@ impl AssetProxyResponse {
 
     /// Consume this wrapper and return the response headers plus optional stream body.
     #[must_use]
-    pub fn into_response_and_body(self) -> (Response, Option<EdgeBody>) {
+    pub fn into_response_and_body(self) -> (Response<EdgeBody>, Option<EdgeBody>) {
         (self.response, self.stream_body)
     }
 }
@@ -186,18 +192,15 @@ struct S3CredentialsCacheKey {
 static S3_CREDENTIALS_CACHE: LazyLock<Mutex<HashMap<S3CredentialsCacheKey, Arc<S3Credentials>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Convert a platform-neutral response into a [`fastly::Response`] for downstream processing.
-///
-/// Shared with `auction/orchestrator.rs`. Both files will migrate off `fastly::Response`
-/// entirely in Phase 2, at which point this conversion helper will be removed.
+/// Convert a platform-neutral response into a buffered [`Response`] for downstream processing.
 ///
 /// # Errors
 ///
 /// Returns [`TrustedServerError::Proxy`] when `platform_resp` carries a
-/// streaming body, which this Fastly-only conversion path cannot materialize.
+/// streaming body, which the buffered proxy path cannot materialize.
 pub(crate) fn platform_response_to_fastly(
     platform_resp: PlatformResponse,
-) -> Result<Response, Report<TrustedServerError>> {
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     let (parts, body) = platform_resp.response.into_parts();
     let body_bytes = match body {
         EdgeBody::Once(bytes) => bytes.to_vec(),
@@ -208,27 +211,19 @@ pub(crate) fn platform_response_to_fastly(
             }));
         }
     };
-    let mut resp = Response::from_status(parts.status.as_u16());
-    for (name, value) in parts.headers.iter() {
-        resp.append_header(name.as_str(), value.as_bytes());
-    }
-    resp.set_body(body_bytes);
-    Ok(resp)
+    Ok(Response::from_parts(parts, EdgeBody::from(body_bytes)))
 }
 
 fn platform_response_to_fastly_asset(platform_resp: PlatformResponse) -> AssetProxyResponse {
     let (parts, body) = platform_resp.response.into_parts();
-    let mut resp = Response::from_status(parts.status.as_u16());
-    for (name, value) in parts.headers.iter() {
-        resp.append_header(name.as_str(), value.as_bytes());
-    }
 
     match body {
-        EdgeBody::Once(bytes) => {
-            resp.set_body(bytes.to_vec());
-            AssetProxyResponse::origin_controlled(resp)
-        }
+        EdgeBody::Once(bytes) => AssetProxyResponse::origin_controlled(Response::from_parts(
+            parts,
+            EdgeBody::from(bytes.to_vec()),
+        )),
         stream_body @ EdgeBody::Stream(_) => {
+            let resp = Response::from_parts(parts, EdgeBody::empty());
             AssetProxyResponse::origin_controlled_stream(resp, stream_body)
         }
     }
@@ -270,7 +265,6 @@ pub async fn stream_asset_body<W: Write>(
 
     Ok(())
 }
-
 #[derive(Deserialize)]
 struct ProxySignReq {
     url: String,
@@ -299,19 +293,16 @@ pub struct ProxyRequestConfig<'a> {
     pub copy_request_headers: bool,
     /// When true, stream the origin response without HTML/CSS rewrites.
     pub stream_passthrough: bool,
-    /// Domain allowlist enforced on the initial target and every redirect hop.
+    /// Domains allowed for the initial request and any redirects.
     ///
-    /// An empty slice disables allowlist enforcement (open mode).
-    /// Integration proxies should pass `&[]`; first-party proxy passes
-    /// `&settings.proxy.allowed_domains`.
+    /// When empty every host is permitted (open mode). Integration proxies
+    /// should leave this empty; first-party handlers should pass
+    /// `&settings.proxy.allowed_domains` to enforce the publisher allowlist.
     pub allowed_domains: &'a [String],
 }
 
 impl<'a> ProxyRequestConfig<'a> {
     /// Build a proxy configuration that follows redirects and forwards the EC ID.
-    ///
-    /// `allowed_domains` defaults to `&[]` (open mode). Override it for the
-    /// first-party proxy by setting `allowed_domains` directly.
     #[must_use]
     pub fn new(target_url: &'a str) -> Self {
         Self {
@@ -363,31 +354,27 @@ const SUPPORTED_ENCODINGS: &str = "gzip, deflate, br";
 /// If `preserve_encoding` is true, the Content-Encoding header is kept (for compressed responses).
 /// If false, Content-Encoding is stripped (for decompressed responses).
 fn rebuild_response_with_body(
-    beresp: &Response,
+    beresp: Response<EdgeBody>,
     content_type: &'static str,
     body: Vec<u8>,
     preserve_encoding: bool,
-) -> Response {
-    let status = beresp.get_status();
-    let headers: Vec<(header::HeaderName, HeaderValue)> = beresp
-        .get_headers()
-        .map(|(name, value)| (name.clone(), value.clone()))
-        .collect();
-    let mut resp = Response::from_status(status);
-    for (name, value) in headers {
-        // Always skip Content-Length (size changed) and Content-Type (we set it)
-        if name == header::CONTENT_LENGTH || name == header::CONTENT_TYPE {
-            continue;
-        }
-        // Skip Content-Encoding only if we're not preserving it
-        if name == header::CONTENT_ENCODING && !preserve_encoding {
-            continue;
-        }
-        resp.append_header(name, value);
+) -> Response<EdgeBody> {
+    let (mut parts, _) = beresp.into_parts();
+
+    // Always skip Content-Length (size changed) and Content-Type (we set it)
+    parts.headers.remove(header::CONTENT_LENGTH);
+    parts.headers.remove(header::CONTENT_TYPE);
+
+    // Skip Content-Encoding only if we're not preserving it
+    if !preserve_encoding {
+        parts.headers.remove(header::CONTENT_ENCODING);
     }
-    resp.set_header(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
-    resp.set_body(body);
-    resp
+
+    parts
+        .headers
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+
+    Response::from_parts(parts, EdgeBody::from(body))
 }
 
 /// Process a response body through a streaming pipeline with the given processor.
@@ -395,29 +382,29 @@ fn rebuild_response_with_body(
 /// Handles decompression, content processing, and re-compression while preserving
 /// the response status and headers.
 fn process_response_with_pipeline<P: StreamProcessor>(
-    mut beresp: Response,
+    mut beresp: Response<EdgeBody>,
     processor: P,
     compression: Compression,
     content_type: &'static str,
     error_context: &'static str,
-) -> Result<Response, Report<TrustedServerError>> {
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     let config = PipelineConfig {
         input_compression: compression,
         output_compression: compression,
         chunk_size: STREAMING_CHUNK_SIZE,
     };
 
-    let body = beresp.take_body();
+    let body = std::mem::replace(beresp.body_mut(), EdgeBody::empty());
     let mut output = Vec::new();
     let mut pipeline = StreamingPipeline::new(config, processor);
     pipeline
-        .process(body, &mut output)
+        .process(body_as_reader(body), &mut output)
         .change_context(TrustedServerError::Proxy {
             message: error_context.to_string(),
         })?;
 
     Ok(rebuild_response_with_body(
-        &beresp,
+        beresp,
         content_type,
         output,
         compression != Compression::None,
@@ -426,28 +413,32 @@ fn process_response_with_pipeline<P: StreamProcessor>(
 
 fn finalize_proxied_response(
     settings: &Settings,
-    req: &Request,
+    req: &Request<EdgeBody>,
     target_url: &str,
-    mut beresp: Response,
-) -> Result<Response, Report<TrustedServerError>> {
+    mut beresp: Response<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     // Determine content-type and content-encoding from response headers
-    let status_code = beresp.get_status().as_u16();
+    let status_code = beresp.status().as_u16();
     let ct_raw = beresp
-        .get_header(header::CONTENT_TYPE)
+        .headers()
+        .get(header::CONTENT_TYPE)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("")
         .to_string();
     let content_encoding = beresp
-        .get_header(header::CONTENT_ENCODING)
+        .headers()
+        .get(header::CONTENT_ENCODING)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("")
         .to_string();
     let cl_raw = beresp
-        .get_header(header::CONTENT_LENGTH)
+        .headers()
+        .get(header::CONTENT_LENGTH)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("-");
     let accept_raw = req
-        .get_header(HEADER_ACCEPT)
+        .headers()
+        .get(HEADER_ACCEPT)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("-");
 
@@ -494,20 +485,24 @@ fn finalize_proxied_response(
 
     // Image handling: set generic content-type if missing and log pixel heuristics
     let req_accept_images = req
-        .get_header(HEADER_ACCEPT)
+        .headers()
+        .get(HEADER_ACCEPT)
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_ascii_lowercase().contains("image/"))
         .unwrap_or(false);
 
     if ct.starts_with("image/") || req_accept_images {
-        if beresp.get_header(header::CONTENT_TYPE).is_none() {
-            beresp.set_header(header::CONTENT_TYPE, "image/*");
+        if beresp.headers().get(header::CONTENT_TYPE).is_none() {
+            beresp
+                .headers_mut()
+                .insert(header::CONTENT_TYPE, HeaderValue::from_static("image/*"));
         }
 
         // Heuristics to log likely tracking pixels without altering response
         let mut is_pixel = false;
         if let Some(cl) = beresp
-            .get_header(header::CONTENT_LENGTH)
+            .headers()
+            .get(header::CONTENT_LENGTH)
             .and_then(|h| h.to_str().ok())
             .and_then(|s| s.parse::<u64>().ok())
         {
@@ -541,22 +536,25 @@ fn finalize_proxied_response(
 }
 
 fn finalize_proxied_response_streaming(
-    req: &Request,
+    req: &Request<EdgeBody>,
     target_url: &str,
-    mut beresp: Response,
-) -> Response {
-    let status_code = beresp.get_status().as_u16();
+    mut beresp: Response<EdgeBody>,
+) -> Response<EdgeBody> {
+    let status_code = beresp.status().as_u16();
     let ct_raw = beresp
-        .get_header(header::CONTENT_TYPE)
+        .headers()
+        .get(header::CONTENT_TYPE)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("")
         .to_string();
     let cl_raw = beresp
-        .get_header(header::CONTENT_LENGTH)
+        .headers()
+        .get(header::CONTENT_LENGTH)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("-");
     let accept_raw = req
-        .get_header(HEADER_ACCEPT)
+        .headers()
+        .get(HEADER_ACCEPT)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("-");
 
@@ -573,19 +571,23 @@ fn finalize_proxied_response_streaming(
     let ct = ct_raw.to_ascii_lowercase();
 
     let req_accept_images = req
-        .get_header(HEADER_ACCEPT)
+        .headers()
+        .get(HEADER_ACCEPT)
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_ascii_lowercase().contains("image/"))
         .unwrap_or(false);
 
     if ct.starts_with("image/") || req_accept_images {
-        if beresp.get_header(header::CONTENT_TYPE).is_none() {
-            beresp.set_header(header::CONTENT_TYPE, "image/*");
+        if beresp.headers().get(header::CONTENT_TYPE).is_none() {
+            beresp
+                .headers_mut()
+                .insert(header::CONTENT_TYPE, HeaderValue::from_static("image/*"));
         }
 
         let mut is_pixel = false;
         if let Some(cl) = beresp
-            .get_header(header::CONTENT_LENGTH)
+            .headers()
+            .get(header::CONTENT_LENGTH)
             .and_then(|h| h.to_str().ok())
             .and_then(|s| s.parse::<u64>().ok())
         {
@@ -621,11 +623,11 @@ fn finalize_proxied_response_streaming(
 /// content processing based on the `stream_passthrough` flag.
 fn finalize_response(
     settings: &Settings,
-    req: &Request,
+    req: &Request<EdgeBody>,
     url: &str,
-    beresp: Response,
+    beresp: Response<EdgeBody>,
     stream_passthrough: bool,
-) -> Result<Response, Report<TrustedServerError>> {
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     if stream_passthrough {
         Ok(finalize_proxied_response_streaming(req, url, beresp))
     } else {
@@ -657,10 +659,10 @@ struct ProxyRequestHeaders<'a> {
 ///   scheme, lacks a host, or the upstream fetch fails
 pub async fn proxy_request(
     settings: &Settings,
-    req: Request,
+    req: Request<EdgeBody>,
     config: ProxyRequestConfig<'_>,
     services: &RuntimeServices,
-) -> Result<Response, Report<TrustedServerError>> {
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     let ProxyRequestConfig {
         target_url,
         follow_redirects,
@@ -918,16 +920,16 @@ async fn send_asset_origin_request(
     }
 }
 
-fn strip_asset_proxy_response_headers(response: &mut Response) {
+fn strip_asset_proxy_response_headers(response: &mut Response<EdgeBody>) {
     // Asset origins must not be able to mutate publisher-domain browser state
     // or security policy through this proxy path.
     for header_name in ASSET_PROXY_STRIP_RESPONSE_HEADERS {
-        response.remove_header(header_name);
+        response.headers_mut().remove(header_name);
     }
 }
 
-fn apply_no_store_cache_control(response: &mut Response) {
-    response.set_header(
+fn apply_no_store_cache_control(response: &mut Response<EdgeBody>) {
+    response.headers_mut().insert(
         header::CACHE_CONTROL,
         HeaderValue::from_static(ASSET_NO_STORE_PRIVATE_CACHE_CONTROL),
     );
@@ -969,7 +971,7 @@ async fn preflight_s3_origin_for_image_optimizer(
         false,
     )
     .await?;
-    let head_status = head_response.response().get_status();
+    let head_status = head_response.response().status();
     if head_status.is_success() || head_status == StatusCode::NOT_MODIFIED {
         return Ok(None);
     }
@@ -1017,11 +1019,11 @@ async fn preflight_s3_origin_for_image_optimizer(
 pub async fn handle_asset_proxy_request(
     settings: &Settings,
     services: &RuntimeServices,
-    req: Request,
+    req: Request<EdgeBody>,
     route: &ProxyAssetRoute,
 ) -> Result<AssetProxyResponse, Report<TrustedServerError>> {
-    let incoming_query = req.get_query_str().unwrap_or("");
-    let mut target_url = build_asset_proxy_target_url(route, req.get_path(), incoming_query)?;
+    let incoming_query = req.uri().query().unwrap_or("");
+    let mut target_url = build_asset_proxy_target_url(route, req.uri().path(), incoming_query)?;
     let skip_image_optimizer = asset_path_skips_image_optimizer(&target_url);
     let image_optimizer = if skip_image_optimizer {
         log::debug!(
@@ -1059,18 +1061,18 @@ pub async fn handle_asset_proxy_request(
 
     let mut outbound_headers = http::HeaderMap::new();
     for header_name in ASSET_PROXY_FORWARD_HEADERS {
-        if let Some(value) = req.get_header(&header_name) {
+        if let Some(value) = req.headers().get(&header_name) {
             outbound_headers.insert(header_name, value.clone());
         }
     }
     outbound_headers.insert(header::HOST, asset_origin_host_header(&target_url)?);
 
-    if should_preflight_s3(route, image_optimizer.is_some(), req.get_method()) {
+    if should_preflight_s3(route, image_optimizer.is_some(), req.method()) {
         if let Some(response) = preflight_s3_origin_for_image_optimizer(
             services,
             route,
             &target_url,
-            req.get_method(),
+            req.method(),
             &outbound_headers,
             &backend_name,
         )
@@ -1083,19 +1085,15 @@ pub async fn handle_asset_proxy_request(
     if let Some(auth) = &route.auth {
         apply_asset_origin_auth(
             services,
-            req.get_method(),
+            req.method(),
             &target_url,
             &mut outbound_headers,
             auth,
         )?;
     }
 
-    let mut platform_req = build_asset_platform_request(
-        req.get_method(),
-        &target_url,
-        &outbound_headers,
-        &backend_name,
-    )?;
+    let mut platform_req =
+        build_asset_platform_request(req.method(), &target_url, &outbound_headers, &backend_name)?;
     if let Some(image_optimizer) = image_optimizer {
         platform_req = platform_req.with_image_optimizer(image_optimizer);
     }
@@ -1133,7 +1131,7 @@ fn upsert_ec_query_param(url: &mut url::Url, ec_id: &str) {
     url.set_query(Some(&serializer.finish()));
 }
 
-fn append_ec_id(req: &Request, target_url_parsed: &mut url::Url) {
+fn append_ec_id(req: &Request<EdgeBody>, target_url_parsed: &mut url::Url) {
     let ec_id_param = match get_ec_id(req) {
         Ok(id) => id,
         Err(e) => {
@@ -1187,17 +1185,17 @@ fn is_host_allowed(host: &str, pattern: &str) -> bool {
 
 async fn proxy_with_redirects(
     settings: &Settings,
-    req: &Request,
+    req: &Request<EdgeBody>,
     target_url_parsed: url::Url,
     follow_redirects: bool,
     body: Option<&[u8]>,
     request_headers: ProxyRequestHeaders<'_>,
     stream_passthrough: bool,
-) -> Result<Response, Report<TrustedServerError>> {
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     const MAX_REDIRECTS: usize = 4;
 
     let mut current_url = target_url_parsed.to_string();
-    let mut current_method: Method = req.get_method().clone();
+    let mut current_method: Method = req.method().clone();
 
     for redirect_attempt in 0..=MAX_REDIRECTS {
         let parsed_url = url::Url::parse(&current_url).map_err(|_| {
@@ -1257,7 +1255,7 @@ async fn proxy_with_redirects(
         let mut outbound_headers = http::HeaderMap::new();
         if request_headers.copy_request_headers {
             for header_name in PROXY_FORWARD_HEADERS {
-                if let Some(v) = req.get_header(&header_name) {
+                if let Some(v) = req.headers().get(&header_name) {
                     outbound_headers.insert(header_name, v.clone());
                 }
             }
@@ -1290,13 +1288,13 @@ async fn proxy_with_redirects(
                 message: "Failed to proxy".to_string(),
             })?;
 
-        let beresp = platform_response_to_fastly(platform_resp)?;
+        let beresp = platform_resp.response;
 
         if !follow_redirects {
             return finalize_response(settings, req, &current_url, beresp, stream_passthrough);
         }
 
-        let status = beresp.get_status();
+        let status = beresp.status();
         let is_redirect = matches!(
             status,
             StatusCode::MOVED_PERMANENTLY
@@ -1311,7 +1309,8 @@ async fn proxy_with_redirects(
         }
 
         let Some(location) = beresp
-            .get_header(header::LOCATION)
+            .headers()
+            .get(header::LOCATION)
             .and_then(|h| h.to_str().ok())
             .filter(|value| !value.is_empty())
         else {
@@ -1394,11 +1393,11 @@ async fn proxy_with_redirects(
 pub async fn handle_first_party_proxy(
     settings: &Settings,
     services: &RuntimeServices,
-    req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
+    req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     // Parse, reconstruct, and validate the signed target URL
     let SignedTarget { target_url, .. } =
-        reconstruct_and_validate_signed_target(settings, req.get_url_str())?;
+        reconstruct_and_validate_signed_target(settings, &req.uri().to_string())?;
 
     proxy_request(
         settings,
@@ -1431,13 +1430,13 @@ pub async fn handle_first_party_proxy(
 pub async fn handle_first_party_click(
     settings: &Settings,
     _services: &RuntimeServices,
-    req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
+    req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     let SignedTarget {
         target_url: full_for_token,
         tsurl,
         had_params,
-    } = reconstruct_and_validate_signed_target(settings, req.get_url_str())?;
+    } = reconstruct_and_validate_signed_target(settings, &req.uri().to_string())?;
 
     let ec_id = match get_ec_id(&req) {
         Ok(id) => id,
@@ -1463,11 +1462,13 @@ pub async fn handle_first_party_click(
 
     // Log click metadata for observability
     let ua = req
-        .get_header(HEADER_USER_AGENT)
+        .headers()
+        .get(HEADER_USER_AGENT)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("");
     let referer = req
-        .get_header(HEADER_REFERER)
+        .headers()
+        .get(HEADER_REFERER)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("");
     log::info!(
@@ -1481,9 +1482,19 @@ pub async fn handle_first_party_click(
     );
 
     // 302 redirect to target URL
-    Ok(Response::from_status(fastly::http::StatusCode::FOUND)
-        .with_header(header::LOCATION, &redirect_target)
-        .with_header(header::CACHE_CONTROL, "no-store, private"))
+    let location = HeaderValue::from_str(&redirect_target).map_err(|_| {
+        Report::new(TrustedServerError::InvalidHeaderValue {
+            message: "invalid redirect target".to_string(),
+        })
+    })?;
+    let mut response = Response::new(EdgeBody::empty());
+    *response.status_mut() = StatusCode::FOUND;
+    response.headers_mut().insert(header::LOCATION, location);
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, private"),
+    );
+    Ok(response)
 }
 
 /// Sign an arbitrary asset URL so creatives can request first-party proxying at runtime.
@@ -1498,20 +1509,25 @@ pub async fn handle_first_party_click(
 pub async fn handle_first_party_proxy_sign(
     settings: &Settings,
     _services: &RuntimeServices,
-    mut req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
-    let method = req.get_method().clone();
+    req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    let method = req.method().clone();
+    let req_url = req.uri().to_string();
 
-    let payload = if method == fastly::http::Method::POST {
-        let body = req.take_body_str();
-        serde_json::from_str::<ProxySignReq>(&body).change_context(TrustedServerError::Proxy {
+    let payload = if method == Method::POST {
+        let body_bytes = req.into_body().into_bytes();
+        enforce_max_body_size(&body_bytes, SIGN_MAX_BODY_BYTES, "first-party sign")?;
+        let body =
+            std::str::from_utf8(&body_bytes).change_context(TrustedServerError::InvalidUtf8 {
+                message: "first-party sign request body should be valid UTF-8".to_string(),
+            })?;
+        serde_json::from_str::<ProxySignReq>(body).change_context(TrustedServerError::Proxy {
             message: "invalid JSON".to_string(),
         })?
     } else {
-        let parsed =
-            url::Url::parse(req.get_url_str()).change_context(TrustedServerError::Proxy {
-                message: "Invalid URL".to_string(),
-            })?;
+        let parsed = url::Url::parse(&req_url).change_context(TrustedServerError::Proxy {
+            message: "Invalid URL".to_string(),
+        })?;
         let url = parsed
             .query_pairs()
             .find(|(k, _)| k == "url")
@@ -1526,7 +1542,7 @@ pub async fn handle_first_party_proxy_sign(
 
     let trimmed = payload.url.trim();
     let abs = if trimmed.starts_with("//") {
-        let default_scheme = url::Url::parse(req.get_url_str())
+        let default_scheme = url::Url::parse(&req_url)
             .ok()
             .map(|u| u.scheme().to_ascii_lowercase())
             .filter(|scheme| !scheme.is_empty())
@@ -1569,12 +1585,15 @@ pub async fn handle_first_party_proxy_sign(
         base: base.to_string(),
     };
 
-    let mut response = Response::from_status(fastly::http::StatusCode::OK);
-    response.set_header(header::CONTENT_TYPE, "application/json; charset=utf-8");
-    response.set_body(
+    let mut response = Response::new(EdgeBody::from(
         serde_json::to_string(&resp).change_context(TrustedServerError::Proxy {
             message: "failed to serialize".to_string(),
         })?,
+    ));
+    *response.status_mut() = StatusCode::OK;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json; charset=utf-8"),
     );
     Ok(response)
 }
@@ -1606,22 +1625,25 @@ struct ProxyRebuildResp {
 pub async fn handle_first_party_proxy_rebuild(
     settings: &Settings,
     _services: &RuntimeServices,
-    mut req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
-    let method = req.get_method().clone();
-    let payload = if method == fastly::http::Method::POST {
-        let body = req.take_body_str();
-        serde_json::from_str::<ProxyRebuildReq>(&body).change_context(
-            TrustedServerError::Proxy {
-                message: "invalid JSON".to_string(),
-            },
-        )?
+    req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    let method = req.method().clone();
+    let req_url = req.uri().to_string();
+    let payload = if method == Method::POST {
+        let body_bytes = req.into_body().into_bytes();
+        enforce_max_body_size(&body_bytes, REBUILD_MAX_BODY_BYTES, "first-party rebuild")?;
+        let body =
+            std::str::from_utf8(&body_bytes).change_context(TrustedServerError::InvalidUtf8 {
+                message: "first-party rebuild request body should be valid UTF-8".to_string(),
+            })?;
+        serde_json::from_str::<ProxyRebuildReq>(body).change_context(TrustedServerError::Proxy {
+            message: "invalid JSON".to_string(),
+        })?
     } else {
         // Support GET: /first-party/proxy-rebuild?tsclick=...&add=...&del=...
-        let parsed =
-            url::Url::parse(req.get_url_str()).change_context(TrustedServerError::Proxy {
-                message: "Invalid URL".to_string(),
-            })?;
+        let parsed = url::Url::parse(&req_url).change_context(TrustedServerError::Proxy {
+            message: "Invalid URL".to_string(),
+        })?;
         let mut tsclick: Option<String> = None;
         let mut add: Option<std::collections::HashMap<String, String>> = None;
         let mut del: Option<Vec<String>> = None;
@@ -1738,11 +1760,21 @@ pub async fn handle_first_party_proxy_rebuild(
         }
     }
 
-    if method == fastly::http::Method::GET {
+    if method == Method::GET {
         // Redirect for GET usage to streamline navigation
-        Ok(Response::from_status(fastly::http::StatusCode::FOUND)
-            .with_header(header::LOCATION, href)
-            .with_header(header::CACHE_CONTROL, "no-store, private"))
+        let location = HeaderValue::from_str(&href).map_err(|_| {
+            Report::new(TrustedServerError::InvalidHeaderValue {
+                message: "invalid rebuild redirect target".to_string(),
+            })
+        })?;
+        let mut response = Response::new(EdgeBody::empty());
+        *response.status_mut() = StatusCode::FOUND;
+        response.headers_mut().insert(header::LOCATION, location);
+        response.headers_mut().insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static("no-store, private"),
+        );
+        Ok(response)
     } else {
         let json = serde_json::to_string(&ProxyRebuildResp {
             href,
@@ -1750,11 +1782,20 @@ pub async fn handle_first_party_proxy_rebuild(
             added,
             removed,
         })
-        .unwrap_or_else(|_| "{}".to_string());
-        Ok(Response::from_status(fastly::http::StatusCode::OK)
-            .with_header(header::CONTENT_TYPE, "application/json; charset=utf-8")
-            .with_header(header::CACHE_CONTROL, "no-store, private")
-            .with_body(json))
+        .change_context(TrustedServerError::Proxy {
+            message: "failed to serialize rebuild response".to_string(),
+        })?;
+        let mut response = Response::new(EdgeBody::from(json));
+        *response.status_mut() = StatusCode::OK;
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json; charset=utf-8"),
+        );
+        response.headers_mut().insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static("no-store, private"),
+        );
+        Ok(response)
     }
 }
 
@@ -1901,8 +1942,79 @@ mod tests {
     use edgezero_core::body::Body as EdgeBody;
     use edgezero_core::http::response_builder as edge_response_builder;
     use error_stack::Report;
-    use fastly::http::{header, HeaderValue, Method, StatusCode};
-    use fastly::{Request, Response};
+    use http::{header, HeaderValue, Method, Request as HttpRequest, Response, StatusCode};
+
+    #[test]
+    fn test_rebuild_response_with_body_preserves_multiple_headers() {
+        let mut response = Response::new(EdgeBody::empty());
+        response
+            .headers_mut()
+            .append(header::SET_COOKIE, HeaderValue::from_static("session=123"));
+        response
+            .headers_mut()
+            .append(header::SET_COOKIE, HeaderValue::from_static("tracker=456"));
+        response
+            .headers_mut()
+            .insert(header::CONTENT_TYPE, HeaderValue::from_static("text/html"));
+
+        let rebuilt =
+            rebuild_response_with_body(response, "application/json", b"{}".to_vec(), false);
+
+        let cookies: Vec<_> = rebuilt
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .filter_map(|h| h.to_str().ok())
+            .collect();
+        assert_eq!(cookies, vec!["session=123", "tracker=456"]);
+        assert_eq!(
+            rebuilt
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "application/json"
+        );
+    }
+
+    fn build_http_request(method: Method, uri: impl AsRef<str>) -> HttpRequest<EdgeBody> {
+        HttpRequest::builder()
+            .method(method)
+            .uri(uri.as_ref())
+            .body(EdgeBody::empty())
+            .expect("should build http request")
+    }
+
+    fn build_http_post_json_request(
+        uri: impl AsRef<str>,
+        body: &serde_json::Value,
+    ) -> HttpRequest<EdgeBody> {
+        HttpRequest::builder()
+            .method(Method::POST)
+            .uri(uri.as_ref())
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .body(EdgeBody::from(body.to_string()))
+            .expect("should build http post request")
+    }
+
+    fn response_body_string(response: http::Response<EdgeBody>) -> String {
+        String::from_utf8(response.into_body().into_bytes().to_vec())
+            .expect("response body should be valid UTF-8")
+    }
+
+    fn build_http_response(status: StatusCode, body: EdgeBody) -> Response<EdgeBody> {
+        let mut response = Response::new(body);
+        *response.status_mut() = status;
+        response
+    }
+
+    fn response_header(response: &Response<EdgeBody>, name: header::HeaderName) -> Option<&str> {
+        response
+            .headers()
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+    }
 
     /// Test double that always returns a streaming (non-buffered) response body.
     ///
@@ -2008,7 +2120,7 @@ mod tests {
     #[tokio::test]
     async fn proxy_missing_param_returns_400() {
         let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://example.com/first-party/proxy");
+        let req = build_http_request(Method::GET, "https://example.com/first-party/proxy");
         let err: Report<TrustedServerError> =
             handle_first_party_proxy(&settings, &noop_services(), req)
                 .await
@@ -2020,7 +2132,7 @@ mod tests {
     async fn proxy_missing_or_invalid_token_returns_400() {
         let settings = create_test_settings();
         // missing tstoken should 400
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://example.com/first-party/proxy?tsurl=https%3A%2F%2Fcdn.example%2Fa.png",
         );
@@ -2037,13 +2149,12 @@ mod tests {
         let body = serde_json::json!({
             "url": "https://cdn.example/asset.js?c=3&b=2",
         });
-        let mut req = Request::new(Method::POST, "https://edge.example/first-party/sign");
-        req.set_body(body.to_string());
-        let mut resp = handle_first_party_proxy_sign(&settings, &noop_services(), req)
+        let req = build_http_post_json_request("https://edge.example/first-party/sign", &body);
+        let resp = handle_first_party_proxy_sign(&settings, &noop_services(), req)
             .await
             .expect("sign ok");
-        assert_eq!(resp.get_status(), StatusCode::OK);
-        let json = resp.take_body_str();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = response_body_string(resp);
         assert!(json.contains("/first-party/proxy?tsurl="), "{}", json);
         assert!(json.contains("tsexp"), "{}", json);
         assert!(
@@ -2059,8 +2170,7 @@ mod tests {
         let body = serde_json::json!({
             "url": "data:image/png;base64,AAAA",
         });
-        let mut req = Request::new(Method::POST, "https://edge.example/first-party/sign");
-        req.set_body(body.to_string());
+        let req = build_http_post_json_request("https://edge.example/first-party/sign", &body);
         let err: Report<TrustedServerError> =
             handle_first_party_proxy_sign(&settings, &noop_services(), req)
                 .await
@@ -2074,17 +2184,12 @@ mod tests {
         let body = serde_json::json!({
             "url": "https://cdn.example.com:9443/img/300x250.svg",
         });
-        let mut req = Request::new(Method::POST, "https://edge.example/first-party/sign");
-        req.set_body(body.to_string());
-        let mut resp = handle_first_party_proxy_sign(&settings, &noop_services(), req)
+        let req = build_http_post_json_request("https://edge.example/first-party/sign", &body);
+        let resp = handle_first_party_proxy_sign(&settings, &noop_services(), req)
             .await
             .expect("should sign URL with non-standard port");
-        assert_eq!(
-            resp.get_status(),
-            StatusCode::OK,
-            "should return 200 for valid sign request"
-        );
-        let json = resp.take_body_str();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = response_body_string(resp);
         // Port 9443 should be preserved (URL-encoded as %3A9443)
         assert!(
             json.contains("%3A9443"),
@@ -2182,7 +2287,7 @@ mod tests {
     #[tokio::test]
     async fn click_missing_params_returns_400() {
         let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://edge.example/first-party/click");
+        let req = build_http_request(Method::GET, "https://edge.example/first-party/click");
         let err: Report<TrustedServerError> =
             handle_first_party_click(&settings, &noop_services(), req)
                 .await
@@ -2197,7 +2302,7 @@ mod tests {
         let params = "foo=1&bar=2";
         let full = format!("{}?{}", tsurl, params);
         let sig = crate::http_util::compute_encrypted_sha256_token(&settings, &full);
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             format!(
                 "https://edge.example/first-party/click?tsurl={}&{}&tstoken={}",
@@ -2209,9 +2314,10 @@ mod tests {
         let resp = handle_first_party_click(&settings, &noop_services(), req)
             .await
             .expect("should redirect");
-        assert_eq!(resp.get_status(), StatusCode::FOUND);
+        assert_eq!(resp.status(), StatusCode::FOUND);
         let loc = resp
-            .get_header(header::LOCATION)
+            .headers()
+            .get(http::header::LOCATION)
             .and_then(|h| h.to_str().ok())
             .unwrap_or("");
         assert_eq!(loc, full);
@@ -2224,7 +2330,7 @@ mod tests {
         let params = "foo=1";
         let full = format!("{}?{}", tsurl, params);
         let sig = crate::http_util::compute_encrypted_sha256_token(&settings, &full);
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::GET,
             format!(
                 "https://edge.example/first-party/click?tsurl={}&{}&tstoken={}",
@@ -2233,15 +2339,18 @@ mod tests {
                 sig
             ),
         );
-        let valid_ec_id = format!("{}.AbCd12", "a".repeat(64));
-        req.set_header(header::COOKIE, format!("ts-ec={valid_ec_id}"));
+        req.headers_mut().insert(
+            crate::constants::HEADER_X_TS_EC,
+            HeaderValue::from_static("ec-123"),
+        );
 
         let resp = handle_first_party_click(&settings, &noop_services(), req)
             .await
             .expect("should redirect");
 
         let loc = resp
-            .get_header(header::LOCATION)
+            .headers()
+            .get(header::LOCATION)
             .and_then(|h| h.to_str().ok())
             .expect("Location header should be present and valid");
         let parsed = url::Url::parse(loc).expect("Location should be a valid URL");
@@ -2250,7 +2359,7 @@ mod tests {
             .map(|(k, v)| (k.into_owned(), v.into_owned()))
             .collect();
         assert_eq!(pairs.remove("foo").as_deref(), Some("1"));
-        assert_eq!(pairs.remove("ts-ec").as_deref(), Some(valid_ec_id.as_str()));
+        assert_eq!(pairs.remove("ts-ec").as_deref(), Some("ec-123"));
         assert!(pairs.is_empty());
     }
 
@@ -2264,16 +2373,18 @@ mod tests {
             "add": {"y": "2"},
             "del": ["x"],
         });
-        let mut req = Request::new(
-            Method::POST,
-            "https://edge.example/first-party/proxy-rebuild",
-        );
-        req.set_body(serde_json::to_string(&body).expect("test JSON should serialize"));
-        let mut resp = handle_first_party_proxy_rebuild(&settings, &noop_services(), req)
+        let req = HttpRequest::builder()
+            .method(Method::POST)
+            .uri("https://edge.example/first-party/proxy-rebuild")
+            .body(EdgeBody::from(
+                serde_json::to_string(&body).expect("test JSON should serialize"),
+            ))
+            .expect("should build proxy rebuild request");
+        let resp = handle_first_party_proxy_rebuild(&settings, &noop_services(), req)
             .await
             .expect("rebuild ok");
-        assert_eq!(resp.get_status(), StatusCode::OK);
-        let json = resp.take_body_str();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = response_body_string(resp);
         assert!(json.contains("/first-party/click?tsurl="));
         assert!(json.contains("tstoken"));
         // Diagnostics
@@ -2346,7 +2457,7 @@ mod tests {
         let clear = "ftp://cdn.example/file.gif";
         // Build a first-party proxy URL with a token for the unsupported scheme
         let first_party = creative::build_proxy_url(&settings, clear);
-        let req = Request::new(Method::GET, format!("https://edge.example{}", first_party));
+        let req = build_http_request(Method::GET, format!("https://edge.example{}", first_party));
         let err: Report<TrustedServerError> =
             handle_first_party_proxy(&settings, &noop_services(), req)
                 .await
@@ -2367,7 +2478,7 @@ mod tests {
             url::form_urlencoded::byte_serialize(tsurl.as_bytes()).collect::<String>(),
             sig
         );
-        let req = Request::new(Method::GET, &url);
+        let req = build_http_request(Method::GET, &url);
         let err: Report<TrustedServerError> =
             handle_first_party_proxy(&settings, &noop_services(), req)
                 .await
@@ -2380,15 +2491,12 @@ mod tests {
         let settings = create_test_settings();
         let clear = "https://cdn.example/landing.html?x=1";
         let first_party = creative::build_click_url(&settings, clear);
-        let req = Request::new(Method::GET, format!("https://edge.example{}", first_party));
+        let req = build_http_request(Method::GET, format!("https://edge.example{}", first_party));
         let resp = handle_first_party_click(&settings, &noop_services(), req)
             .await
             .expect("should redirect");
-        assert_eq!(resp.get_status(), StatusCode::FOUND);
-        let cc = resp
-            .get_header(header::CACHE_CONTROL)
-            .and_then(|h| h.to_str().ok())
-            .unwrap_or("");
+        assert_eq!(resp.status(), StatusCode::FOUND);
+        let cc = response_header(&resp, header::CACHE_CONTROL).unwrap_or("");
         assert!(cc.contains("no-store"));
         assert!(cc.contains("private"));
     }
@@ -2403,38 +2511,40 @@ mod tests {
         let settings = create_test_settings();
         // HTML with an external image that should be proxied in rewrite
         let html = r#"<html><body><img src="https://cdn.example/a.png"></body></html>"#;
-        let beresp = Response::from_status(StatusCode::OK)
-            .with_header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-            .with_header(header::CACHE_CONTROL, "public, max-age=60")
-            .with_header(header::SET_COOKIE, "a=1; Path=/; Secure")
-            .with_body(html);
+        let mut beresp = build_http_response(StatusCode::OK, EdgeBody::from(html));
+        beresp.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+        );
+        beresp.headers_mut().insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static("public, max-age=60"),
+        );
+        beresp.headers_mut().insert(
+            header::SET_COOKIE,
+            HeaderValue::from_static("a=1; Path=/; Secure"),
+        );
         // Sanity: header present and creative rewrite works directly
-        let ct_pre = beresp
-            .get_header(header::CONTENT_TYPE)
-            .and_then(|h| h.to_str().ok())
+        let ct_pre = response_header(&beresp, header::CONTENT_TYPE)
             .unwrap_or("")
             .to_string();
         assert!(ct_pre.contains("text/html"), "ct_pre={}", ct_pre);
         let direct = creative::rewrite_creative_html(&settings, html);
         assert!(direct.contains("/first-party/proxy?tsurl="), "{}", direct);
-        let req = Request::new(Method::GET, "https://edge.example/first-party/proxy");
+        let req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
         let out = finalize(&settings, &req, "https://cdn.example/a.png", beresp)
             .expect("finalize should succeed");
-        let ct = out
-            .get_header(header::CONTENT_TYPE)
+        let ct = response_header(&out, header::CONTENT_TYPE)
             .expect("Content-Type header should be present")
-            .to_str()
-            .expect("Content-Type should be valid UTF-8");
+            .to_string();
         assert_eq!(ct, "text/html; charset=utf-8");
-        let cc = out
-            .get_header(header::CACHE_CONTROL)
-            .and_then(|h| h.to_str().ok())
-            .unwrap_or("");
+        let cc = response_header(&out, header::CACHE_CONTROL)
+            .unwrap_or("")
+            .to_string();
         assert_eq!(cc, "public, max-age=60");
-        let cookie = out
-            .get_header(header::SET_COOKIE)
-            .and_then(|h| h.to_str().ok())
-            .unwrap_or("");
+        let cookie = response_header(&out, header::SET_COOKIE)
+            .unwrap_or("")
+            .to_string();
         assert!(cookie.contains("a=1"));
     }
 
@@ -2442,19 +2552,18 @@ mod tests {
     fn css_response_is_rewritten_and_content_type_set() {
         let settings = create_test_settings();
         let css = "body{background:url(https://cdn.example/bg.png)}";
-        let beresp = Response::from_status(StatusCode::OK)
-            .with_header(header::CONTENT_TYPE, "text/css")
-            .with_body(css);
-        let req = Request::new(Method::GET, "https://edge.example/first-party/proxy");
-        let mut out = finalize(&settings, &req, "https://cdn.example/bg.png", beresp)
+        let mut beresp = build_http_response(StatusCode::OK, EdgeBody::from(css));
+        beresp
+            .headers_mut()
+            .insert(header::CONTENT_TYPE, HeaderValue::from_static("text/css"));
+        let req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
+        let out = finalize(&settings, &req, "https://cdn.example/bg.png", beresp)
             .expect("finalize should succeed");
-        let body = out.take_body_str();
-        assert!(body.contains("/first-party/proxy?tsurl="), "{}", body);
-        let ct = out
-            .get_header(header::CONTENT_TYPE)
+        let ct = response_header(&out, header::CONTENT_TYPE)
             .expect("Content-Type header should be present")
-            .to_str()
-            .expect("Content-Type should be valid UTF-8");
+            .to_string();
+        let body = response_body_string(out);
+        assert!(body.contains("/first-party/proxy?tsurl="), "{}", body);
         assert_eq!(ct, "text/css; charset=utf-8");
     }
 
@@ -2474,12 +2583,14 @@ mod tests {
   </body>
 </html>"#;
 
-        let beresp = Response::from_status(StatusCode::OK)
-            .with_header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-            .with_body(html);
+        let mut beresp = build_http_response(StatusCode::OK, EdgeBody::from(html));
+        beresp.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+        );
 
-        let req = Request::new(Method::GET, "https://edge.example/first-party/proxy");
-        let mut out = finalize(
+        let req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
+        let out = finalize(
             &settings,
             &req,
             "https://cdn.example.com:9443/creatives/300x250.html",
@@ -2487,7 +2598,7 @@ mod tests {
         )
         .expect("should finalize HTML response with non-standard port URL");
 
-        let body = out.take_body_str();
+        let body = response_body_string(out);
 
         // Port 9443 should be preserved (URL-encoded as %3A9443)
         assert!(
@@ -2500,38 +2611,36 @@ mod tests {
     #[test]
     fn image_accept_sets_generic_content_type_when_missing() {
         let settings = create_test_settings();
-        let beresp = Response::from_status(StatusCode::OK).with_body("PNG");
-        let mut req = Request::new(Method::GET, "https://edge.example/first-party/proxy");
-        req.set_header(HEADER_ACCEPT, "image/*");
+        let beresp = build_http_response(StatusCode::OK, EdgeBody::from("PNG"));
+        let mut req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
+        req.headers_mut()
+            .insert(HEADER_ACCEPT, HeaderValue::from_static("image/*"));
         let out = finalize(&settings, &req, "https://cdn.example/pixel.gif", beresp)
             .expect("finalize should succeed");
         // Since CT was missing and Accept indicates image, it should set generic image/*
-        let ct = out
-            .get_header(header::CONTENT_TYPE)
-            .expect("Content-Type header should be present")
-            .to_str()
-            .expect("Content-Type should be valid UTF-8");
+        let ct = response_header(&out, header::CONTENT_TYPE)
+            .expect("Content-Type header should be present");
         assert_eq!(ct, "image/*");
     }
 
     #[test]
     fn non_image_non_html_passthrough() {
         let settings = create_test_settings();
-        let beresp = Response::from_status(StatusCode::ACCEPTED)
-            .with_header(header::CONTENT_TYPE, "application/json")
-            .with_body("{\"ok\":true}");
-        let req = Request::new(Method::GET, "https://edge.example/first-party/proxy");
-        let mut out = finalize(&settings, &req, "https://api.example/ok", beresp)
+        let mut beresp = build_http_response(StatusCode::ACCEPTED, EdgeBody::from("{\"ok\":true}"));
+        beresp.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        let req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
+        let out = finalize(&settings, &req, "https://api.example/ok", beresp)
             .expect("finalize should succeed");
         // Should not rewrite, preserve status and content-type
-        assert_eq!(out.get_status(), StatusCode::ACCEPTED);
-        let ct = out
-            .get_header(header::CONTENT_TYPE)
+        assert_eq!(out.status(), StatusCode::ACCEPTED);
+        let ct = response_header(&out, header::CONTENT_TYPE)
             .expect("Content-Type header should be present")
-            .to_str()
-            .expect("Content-Type should be valid UTF-8");
+            .to_string();
         assert_eq!(ct, "application/json");
-        let body = out.take_body_str();
+        let body = response_body_string(out);
         assert_eq!(body, "{\"ok\":true}");
     }
 
@@ -2552,28 +2661,28 @@ mod tests {
             .expect("gzip write should succeed");
         let compressed = encoder.finish().expect("gzip finish should succeed");
 
-        let beresp = Response::from_status(StatusCode::OK)
-            .with_header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-            .with_header(header::CONTENT_ENCODING, "gzip")
-            .with_body(compressed);
+        let mut beresp = build_http_response(StatusCode::OK, EdgeBody::from(compressed));
+        beresp.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+        );
+        beresp
+            .headers_mut()
+            .insert(header::CONTENT_ENCODING, HeaderValue::from_static("gzip"));
 
-        let req = Request::new(Method::GET, "https://edge.example/first-party/proxy");
+        let req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
         let out = finalize(&settings, &req, "https://cdn.example/a.png", beresp)
             .expect("finalize should process and succeed");
 
         // Content-Encoding should be preserved (gzip in -> gzip out)
-        let ce = out
-            .get_header(header::CONTENT_ENCODING)
+        let ce = response_header(&out, header::CONTENT_ENCODING)
             .expect("Content-Encoding should be preserved")
-            .to_str()
-            .expect("Content-Encoding should be valid UTF-8");
+            .to_string();
         assert_eq!(ce, "gzip");
 
-        let ct = out
-            .get_header(header::CONTENT_TYPE)
+        let ct = response_header(&out, header::CONTENT_TYPE)
             .expect("Content-Type header should be present")
-            .to_str()
-            .expect("Content-Type should be valid UTF-8");
+            .to_string();
         assert_eq!(ct, "text/html; charset=utf-8");
 
         // Decompress output to verify content was rewritten
@@ -2609,28 +2718,27 @@ mod tests {
                 .expect("brotli write should succeed");
         }
 
-        let beresp = Response::from_status(StatusCode::OK)
-            .with_header(header::CONTENT_TYPE, "text/css")
-            .with_header(header::CONTENT_ENCODING, "br")
-            .with_body(compressed);
+        let mut beresp = build_http_response(StatusCode::OK, EdgeBody::from(compressed));
+        beresp
+            .headers_mut()
+            .insert(header::CONTENT_TYPE, HeaderValue::from_static("text/css"));
+        beresp
+            .headers_mut()
+            .insert(header::CONTENT_ENCODING, HeaderValue::from_static("br"));
 
-        let req = Request::new(Method::GET, "https://edge.example/first-party/proxy");
+        let req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
         let out = finalize(&settings, &req, "https://cdn.example/bg.png", beresp)
             .expect("finalize should process brotli and succeed");
 
         // Content-Encoding should be preserved (br in -> br out)
-        let ce = out
-            .get_header(header::CONTENT_ENCODING)
+        let ce = response_header(&out, header::CONTENT_ENCODING)
             .expect("Content-Encoding should be preserved")
-            .to_str()
-            .expect("Content-Encoding should be valid UTF-8");
+            .to_string();
         assert_eq!(ce, "br");
 
-        let ct = out
-            .get_header(header::CONTENT_TYPE)
+        let ct = response_header(&out, header::CONTENT_TYPE)
             .expect("Content-Type header should be present")
-            .to_str()
-            .expect("Content-Type should be valid UTF-8");
+            .to_string();
         assert_eq!(ct, "text/css; charset=utf-8");
 
         // Decompress output to verify content was rewritten
@@ -2649,70 +2757,32 @@ mod tests {
     }
 
     #[test]
-    fn rebuild_response_with_body_preserves_multiple_set_cookie_headers() {
-        let mut beresp = Response::from_status(StatusCode::OK);
-        beresp.append_header(header::SET_COOKIE, "first=1; Path=/; HttpOnly");
-        beresp.append_header(header::SET_COOKIE, "second=2; Path=/; Secure");
-        beresp.set_header(header::CONTENT_TYPE, "text/plain");
-        beresp.set_header(header::CONTENT_LENGTH, "999");
-
-        let rebuilt = rebuild_response_with_body(
-            &beresp,
-            "text/html; charset=utf-8",
-            b"rewritten".to_vec(),
-            false,
-        );
-
-        let set_cookie_values: Vec<&str> = rebuilt
-            .get_headers()
-            .filter(|(name, _)| *name == header::SET_COOKIE)
-            .map(|(_, value)| value.to_str().expect("should be valid Set-Cookie"))
-            .collect();
-        assert_eq!(
-            set_cookie_values,
-            vec!["first=1; Path=/; HttpOnly", "second=2; Path=/; Secure"],
-            "should preserve multiple Set-Cookie headers"
-        );
-        assert_eq!(
-            rebuilt
-                .get_header(header::CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok()),
-            Some("text/html; charset=utf-8"),
-            "should set rewritten Content-Type"
-        );
-        assert!(
-            rebuilt.get_header(header::CONTENT_LENGTH).is_none(),
-            "should not preserve stale Content-Length"
-        );
-    }
-
-    #[test]
     fn html_uncompressed_response_is_processed_without_encoding() {
         let settings = create_test_settings();
         let html = r#"<html><body><img src="https://cdn.example/a.png"></body></html>"#;
 
-        let beresp = Response::from_status(StatusCode::OK)
-            .with_header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-            .with_body(html);
+        let mut beresp = build_http_response(StatusCode::OK, EdgeBody::from(html));
+        beresp.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+        );
 
-        let req = Request::new(Method::GET, "https://edge.example/first-party/proxy");
-        let mut out = finalize(&settings, &req, "https://cdn.example/a.png", beresp)
+        let req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
+        let out = finalize(&settings, &req, "https://cdn.example/a.png", beresp)
             .expect("finalize should succeed");
 
         // No Content-Encoding since input was uncompressed
         assert!(
-            out.get_header(header::CONTENT_ENCODING).is_none(),
+            response_header(&out, header::CONTENT_ENCODING).is_none(),
             "Content-Encoding should not be set for uncompressed input"
         );
 
-        let ct = out
-            .get_header(header::CONTENT_TYPE)
+        let ct = response_header(&out, header::CONTENT_TYPE)
             .expect("Content-Type header should be present")
-            .to_str()
-            .expect("Content-Type should be valid UTF-8");
+            .to_string();
         assert_eq!(ct, "text/html; charset=utf-8");
 
-        let body = out.take_body_str();
+        let body = response_body_string(out);
         assert!(
             body.contains("/first-party/proxy?tsurl="),
             "HTML should be rewritten: {}",
@@ -2732,7 +2802,7 @@ mod tests {
             Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
         );
         let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://example.com/");
+        let req = build_http_request(Method::GET, "https://example.com/");
 
         let result = proxy_request(
             &settings,
@@ -2770,10 +2840,19 @@ mod tests {
             Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
         );
         let settings = create_test_settings();
-        let mut req = Request::new(Method::GET, "https://example.com/");
-        req.set_header(header::USER_AGENT, "test-agent/1.0");
-        req.set_header(header::ACCEPT, "text/html");
-        req.set_header(header::ACCEPT_LANGUAGE, "en-US");
+        let mut req = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .body(EdgeBody::empty())
+            .expect("should build test request");
+        req.headers_mut().insert(
+            header::USER_AGENT,
+            HeaderValue::from_static("test-agent/1.0"),
+        );
+        req.headers_mut()
+            .insert(header::ACCEPT, HeaderValue::from_static("text/html"));
+        req.headers_mut()
+            .insert(header::ACCEPT_LANGUAGE, HeaderValue::from_static("en-US"));
 
         let result = proxy_request(
             &settings,
@@ -2820,6 +2899,91 @@ mod tests {
             header_value("accept-encoding").as_deref(),
             Some(SUPPORTED_ENCODINGS),
             "should override Accept-Encoding with supported encodings"
+        );
+    }
+
+    #[tokio::test]
+    async fn proxy_request_passes_through_streaming_platform_response_body() {
+        // HTTP types can carry streaming bodies; proxy_request returns Ok even when
+        // the origin sends a streaming body (unlike the old Fastly path which required
+        // materialising the body before wrapping it in fastly::Response).
+        let services = build_services_with_http_client(
+            Arc::new(StreamingResponseHttpClient) as Arc<dyn PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let req = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .body(EdgeBody::empty())
+            .expect("should build test request");
+
+        let result = proxy_request(
+            &settings,
+            req,
+            ProxyRequestConfig {
+                target_url: "https://example.com/resource",
+                follow_redirects: false,
+                forward_ec_id: false,
+                body: None,
+                headers: Vec::new(),
+                copy_request_headers: false,
+                stream_passthrough: false,
+                allowed_domains: &[],
+            },
+            &services,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "should pass streaming body through with HTTP types: {result:?}"
+        );
+        assert_eq!(
+            result.expect("should succeed").status(),
+            StatusCode::OK,
+            "should preserve the origin status code"
+        );
+    }
+
+    #[test]
+    fn rebuild_response_with_body_preserves_multiple_set_cookie_headers() {
+        let mut beresp = Response::new(EdgeBody::empty());
+        *beresp.status_mut() = StatusCode::OK;
+        beresp.headers_mut().append(
+            header::SET_COOKIE,
+            HeaderValue::from_static("a=1; Path=/; Secure"),
+        );
+        beresp.headers_mut().append(
+            header::SET_COOKIE,
+            HeaderValue::from_static("b=2; Path=/; Secure"),
+        );
+
+        let rebuilt = rebuild_response_with_body(
+            beresp,
+            "text/html; charset=utf-8",
+            b"rewritten".to_vec(),
+            false,
+        );
+
+        let cookies: Vec<String> = rebuilt
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .into_iter()
+            .map(|value| {
+                value
+                    .to_str()
+                    .expect("should preserve UTF-8 Set-Cookie header values")
+                    .to_string()
+            })
+            .collect();
+
+        assert_eq!(
+            cookies,
+            vec![
+                "a=1; Path=/; Secure".to_string(),
+                "b=2; Path=/; Secure".to_string(),
+            ],
+            "should preserve every Set-Cookie value when rebuilding the response"
         );
     }
 
@@ -2963,23 +3127,58 @@ mod tests {
             Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
         );
         let settings = create_test_settings();
-        let mut req = Request::new(
+        let mut req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/foo.jpg?auto=webp",
         );
-        req.set_header(header::USER_AGENT, "asset-agent/1.0");
-        req.set_header(header::ACCEPT, "image/avif,image/webp,image/*,*/*;q=0.8");
-        req.set_header(header::ACCEPT_ENCODING, "gzip, br");
-        req.set_header(header::ACCEPT_LANGUAGE, "en-US");
-        req.set_header(header::REFERER, "https://www.example.com/article");
-        req.set_header(header::IF_NONE_MATCH, "\"asset-etag\"");
-        req.set_header(header::IF_MODIFIED_SINCE, "Thu, 13 Mar 2025 08:00:00 GMT");
-        req.set_header(header::IF_MATCH, "\"asset-precondition\"");
-        req.set_header(header::IF_UNMODIFIED_SINCE, "Thu, 13 Mar 2025 09:00:00 GMT");
-        req.set_header(header::RANGE, "bytes=0-1023");
-        req.set_header(header::IF_RANGE, "\"asset-range\"");
-        req.set_header(HEADER_X_FORWARDED_FOR, "198.51.100.10");
-        req.set_header(header::HeaderName::from_static("x-custom-test"), "drop-me");
+        req.headers_mut().insert(
+            header::USER_AGENT,
+            HeaderValue::from_static("asset-agent/1.0"),
+        );
+        req.headers_mut().insert(
+            header::ACCEPT,
+            HeaderValue::from_static("image/avif,image/webp,image/*,*/*;q=0.8"),
+        );
+        req.headers_mut().insert(
+            header::ACCEPT_ENCODING,
+            HeaderValue::from_static("gzip, br"),
+        );
+        req.headers_mut()
+            .insert(header::ACCEPT_LANGUAGE, HeaderValue::from_static("en-US"));
+        req.headers_mut().insert(
+            header::REFERER,
+            HeaderValue::from_static("https://www.example.com/article"),
+        );
+        req.headers_mut().insert(
+            header::IF_NONE_MATCH,
+            HeaderValue::from_static("\"asset-etag\""),
+        );
+        req.headers_mut().insert(
+            header::IF_MODIFIED_SINCE,
+            HeaderValue::from_static("Thu, 13 Mar 2025 08:00:00 GMT"),
+        );
+        req.headers_mut().insert(
+            header::IF_MATCH,
+            HeaderValue::from_static("\"asset-precondition\""),
+        );
+        req.headers_mut().insert(
+            header::IF_UNMODIFIED_SINCE,
+            HeaderValue::from_static("Thu, 13 Mar 2025 09:00:00 GMT"),
+        );
+        req.headers_mut()
+            .insert(header::RANGE, HeaderValue::from_static("bytes=0-1023"));
+        req.headers_mut().insert(
+            header::IF_RANGE,
+            HeaderValue::from_static("\"asset-range\""),
+        );
+        req.headers_mut().insert(
+            HEADER_X_FORWARDED_FOR,
+            HeaderValue::from_static("198.51.100.10"),
+        );
+        req.headers_mut().insert(
+            header::HeaderName::from_static("x-custom-test"),
+            HeaderValue::from_static("drop-me"),
+        );
 
         let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com:8443");
         let response = handle_asset_proxy_request(&settings, &services, req, &route)
@@ -2987,7 +3186,7 @@ mod tests {
             .expect("should proxy asset request")
             .into_response()
             .expect("should return buffered asset response");
-        assert_eq!(response.get_status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let all_headers = stub.recorded_request_headers();
         assert_eq!(all_headers.len(), 1, "should have captured one request");
@@ -3072,7 +3271,7 @@ mod tests {
             Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
         );
         let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://www.example.com/.images/foo.jpg");
+        let req = build_http_request(Method::GET, "https://www.example.com/.images/foo.jpg");
 
         let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
         let response = handle_asset_proxy_request(&settings, &services, req, &route)
@@ -3082,21 +3281,22 @@ mod tests {
             .expect("should return buffered asset response");
 
         assert!(
-            response.get_header(header::SET_COOKIE).is_none(),
+            response.headers().get(header::SET_COOKIE).is_none(),
             "should strip upstream Set-Cookie headers from asset responses"
         );
         assert!(
             response
-                .get_header(header::STRICT_TRANSPORT_SECURITY)
+                .headers()
+                .get(header::STRICT_TRANSPORT_SECURITY)
                 .is_none(),
             "should strip upstream HSTS headers from asset responses"
         );
         assert!(
-            response.get_header("clear-site-data").is_none(),
+            response.headers().get("clear-site-data").is_none(),
             "should strip upstream Clear-Site-Data headers from asset responses"
         );
         assert_eq!(
-            response.get_header_str(header::ETAG),
+            response_header(&response, header::ETAG),
             Some("\"asset-etag\""),
             "should preserve safe cache validator headers on asset responses"
         );
@@ -3182,7 +3382,7 @@ mod tests {
             Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
         );
         let settings = create_test_settings();
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/foo.jpg?profile=medium&ar=1-1",
         );
@@ -3258,7 +3458,7 @@ mod tests {
         settings.image_optimizer = ImageOptimizerSettings {
             profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
         };
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/foo.jpg?profile=medium",
         );
@@ -3316,7 +3516,7 @@ mod tests {
         settings.image_optimizer = ImageOptimizerSettings {
             profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
         };
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/foo.jpg?profile=medium&ar=1-1&x=71&y=bad",
         );
@@ -3371,7 +3571,7 @@ mod tests {
         settings.image_optimizer = ImageOptimizerSettings {
             profile_sets: HashMap::from([("default_images".to_string(), profile_set)]),
         };
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/logo.SVG?profile=unknown&ar=1-1",
         );
@@ -3410,7 +3610,7 @@ mod tests {
         settings.image_optimizer = ImageOptimizerSettings {
             profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
         };
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.image/options/id/logo.svg?profile=medium",
         );
@@ -3449,19 +3649,19 @@ mod tests {
             Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
         );
         let settings = create_test_settings();
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/logo.svg?profile=medium",
         );
         let route = test_s3_image_optimizer_route();
 
-        let mut response = handle_asset_proxy_request(&settings, &services, req, &route)
+        let response = handle_asset_proxy_request(&settings, &services, req, &route)
             .await
             .expect("should proxy raw SVG asset through S3 route")
             .into_response()
             .expect("should return buffered asset response");
 
-        assert_eq!(response.take_body_str(), "raw-svg");
+        assert_eq!(response_body_string(response), "raw-svg");
         assert_eq!(
             stub.recorded_request_methods(),
             vec!["GET"],
@@ -3492,20 +3692,20 @@ mod tests {
         settings.image_optimizer = ImageOptimizerSettings {
             profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
         };
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/foo.jpg?profile=medium",
         );
         let route = test_s3_image_optimizer_route();
 
-        let mut response = handle_asset_proxy_request(&settings, &services, req, &route)
+        let response = handle_asset_proxy_request(&settings, &services, req, &route)
             .await
             .expect("should proxy optimized S3 asset request")
             .into_response()
             .expect("should return buffered asset response");
 
-        assert_eq!(response.get_status(), StatusCode::OK);
-        assert_eq!(response.take_body_str(), "optimized");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_body_string(response), "optimized");
         assert_eq!(
             stub.recorded_request_methods(),
             vec!["HEAD", "GET"],
@@ -3557,7 +3757,7 @@ mod tests {
         settings.image_optimizer = ImageOptimizerSettings {
             profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
         };
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/missing.jpg?profile=medium",
         );
@@ -3571,21 +3771,21 @@ mod tests {
             AssetProxyCachePolicy::NoStorePrivate,
             "should carry a typed no-store policy for router finalization"
         );
-        let mut response = asset_response
+        let response = asset_response
             .into_response()
             .expect("should return buffered asset response");
 
-        assert_eq!(response.get_status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert_eq!(
-            response.get_header_str(header::CACHE_CONTROL),
+            response_header(&response, header::CACHE_CONTROL),
             Some("no-store, private"),
             "S3 origin errors should not be cached"
         );
         assert!(
-            response.get_header(header::SET_COOKIE).is_none(),
+            response.headers().get(header::SET_COOKIE).is_none(),
             "raw S3 error should still strip unsafe response headers"
         );
-        let body = response.take_body_str();
+        let body = response_body_string(response);
         assert!(body.contains("NoSuchKey"), "should return S3 error body");
         assert!(
             body.contains("image/upload/missing.jpg"),
@@ -3621,19 +3821,19 @@ mod tests {
         settings.image_optimizer = ImageOptimizerSettings {
             profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
         };
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/foo.jpg?profile=medium&_io_debug=1",
         );
         let route = test_s3_image_optimizer_route();
 
-        let mut response = handle_asset_proxy_request(&settings, &services, req, &route)
+        let response = handle_asset_proxy_request(&settings, &services, req, &route)
             .await
             .expect("should proxy debug S3 asset request")
             .into_response()
             .expect("should return buffered asset response");
 
-        assert_eq!(response.take_body_str(), "raw");
+        assert_eq!(response_body_string(response), "raw");
         assert_eq!(
             stub.recorded_request_methods(),
             vec!["GET"],
@@ -3662,7 +3862,7 @@ mod tests {
         settings.image_optimizer = ImageOptimizerSettings {
             profile_sets: HashMap::from([("default_images".to_string(), test_profile_set())]),
         };
-        let req = Request::new(
+        let req = build_http_request(
             Method::GET,
             "https://www.example.com/.images/foo.jpg?profile=medium&_io_debug=1",
         );
@@ -3691,30 +3891,31 @@ mod tests {
             Arc::new(StreamingResponseHttpClient) as Arc<dyn PlatformHttpClient>
         );
         let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://www.example.com/.images/foo.jpg");
+        let req = build_http_request(Method::GET, "https://www.example.com/.images/foo.jpg");
         let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
 
         let (response, stream_body) = handle_asset_proxy_request(&settings, &services, req, &route)
             .await
             .expect("should proxy a streaming asset response")
             .into_response_and_body();
-        assert_eq!(response.get_status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
         assert!(
-            response.get_header(header::SET_COOKIE).is_none(),
+            response.headers().get(header::SET_COOKIE).is_none(),
             "should strip upstream Set-Cookie headers from streaming asset responses"
         );
         assert!(
             response
-                .get_header(header::STRICT_TRANSPORT_SECURITY)
+                .headers()
+                .get(header::STRICT_TRANSPORT_SECURITY)
                 .is_none(),
             "should strip upstream HSTS headers from streaming asset responses"
         );
         assert!(
-            response.get_header("clear-site-data").is_none(),
+            response.headers().get("clear-site-data").is_none(),
             "should strip upstream Clear-Site-Data headers from streaming asset responses"
         );
         assert_eq!(
-            response.get_header_str(header::ETAG),
+            response_header(&response, header::ETAG),
             Some("\"stream-etag\""),
             "should preserve safe cache validator headers on streaming asset responses"
         );
@@ -3758,7 +3959,7 @@ mod tests {
             Arc::new(StreamingResponseHttpClient) as Arc<dyn PlatformHttpClient>
         );
         let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://www.example.com/.images/foo.jpg");
+        let req = build_http_request(Method::GET, "https://www.example.com/.images/foo.jpg");
         let route = ProxyAssetRoute::new("/.images/", "https://assets.example.com");
         let asset_response = handle_asset_proxy_request(&settings, &services, req, &route)
             .await
@@ -3770,43 +3971,6 @@ mod tests {
         assert!(
             format!("{err:?}").contains("streaming asset response cannot be converted"),
             "should describe the buffered conversion failure: {err:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn proxy_request_returns_error_for_streaming_platform_response_body() {
-        let services = build_services_with_http_client(
-            Arc::new(StreamingResponseHttpClient) as Arc<dyn PlatformHttpClient>
-        );
-        let settings = create_test_settings();
-        let req = Request::new(Method::GET, "https://example.com/");
-
-        let err = proxy_request(
-            &settings,
-            req,
-            ProxyRequestConfig {
-                target_url: "https://example.com/resource",
-                follow_redirects: false,
-                forward_ec_id: false,
-                body: None,
-                headers: Vec::new(),
-                copy_request_headers: false,
-                stream_passthrough: false,
-                allowed_domains: &[],
-            },
-            &services,
-        )
-        .await
-        .expect_err("should reject streaming platform responses");
-
-        assert_eq!(
-            err.current_context().status_code(),
-            StatusCode::BAD_GATEWAY,
-            "should surface a proxy failure instead of truncating the body"
-        );
-        assert!(
-            format!("{err:?}").contains("streaming platform response body"),
-            "should describe the unsupported streaming body: {err:?}"
         );
     }
 
@@ -4046,8 +4210,9 @@ mod tests {
             urlencoding::encode(target),
             token,
         );
-        let req = Request::new(Method::GET, url);
-        let err = handle_first_party_proxy(&settings, &noop_services(), req)
+        let req = build_http_request(Method::GET, url);
+        let services = crate::platform::test_support::noop_services();
+        let err = handle_first_party_proxy(&settings, &services, req)
             .await
             .expect_err("should block initial target not in allowlist");
         assert_eq!(
@@ -4061,6 +4226,46 @@ mod tests {
                 TrustedServerError::AllowlistViolation { .. }
             ),
             "should be AllowlistViolation error"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_rejects_oversized_body() {
+        let settings = create_test_settings();
+        let oversized = vec![b'x'; 65537];
+        let req = HttpRequest::builder()
+            .method(Method::POST)
+            .uri("https://edge.example/first-party/sign")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(EdgeBody::from(oversized))
+            .expect("should build request");
+        let err = handle_first_party_proxy_sign(&settings, &noop_services(), req)
+            .await
+            .expect_err("should reject oversized body");
+        assert_eq!(
+            err.current_context().status_code(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "should return 413 for oversized sign body"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_rejects_oversized_body() {
+        let settings = create_test_settings();
+        let oversized = vec![b'x'; 65537];
+        let req = HttpRequest::builder()
+            .method(Method::POST)
+            .uri("https://edge.example/first-party/proxy-rebuild")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(EdgeBody::from(oversized))
+            .expect("should build request");
+        let err = handle_first_party_proxy_rebuild(&settings, &noop_services(), req)
+            .await
+            .expect_err("should reject oversized body");
+        assert_eq!(
+            err.current_context().status_code(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "should return 413 for oversized rebuild body"
         );
     }
 }

--- a/crates/trusted-server-core/src/proxy.rs
+++ b/crates/trusted-server-core/src/proxy.rs
@@ -31,6 +31,9 @@ use crate::streaming_processor::{Compression, PipelineConfig, StreamProcessor, S
 /// Chunk size used for streaming content through the rewrite pipeline.
 const STREAMING_CHUNK_SIZE: usize = 8192;
 
+/// Fallback `Content-Type` for image-like responses missing an origin type.
+const IMAGE_FALLBACK_CONTENT_TYPE: &str = "application/octet-stream";
+
 const SIGN_MAX_BODY_BYTES: usize = 65536;
 const REBUILD_MAX_BODY_BYTES: usize = 65536;
 
@@ -265,6 +268,7 @@ pub async fn stream_asset_body<W: Write>(
 
     Ok(())
 }
+
 #[derive(Deserialize)]
 struct ProxySignReq {
     url: String,
@@ -483,7 +487,7 @@ fn finalize_proxied_response(
         );
     }
 
-    // Image handling: set generic content-type if missing and log pixel heuristics
+    // Image handling: set a valid fallback content type if missing and log pixel heuristics
     let req_accept_images = req
         .headers()
         .get(HEADER_ACCEPT)
@@ -493,9 +497,10 @@ fn finalize_proxied_response(
 
     if ct.starts_with("image/") || req_accept_images {
         if beresp.headers().get(header::CONTENT_TYPE).is_none() {
-            beresp
-                .headers_mut()
-                .insert(header::CONTENT_TYPE, HeaderValue::from_static("image/*"));
+            beresp.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(IMAGE_FALLBACK_CONTENT_TYPE),
+            );
         }
 
         // Heuristics to log likely tracking pixels without altering response
@@ -579,9 +584,10 @@ fn finalize_proxied_response_streaming(
 
     if ct.starts_with("image/") || req_accept_images {
         if beresp.headers().get(header::CONTENT_TYPE).is_none() {
-            beresp
-                .headers_mut()
-                .insert(header::CONTENT_TYPE, HeaderValue::from_static("image/*"));
+            beresp.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(IMAGE_FALLBACK_CONTENT_TYPE),
+            );
         }
 
         let mut is_pixel = false;
@@ -1383,9 +1389,9 @@ async fn proxy_with_redirects(
 /// - Proxies the decoded URL via a dynamic backend derived from scheme/host/port.
 /// - If the response `Content-Type` contains `text/html`, rewrites the HTML creative
 ///   (img/srcset/iframe to first-party) before returning `text/html; charset=utf-8`.
-/// - If the response is an image or the request `Accept` indicates images, ensures a
-///   generic `image/*` content type if origin omitted it, and logs likely 1×1 pixels
-///   using simple size/URL heuristics. No special response (still proxied).
+/// - If the response is an image or the request `Accept` indicates images, ensures an
+///   `application/octet-stream` content type if origin omitted it, and logs likely 1×1
+///   pixels using simple size/URL heuristics. No special response (still proxied).
 ///
 /// # Errors
 ///
@@ -1919,7 +1925,8 @@ mod tests {
         handle_first_party_proxy, handle_first_party_proxy_rebuild, handle_first_party_proxy_sign,
         is_host_allowed, proxy_request, rebuild_response_with_body,
         reconstruct_and_validate_signed_target, redirect_is_permitted, stream_asset_body,
-        AssetProxyCachePolicy, ProxyRequestConfig, SUPPORTED_ENCODINGS,
+        AssetProxyCachePolicy, ProxyRequestConfig, IMAGE_FALLBACK_CONTENT_TYPE,
+        SUPPORTED_ENCODINGS,
     };
     use crate::constants::{HEADER_ACCEPT, HEADER_X_FORWARDED_FOR};
     use crate::creative;
@@ -2503,8 +2510,9 @@ mod tests {
 
     // --- Finalization path tests (no network) ---
 
-    // Access the finalize function within the crate for testing
+    // Access the finalize helpers within the crate for testing
     use super::finalize_proxied_response as finalize;
+    use super::finalize_proxied_response_streaming as finalize_streaming;
 
     #[test]
     fn html_response_is_rewritten_and_content_type_set() {
@@ -2609,7 +2617,7 @@ mod tests {
     }
 
     #[test]
-    fn image_accept_sets_generic_content_type_when_missing() {
+    fn image_accept_sets_fallback_content_type_when_missing() {
         let settings = create_test_settings();
         let beresp = build_http_response(StatusCode::OK, EdgeBody::from("PNG"));
         let mut req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
@@ -2617,10 +2625,24 @@ mod tests {
             .insert(HEADER_ACCEPT, HeaderValue::from_static("image/*"));
         let out = finalize(&settings, &req, "https://cdn.example/pixel.gif", beresp)
             .expect("finalize should succeed");
-        // Since CT was missing and Accept indicates image, it should set generic image/*
+        // Since CT was missing and Accept indicates image, it should set a valid fallback.
         let ct = response_header(&out, header::CONTENT_TYPE)
-            .expect("Content-Type header should be present");
-        assert_eq!(ct, "image/*");
+            .expect("should include Content-Type header");
+        assert_eq!(ct, IMAGE_FALLBACK_CONTENT_TYPE);
+    }
+
+    #[test]
+    fn streaming_image_accept_sets_fallback_content_type_when_missing() {
+        let beresp = build_http_response(StatusCode::OK, EdgeBody::from("GIF"));
+        let mut req = build_http_request(Method::GET, "https://edge.example/first-party/proxy");
+        req.headers_mut()
+            .insert(HEADER_ACCEPT, HeaderValue::from_static("image/*"));
+
+        let out = finalize_streaming(&req, "https://cdn.example/pixel.gif", beresp);
+        let ct = response_header(&out, header::CONTENT_TYPE)
+            .expect("should include Content-Type header");
+
+        assert_eq!(ct, IMAGE_FALLBACK_CONTENT_TYPE);
     }
 
     #[test]

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -10,6 +10,17 @@
 //! Unsupported `Content-Encoding` values must bypass rewriting entirely. The
 //! streaming processor treats unknown encodings as identity, so publisher code
 //! must gate them out before the body enters the rewrite pipeline.
+//!
+//! **Note on platform coupling:** This module is currently coupled to
+//! `fastly::Body`/`Request`/`Response` at its handler boundaries — the entry
+//! points ([`handle_publisher_request`], [`stream_publisher_body`]) still
+//! accept and return `fastly::Body` and `fastly::Response`. The streaming
+//! processor itself is generic: `process_response_streaming` writes into
+//! any [`Write`] (a `Vec<u8>` for buffered routes, a `StreamingBody` for the
+//! streaming route). The HTTP-type coupling will be addressed in the
+//! platform HTTP-type migration alongside all other
+//! `fastly::Request`/`Response`/`Body` migrations. It is not a
+//! content-rewriting concern.
 
 use std::io::Write;
 
@@ -206,15 +217,12 @@ fn process_response_streaming<W: Write>(
 ) -> Result<(), Report<TrustedServerError>> {
     let is_html = params.content_type.contains("text/html");
     let is_rsc_flight = params.content_type.contains("text/x-component");
-    // lgtm[rust/cleartext-logging]
-    // This debug log records content-shape metadata and hostnames only; no secrets are logged.
     log::debug!(
-        "process_response_streaming: content_type={}, content_encoding={}, is_html={}, is_rsc_flight={}, origin_host={}",
+        "process_response_streaming: content_type={}, content_encoding={}, is_html={}, is_rsc_flight={}",
         params.content_type,
         params.content_encoding,
         is_html,
-        is_rsc_flight,
-        params.origin_host
+        is_rsc_flight
     );
 
     let compression = Compression::from_content_encoding(params.content_encoding);
@@ -438,12 +446,9 @@ pub fn handle_publisher_request(
     let request_scheme = &request_info.scheme;
 
     log::debug!(
-        "Request info: host={}, scheme={} (X-Forwarded-Host: {:?}, Host: {:?}, X-Forwarded-Proto: {:?})",
-        request_host,
-        request_scheme,
-        req.get_header("x-forwarded-host"),
-        req.get_header(header::HOST),
-        req.get_header("x-forwarded-proto"),
+        "Request info extracted: has_host={}, scheme={}",
+        !request_host.is_empty(),
+        request_scheme
     );
 
     // Generate a new EC ID only for document navigations. Subresource
@@ -455,34 +460,27 @@ pub fn handle_publisher_request(
             log::warn!("EC generation failed: {err:?}");
         }
     } else {
-        log::debug!(
-            "EC generation skipped: non-document request (path={})",
-            req.get_path(),
-        );
+        log::debug!("EC generation skipped: non-document request");
     }
 
     let ec_allowed = ec_context.ec_allowed();
     log::debug!(
-        "Proxy EC ID: {:?}, ec_allowed: {ec_allowed}",
-        ec_context.ec_value(),
+        "Proxy EC state: has_ec_id={}, ec_allowed={ec_allowed}",
+        ec_context.ec_value().is_some(),
     );
 
-    let backend_name = BackendConfig::from_url(
+    let backend_name = BackendConfig::from_url_with_host_header_override(
         &settings.publisher.origin_url,
         settings.proxy.certificate_check,
+        settings.publisher.origin_host_header_override.as_deref(),
     )?;
     let origin_host = settings.publisher.origin_host();
+    let origin_host_header = settings.publisher.origin_host_header();
 
-    // lgtm[rust/cleartext-logging]
-    // This debug log records backend routing metadata only; `Settings` secrets remain redacted.
-    log::debug!(
-        "Proxying to dynamic backend: {} (from {})",
-        backend_name,
-        settings.publisher.origin_url
-    );
+    log::debug!("Proxying request to configured publisher backend");
     // Only advertise encodings the rewrite pipeline can decode and re-encode.
     restrict_accept_encoding(&mut req);
-    req.set_header("host", &origin_host);
+    req.set_header("host", &origin_host_header);
 
     let mut response = req
         .send(&backend_name)
@@ -490,10 +488,11 @@ pub fn handle_publisher_request(
             message: "Failed to proxy request to origin".to_string(),
         })?;
 
-    log::debug!("Response headers:");
-    for (name, value) in response.get_headers() {
-        log::debug!("  {}: {:?}", name, value);
-    }
+    log::debug!(
+        "Publisher origin response received: status={}, header_count={}",
+        response.get_status(),
+        response.get_headers().count()
+    );
 
     let content_type = response
         .get_header(header::CONTENT_TYPE)
@@ -537,15 +536,11 @@ pub fn handle_publisher_request(
                     status,
                 );
             } else if !is_supported_content_encoding(&content_encoding) {
-                log::warn!(
-                    "Unsupported Content-Encoding '{}' - returning response unmodified",
-                    content_encoding,
-                );
+                log::warn!("Unsupported Content-Encoding; returning response unmodified");
             } else {
                 log::debug!(
-                    "Skipping response processing - Content-Type: '{}', request_host: '{}', status: {}",
+                    "Skipping response processing - Content-Type: '{}', status: {}",
                     content_type,
-                    request_host,
                     status,
                 );
             }
@@ -553,11 +548,9 @@ pub fn handle_publisher_request(
         }
         ResponseRoute::Stream => {
             log::debug!(
-                "Streaming response - Content-Type: {}, Content-Encoding: {}, Request Host: {}, Origin Host: {}",
+                "Streaming response - Content-Type: {}, Content-Encoding: {}",
                 content_type,
-                content_encoding,
-                request_host,
-                origin_host,
+                content_encoding
             );
 
             let body = response.take_body();
@@ -578,11 +571,9 @@ pub fn handle_publisher_request(
         }
         ResponseRoute::BufferedProcessed => {
             log::debug!(
-                "Buffered response - Content-Type: {}, Content-Encoding: {}, Request Host: {}, Origin Host: {}",
+                "Buffered response - Content-Type: {}, Content-Encoding: {}",
                 content_type,
-                content_encoding,
-                request_host,
-                origin_host,
+                content_encoding
             );
 
             let body = response.take_body();

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -23,41 +23,52 @@
 //! content-rewriting concern.
 
 use std::io::Write;
+use std::time::Duration;
 
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::http::{header, StatusCode};
-use fastly::{Body, Request, Response};
+use http::{header, HeaderValue, Request, Response, StatusCode, Uri};
 
-use crate::backend::BackendConfig;
-use crate::compat;
 use crate::constants::HEADER_X_COMPRESS_HINT;
-use crate::ec::kv::KvIdentityGraph;
-use crate::ec::EcContext;
 use crate::error::TrustedServerError;
-use crate::http_util::{is_navigation_request, serve_static_with_etag, RequestInfo};
+use crate::http_util::{serve_static_with_etag, RequestInfo};
 use crate::integrations::IntegrationRegistry;
-use crate::platform::RuntimeServices;
+use crate::platform::{PlatformBackendSpec, PlatformHttpRequest, RuntimeServices};
 use crate::rsc_flight::RscFlightUrlRewriter;
 use crate::settings::Settings;
 use crate::streaming_processor::{Compression, PipelineConfig, StreamProcessor, StreamingPipeline};
 use crate::streaming_replacer::create_url_replacer;
 
 const SUPPORTED_ENCODING_VALUES: [&str; 3] = ["gzip", "deflate", "br"];
+const DEFAULT_PUBLISHER_FIRST_BYTE_TIMEOUT: Duration = Duration::from_secs(15);
 
-fn restrict_accept_encoding(req: &mut Request) {
+fn body_as_reader(body: EdgeBody) -> std::io::Cursor<bytes::Bytes> {
+    std::io::Cursor::new(body.into_bytes())
+}
+
+fn not_found_response() -> Response<EdgeBody> {
+    let mut response = Response::new(EdgeBody::from("Not Found"));
+    *response.status_mut() = StatusCode::NOT_FOUND;
+    response
+}
+
+fn restrict_accept_encoding(req: &mut Request<EdgeBody>) {
     // If the client sent no Accept-Encoding, leave the request unchanged so the
     // origin responds without compression. Adding encodings here would cause the
     // origin to compress its response even though the client never asked for it,
     // and the client would then receive content it cannot decode.
     let Some(current) = req
-        .get_header(header::ACCEPT_ENCODING)
+        .headers()
+        .get(header::ACCEPT_ENCODING)
         .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
     else {
         return;
     };
-    req.set_header(
+    req.headers_mut().insert(
         header::ACCEPT_ENCODING,
-        select_supported_accept_encoding(current),
+        HeaderValue::from_str(&select_supported_accept_encoding(&current))
+            .expect("supported accept-encoding should be a valid header value"),
     );
 }
 
@@ -130,27 +141,25 @@ fn accept_encoding_qvalue(header_value: &str, target: &str) -> Option<f32> {
 ///
 /// This function never returns an error; the Result type is for API consistency.
 pub fn handle_tsjs_dynamic(
-    req: &Request,
+    req: &Request<EdgeBody>,
     integration_registry: &IntegrationRegistry,
-) -> Result<Response, Report<TrustedServerError>> {
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     const PREFIX: &str = "/static/tsjs=";
     const UNIFIED_FILENAMES: &[&str] = &["tsjs-unified.js", "tsjs-unified.min.js"];
 
-    let path = req.get_path();
+    let path = req.uri().path();
     if !path.starts_with(PREFIX) {
-        return Ok(Response::from_status(StatusCode::NOT_FOUND).with_body("Not Found"));
+        return Ok(not_found_response());
     }
     let filename = &path[PREFIX.len()..];
-    let http_req = compat::from_fastly_headers_ref(req);
 
     if UNIFIED_FILENAMES.contains(&filename) {
         // Serve core + immediate modules (excludes deferred like prebid)
         let module_ids = integration_registry.js_module_ids_immediate();
         let body = trusted_server_js::concatenate_modules(&module_ids);
-        let http_resp =
-            serve_static_with_etag(&body, &http_req, "application/javascript; charset=utf-8");
-        let mut resp = compat::to_fastly_response(http_resp);
-        resp.set_header(HEADER_X_COMPRESS_HINT, "on");
+        let mut resp = serve_static_with_etag(&body, req, "application/javascript; charset=utf-8");
+        resp.headers_mut()
+            .insert(HEADER_X_COMPRESS_HINT, HeaderValue::from_static("on"));
         return Ok(resp);
     }
 
@@ -158,18 +167,18 @@ pub fn handle_tsjs_dynamic(
         // Only serve if the deferred module is actually enabled
         let deferred_ids = integration_registry.js_module_ids_deferred();
         if !deferred_ids.contains(&module_id) {
-            return Ok(Response::from_status(StatusCode::NOT_FOUND).with_body("Not Found"));
+            return Ok(not_found_response());
         }
         if let Some(content) = trusted_server_js::module_bundle(module_id) {
-            let http_resp =
-                serve_static_with_etag(content, &http_req, "application/javascript; charset=utf-8");
-            let mut resp = compat::to_fastly_response(http_resp);
-            resp.set_header(HEADER_X_COMPRESS_HINT, "on");
+            let mut resp =
+                serve_static_with_etag(content, req, "application/javascript; charset=utf-8");
+            resp.headers_mut()
+                .insert(HEADER_X_COMPRESS_HINT, HeaderValue::from_static("on"));
             return Ok(resp);
         }
     }
 
-    Ok(Response::from_status(StatusCode::NOT_FOUND).with_body("Not Found"))
+    Ok(not_found_response())
 }
 
 /// Extract a module ID from a deferred-module filename like `tsjs-prebid.min.js`.
@@ -211,7 +220,7 @@ struct ProcessResponseParams<'a> {
 ///
 /// Returns an error if processor creation or chunk processing fails.
 fn process_response_streaming<W: Write>(
-    body: Body,
+    body: EdgeBody,
     output: &mut W,
     params: &ProcessResponseParams,
 ) -> Result<(), Report<TrustedServerError>> {
@@ -240,7 +249,7 @@ fn process_response_streaming<W: Write>(
             params.settings,
             params.integration_registry,
         )?;
-        StreamingPipeline::new(config, processor).process(body, output)?;
+        StreamingPipeline::new(config, processor).process(body_as_reader(body), output)?;
     } else if is_rsc_flight {
         // RSC Flight responses are length-prefixed (T rows). A naive string replacement will
         // corrupt the stream by changing byte lengths without updating the prefixes.
@@ -250,7 +259,7 @@ fn process_response_streaming<W: Write>(
             params.request_host,
             params.request_scheme,
         );
-        StreamingPipeline::new(config, processor).process(body, output)?;
+        StreamingPipeline::new(config, processor).process(body_as_reader(body), output)?;
     } else {
         let replacer = create_url_replacer(
             params.origin_host,
@@ -258,7 +267,7 @@ fn process_response_streaming<W: Write>(
             params.request_host,
             params.request_scheme,
         );
-        StreamingPipeline::new(config, replacer).process(body, output)?;
+        StreamingPipeline::new(config, replacer).process(body_as_reader(body), output)?;
     }
 
     Ok(())
@@ -289,24 +298,46 @@ fn create_html_stream_processor(
 /// should be streamed or has already been buffered.
 pub enum PublisherResponse {
     /// Response is fully buffered and ready to send via `send_to_client()`.
-    Buffered(Response),
-    /// Response headers are ready for a streaming response. EC finalization is
-    /// header-only and must run before the adapter commits the headers.
+    Buffered(Response<EdgeBody>),
+    /// Response headers are ready for a streaming response. Covers processable
+    /// content on any status (2xx or non-2xx — e.g., branded 404/500 HTML and
+    /// error JSON still get URL rewriting) where the encoding is supported
+    /// and either the content is non-HTML or no HTML post-processors are
+    /// registered. The caller must:
+    /// 1. Call `finalize_response()` on the response
+    /// 2. Call `response.stream_to_client()` to get a `StreamingBody`
+    /// 3. Call `stream_publisher_body()` with the body and streaming writer
+    /// 4. Call `StreamingBody::finish()`
+    ///
+    /// **Interim (PR 15):** `body` has already been fully materialised into
+    /// WASM heap by the platform HTTP client.  `stream_publisher_body` reads
+    /// from an in-memory buffer, not a live origin stream.  The origin-side
+    /// peak is bounded by `MAX_PLATFORM_RESPONSE_BODY_BYTES`.
     Stream {
-        /// Response with all non-EC headers set but body not yet written.
-        response: Response,
+        /// Response with all headers set (EC ID, cookies, etc.)
+        /// but body not yet written. `Content-Length` already removed.
+        response: Response<EdgeBody>,
         /// Origin body to be piped through the streaming pipeline.
-        body: Body,
-        /// Parameters for [`process_response_streaming`].
+        body: EdgeBody,
+        /// Parameters for `process_response_streaming`.
         params: OwnedProcessResponseParams,
     },
-    /// Non-processable `2xx` response (images, fonts, video). The adapter must
-    /// reattach the body before sending it to the client.
+    /// Non-processable 2xx response (images, fonts, video). The adapter must
+    /// reattach the body via setting the body before returning.
+    /// `finalize_response()` and `send_to_client()` are applied at the outer
+    /// response-dispatch level, not in this arm.
+    ///
+    /// `Content-Length` is preserved — the body is unmodified.
+    ///
+    /// **Interim (PR 15):** `body` has been fully materialised into WASM heap.
+    /// Previously, binary assets streamed lazily from origin with no WASM
+    /// buffering.  This path is now bounded by `MAX_PLATFORM_RESPONSE_BODY_BYTES`;
+    /// assets exceeding that limit return an error instead of exhausting heap.
     PassThrough {
-        /// Response with headers set but body not yet written.
-        response: Response,
+        /// Response with all headers set but body not yet written.
+        response: Response<EdgeBody>,
         /// Origin body to stream directly to the client.
-        body: Body,
+        body: EdgeBody,
     },
 }
 
@@ -383,7 +414,9 @@ pub struct OwnedProcessResponseParams {
 /// Stream the publisher response body through the processing pipeline.
 ///
 /// Called by the adapter after `stream_to_client()` has committed the response
-/// headers. Writes processed chunks directly to `output`.
+/// headers. Runs synchronously against an already-materialised body; the async
+/// I/O happened upstream in [`handle_publisher_request`]. Writes processed
+/// chunks directly to `output`.
 ///
 /// # Errors
 ///
@@ -391,7 +424,7 @@ pub struct OwnedProcessResponseParams {
 /// committed, the caller should log the error and drop the `StreamingBody`
 /// (client sees a truncated response).
 pub fn stream_publisher_body<W: Write>(
-    body: Body,
+    body: EdgeBody,
     output: &mut W,
     params: &OwnedProcessResponseParams,
     settings: &Settings,
@@ -422,87 +455,106 @@ pub fn stream_publisher_body<W: Write>(
 ///
 /// # Errors
 ///
-/// Returns a [`TrustedServerError`] if:
-/// - The proxy request fails
-/// - The origin backend is unreachable
-pub fn handle_publisher_request(
+/// Returns a [`TrustedServerError`] if the proxy request fails or the
+/// origin backend is unreachable.
+pub async fn handle_publisher_request(
     settings: &Settings,
     integration_registry: &IntegrationRegistry,
     services: &RuntimeServices,
-    kv: Option<&KvIdentityGraph>,
-    ec_context: &mut EcContext,
-    mut req: Request,
+    mut req: Request<EdgeBody>,
 ) -> Result<PublisherResponse, Report<TrustedServerError>> {
     log::debug!("Proxying request to publisher_origin");
 
     // Prebid.js requests are not intercepted here anymore. The HTML processor removes
     // publisher-supplied Prebid scripts; the unified TSJS bundle includes Prebid.js when enabled.
 
-    let http_req = compat::from_fastly_headers_ref(&req);
-
     // Extract request host and scheme (uses Host header and TLS detection after edge sanitization)
-    let request_info = RequestInfo::from_request(&http_req, &services.client_info);
+    let request_info = RequestInfo::from_request(&req, services.client_info());
     let request_host = &request_info.host;
     let request_scheme = &request_info.scheme;
 
     log::debug!(
-        "Request info extracted: has_host={}, scheme={}",
-        !request_host.is_empty(),
-        request_scheme
+        "Request info: host={}, scheme={} (X-Forwarded-Host: {:?}, Host: {:?}, X-Forwarded-Proto: {:?})",
+        request_host,
+        request_scheme,
+        req.headers().get("x-forwarded-host"),
+        req.headers().get(header::HOST),
+        req.headers().get("x-forwarded-proto"),
     );
 
-    // Generate a new EC ID only for document navigations. Subresource
-    // requests (fonts, images, CSS) may lack consent signals such as the
-    // Sec-GPC header, so we skip generation to avoid setting identity
-    // cookies when the user's consent preference is unknown.
-    if is_navigation_request(&http_req) {
-        if let Err(err) = ec_context.generate_if_needed(settings, kv) {
-            log::warn!("EC generation failed: {err:?}");
-        }
-    } else {
-        log::debug!("EC generation skipped: non-document request");
-    }
-
-    let ec_allowed = ec_context.ec_allowed();
-    log::debug!(
-        "Proxy EC state: has_ec_id={}, ec_allowed={ec_allowed}",
-        ec_context.ec_value().is_some(),
-    );
-
-    let backend_name = BackendConfig::from_url_with_host_header_override(
-        &settings.publisher.origin_url,
-        settings.proxy.certificate_check,
-        settings.publisher.origin_host_header_override.as_deref(),
+    let parsed_origin = url::Url::parse(&settings.publisher.origin_url).change_context(
+        TrustedServerError::Proxy {
+            message: format!("Invalid origin_url: {}", settings.publisher.origin_url),
+        },
     )?;
+    let origin_scheme = parsed_origin.scheme().to_string();
+    let origin_host_without_port = parsed_origin.host_str().ok_or_else(|| {
+        Report::new(TrustedServerError::Proxy {
+            message: "Missing host in origin_url".to_string(),
+        })
+    })?;
+    let backend_name = services
+        .backend()
+        .ensure(&PlatformBackendSpec {
+            scheme: origin_scheme.clone(),
+            host: origin_host_without_port.to_string(),
+            port: parsed_origin.port(),
+            certificate_check: settings.proxy.certificate_check,
+            first_byte_timeout: DEFAULT_PUBLISHER_FIRST_BYTE_TIMEOUT,
+        })
+        .change_context(TrustedServerError::Proxy {
+            message: "backend registration failed".to_string(),
+        })?;
     let origin_host = settings.publisher.origin_host();
     let origin_host_header = settings.publisher.origin_host_header();
+    let origin_path_and_query = req
+        .uri()
+        .path_and_query()
+        .map(http::uri::PathAndQuery::as_str)
+        .unwrap_or("/");
+    let target_uri = format!("{origin_scheme}://{origin_host}{origin_path_and_query}")
+        .parse::<Uri>()
+        .change_context(TrustedServerError::Proxy {
+            message: "invalid publisher origin uri".to_string(),
+        })?;
 
     log::debug!("Proxying request to configured publisher backend");
     // Only advertise encodings the rewrite pipeline can decode and re-encode.
     restrict_accept_encoding(&mut req);
-    req.set_header("host", &origin_host_header);
+    *req.uri_mut() = target_uri;
+    req.headers_mut().insert(
+        header::HOST,
+        HeaderValue::from_str(&origin_host_header).change_context(TrustedServerError::Proxy {
+            message: "invalid publisher origin host header".to_string(),
+        })?,
+    );
 
-    let mut response = req
-        .send(&backend_name)
+    let mut response = services
+        .http_client()
+        .send(PlatformHttpRequest::new(req, backend_name))
+        .await
         .change_context(TrustedServerError::Proxy {
             message: "Failed to proxy request to origin".to_string(),
-        })?;
+        })?
+        .response;
 
     log::debug!(
         "Publisher origin response received: status={}, header_count={}",
-        response.get_status(),
-        response.get_headers().count()
+        response.status(),
+        response.headers().len()
     );
 
     let content_type = response
-        .get_header(header::CONTENT_TYPE)
+        .headers()
+        .get(header::CONTENT_TYPE)
         .map(|h| h.to_str().unwrap_or_default())
         .unwrap_or_default()
         .to_string();
 
-    let status = response.get_status();
+    let status = response.status();
     let content_encoding = response
-        .get_header(header::CONTENT_ENCODING)
+        .headers()
+        .get(header::CONTENT_ENCODING)
         .map(|h| h.to_str().unwrap_or_default())
         .unwrap_or_default()
         .to_lowercase();
@@ -523,7 +575,8 @@ pub fn handle_publisher_request(
                 content_type,
                 status,
             );
-            let body = response.take_body();
+            let (parts, body) = response.into_parts();
+            let response = Response::from_parts(parts, EdgeBody::empty());
             Ok(PublisherResponse::PassThrough { response, body })
         }
         ResponseRoute::BufferedUnmodified => {
@@ -553,8 +606,8 @@ pub fn handle_publisher_request(
                 content_encoding
             );
 
-            let body = response.take_body();
-            response.remove_header(header::CONTENT_LENGTH);
+            let body = std::mem::replace(response.body_mut(), EdgeBody::empty());
+            response.headers_mut().remove(header::CONTENT_LENGTH);
 
             Ok(PublisherResponse::Stream {
                 response,
@@ -576,7 +629,7 @@ pub fn handle_publisher_request(
                 content_encoding
             );
 
-            let body = response.take_body();
+            let body = std::mem::replace(response.body_mut(), EdgeBody::empty());
             let params = ProcessResponseParams {
                 content_encoding: &content_encoding,
                 origin_host: &origin_host,
@@ -590,8 +643,11 @@ pub fn handle_publisher_request(
             let mut output = Vec::new();
             process_response_streaming(body, &mut output, &params)?;
 
-            response.set_header(header::CONTENT_LENGTH, output.len().to_string());
-            response.set_body(Body::from(output));
+            response.headers_mut().insert(
+                header::CONTENT_LENGTH,
+                HeaderValue::from(output.len() as u64),
+            );
+            *response.body_mut() = EdgeBody::from(output);
 
             Ok(PublisherResponse::Buffered(response))
         }
@@ -619,64 +675,25 @@ fn is_supported_content_encoding(encoding: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Read as _, Write as _};
-
-    use brotli::enc::writer::CompressorWriter;
-    use brotli::Decompressor;
-    use flate2::read::GzDecoder;
-    use flate2::write::GzEncoder;
-
     use super::*;
     use crate::integrations::IntegrationRegistry;
+    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
     use crate::test_support::tests::create_test_settings;
-    use fastly::http::{header, Method, StatusCode};
+    use edgezero_core::body::Body as EdgeBody;
+    use http::{header, Method, Request as HttpRequest, StatusCode};
+    use std::sync::Arc;
 
-    fn gzip_encode(input: &[u8]) -> Vec<u8> {
-        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
-        encoder
-            .write_all(input)
-            .expect("should write gzip test input");
-        encoder.finish().expect("should finish gzip encoding")
+    fn build_request(method: Method, uri: &str) -> HttpRequest<EdgeBody> {
+        HttpRequest::builder()
+            .method(method)
+            .uri(uri)
+            .body(EdgeBody::empty())
+            .expect("should build test request")
     }
 
-    fn gzip_decode(input: &[u8]) -> Vec<u8> {
-        let mut decoder = GzDecoder::new(input);
-        let mut output = Vec::new();
-        decoder
-            .read_to_end(&mut output)
-            .expect("should decode gzip test output");
-        output
-    }
-
-    fn brotli_encode(input: &[u8]) -> Vec<u8> {
-        let mut encoder = CompressorWriter::new(Vec::new(), 4096, 5, 22);
-        encoder
-            .write_all(input)
-            .expect("should write brotli test input");
-        encoder.into_inner()
-    }
-
-    fn brotli_decode(input: &[u8]) -> Vec<u8> {
-        let mut decoder = Decompressor::new(input, 4096);
-        let mut output = Vec::new();
-        decoder
-            .read_to_end(&mut output)
-            .expect("should decode brotli test output");
-        output
-    }
-
-    fn make_stream_params(
-        settings: &Settings,
-        content_encoding: &str,
-    ) -> OwnedProcessResponseParams {
-        OwnedProcessResponseParams {
-            content_encoding: content_encoding.to_owned(),
-            origin_host: settings.publisher.origin_host(),
-            origin_url: settings.publisher.origin_url.clone(),
-            request_host: settings.publisher.domain.clone(),
-            request_scheme: "https".to_owned(),
-            content_type: "application/json".to_owned(),
-        }
+    fn response_body_string(response: http::Response<EdgeBody>) -> String {
+        String::from_utf8(response.into_body().into_bytes().to_vec())
+            .expect("response body should be valid UTF-8")
     }
 
     #[test]
@@ -981,22 +998,30 @@ mod tests {
     fn pass_through_preserves_body_and_content_length() {
         let image_bytes: Vec<u8> = (0..=255).cycle().take(4096).collect();
 
-        let mut response = Response::from_status(StatusCode::OK);
-        response.set_header("content-type", "image/png");
-        response.set_header("content-length", image_bytes.len().to_string());
-        response.set_body(Body::from(image_bytes.clone()));
+        let mut response = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "image/png")
+            .header(header::CONTENT_LENGTH, image_bytes.len() as u64)
+            .body(EdgeBody::from(image_bytes.clone()))
+            .expect("should build test response");
 
-        let body = response.take_body();
+        // Simulate PassThrough: take body then reattach
+        let body = std::mem::replace(response.body_mut(), EdgeBody::empty());
+        // Body is unmodified — Content-Length stays correct
         assert_eq!(
             response
-                .get_header_str("content-length")
+                .headers()
+                .get(header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
                 .expect("should have content-length"),
             "4096",
             "Content-Length should be preserved for pass-through"
         );
 
-        response.set_body(body);
-        let output = response.into_body().into_bytes();
+        // Reattach and verify body content
+        *response.body_mut() = body;
+        let (_, final_body) = response.into_parts();
+        let output = final_body.into_bytes();
         assert_eq!(
             output, image_bytes,
             "pass-through should preserve body byte-for-byte"
@@ -1008,15 +1033,23 @@ mod tests {
         let test_encodings = vec!["gzip", "deflate", "br", "identity", ""];
 
         for encoding in test_encodings {
-            let mut req = Request::new(Method::GET, "https://test.example.com/page");
-            req.set_header("accept-encoding", "gzip, deflate, br");
+            let mut req = build_request(Method::GET, "https://test.example.com/page");
+            req.headers_mut().insert(
+                header::ACCEPT_ENCODING,
+                http::HeaderValue::from_static("gzip, deflate, br"),
+            );
 
             if !encoding.is_empty() {
-                req.set_header("content-encoding", encoding);
+                req.headers_mut().insert(
+                    header::CONTENT_ENCODING,
+                    http::HeaderValue::from_str(encoding)
+                        .expect("content encoding should be valid"),
+                );
             }
 
             let content_encoding = req
-                .get_header("content-encoding")
+                .headers()
+                .get(header::CONTENT_ENCODING)
                 .map(|h| h.to_str().unwrap_or_default())
                 .unwrap_or_default();
 
@@ -1026,12 +1059,13 @@ mod tests {
 
     #[test]
     fn publisher_proxy_does_not_add_accept_encoding_when_absent() {
-        let mut req = Request::new(Method::GET, "https://test.example.com/page");
+        let mut req = build_request(Method::GET, "https://test.example.com/page");
+        // No Accept-Encoding header set by the client.
 
         restrict_accept_encoding(&mut req);
 
         assert_eq!(
-            req.get_header_str(header::ACCEPT_ENCODING),
+            req.headers().get(header::ACCEPT_ENCODING),
             None,
             "publisher proxy should not inject Accept-Encoding when the client sent none"
         );
@@ -1039,13 +1073,18 @@ mod tests {
 
     #[test]
     fn publisher_proxy_limits_accept_encoding_to_supported_values() {
-        let mut req = Request::new(Method::GET, "https://test.example.com/page");
-        req.set_header(header::ACCEPT_ENCODING, "gzip, deflate, br, zstd");
+        let mut req = build_request(Method::GET, "https://test.example.com/page");
+        req.headers_mut().insert(
+            header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("gzip, deflate, br, zstd"),
+        );
 
         restrict_accept_encoding(&mut req);
 
         assert_eq!(
-            req.get_header_str(header::ACCEPT_ENCODING),
+            req.headers()
+                .get(header::ACCEPT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
             Some("gzip, deflate, br"),
             "publisher fallback should only advertise encodings the rewrite pipeline supports"
         );
@@ -1053,13 +1092,18 @@ mod tests {
 
     #[test]
     fn publisher_proxy_preserves_identity_only_accept_encoding() {
-        let mut req = Request::new(Method::GET, "https://test.example.com/page");
-        req.set_header(header::ACCEPT_ENCODING, "identity");
+        let mut req = build_request(Method::GET, "https://test.example.com/page");
+        req.headers_mut().insert(
+            header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("identity"),
+        );
 
         restrict_accept_encoding(&mut req);
 
         assert_eq!(
-            req.get_header_str(header::ACCEPT_ENCODING),
+            req.headers()
+                .get(header::ACCEPT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
             Some("identity"),
             "publisher fallback should preserve identity-only clients"
         );
@@ -1067,13 +1111,18 @@ mod tests {
 
     #[test]
     fn publisher_proxy_respects_supported_client_subset() {
-        let mut req = Request::new(Method::GET, "https://test.example.com/page");
-        req.set_header(header::ACCEPT_ENCODING, "br, gzip;q=0, zstd");
+        let mut req = build_request(Method::GET, "https://test.example.com/page");
+        req.headers_mut().insert(
+            header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("br, gzip;q=0, zstd"),
+        );
 
         restrict_accept_encoding(&mut req);
 
         assert_eq!(
-            req.get_header_str(header::ACCEPT_ENCODING),
+            req.headers()
+                .get(header::ACCEPT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
             Some("br"),
             "publisher fallback should only advertise the supported encodings the client accepts"
         );
@@ -1081,105 +1130,20 @@ mod tests {
 
     #[test]
     fn publisher_proxy_falls_back_to_identity_for_unsupported_client_encodings() {
-        let mut req = Request::new(Method::GET, "https://test.example.com/page");
-        req.set_header(header::ACCEPT_ENCODING, "zstd");
+        let mut req = build_request(Method::GET, "https://test.example.com/page");
+        req.headers_mut().insert(
+            header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("zstd"),
+        );
 
         restrict_accept_encoding(&mut req);
 
         assert_eq!(
-            req.get_header_str(header::ACCEPT_ENCODING),
+            req.headers()
+                .get(header::ACCEPT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
             Some("identity"),
             "publisher fallback should request identity when the client only accepts unsupported encodings"
-        );
-    }
-
-    #[test]
-    fn stream_publisher_body_round_trips_gzip() {
-        let settings = create_test_settings();
-        let integration_registry =
-            IntegrationRegistry::new(&settings).expect("should create integration registry");
-        let input = b"{\"asset\":\"https://origin.test-publisher.com/path/file.js\"}";
-        let compressed = gzip_encode(input);
-        let params = make_stream_params(&settings, "gzip");
-        let mut output = Vec::new();
-
-        stream_publisher_body(
-            Body::from(compressed),
-            &mut output,
-            &params,
-            &settings,
-            &integration_registry,
-        )
-        .expect("should stream gzip response through rewrite pipeline");
-
-        let decoded = gzip_decode(&output);
-        let decoded = String::from_utf8(decoded).expect("should decode rewritten gzip payload");
-        assert!(
-            decoded.contains("https://test-publisher.com/path/file.js"),
-            "should rewrite origin URLs to the request host"
-        );
-        assert!(
-            !decoded.contains("origin.test-publisher.com"),
-            "should remove the origin hostname from the rewritten payload"
-        );
-    }
-
-    #[test]
-    fn stream_publisher_body_round_trips_brotli() {
-        let settings = create_test_settings();
-        let integration_registry =
-            IntegrationRegistry::new(&settings).expect("should create integration registry");
-        let input = b"{\"asset\":\"https://origin.test-publisher.com/path/file.css\"}";
-        let compressed = brotli_encode(input);
-        let params = make_stream_params(&settings, "br");
-        let mut output = Vec::new();
-
-        stream_publisher_body(
-            Body::from(compressed),
-            &mut output,
-            &params,
-            &settings,
-            &integration_registry,
-        )
-        .expect("should stream brotli response through rewrite pipeline");
-
-        let decoded = brotli_decode(&output);
-        let decoded = String::from_utf8(decoded).expect("should decode rewritten brotli payload");
-        assert!(
-            decoded.contains("https://test-publisher.com/path/file.css"),
-            "should rewrite origin URLs to the request host"
-        );
-        assert!(
-            !decoded.contains("origin.test-publisher.com"),
-            "should remove the origin hostname from the rewritten payload"
-        );
-    }
-
-    #[test]
-    fn request_ec_uses_cookie_not_header() {
-        let settings = create_test_settings();
-        let header_ec = format!("{}.HdrId1", "a".repeat(64));
-        let cookie_ec = format!("{}.CkId01", "b".repeat(64));
-        let mut req = Request::new(Method::GET, "https://test.example.com/page");
-        req.set_header("x-ts-ec", &header_ec);
-        req.set_header("cookie", format!("ts-ec={cookie_ec}; other=value"));
-
-        let ec_context =
-            EcContext::read_from_request(&settings, &req).expect("should read EC context");
-
-        assert_eq!(
-            ec_context.ec_value(),
-            Some(cookie_ec.as_str()),
-            "should resolve request EC ID from cookie"
-        );
-        assert!(
-            ec_context.cookie_was_present(),
-            "should detect cookie was present"
-        );
-        assert_eq!(
-            ec_context.existing_cookie_ec_id(),
-            Some(cookie_ec.as_str()),
-            "should return cookie EC value for revocation"
         );
     }
 
@@ -1188,13 +1152,13 @@ mod tests {
         let settings = create_test_settings();
         let registry =
             IntegrationRegistry::new(&settings).expect("should create integration registry");
-        let req = Request::new(
+        let req = build_request(
             Method::GET,
             "https://publisher.example/static/tsjs=unknown.js",
         );
 
         let response = handle_tsjs_dynamic(&req, &registry).expect("should handle tsjs request");
-        assert_eq!(response.get_status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[test]
@@ -1202,13 +1166,13 @@ mod tests {
         let settings = create_test_settings();
         let registry =
             IntegrationRegistry::new(&settings).expect("should create integration registry");
-        let req = Request::new(
+        let req = build_request(
             Method::GET,
             "https://publisher.example/static/tsjs=tsjs-unified.min.js",
         );
 
         let response = handle_tsjs_dynamic(&req, &registry).expect("should handle tsjs request");
-        assert_eq!(response.get_status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[test]
@@ -1254,14 +1218,14 @@ mod tests {
         let settings = create_test_settings();
         let registry =
             IntegrationRegistry::new(&settings).expect("should create integration registry");
-        let req = Request::new(
+        let req = build_request(
             Method::GET,
             "https://publisher.example/static/tsjs=tsjs-prebid.min.js",
         );
 
         let response = handle_tsjs_dynamic(&req, &registry).expect("should handle tsjs request");
         assert_eq!(
-            response.get_status(),
+            response.status(),
             StatusCode::OK,
             "should serve deferred prebid module when enabled"
         );
@@ -1282,14 +1246,14 @@ mod tests {
             .expect("should update prebid config");
         let registry =
             IntegrationRegistry::new(&settings).expect("should create integration registry");
-        let req = Request::new(
+        let req = build_request(
             Method::GET,
             "https://publisher.example/static/tsjs=tsjs-prebid.min.js",
         );
 
         let response = handle_tsjs_dynamic(&req, &registry).expect("should handle tsjs request");
         assert_eq!(
-            response.get_status(),
+            response.status(),
             StatusCode::NOT_FOUND,
             "should return 404 for disabled deferred module"
         );
@@ -1300,16 +1264,341 @@ mod tests {
         let settings = create_test_settings();
         let registry =
             IntegrationRegistry::new(&settings).expect("should create integration registry");
-        let req = Request::new(
+        let req = build_request(
             Method::GET,
             "https://publisher.example/static/tsjs=tsjs-evil.min.js",
         );
 
         let response = handle_tsjs_dynamic(&req, &registry).expect("should handle tsjs request");
         assert_eq!(
-            response.get_status(),
+            response.status(),
             StatusCode::NOT_FOUND,
             "should reject unknown module names"
+        );
+    }
+
+    #[tokio::test]
+    async fn publisher_request_uses_platform_http_client_with_http_types() {
+        let settings = create_test_settings();
+        let registry =
+            IntegrationRegistry::new(&settings).expect("should create integration registry");
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"origin response".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let req = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("https://publisher.example/page")
+            .header(header::HOST, "publisher.example")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let pub_response = handle_publisher_request(&settings, &registry, &services, req)
+            .await
+            .expect("should proxy publisher request");
+        let response = match pub_response {
+            PublisherResponse::Buffered(r) => r,
+            PublisherResponse::PassThrough { mut response, body } => {
+                *response.body_mut() = body;
+                response
+            }
+            PublisherResponse::Stream { response, .. } => response,
+        };
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_body_string(response), "origin response");
+        assert_eq!(
+            stub.recorded_backend_names(),
+            vec!["stub-backend".to_string()],
+            "should proxy through the platform http client"
+        );
+    }
+
+    #[test]
+    fn stream_publisher_body_preserves_gzip_round_trip() {
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+
+        let settings = create_test_settings();
+        let registry =
+            IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+        // Compress CSS containing an origin URL that should be rewritten.
+        // CSS uses the text URL replacer (not lol_html), so inline URLs are rewritten.
+        let html = b"body { background: url('https://origin.example.com/page'); }";
+        let mut compressed = Vec::new();
+        {
+            let mut encoder = GzEncoder::new(&mut compressed, flate2::Compression::default());
+            encoder.write_all(html).expect("should compress");
+            encoder.finish().expect("should finish compression");
+        }
+
+        let body = EdgeBody::from(compressed);
+        let params = OwnedProcessResponseParams {
+            content_encoding: "gzip".to_string(),
+            origin_host: "origin.example.com".to_string(),
+            origin_url: "https://origin.example.com".to_string(),
+            request_host: "proxy.example.com".to_string(),
+            request_scheme: "https".to_string(),
+            content_type: "text/css".to_string(),
+        };
+
+        let mut output = Vec::new();
+        stream_publisher_body(body, &mut output, &params, &settings, &registry)
+            .expect("should process gzip CSS");
+
+        // Decompress output
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+        let mut decoder = GzDecoder::new(&output[..]);
+        let mut decompressed = String::new();
+        decoder
+            .read_to_string(&mut decompressed)
+            .expect("should decompress output");
+
+        assert!(
+            decompressed.contains("proxy.example.com"),
+            "should rewrite origin to proxy. Got: {decompressed}"
+        );
+        assert!(
+            !decompressed.contains("origin.example.com"),
+            "should not contain original host. Got: {decompressed}"
+        );
+    }
+
+    /// Empty origin body on the streaming route must produce no output
+    /// without erroring. Exercises the `Ok(0)` branch of `process_chunks`
+    /// plus the processor's `is_last=true, chunk=[]` terminal call.
+    #[test]
+    fn stream_publisher_body_handles_empty_body() {
+        let settings = create_test_settings();
+        let registry =
+            IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+        let params = OwnedProcessResponseParams {
+            content_encoding: String::new(),
+            origin_host: "origin.example.com".to_string(),
+            origin_url: "https://origin.example.com".to_string(),
+            request_host: "proxy.example.com".to_string(),
+            request_scheme: "https".to_string(),
+            content_type: "text/html; charset=utf-8".to_string(),
+        };
+
+        let mut output = Vec::new();
+        stream_publisher_body(
+            EdgeBody::empty(),
+            &mut output,
+            &params,
+            &settings,
+            &registry,
+        )
+        .expect("should succeed on empty body");
+
+        assert!(
+            output.is_empty(),
+            "empty origin body should produce empty streaming output. Got: {output:?}"
+        );
+    }
+
+    /// Mid-stream decoder failure must surface as an error. The adapter
+    /// relies on this: once headers are committed, it logs and drops the
+    /// `StreamingBody` so the client sees a truncated response. If a decode
+    /// failure silently emitted bytes, the client would see a malformed
+    /// document instead.
+    #[test]
+    fn stream_publisher_body_surfaces_mid_stream_decode_error() {
+        let settings = create_test_settings();
+        let registry =
+            IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+        // Claim gzip encoding but feed non-gzip bytes. The GzDecoder will
+        // error as soon as it tries to read the gzip header.
+        let params = OwnedProcessResponseParams {
+            content_encoding: "gzip".to_string(),
+            origin_host: "origin.example.com".to_string(),
+            origin_url: "https://origin.example.com".to_string(),
+            request_host: "proxy.example.com".to_string(),
+            request_scheme: "https".to_string(),
+            content_type: "text/html".to_string(),
+        };
+
+        let bogus_body = EdgeBody::from(b"<html>not gzip</html>".to_vec());
+        let mut output = Vec::new();
+        let result = stream_publisher_body(bogus_body, &mut output, &params, &settings, &registry);
+
+        assert!(
+            result.is_err(),
+            "decoding bogus gzip as gzip should return Err so the adapter can drop the stream"
+        );
+    }
+
+    /// Pass-through dispatch contract: the adapter treats `PublisherResponse::PassThrough`
+    /// by reattaching the origin body unchanged and letting Fastly emit it.
+    /// Simulate that step and assert byte identity plus Content-Length
+    /// preservation. Distinct from `pass_through_preserves_body_and_content_length`
+    /// which only tests the header preservation; this one walks the full
+    /// take-then-reattach pattern the adapter uses.
+    #[test]
+    fn publisher_response_pass_through_reattach_preserves_bytes() {
+        // Simulate a 2xx image/png response: Body::from(bytes), take_body(),
+        // then set_body(body). `classify_response_route` already picks
+        // PassThrough for this combination; this covers the adapter's
+        // reattachment half of the contract.
+        let image_bytes: Vec<u8> = (0..=127).cycle().take(2048).collect();
+
+        let mut response = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "image/png")
+            .header(header::CONTENT_LENGTH, image_bytes.len() as u64)
+            .body(EdgeBody::from(image_bytes.clone()))
+            .expect("should build test response");
+
+        // Mirror adapter: take body, then reattach.
+        let body = std::mem::replace(response.body_mut(), EdgeBody::empty());
+        *response.body_mut() = body;
+
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .expect("content-length should survive"),
+            "2048"
+        );
+        let (_, final_body) = response.into_parts();
+        let round_trip = final_body.into_bytes();
+        assert_eq!(
+            round_trip, image_bytes,
+            "pass-through reattach must preserve bytes exactly"
+        );
+    }
+
+    /// Buffered-processed dispatch contract: HTML with a registered post-processor
+    /// routes through `BufferedProcessed`, and the handler path sets
+    /// `Content-Length` from the processed body length. Verify that invariant
+    /// via the classifier + `process_response_streaming` composition.
+    #[test]
+    fn buffered_processed_sets_content_length_from_processed_body() {
+        // Configure nextjs so a post-processor is registered.
+        let mut settings = create_test_settings();
+        settings
+            .integrations
+            .insert_config(
+                "nextjs",
+                &serde_json::json!({
+                    "enabled": true,
+                    "rewrite_attributes": ["href", "link", "url"],
+                }),
+            )
+            .expect("should update nextjs config");
+
+        let registry =
+            IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+        assert!(
+            registry.has_html_post_processors(),
+            "nextjs integration must register an HTML post-processor"
+        );
+        assert_eq!(
+            classify_response_route(
+                StatusCode::OK,
+                "text/html; charset=utf-8",
+                "",
+                "proxy.example.com",
+                registry.has_html_post_processors(),
+            ),
+            ResponseRoute::BufferedProcessed,
+            "HTML with post-processors must route to BufferedProcessed"
+        );
+
+        // Feed a small HTML body through the same pipeline the
+        // BufferedProcessed arm uses (Vec<u8> output).
+        let html =
+            b"<html><body><a href=\"https://origin.example.com/page\">link</a></body></html>";
+        let body = EdgeBody::from(html.to_vec());
+
+        let params = OwnedProcessResponseParams {
+            content_encoding: String::new(),
+            origin_host: "origin.example.com".to_string(),
+            origin_url: "https://origin.example.com".to_string(),
+            request_host: "proxy.example.com".to_string(),
+            request_scheme: "https".to_string(),
+            content_type: "text/html; charset=utf-8".to_string(),
+        };
+        let mut output = Vec::new();
+        stream_publisher_body(body, &mut output, &params, &settings, &registry)
+            .expect("should process buffered HTML");
+
+        assert!(
+            !output.is_empty(),
+            "buffered processed output must not be empty"
+        );
+        let as_str = std::str::from_utf8(&output).expect("output should be valid UTF-8");
+        assert!(
+            as_str.contains("proxy.example.com"),
+            "origin must be rewritten. Got: {as_str}"
+        );
+        assert!(
+            !as_str.contains("origin.example.com"),
+            "origin host must not leak. Got: {as_str}"
+        );
+    }
+
+    /// Document-state survives from the streaming pass into the post-processor.
+    /// `NextJsRscPlaceholderRewriter` writes into `IntegrationDocumentState`
+    /// during streaming; `NextJsHtmlPostProcessor` reads it and substitutes.
+    /// Regression test: with post-processors registered, placeholders must
+    /// be inserted during streaming and substituted out of the final output.
+    #[test]
+    fn document_state_placeholders_substitute_through_accumulating_path() {
+        let mut settings = create_test_settings();
+        settings
+            .integrations
+            .insert_config(
+                "nextjs",
+                &serde_json::json!({
+                    "enabled": true,
+                    "rewrite_attributes": ["href", "link", "url"],
+                }),
+            )
+            .expect("should update nextjs config");
+        let registry =
+            IntegrationRegistry::new(&settings).expect("should create integration registry");
+
+        // Small, single-fragment RSC script — placeholder path (not fallback).
+        let html = br#"<html><body><script>self.__next_f.push([1,"1:{\"link\":\"https://origin.example.com/page\"}"])</script></body></html>"#;
+        let params = OwnedProcessResponseParams {
+            content_encoding: String::new(),
+            origin_host: "origin.example.com".to_string(),
+            origin_url: "https://origin.example.com".to_string(),
+            request_host: "proxy.example.com".to_string(),
+            request_scheme: "https".to_string(),
+            content_type: "text/html".to_string(),
+        };
+
+        let mut output = Vec::new();
+        stream_publisher_body(
+            EdgeBody::from(html.to_vec()),
+            &mut output,
+            &params,
+            &settings,
+            &registry,
+        )
+        .expect("should process RSC push");
+
+        let processed = String::from_utf8(output).expect("valid UTF-8");
+        assert!(
+            !processed.contains("__ts_rsc_payload_"),
+            "placeholder must be substituted before reaching output. Got: {processed}"
+        );
+        assert!(
+            processed.contains("proxy.example.com/page"),
+            "origin URL must be rewritten in the substituted payload. Got: {processed}"
+        );
+        assert!(
+            !processed.contains("origin.example.com"),
+            "origin host must not leak. Got: {processed}"
         );
     }
 }

--- a/crates/trusted-server-core/src/redacted.rs
+++ b/crates/trusted-server-core/src/redacted.rs
@@ -1,7 +1,7 @@
 // NOTE: This file is also included in build.rs via #[path].
 // It must remain self-contained (no `crate::` imports).
 
-//! A wrapper type that redacts sensitive values in [`Debug`] and [`Display`] output.
+//! A wrapper type that redacts sensitive values in [`Debug`] and [`fmt::Display`] output.
 //!
 //! Use [`Redacted`] for secrets, passwords, API keys, and other sensitive values
 //! that must never appear in logs or error messages.
@@ -10,7 +10,7 @@ use core::fmt;
 
 use serde::{Deserialize, Serialize};
 
-/// Wraps a value so that [`Debug`] and [`Display`] print `[REDACTED]`
+/// Wraps a value so that [`Debug`] and [`fmt::Display`] print `[REDACTED]`
 /// instead of the inner contents.
 ///
 /// Access the real value via [`expose`](Redacted::expose). Callers must

--- a/crates/trusted-server-core/src/request_signing/endpoints.rs
+++ b/crates/trusted-server-core/src/request_signing/endpoints.rs
@@ -3,16 +3,26 @@
 //! This module provides endpoint handlers for JWKS retrieval, signature verification,
 //! key rotation, and key deactivation operations.
 
+use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use fastly::{Request, Response};
+use http::{header, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{IntoHttpResponse, TrustedServerError};
+use crate::http_util::enforce_max_body_size;
 use crate::platform::RuntimeServices;
 use crate::request_signing::discovery::TrustedServerDiscovery;
 use crate::request_signing::rotation::KeyRotationManager;
 use crate::request_signing::signing;
 use crate::settings::Settings;
+
+fn json_response(status: StatusCode, body: String) -> Response<EdgeBody> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+        .body(EdgeBody::from(body.into_bytes()))
+        .expect("should build json response")
+}
 
 /// Retrieves and returns the trusted-server discovery document.
 ///
@@ -26,8 +36,8 @@ use crate::settings::Settings;
 pub fn handle_trusted_server_discovery(
     _settings: &Settings,
     services: &RuntimeServices,
-    _req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
+    _req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     let jwks_json = crate::request_signing::jwks::get_active_jwks(services).change_context(
         TrustedServerError::Configuration {
             message: "failed to retrieve JWKS".into(),
@@ -47,9 +57,7 @@ pub fn handle_trusted_server_discovery(
         },
     )?;
 
-    Ok(Response::from_status(200)
-        .with_content_type(mime::APPLICATION_JSON)
-        .with_body(json))
+    Ok(json_response(StatusCode::OK, json))
 }
 
 /// JSON request body for the signature verification endpoint.
@@ -77,6 +85,9 @@ pub struct VerifySignatureResponse {
     pub error: Option<String>,
 }
 
+const VERIFY_MAX_BODY_BYTES: usize = 4096;
+const ADMIN_MAX_BODY_BYTES: usize = 4096;
+
 /// Will verify a signature given a payload and kid
 /// Useful for testing integration with signatures
 ///
@@ -87,11 +98,12 @@ pub struct VerifySignatureResponse {
 pub fn handle_verify_signature(
     _settings: &Settings,
     services: &RuntimeServices,
-    mut req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
-    let body = req.take_body_str();
+    req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    let body = req.into_body().into_bytes();
+    enforce_max_body_size(&body, VERIFY_MAX_BODY_BYTES, "verify-signature")?;
     let verify_req: VerifySignatureRequest =
-        serde_json::from_str(&body).change_context(TrustedServerError::Configuration {
+        serde_json::from_slice(&body).change_context(TrustedServerError::Configuration {
             message: "invalid JSON request body".into(),
         })?;
 
@@ -132,9 +144,7 @@ pub fn handle_verify_signature(
         })
     })?;
 
-    Ok(Response::from_status(200)
-        .with_content_type(mime::APPLICATION_JSON)
-        .with_body(response_json))
+    Ok(json_response(StatusCode::OK, response_json))
 }
 
 /// JSON request body for the key-rotation endpoint.
@@ -226,18 +236,19 @@ fn validate_kid(kid: &str) -> Result<(), Report<TrustedServerError>> {
 pub fn handle_rotate_key(
     settings: &Settings,
     services: &RuntimeServices,
-    mut req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
+    req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     let SigningStoreIds {
         config_store_id,
         secret_store_id,
     } = signing_store_ids(settings)?;
 
-    let body = req.take_body_str();
+    let body = req.into_body().into_bytes();
+    enforce_max_body_size(&body, ADMIN_MAX_BODY_BYTES, "rotate-key")?;
     let rotate_req: RotateKeyRequest = if body.is_empty() {
         RotateKeyRequest { kid: None }
     } else {
-        serde_json::from_str(&body).change_context(TrustedServerError::Configuration {
+        serde_json::from_slice(&body).change_context(TrustedServerError::Configuration {
             message: "invalid JSON request body".into(),
         })?
     };
@@ -274,9 +285,7 @@ pub fn handle_rotate_key(
                 })
             })?;
 
-            Ok(Response::from_status(200)
-                .with_content_type(mime::APPLICATION_JSON)
-                .with_body(response_json))
+            Ok(json_response(StatusCode::OK, response_json))
         }
         Err(e) => {
             let status = e.current_context().status_code();
@@ -296,9 +305,7 @@ pub fn handle_rotate_key(
                 })
             })?;
 
-            Ok(Response::from_status(status)
-                .with_content_type(mime::APPLICATION_JSON)
-                .with_body(response_json))
+            Ok(json_response(status, response_json))
         }
     }
 }
@@ -348,16 +355,17 @@ pub struct DeactivateKeyResponse {
 pub fn handle_deactivate_key(
     settings: &Settings,
     services: &RuntimeServices,
-    mut req: Request,
-) -> Result<Response, Report<TrustedServerError>> {
+    req: Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
     let SigningStoreIds {
         config_store_id,
         secret_store_id,
     } = signing_store_ids(settings)?;
 
-    let body = req.take_body_str();
+    let body = req.into_body().into_bytes();
+    enforce_max_body_size(&body, ADMIN_MAX_BODY_BYTES, "deactivate-key")?;
     let deactivate_req: DeactivateKeyRequest =
-        serde_json::from_str(&body).change_context(TrustedServerError::Configuration {
+        serde_json::from_slice(&body).change_context(TrustedServerError::Configuration {
             message: "invalid JSON request body".into(),
         })?;
 
@@ -397,9 +405,7 @@ pub fn handle_deactivate_key(
                 })
             })?;
 
-            Ok(Response::from_status(200)
-                .with_content_type(mime::APPLICATION_JSON)
-                .with_body(response_json))
+            Ok(json_response(StatusCode::OK, response_json))
         }
         Err(e) => {
             let status = e.current_context().status_code();
@@ -422,22 +428,53 @@ pub fn handle_deactivate_key(
                 })
             })?;
 
-            Ok(Response::from_status(status)
-                .with_content_type(mime::APPLICATION_JSON)
-                .with_body(response_json))
+            Ok(json_response(status, response_json))
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use edgezero_core::body::Body as EdgeBody;
+    use error_stack::Report;
+    use http::{header, Method, Request as HttpRequest, StatusCode};
+
+    use crate::error::IntoHttpResponse;
     use crate::platform::{
         test_support::{build_request_signing_services, build_services_with_config, noop_services},
         PlatformConfigStore, PlatformError, StoreId, StoreName,
     };
 
     use super::*;
-    use fastly::http::{Method, StatusCode};
+
+    fn build_request(method: Method, uri: &str, body: Option<&str>) -> HttpRequest<EdgeBody> {
+        let body = match body {
+            Some(body) => EdgeBody::from(body.as_bytes().to_vec()),
+            None => EdgeBody::empty(),
+        };
+
+        HttpRequest::builder()
+            .method(method)
+            .uri(uri)
+            .body(body)
+            .expect("should build request")
+    }
+
+    fn response_body_string(response: http::Response<EdgeBody>) -> String {
+        String::from_utf8(response.into_body().into_bytes().to_vec())
+            .expect("should decode response body")
+    }
+
+    fn assert_json_content_type(response: &http::Response<EdgeBody>) {
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some(mime::APPLICATION_JSON.as_ref()),
+            "should return application/json content type"
+        );
+    }
 
     /// Config store stub that returns a minimal JWKS with one Ed25519 key.
     struct StubJwksConfigStore;
@@ -482,19 +519,18 @@ mod tests {
         };
 
         let body = serde_json::to_string(&verify_req).expect("should serialize verify request");
-        let mut req = Request::new(Method::POST, "https://test.com/verify-signature");
-        req.set_body(body);
-
-        let mut resp = handle_verify_signature(&settings, &services, req)
-            .expect("should handle verification request");
-        assert_eq!(resp.get_status(), StatusCode::OK);
-        assert_eq!(
-            resp.get_content_type(),
-            Some(mime::APPLICATION_JSON),
-            "should return application/json content type"
+        let req = build_request(
+            Method::POST,
+            "https://test.com/verify-signature",
+            Some(&body),
         );
 
-        let resp_body = resp.take_body_str();
+        let resp = handle_verify_signature(&settings, &services, req)
+            .expect("should handle verification request");
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_json_content_type(&resp);
+
+        let resp_body = response_body_string(resp);
         let verify_resp: VerifySignatureResponse =
             serde_json::from_str(&resp_body).expect("should deserialize verify response");
 
@@ -522,19 +558,18 @@ mod tests {
         };
 
         let body = serde_json::to_string(&verify_req).expect("should serialize verify request");
-        let mut req = Request::new(Method::POST, "https://test.com/verify-signature");
-        req.set_body(body);
-
-        let mut resp = handle_verify_signature(&settings, &services, req)
-            .expect("should handle verification request");
-        assert_eq!(resp.get_status(), StatusCode::OK);
-        assert_eq!(
-            resp.get_content_type(),
-            Some(mime::APPLICATION_JSON),
-            "should return application/json content type"
+        let req = build_request(
+            Method::POST,
+            "https://test.com/verify-signature",
+            Some(&body),
         );
 
-        let resp_body = resp.take_body_str();
+        let resp = handle_verify_signature(&settings, &services, req)
+            .expect("should handle verification request");
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_json_content_type(&resp);
+
+        let resp_body = response_body_string(resp);
         let verify_resp: VerifySignatureResponse =
             serde_json::from_str(&resp_body).expect("should deserialize verify response");
 
@@ -557,16 +592,19 @@ mod tests {
         };
 
         let body = serde_json::to_string(&verify_req).expect("should serialize verify request");
-        let mut req = Request::new(Method::POST, "https://test.com/verify-signature");
-        req.set_body(body);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/verify-signature",
+            Some(&body),
+        );
 
         let services = noop_services();
-        let mut resp = handle_verify_signature(&settings, &services, req)
+        let resp = handle_verify_signature(&settings, &services, req)
             .expect("should return a verification response for internal errors");
 
-        assert_eq!(resp.get_status(), StatusCode::OK, "should return 200 OK");
+        assert_eq!(resp.status(), StatusCode::OK, "should return 200 OK");
 
-        let resp_body = resp.take_body_str();
+        let resp_body = response_body_string(resp);
         let verify_resp: VerifySignatureResponse =
             serde_json::from_str(&resp_body).expect("should deserialize verify response");
 
@@ -591,8 +629,11 @@ mod tests {
     fn test_handle_verify_signature_malformed_request() {
         let settings = crate::test_support::tests::create_test_settings();
 
-        let mut req = Request::new(Method::POST, "https://test.com/verify-signature");
-        req.set_body("not valid json");
+        let req = build_request(
+            Method::POST,
+            "https://test.com/verify-signature",
+            Some("not valid json"),
+        );
 
         let result = handle_verify_signature(&settings, &noop_services(), req);
         assert!(result.is_err(), "Malformed JSON should error");
@@ -601,18 +642,18 @@ mod tests {
     #[test]
     fn test_handle_rotate_key_with_empty_body() {
         let settings = crate::test_support::tests::create_test_settings();
-        let req = Request::new(Method::POST, "https://test.com/_ts/admin/keys/rotate");
+        let req = build_request(Method::POST, "https://test.com/admin/keys/rotate", None);
 
-        let mut resp = handle_rotate_key(&settings, &noop_services(), req)
+        let resp = handle_rotate_key(&settings, &noop_services(), req)
             .expect("should return a response even when stores are unavailable");
 
         assert_eq!(
-            resp.get_status(),
+            resp.status(),
             StatusCode::INTERNAL_SERVER_ERROR,
             "should return 500 when store writes fail"
         );
 
-        let body = resp.take_body_str();
+        let body = response_body_string(resp);
         let response: RotateKeyResponse =
             serde_json::from_str(&body).expect("should deserialize rotate response");
 
@@ -635,19 +676,22 @@ mod tests {
         };
 
         let body_json = serde_json::to_string(&req_body).expect("should serialize rotate request");
-        let mut req = Request::new(Method::POST, "https://test.com/_ts/admin/keys/rotate");
-        req.set_body(body_json);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/rotate",
+            Some(&body_json),
+        );
 
-        let mut resp = handle_rotate_key(&settings, &noop_services(), req)
+        let resp = handle_rotate_key(&settings, &noop_services(), req)
             .expect("should return a response even when stores are unavailable");
 
         assert_eq!(
-            resp.get_status(),
+            resp.status(),
             StatusCode::INTERNAL_SERVER_ERROR,
             "should return 500 when store writes fail"
         );
 
-        let body = resp.take_body_str();
+        let body = response_body_string(resp);
         let response: RotateKeyResponse =
             serde_json::from_str(&body).expect("should deserialize rotate response");
 
@@ -664,8 +708,11 @@ mod tests {
     #[test]
     fn test_handle_rotate_key_invalid_json() {
         let settings = crate::test_support::tests::create_test_settings();
-        let mut req = Request::new(Method::POST, "https://test.com/_ts/admin/keys/rotate");
-        req.set_body("invalid json");
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/rotate",
+            Some("invalid json"),
+        );
 
         let result = handle_rotate_key(&settings, &noop_services(), req);
         assert!(result.is_err(), "Invalid JSON should return error");
@@ -680,19 +727,22 @@ mod tests {
         };
 
         let body_json = serde_json::to_string(&req_body).expect("should serialize rotate request");
-        let mut req = Request::new(Method::POST, "https://test.com/admin/keys/rotate");
-        req.set_body(body_json);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/rotate",
+            Some(&body_json),
+        );
 
-        let mut resp = handle_rotate_key(&settings, &noop_services(), req)
+        let resp = handle_rotate_key(&settings, &noop_services(), req)
             .expect("should return a response for invalid kid");
 
         assert_eq!(
-            resp.get_status(),
+            resp.status(),
             StatusCode::BAD_REQUEST,
             "should reject malformed kid as a bad request"
         );
 
-        let body = resp.take_body_str();
+        let body = response_body_string(resp);
         let response: RotateKeyResponse =
             serde_json::from_str(&body).expect("should deserialize rotate response");
 
@@ -720,19 +770,22 @@ mod tests {
 
         let body_json =
             serde_json::to_string(&req_body).expect("should serialize deactivate request");
-        let mut req = Request::new(Method::POST, "https://test.com/_ts/admin/keys/deactivate");
-        req.set_body(body_json);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/deactivate",
+            Some(&body_json),
+        );
 
-        let mut resp = handle_deactivate_key(&settings, &noop_services(), req)
+        let resp = handle_deactivate_key(&settings, &noop_services(), req)
             .expect("should return a response even when stores are unavailable");
 
         assert_eq!(
-            resp.get_status(),
+            resp.status(),
             StatusCode::INTERNAL_SERVER_ERROR,
             "should return 500 when active-kids cannot be read"
         );
 
-        let body = resp.take_body_str();
+        let body = response_body_string(resp);
         let response: DeactivateKeyResponse =
             serde_json::from_str(&body).expect("should deserialize deactivate response");
 
@@ -757,19 +810,22 @@ mod tests {
 
         let body_json =
             serde_json::to_string(&req_body).expect("should serialize deactivate request");
-        let mut req = Request::new(Method::POST, "https://test.com/_ts/admin/keys/deactivate");
-        req.set_body(body_json);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/deactivate",
+            Some(&body_json),
+        );
 
-        let mut resp = handle_deactivate_key(&settings, &noop_services(), req)
+        let resp = handle_deactivate_key(&settings, &noop_services(), req)
             .expect("should return a response even when stores are unavailable");
 
         assert_eq!(
-            resp.get_status(),
+            resp.status(),
             StatusCode::INTERNAL_SERVER_ERROR,
             "should return 500 when active-kids cannot be read"
         );
 
-        let body = resp.take_body_str();
+        let body = response_body_string(resp);
         let response: DeactivateKeyResponse =
             serde_json::from_str(&body).expect("should deserialize deactivate response");
 
@@ -790,8 +846,11 @@ mod tests {
     #[test]
     fn test_handle_deactivate_key_invalid_json() {
         let settings = crate::test_support::tests::create_test_settings();
-        let mut req = Request::new(Method::POST, "https://test.com/_ts/admin/keys/deactivate");
-        req.set_body("invalid json");
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/deactivate",
+            Some("invalid json"),
+        );
 
         let result = handle_deactivate_key(&settings, &noop_services(), req);
         assert!(result.is_err(), "Invalid JSON should return error");
@@ -808,19 +867,22 @@ mod tests {
 
         let body_json =
             serde_json::to_string(&req_body).expect("should serialize deactivate request");
-        let mut req = Request::new(Method::POST, "https://test.com/admin/keys/deactivate");
-        req.set_body(body_json);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/deactivate",
+            Some(&body_json),
+        );
 
-        let mut resp = handle_deactivate_key(&settings, &noop_services(), req)
+        let resp = handle_deactivate_key(&settings, &noop_services(), req)
             .expect("should return a response for invalid kid");
 
         assert_eq!(
-            resp.get_status(),
+            resp.status(),
             StatusCode::BAD_REQUEST,
             "should reject malformed kid as a bad request"
         );
 
-        let body = resp.take_body_str();
+        let body = response_body_string(resp);
         let response: DeactivateKeyResponse =
             serde_json::from_str(&body).expect("should deserialize deactivate response");
 
@@ -834,6 +896,60 @@ mod tests {
                 .as_deref()
                 .is_some_and(|error| error.contains("kid must contain only")),
             "should explain the kid character restrictions"
+        );
+    }
+
+    #[test]
+    fn verify_signature_rejects_oversized_body() {
+        let settings = crate::test_support::tests::create_test_settings();
+        let oversized = "x".repeat(VERIFY_MAX_BODY_BYTES + 1);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/verify-signature",
+            Some(&oversized),
+        );
+        let err = handle_verify_signature(&settings, &noop_services(), req)
+            .expect_err("should reject oversized body");
+        assert_eq!(
+            err.current_context().status_code(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "should return 413 for verify-signature body over limit"
+        );
+    }
+
+    #[test]
+    fn rotate_key_rejects_oversized_body() {
+        let settings = crate::test_support::tests::create_test_settings();
+        let oversized = "x".repeat(ADMIN_MAX_BODY_BYTES + 1);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/rotate",
+            Some(&oversized),
+        );
+        let err = handle_rotate_key(&settings, &noop_services(), req)
+            .expect_err("should reject oversized body");
+        assert_eq!(
+            err.current_context().status_code(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "should return 413 for rotate-key body over limit"
+        );
+    }
+
+    #[test]
+    fn deactivate_key_rejects_oversized_body() {
+        let settings = crate::test_support::tests::create_test_settings();
+        let oversized = "x".repeat(ADMIN_MAX_BODY_BYTES + 1);
+        let req = build_request(
+            Method::POST,
+            "https://test.com/admin/keys/deactivate",
+            Some(&oversized),
+        );
+        let err = handle_deactivate_key(&settings, &noop_services(), req)
+            .expect_err("should reject oversized body");
+        assert_eq!(
+            err.current_context().status_code(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "should return 413 for deactivate-key body over limit"
         );
     }
 
@@ -883,9 +999,10 @@ mod tests {
     #[test]
     fn test_handle_trusted_server_discovery() {
         let settings = crate::test_support::tests::create_test_settings();
-        let req = Request::new(
+        let req = build_request(
             Method::GET,
             "https://test.com/.well-known/trusted-server.json",
+            None,
         );
 
         // noop_services() config store always returns Err, so the discovery
@@ -901,18 +1018,19 @@ mod tests {
     #[test]
     fn test_handle_trusted_server_discovery_returns_jwks_document() {
         let settings = crate::test_support::tests::create_test_settings();
-        let req = Request::new(
+        let req = build_request(
             Method::GET,
             "https://test.com/.well-known/trusted-server.json",
+            None,
         );
 
         let services = build_services_with_config(StubJwksConfigStore);
-        let mut resp = handle_trusted_server_discovery(&settings, &services, req)
+        let resp = handle_trusted_server_discovery(&settings, &services, req)
             .expect("should return discovery document when config store is populated");
 
-        assert_eq!(resp.get_status(), StatusCode::OK, "should return 200 OK");
+        assert_eq!(resp.status(), StatusCode::OK, "should return 200 OK");
 
-        let body = resp.take_body_str();
+        let body = response_body_string(resp);
         let discovery: serde_json::Value =
             serde_json::from_str(&body).expect("should parse discovery document as JSON");
 

--- a/crates/trusted-server-core/src/s3_sigv4.rs
+++ b/crates/trusted-server-core/src/s3_sigv4.rs
@@ -1,0 +1,375 @@
+//! Minimal AWS Signature Version 4 signing for `S3` asset requests.
+//!
+//! Asset routes use this module for read-only `S3` origins. The signer emits
+//! header-based `SigV4` authentication with `UNSIGNED-PAYLOAD`, so it does not
+//! need `AWS` SDK credential providers, request-body hashing, or presigned query
+//! parameters. The caller must provide the final origin URL and `Host` header
+//! after any path rewrite or query-strip policy has run.
+//!
+//! Canonicalization follows the URL that will be sent to `S3`. Existing percent
+//! escapes in path and query components are preserved and normalized to upper
+//! case, while raw reserved bytes are encoded using `AWS` percent-encoding rules.
+
+use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
+use error_stack::Report;
+use hmac::{Hmac, Mac};
+use http::{header, HeaderMap, HeaderValue, Method};
+use sha2::{Digest as _, Sha256};
+use url::Url;
+
+use crate::error::TrustedServerError;
+use crate::redacted::Redacted;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+const SERVICE: &str = "s3";
+const TERMINATOR: &str = "aws4_request";
+const UNSIGNED_PAYLOAD: &str = "UNSIGNED-PAYLOAD";
+
+/// `AWS` credentials used to sign an `S3` request.
+///
+/// Values are loaded from the configured runtime secret store by the caller and
+/// may be cached between signatures. Temporary credentials can include a session
+/// token, which becomes the signed `x-amz-security-token` header.
+#[derive(Debug, Clone)]
+pub struct S3Credentials {
+    /// `AWS` access key ID.
+    pub access_key_id: String,
+    /// `AWS` secret access key.
+    pub secret_access_key: Redacted<String>,
+    /// Optional `AWS` session token for temporary credentials.
+    pub session_token: Option<Redacted<String>>,
+}
+
+/// Sign an `S3` request header map using AWS Signature Version 4.
+///
+/// The request URL and header map must already reflect the final origin request
+/// that `S3` will receive, including path, query, and `Host` header. Existing
+/// `Authorization` and `x-amz-*` signing headers are replaced so forwarded
+/// client headers cannot influence the signature.
+///
+/// This signer is scoped to read-only asset proxying. It always signs with
+/// `x-amz-content-sha256: UNSIGNED-PAYLOAD`, which is valid for `GET` and
+/// `HEAD` object reads and avoids buffering or hashing a request body.
+///
+/// # Errors
+///
+/// Returns a proxy error when a required signing header is missing or a signing
+/// header value is invalid.
+pub fn sign_headers(
+    method: &Method,
+    url: &Url,
+    headers: &mut HeaderMap,
+    region: &str,
+    credentials: &S3Credentials,
+    now: SystemTime,
+) -> Result<(), Report<TrustedServerError>> {
+    let datetime = DateTime::<Utc>::from(now);
+    let amz_date = datetime.format("%Y%m%dT%H%M%SZ").to_string();
+    let date_stamp = datetime.format("%Y%m%d").to_string();
+
+    headers.remove(header::AUTHORIZATION);
+    headers.remove("x-amz-date");
+    headers.remove("x-amz-content-sha256");
+    headers.remove("x-amz-security-token");
+
+    headers.insert(
+        "x-amz-date",
+        HeaderValue::from_str(&amz_date).change_context_invalid_header("x-amz-date")?,
+    );
+    headers.insert(
+        "x-amz-content-sha256",
+        HeaderValue::from_static(UNSIGNED_PAYLOAD),
+    );
+    if let Some(token) = credentials
+        .session_token
+        .as_ref()
+        .map(Redacted::expose)
+        .filter(|token| !token.is_empty())
+    {
+        headers.insert(
+            "x-amz-security-token",
+            HeaderValue::from_str(token).change_context_invalid_header("x-amz-security-token")?,
+        );
+    }
+
+    let (canonical_headers, signed_headers) = canonical_headers(headers)?;
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        method.as_str(),
+        canonical_uri(url),
+        canonical_query(url),
+        canonical_headers,
+        signed_headers,
+        UNSIGNED_PAYLOAD,
+    );
+    let canonical_request_hash = hex_sha256(canonical_request.as_bytes());
+    let credential_scope = format!("{date_stamp}/{region}/{SERVICE}/{TERMINATOR}");
+    let string_to_sign =
+        format!("{ALGORITHM}\n{amz_date}\n{credential_scope}\n{canonical_request_hash}");
+    let signing_key = signing_key(credentials.secret_access_key.expose(), &date_stamp, region);
+    let signature = hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+    let authorization = format!(
+        "{ALGORITHM} Credential={}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}",
+        credentials.access_key_id,
+    );
+
+    headers.insert(
+        header::AUTHORIZATION,
+        HeaderValue::from_str(&authorization).change_context_invalid_header("authorization")?,
+    );
+
+    Ok(())
+}
+
+fn canonical_headers(headers: &HeaderMap) -> Result<(String, String), Report<TrustedServerError>> {
+    let mut names = vec!["host", "x-amz-content-sha256", "x-amz-date"];
+    if headers.contains_key("x-amz-security-token") {
+        names.push("x-amz-security-token");
+    }
+    names.sort_unstable();
+
+    let mut canonical = String::new();
+    for name in &names {
+        let value = headers.get(*name).ok_or_else(|| {
+            Report::new(TrustedServerError::Proxy {
+                message: format!("missing required S3 signing header `{name}`"),
+            })
+        })?;
+        canonical.push_str(name);
+        canonical.push(':');
+        canonical.push_str(&normalize_header_value(value)?);
+        canonical.push('\n');
+    }
+
+    Ok((canonical, names.join(";")))
+}
+
+fn normalize_header_value(value: &HeaderValue) -> Result<String, Report<TrustedServerError>> {
+    let value = value.to_str().map_err(|err| {
+        Report::new(TrustedServerError::InvalidHeaderValue {
+            message: format!("S3 signing header value is not valid text: {err}"),
+        })
+    })?;
+    Ok(value.split_whitespace().collect::<Vec<_>>().join(" "))
+}
+
+fn canonical_uri(url: &Url) -> String {
+    aws_percent_encode_preserving_escapes(url.path(), false)
+}
+
+fn canonical_query(url: &Url) -> String {
+    let Some(query) = url.query().filter(|query| !query.is_empty()) else {
+        return String::new();
+    };
+
+    let mut pairs: Vec<(String, String)> = query
+        .split('&')
+        .map(|part| {
+            let (key, value) = part.split_once('=').unwrap_or((part, ""));
+            (
+                aws_percent_encode_preserving_escapes(key, true),
+                aws_percent_encode_preserving_escapes(value, true),
+            )
+        })
+        .collect();
+    pairs.sort_unstable();
+    pairs
+        .into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn aws_percent_encode_preserving_escapes(value: &str, encode_slash: bool) -> String {
+    let bytes = value.as_bytes();
+    let mut out = String::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && bytes[index + 1].is_ascii_hexdigit()
+            && bytes[index + 2].is_ascii_hexdigit()
+        {
+            out.push('%');
+            out.push(char::from(bytes[index + 1].to_ascii_uppercase()));
+            out.push(char::from(bytes[index + 2].to_ascii_uppercase()));
+            index += 3;
+            continue;
+        }
+        push_aws_percent_encoded_byte(&mut out, bytes[index], encode_slash);
+        index += 1;
+    }
+    out
+}
+
+fn push_aws_percent_encoded_byte(out: &mut String, byte: u8, encode_slash: bool) {
+    match byte {
+        b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+            out.push(char::from(byte));
+        }
+        b'/' if !encode_slash => out.push('/'),
+        other => out.push_str(&format!("%{other:02X}")),
+    }
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn hmac_sha256(key: &[u8], message: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("should create HMAC from arbitrary key");
+    mac.update(message);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn signing_key(secret_access_key: &str, date_stamp: &str, region: &str) -> Vec<u8> {
+    let date_key = hmac_sha256(
+        format!("AWS4{secret_access_key}").as_bytes(),
+        date_stamp.as_bytes(),
+    );
+    let region_key = hmac_sha256(&date_key, region.as_bytes());
+    let service_key = hmac_sha256(&region_key, SERVICE.as_bytes());
+    hmac_sha256(&service_key, TERMINATOR.as_bytes())
+}
+
+trait HeaderValueResultExt<T> {
+    fn change_context_invalid_header(self, name: &str) -> Result<T, Report<TrustedServerError>>;
+}
+
+impl<T> HeaderValueResultExt<T> for Result<T, http::header::InvalidHeaderValue> {
+    fn change_context_invalid_header(self, name: &str) -> Result<T, Report<TrustedServerError>> {
+        self.map_err(|err| {
+            Report::new(TrustedServerError::InvalidHeaderValue {
+                message: format!("invalid S3 signing header `{name}`: {err}"),
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signs_stable_s3_get_fixture() {
+        let url = Url::parse("https://examplebucket.s3.amazonaws.com/test.txt")
+            .expect("should parse URL");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::HOST,
+            HeaderValue::from_static("examplebucket.s3.amazonaws.com"),
+        );
+        let credentials = S3Credentials {
+            access_key_id: "AKIAIOSFODNN7EXAMPLE".to_string(),
+            secret_access_key: Redacted::new(
+                "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            ),
+            session_token: None,
+        };
+        let now = DateTime::parse_from_rfc3339("2013-05-24T00:00:00Z")
+            .expect("should parse fixture date")
+            .with_timezone(&Utc)
+            .into();
+
+        sign_headers(
+            &Method::GET,
+            &url,
+            &mut headers,
+            "us-east-1",
+            &credentials,
+            now,
+        )
+        .expect("should sign request");
+
+        assert_eq!(
+            headers.get("x-amz-content-sha256"),
+            Some(&HeaderValue::from_static(UNSIGNED_PAYLOAD)),
+            "should use unsigned payload for read-only asset requests"
+        );
+        let authorization = headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .expect("should set authorization header");
+        assert_eq!(
+            authorization,
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=17ee2dc4ebe24953b3ebb4aad72c73aada1b27aa77109a55301af128fdcf571f",
+            "should include expected credential scope, signed headers, and signature"
+        );
+    }
+
+    #[test]
+    fn credentials_debug_redacts_secret_material() {
+        let credentials = S3Credentials {
+            access_key_id: "AKIAIOSFODNN7EXAMPLE".to_string(),
+            secret_access_key: Redacted::new("debug-secret-key".to_string()),
+            session_token: Some(Redacted::new("debug-session-token".to_string())),
+        };
+
+        let debug_output = format!("{credentials:?}");
+
+        assert!(
+            debug_output.contains("AKIAIOSFODNN7EXAMPLE"),
+            "should leave non-secret access key ID visible"
+        );
+        assert!(
+            debug_output.contains("[REDACTED]"),
+            "should show redaction markers for secret fields"
+        );
+        assert!(
+            !debug_output.contains("debug-secret-key"),
+            "should not expose the secret access key in Debug output"
+        );
+        assert!(
+            !debug_output.contains("debug-session-token"),
+            "should not expose the session token in Debug output"
+        );
+    }
+
+    #[test]
+    fn canonical_uri_preserves_existing_percent_encoded_path() {
+        let url = Url::parse("https://bucket.s3.us-east-1.amazonaws.com/foo%20bar/%e2%9c%93.jpg")
+            .expect("should parse URL");
+
+        assert_eq!(canonical_uri(&url), "/foo%20bar/%E2%9C%93.jpg");
+    }
+
+    #[test]
+    fn canonical_uri_encodes_raw_path_bytes_without_double_encoding() {
+        let url = Url::parse("https://bucket.s3.us-east-1.amazonaws.com/image*name%20raw.jpg")
+            .expect("should parse URL");
+
+        assert_eq!(canonical_uri(&url), "/image%2Aname%20raw.jpg");
+    }
+
+    #[test]
+    fn canonical_query_sorts_and_encodes() {
+        let url = Url::parse("https://bucket.s3.us-east-1.amazonaws.com/object?z=two&a=sp ace")
+            .expect("should parse URL");
+        assert_eq!(canonical_query(&url), "a=sp%20ace&z=two");
+    }
+
+    #[test]
+    fn canonical_query_empty_query_is_empty() {
+        let url = Url::parse("https://bucket.s3.us-east-1.amazonaws.com/object?")
+            .expect("should parse URL");
+
+        assert_eq!(canonical_query(&url), "");
+    }
+
+    #[test]
+    fn canonical_query_preserves_plus_and_existing_escapes() {
+        let url = Url::parse(
+            "https://bucket.s3.us-east-1.amazonaws.com/object?v=a+b&space=a%20b&slash=a/b&encoded=a%2bb&empty",
+        )
+        .expect("should parse URL");
+
+        assert_eq!(
+            canonical_query(&url),
+            "empty=&encoded=a%2Bb&slash=a%2Fb&space=a%20b&v=a%2Bb"
+        );
+    }
+}

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -3,7 +3,7 @@ use error_stack::{Report, ResultExt};
 use regex::Regex;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::sync::OnceLock;
@@ -13,12 +13,15 @@ use validator::{Validate, ValidationError};
 use crate::auction_config_types::AuctionConfig;
 use crate::consent_config::ConsentConfig;
 use crate::error::TrustedServerError;
+use crate::host_header::validate_host_header_override_value;
+use crate::platform::PlatformImageOptimizerRegion;
 use crate::redacted::Redacted;
 
 pub const ENVIRONMENT_VARIABLE_PREFIX: &str = "TRUSTED_SERVER";
 pub const ENVIRONMENT_VARIABLE_SEPARATOR: &str = "__";
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct Publisher {
     #[validate(custom(function = validate_publisher_domain))]
     pub domain: String,
@@ -28,6 +31,10 @@ pub struct Publisher {
     pub cookie_domain: String,
     #[validate(custom(function = validate_no_trailing_slash))]
     pub origin_url: String,
+    /// Optional outbound Host header to send while connecting to `origin_url`.
+    #[serde(default)]
+    #[validate(custom(function = validate_host_header_override))]
+    pub origin_host_header_override: Option<String>,
     /// Secret used to encrypt/decrypt proxied URLs in `/first-party/proxy`.
     /// Keep this secret stable to allow existing links to decode.
     #[validate(custom(function = validate_redacted_not_empty))]
@@ -69,6 +76,7 @@ impl Publisher {
     ///     domain: "example.com".to_string(),
     ///     cookie_domain: ".example.com".to_string(),
     ///     origin_url: "https://origin.example.com:8080".to_string(),
+    ///     origin_host_header_override: None,
     ///     proxy_secret: Redacted::new("proxy-secret".to_string()),
     /// };
     /// assert_eq!(publisher.origin_host(), "origin.example.com:8080");
@@ -85,6 +93,14 @@ impl Publisher {
                 })
             })
             .unwrap_or_else(|| self.origin_url.clone())
+    }
+
+    /// Returns the outbound Host header for proxied publisher-origin requests.
+    #[must_use]
+    pub fn origin_host_header(&self) -> String {
+        self.origin_host_header_override
+            .clone()
+            .unwrap_or_else(|| self.origin_host())
     }
 }
 
@@ -564,6 +580,933 @@ fn default_request_signing_enabled() -> bool {
     false
 }
 
+fn default_s3_secret_store() -> String {
+    "s3-auth".to_string()
+}
+
+fn default_s3_access_key_id() -> String {
+    "access_key_id".to_string()
+}
+
+fn default_s3_secret_access_key() -> String {
+    "secret_access_key".to_string()
+}
+
+fn default_asset_image_optimizer_enabled() -> bool {
+    true
+}
+
+fn default_profile_param() -> String {
+    "profile".to_string()
+}
+
+fn default_aspect_ratio_param() -> String {
+    "ar".to_string()
+}
+
+fn default_debug_param() -> String {
+    "_io_debug".to_string()
+}
+
+fn default_default_profile() -> String {
+    "default".to_string()
+}
+
+fn default_crop_offset_x_param() -> String {
+    "x".to_string()
+}
+
+fn default_crop_offset_y_param() -> String {
+    "y".to_string()
+}
+
+fn default_crop_offset_buckets() -> Vec<u32> {
+    vec![10, 30, 50, 70, 90]
+}
+
+fn default_crop_offset_value() -> u32 {
+    50
+}
+
+/// Query-string handling policy for upstream origin requests.
+///
+/// Plain asset routes default to [`Self::Preserve`]. Image-optimized asset
+/// routes default to [`Self::Strip`] because transformation query parameters are
+/// not usually part of the origin object identity.
+#[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OriginQueryPolicy {
+    /// Preserve the incoming query string on the origin request.
+    Preserve,
+    /// Strip the incoming query string before sending to origin.
+    Strip,
+}
+
+/// Authentication configuration for an asset origin.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AssetOriginAuth {
+    /// Sign asset origin requests with AWS Signature Version 4 for `S3`.
+    #[serde(rename = "s3_sigv4", alias = "s3_sig_v4")]
+    S3SigV4(S3SigV4AuthConfig),
+}
+
+impl AssetOriginAuth {
+    fn normalize(&mut self) {
+        match self {
+            Self::S3SigV4(config) => config.normalize(),
+        }
+    }
+
+    fn prepare_runtime(&self) -> Result<(), Report<TrustedServerError>> {
+        match self {
+            Self::S3SigV4(config) => config.prepare_runtime(),
+        }
+    }
+
+    /// Return the configured origin query policy, if any.
+    #[must_use]
+    pub fn origin_query_policy(&self) -> Option<OriginQueryPolicy> {
+        match self {
+            Self::S3SigV4(config) => config.origin_query,
+        }
+    }
+}
+
+/// AWS Signature Version 4 configuration for `S3` asset origins.
+///
+/// The route `origin_url` must use the same `S3` host that `AWS` validates in
+/// the `SigV4` canonical request. Credentials are read from the named runtime
+/// secret store and cached per process by configured secret names.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct S3SigV4AuthConfig {
+    /// `AWS` region used in the credential scope.
+    pub region: String,
+    /// Runtime secret store containing `S3` credentials.
+    #[serde(default = "default_s3_secret_store")]
+    pub secret_store: String,
+    /// Secret name containing the `AWS` access key ID.
+    #[serde(default = "default_s3_access_key_id")]
+    pub access_key_id: String,
+    /// Secret name containing the `AWS` secret access key.
+    #[serde(default = "default_s3_secret_access_key")]
+    pub secret_access_key: String,
+    /// Optional secret name containing an `AWS` session token.
+    #[serde(default)]
+    pub session_token: Option<String>,
+    /// Query-string handling policy for the signed `S3` origin request.
+    ///
+    /// Set this to `strip` when request query parameters are transformation
+    /// inputs rather than `S3` object identity. If omitted, image-optimized routes
+    /// strip queries and plain routes preserve them.
+    #[serde(default)]
+    pub origin_query: Option<OriginQueryPolicy>,
+}
+
+fn s3_region_is_valid(region: &str) -> bool {
+    region
+        .bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+impl S3SigV4AuthConfig {
+    fn normalize(&mut self) {
+        self.region = self.region.trim().to_string();
+        self.secret_store = self.secret_store.trim().to_string();
+        self.access_key_id = self.access_key_id.trim().to_string();
+        self.secret_access_key = self.secret_access_key.trim().to_string();
+        self.session_token = self
+            .session_token
+            .take()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+
+    fn prepare_runtime(&self) -> Result<(), Report<TrustedServerError>> {
+        if self.region.is_empty() {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: "proxy.asset_routes auth s3_sigv4 region must not be empty".to_string(),
+            }));
+        }
+        if !s3_region_is_valid(&self.region) {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message:
+                    "proxy.asset_routes auth s3_sigv4 region must contain only lowercase letters, digits, and '-'"
+                        .to_string(),
+            }));
+        }
+        if self.secret_store.is_empty()
+            || self.access_key_id.is_empty()
+            || self.secret_access_key.is_empty()
+        {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: "proxy.asset_routes auth s3_sigv4 secret names must not be empty"
+                    .to_string(),
+            }));
+        }
+        Ok(())
+    }
+}
+
+/// Route-level Image Optimizer configuration for asset proxying.
+///
+/// This block only selects the processing region and profile set. The actual
+/// transformation table lives under top-level [`ImageOptimizerSettings`] so
+/// multiple routes can share one closed set of profiles.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AssetImageOptimizerConfig {
+    /// Enables Image Optimizer for this route when the table is present.
+    #[serde(
+        default = "default_asset_image_optimizer_enabled",
+        deserialize_with = "bool_from_bool_or_str"
+    )]
+    pub enabled: bool,
+    /// Image Optimizer processing region.
+    pub region: String,
+    /// Name of the top-level profile set used to convert request query params.
+    pub profile_set: String,
+    /// Query-string handling policy for the origin request.
+    ///
+    /// `preserve` is rejected while Image Optimizer is enabled because Fastly `IO`
+    /// can interpret arbitrary request query parameters as transformation
+    /// inputs outside the configured profile table.
+    #[serde(default)]
+    pub origin_query: Option<OriginQueryPolicy>,
+}
+
+impl AssetImageOptimizerConfig {
+    fn normalize(&mut self) {
+        self.region = self.region.trim().to_string();
+        self.profile_set = self.profile_set.trim().to_string();
+    }
+
+    fn prepare_runtime(&self) -> Result<(), Report<TrustedServerError>> {
+        if !self.enabled {
+            return Ok(());
+        }
+        if self.region.is_empty() || self.profile_set.is_empty() {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message:
+                    "proxy.asset_routes image_optimizer region and profile_set must not be empty"
+                        .to_string(),
+            }));
+        }
+        if PlatformImageOptimizerRegion::parse(&self.region).is_none() {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "proxy.asset_routes image_optimizer region `{}` is not supported",
+                    self.region
+                ),
+            }));
+        }
+        Ok(())
+    }
+}
+
+/// Behavior when a requested image profile is missing or unknown.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UnknownProfilePolicy {
+    /// Use the configured default profile.
+    #[default]
+    UseDefault,
+    /// Reject the request.
+    Reject,
+}
+
+/// Top-level reusable Image Optimizer configuration.
+///
+/// Profile sets are keyed by arbitrary deployment-local names. Keep customer or
+/// site-specific profile tables in private configuration overlays when those
+/// values should not be committed to the public repository.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct ImageOptimizerSettings {
+    /// Named profile sets referenced by asset routes.
+    #[serde(default)]
+    pub profile_sets: HashMap<String, ImageOptimizerProfileSet>,
+}
+
+impl ImageOptimizerSettings {
+    fn normalize(&mut self) {
+        self.profile_sets = self
+            .profile_sets
+            .drain()
+            .map(|(key, mut profile_set)| {
+                profile_set.normalize();
+                (key.trim().to_string(), profile_set)
+            })
+            .filter(|(key, _)| !key.is_empty())
+            .collect();
+    }
+
+    /// Eagerly validate configured image profile sets.
+    pub(crate) fn prepare_runtime(&self) -> Result<(), Report<TrustedServerError>> {
+        for (name, profile_set) in &self.profile_sets {
+            profile_set.prepare_runtime(name)?;
+        }
+        Ok(())
+    }
+}
+
+/// Named set of profile-table Image Optimizer mappings.
+///
+/// Each profile value is a URL-encoded parameter string using the strict
+/// supported subset: `quality`, `resize-filter`, `format`, `width`, `height`,
+/// and `crop`. Profile-specific parameters override [`Self::base_params`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImageOptimizerProfileSet {
+    /// Params applied to every profile before profile-specific params.
+    #[serde(default)]
+    pub base_params: String,
+    /// Profile used when the query omits or does not recognize a profile.
+    #[serde(default = "default_default_profile")]
+    pub default_profile: String,
+    /// Unknown profile handling policy.
+    #[serde(default)]
+    pub unknown_profile: UnknownProfilePolicy,
+    /// Query parameter that carries the profile name.
+    #[serde(default = "default_profile_param")]
+    pub profile_param: String,
+    /// Query parameter that carries an aspect ratio override.
+    #[serde(default = "default_aspect_ratio_param")]
+    pub aspect_ratio_param: String,
+    /// Query parameter that disables `IO` for a request when set to `1`.
+    #[serde(default = "default_debug_param")]
+    pub debug_param: String,
+    /// Profile name to IO param string mapping.
+    ///
+    /// Values use query-string syntax, for example `format=auto&width=828`.
+    #[serde(default)]
+    pub profiles: HashMap<String, String>,
+    /// Optional aspect-ratio override rules.
+    #[serde(default)]
+    pub aspect_ratios: Option<ImageOptimizerAspectRatioConfig>,
+    /// Optional crop offset bucketing rules.
+    #[serde(default)]
+    pub crop_offsets: Option<ImageOptimizerCropOffsetsConfig>,
+}
+
+impl ImageOptimizerProfileSet {
+    fn normalize(&mut self) {
+        self.base_params = self.base_params.trim().to_string();
+        self.default_profile = self.default_profile.trim().to_string();
+        self.profile_param = self.profile_param.trim().to_string();
+        self.aspect_ratio_param = self.aspect_ratio_param.trim().to_string();
+        self.debug_param = self.debug_param.trim().to_string();
+        self.profiles = self
+            .profiles
+            .drain()
+            .map(|(key, value)| (key.trim().to_string(), value.trim().to_string()))
+            .filter(|(key, _)| !key.is_empty())
+            .collect();
+        if let Some(config) = &mut self.aspect_ratios {
+            config.normalize();
+        }
+        if let Some(config) = &mut self.crop_offsets {
+            config.normalize();
+        }
+    }
+
+    fn prepare_runtime(&self, name: &str) -> Result<(), Report<TrustedServerError>> {
+        if self.default_profile.is_empty()
+            || self.profile_param.is_empty()
+            || self.aspect_ratio_param.is_empty()
+            || self.debug_param.is_empty()
+        {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "image_optimizer.profile_sets `{name}` parameter names and default_profile must not be empty"
+                ),
+            }));
+        }
+        if !self.profiles.contains_key(&self.default_profile) {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "image_optimizer.profile_sets `{name}` default_profile `{}` is not defined",
+                    self.default_profile
+                ),
+            }));
+        }
+        validate_image_optimizer_profile_set(name, self)?;
+        if let Some(config) = &self.aspect_ratios {
+            config.prepare_runtime(name, &self.profiles)?;
+        }
+        if let Some(config) = &self.crop_offsets {
+            config.prepare_runtime(name)?;
+        }
+        Ok(())
+    }
+}
+
+/// Aspect-ratio override configuration for an Image Optimizer profile set.
+///
+/// When a request uses an allowed profile and an allowed ratio value, the
+/// profile crop is replaced with an aspect-ratio crop derived from the request
+/// query value.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImageOptimizerAspectRatioConfig {
+    /// Allowed aspect ratio query values such as `1-1` or `16-9`.
+    #[serde(default, deserialize_with = "vec_from_seq_or_map")]
+    pub allowed: Vec<String>,
+    /// Profiles that accept aspect-ratio overrides.
+    #[serde(default, deserialize_with = "vec_from_seq_or_map")]
+    pub profiles: Vec<String>,
+}
+
+impl ImageOptimizerAspectRatioConfig {
+    fn normalize(&mut self) {
+        self.allowed = self
+            .allowed
+            .iter()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .collect();
+        self.profiles = self
+            .profiles
+            .iter()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .collect();
+    }
+
+    fn prepare_runtime(
+        &self,
+        name: &str,
+        configured_profiles: &HashMap<String, String>,
+    ) -> Result<(), Report<TrustedServerError>> {
+        for ratio in &self.allowed {
+            if parse_aspect_ratio_value(ratio).is_none() {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "image_optimizer.profile_sets `{name}` aspect ratio `{ratio}` must look like `width-height`"
+                    ),
+                }));
+            }
+        }
+        for profile in &self.profiles {
+            if !configured_profiles.contains_key(profile) {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "image_optimizer.profile_sets `{name}` aspect ratio profile `{profile}` is not defined"
+                    ),
+                }));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Behavior when a bare crop has no explicit x/y offsets.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissingCropOffsetMode {
+    /// Append Fastly `IO` `smart` crop mode.
+    #[default]
+    Smart,
+    /// Leave the crop as-is.
+    None,
+}
+
+/// Crop offset normalization configuration.
+///
+/// Offset bucketing caps output variant cardinality. Request values outside
+/// `0..=100` or values that fail to parse fall back to [`Self::default`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImageOptimizerCropOffsetsConfig {
+    /// Enable crop offset normalization.
+    #[serde(
+        default = "default_asset_image_optimizer_enabled",
+        deserialize_with = "bool_from_bool_or_str"
+    )]
+    pub enabled: bool,
+    /// Query parameter containing the x-axis offset.
+    #[serde(default = "default_crop_offset_x_param")]
+    pub x_param: String,
+    /// Query parameter containing the y-axis offset.
+    #[serde(default = "default_crop_offset_y_param")]
+    pub y_param: String,
+    /// Sorted offset buckets used to cap variant cardinality.
+    #[serde(
+        default = "default_crop_offset_buckets",
+        deserialize_with = "vec_from_seq_or_map"
+    )]
+    pub buckets: Vec<u32>,
+    /// Default offset used when input is missing or invalid.
+    #[serde(default = "default_crop_offset_value")]
+    pub default: u32,
+    /// Behavior when neither x nor y is present.
+    #[serde(default)]
+    pub when_missing: MissingCropOffsetMode,
+}
+
+impl ImageOptimizerCropOffsetsConfig {
+    fn normalize(&mut self) {
+        self.x_param = self.x_param.trim().to_string();
+        self.y_param = self.y_param.trim().to_string();
+        self.buckets.sort_unstable();
+        self.buckets.dedup();
+    }
+
+    fn prepare_runtime(&self, name: &str) -> Result<(), Report<TrustedServerError>> {
+        if self.x_param.is_empty() || self.y_param.is_empty() {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "image_optimizer.profile_sets `{name}` crop offset param names must not be empty"
+                ),
+            }));
+        }
+        if self.buckets.is_empty()
+            || self.buckets.iter().any(|bucket| *bucket > 100)
+            || self.default > 100
+        {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "image_optimizer.profile_sets `{name}` crop offset buckets/default must be in 0..=100"
+                ),
+            }));
+        }
+        Ok(())
+    }
+}
+
+fn parse_aspect_ratio_value(value: &str) -> Option<(u32, u32)> {
+    let (width, height) = value.split_once('-')?;
+    let width = width.parse::<u32>().ok()?;
+    let height = height.parse::<u32>().ok()?;
+    if width == 0 || height == 0 {
+        return None;
+    }
+    Some((width, height))
+}
+
+fn validate_image_optimizer_profile_set(
+    name: &str,
+    profile_set: &ImageOptimizerProfileSet,
+) -> Result<(), Report<TrustedServerError>> {
+    validate_image_optimizer_param_string(name, "base_params", &profile_set.base_params)?;
+    for (profile_name, params) in &profile_set.profiles {
+        validate_image_optimizer_param_string(name, profile_name, params)?;
+    }
+    Ok(())
+}
+
+fn validate_image_optimizer_param_string(
+    set_name: &str,
+    profile_name: &str,
+    params: &str,
+) -> Result<(), Report<TrustedServerError>> {
+    for (key, value) in url::form_urlencoded::parse(params.as_bytes()) {
+        match key.as_ref() {
+            "format" => validate_image_optimizer_format(set_name, profile_name, value.as_ref())?,
+            "quality" => {
+                validate_bounded_u32_param(
+                    set_name,
+                    profile_name,
+                    "quality",
+                    value.as_ref(),
+                    0,
+                    100,
+                )?;
+            }
+            "resize-filter" => {
+                validate_resize_filter(set_name, profile_name, value.as_ref())?;
+            }
+            "width" | "height" => {
+                validate_positive_u32_param(set_name, profile_name, key.as_ref(), value.as_ref())?;
+            }
+            "crop" => validate_crop_param(set_name, profile_name, value.as_ref())?,
+            unsupported => {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` uses unsupported parameter `{unsupported}`"
+                    ),
+                }));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_image_optimizer_format(
+    set_name: &str,
+    profile_name: &str,
+    value: &str,
+) -> Result<(), Report<TrustedServerError>> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "auto" | "avif" | "gif" | "jpeg" | "jpg" | "jxl" | "jpegxl" | "mp4" | "png"
+        | "webp" => Ok(()),
+        _ => Err(Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` has unsupported format `{value}`"
+            ),
+        })),
+    }
+}
+
+fn validate_resize_filter(
+    set_name: &str,
+    profile_name: &str,
+    value: &str,
+) -> Result<(), Report<TrustedServerError>> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "nearest" | "bilinear" | "bicubic" | "lanczos2" | "lanczos3" => Ok(()),
+        _ => Err(Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` has unsupported resize-filter `{value}`"
+            ),
+        })),
+    }
+}
+
+fn validate_positive_u32_param(
+    set_name: &str,
+    profile_name: &str,
+    param_name: &str,
+    value: &str,
+) -> Result<(), Report<TrustedServerError>> {
+    let parsed = value.parse::<u32>().map_err(|err| {
+        Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` parameter `{param_name}` must be an integer: {err}"
+            ),
+        })
+    })?;
+    if parsed == 0 {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` parameter `{param_name}` must be greater than zero"
+            ),
+        }));
+    }
+    Ok(())
+}
+
+fn validate_bounded_u32_param(
+    set_name: &str,
+    profile_name: &str,
+    param_name: &str,
+    value: &str,
+    min: u32,
+    max: u32,
+) -> Result<(), Report<TrustedServerError>> {
+    let parsed = value.parse::<u32>().map_err(|err| {
+        Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` parameter `{param_name}` must be an integer: {err}"
+            ),
+        })
+    })?;
+    if parsed < min || parsed > max {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` parameter `{param_name}` must be in {min}..={max}"
+            ),
+        }));
+    }
+    Ok(())
+}
+
+fn validate_crop_param(
+    set_name: &str,
+    profile_name: &str,
+    value: &str,
+) -> Result<(), Report<TrustedServerError>> {
+    let mut parts = value.split(',');
+    let ratio = parts.next().unwrap_or_default();
+    let Some((width, height)) = ratio.split_once(':') else {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` crop `{value}` must look like `width:height`"
+            ),
+        }));
+    };
+    validate_positive_u32_param(set_name, profile_name, "crop width", width)?;
+    validate_positive_u32_param(set_name, profile_name, "crop height", height)?;
+
+    let mut has_smart = false;
+    let mut has_offset_x = false;
+    let mut has_offset_y = false;
+    for suffix in parts {
+        if suffix == "smart" {
+            has_smart = true;
+        } else if let Some(offset) = suffix.strip_prefix("offset-x") {
+            validate_bounded_u32_param(set_name, profile_name, "crop offset-x", offset, 0, 100)?;
+            has_offset_x = true;
+        } else if let Some(offset) = suffix.strip_prefix("offset-y") {
+            validate_bounded_u32_param(set_name, profile_name, "crop offset-y", offset, 0, 100)?;
+            has_offset_y = true;
+        } else {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` crop has unsupported suffix `{suffix}`"
+                ),
+            }));
+        }
+    }
+
+    if has_smart && (has_offset_x || has_offset_y) {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` crop cannot combine smart with offsets"
+            ),
+        }));
+    }
+    if has_offset_x != has_offset_y {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` crop offsets must include both offset-x and offset-y"
+            ),
+        }));
+    }
+    Ok(())
+}
+
+/// A path-prefix asset route that proxies matched first-party requests to an alternate origin.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct ProxyAssetRoute {
+    /// Path prefix matched against the incoming request path. Must start with `/`.
+    ///
+    /// Matching uses string-prefix semantics, not path-segment semantics. Include
+    /// a trailing `/` unless you intentionally want `/static` to match paths such
+    /// as `/staticfile.js`.
+    pub prefix: String,
+    /// Absolute `http` or `https` origin used for upstream requests.
+    ///
+    /// Only the scheme, host, and port are used. Any path or query configured on
+    /// this URL is rejected because the incoming request path/query, or the
+    /// configured rewrite result, replaces them at runtime.
+    pub origin_url: String,
+    /// Optional regex matched against the incoming request path before proxying.
+    pub path_pattern: Option<String>,
+    /// Optional regex replacement used with [`Self::path_pattern`] to build the upstream path.
+    ///
+    /// Must be configured together with [`Self::path_pattern`] and must produce a
+    /// path that starts with `/`.
+    pub target_path: Option<String>,
+    /// Optional origin authentication configuration.
+    #[serde(default)]
+    pub auth: Option<AssetOriginAuth>,
+    /// Optional Image Optimizer configuration.
+    #[serde(default)]
+    pub image_optimizer: Option<AssetImageOptimizerConfig>,
+    #[serde(skip, default)]
+    compiled_pattern: OnceLock<Result<Regex, String>>,
+}
+
+impl ProxyAssetRoute {
+    /// Create an asset route with the required prefix and origin URL.
+    #[must_use]
+    pub fn new(prefix: impl Into<String>, origin_url: impl Into<String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            origin_url: origin_url.into(),
+            ..Self::default()
+        }
+    }
+
+    fn normalize(&mut self) {
+        self.prefix = self.prefix.trim().to_string();
+        self.origin_url = self.origin_url.trim().to_string();
+        self.path_pattern = self
+            .path_pattern
+            .take()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        self.target_path = self
+            .target_path
+            .take()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        if let Some(auth) = &mut self.auth {
+            auth.normalize();
+        }
+        if let Some(image_optimizer) = &mut self.image_optimizer {
+            image_optimizer.normalize();
+        }
+    }
+
+    fn compiled_path_pattern(&self) -> Result<Option<&Regex>, Report<TrustedServerError>> {
+        let Some(pattern) = self.path_pattern.as_deref() else {
+            return Ok(None);
+        };
+
+        match self
+            .compiled_pattern
+            .get_or_init(|| Regex::new(pattern).map_err(|err| err.to_string()))
+        {
+            Ok(regex) => Ok(Some(regex)),
+            Err(message) => Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "proxy.asset_routes path_pattern `{pattern}` failed to compile: {message}"
+                ),
+            })),
+        }
+    }
+
+    /// Rewrite a matched request path to the configured upstream target path.
+    ///
+    /// # Errors
+    ///
+    /// Returns a proxy/configuration error if the rewrite is incomplete, does not
+    /// match the request path, or produces a path that does not start with `/`.
+    pub fn target_path_for(&self, path: &str) -> Result<String, Report<TrustedServerError>> {
+        match (&self.path_pattern, &self.target_path) {
+            (None, None) => Ok(path.to_string()),
+            (Some(_), Some(target_path)) => {
+                let Some(regex) = self.compiled_path_pattern()? else {
+                    return Err(Report::new(TrustedServerError::Configuration {
+                        message: format!(
+                            "proxy.asset_routes prefix `{}` must configure path_pattern and target_path together",
+                            self.prefix
+                        ),
+                    }));
+                };
+
+                if !regex.is_match(path) {
+                    return Err(Report::new(TrustedServerError::Proxy {
+                        message: format!(
+                            "asset path `{path}` matched prefix `{}` but did not match path_pattern",
+                            self.prefix
+                        ),
+                    }));
+                }
+
+                let rewritten = regex.replace(path, target_path.as_str()).into_owned();
+                if !rewritten.starts_with('/') {
+                    return Err(Report::new(TrustedServerError::Configuration {
+                        message: format!(
+                            "proxy.asset_routes prefix `{}` rewrote `{path}` to `{rewritten}`, which must start with '/'",
+                            self.prefix
+                        ),
+                    }));
+                }
+
+                Ok(rewritten)
+            }
+            _ => Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "proxy.asset_routes prefix `{}` must configure path_pattern and target_path together",
+                    self.prefix
+                ),
+            })),
+        }
+    }
+
+    /// Eagerly validate runtime-only asset-route configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns a configuration error if the asset-route prefix, origin URL, or
+    /// path rewrite settings are invalid.
+    pub fn prepare_runtime(&self) -> Result<(), Report<TrustedServerError>> {
+        validate_asset_route_prefix(&self.prefix).map_err(|err| {
+            Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "proxy.asset_routes prefix `{}` is invalid: {err}",
+                    self.prefix
+                ),
+            })
+        })?;
+
+        validate_proxy_origin_url(&self.origin_url).map_err(|err| {
+            Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "proxy.asset_routes origin_url `{}` is invalid: {err}",
+                    self.origin_url
+                ),
+            })
+        })?;
+
+        if matches!(&self.auth, Some(AssetOriginAuth::S3SigV4(_))) {
+            let parsed_origin = Url::parse(&self.origin_url).map_err(|err| {
+                Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "proxy.asset_routes origin_url `{}` is invalid: {err}",
+                        self.origin_url
+                    ),
+                })
+            })?;
+            if parsed_origin.scheme() != "https" {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "proxy.asset_routes origin_url `{}` must use https when auth type is s3_sigv4",
+                        self.origin_url
+                    ),
+                }));
+            }
+        }
+
+        match (&self.path_pattern, &self.target_path) {
+            (None, None) | (Some(_), Some(_)) => {}
+            _ => {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "proxy.asset_routes prefix `{}` must configure path_pattern and target_path together",
+                        self.prefix
+                    ),
+                }));
+            }
+        }
+
+        if let Some(auth) = &self.auth {
+            auth.prepare_runtime()?;
+        }
+        if let Some(image_optimizer) = &self.image_optimizer {
+            image_optimizer.prepare_runtime()?;
+        }
+        if self.image_optimizer_enabled()
+            && self.origin_query_policy() == OriginQueryPolicy::Preserve
+        {
+            return Err(Report::new(TrustedServerError::Configuration {
+                message: format!(
+                    "proxy.asset_routes prefix `{}` cannot preserve origin query while image_optimizer is enabled; profile-table IO requires origin_query = \"strip\"",
+                    self.prefix
+                ),
+            }));
+        }
+
+        self.compiled_path_pattern().map(|_| ())
+    }
+
+    /// Return true when this route has enabled Image Optimizer configuration.
+    #[must_use]
+    pub fn image_optimizer_enabled(&self) -> bool {
+        self.image_optimizer
+            .as_ref()
+            .is_some_and(|config| config.enabled)
+    }
+
+    /// Return the effective origin query policy for this asset route.
+    ///
+    /// Precedence is auth-level `origin_query`, then enabled Image Optimizer
+    /// `origin_query`, then the route default. The default is `strip` for
+    /// enabled Image Optimizer routes and `preserve` otherwise.
+    #[must_use]
+    pub fn origin_query_policy(&self) -> OriginQueryPolicy {
+        if let Some(policy) = self
+            .auth
+            .as_ref()
+            .and_then(AssetOriginAuth::origin_query_policy)
+        {
+            return policy;
+        }
+        if let Some(policy) = self
+            .image_optimizer
+            .as_ref()
+            .filter(|config| config.enabled)
+            .and_then(|config| config.origin_query)
+        {
+            return policy;
+        }
+        if self.image_optimizer_enabled() {
+            OriginQueryPolicy::Strip
+        } else {
+            OriginQueryPolicy::Preserve
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Proxy {
     /// Enable TLS certificate verification when proxying to HTTPS origins.
@@ -582,6 +1525,9 @@ pub struct Proxy {
     /// initiated by signed first-party proxy URLs.
     #[serde(default, deserialize_with = "vec_from_seq_or_map")]
     pub allowed_domains: Vec<String>,
+    /// Path-prefix-based asset proxy routes evaluated before publisher fallback.
+    #[serde(default, deserialize_with = "vec_from_seq_or_map")]
+    pub asset_routes: Vec<ProxyAssetRoute>,
 }
 
 fn default_certificate_check() -> bool {
@@ -600,6 +1546,7 @@ impl Default for Proxy {
         Self {
             certificate_check: default_certificate_check(),
             allowed_domains: Vec::new(),
+            asset_routes: Vec::new(),
         }
     }
 }
@@ -634,6 +1581,63 @@ impl Proxy {
                 "proxy.allowed_domains is empty: all redirect destinations are permitted (open mode)"
             );
         }
+
+        for route in &mut self.asset_routes {
+            route.normalize();
+        }
+
+        let mut seen_prefixes = HashSet::new();
+        for route in &self.asset_routes {
+            if !route.prefix.is_empty() && !seen_prefixes.insert(route.prefix.clone()) {
+                log::warn!(
+                    "proxy.asset_routes contains duplicate prefix `{}`; the first configured route will be used",
+                    route.prefix
+                );
+            }
+
+            if !route.prefix.is_empty() && route.prefix != "/" && !route.prefix.ends_with('/') {
+                log::warn!(
+                    "proxy.asset_routes prefix `{}` does not end with `/`; matching uses raw string-prefix semantics, so this also matches paths such as `{}example`",
+                    route.prefix,
+                    route.prefix
+                );
+            }
+        }
+    }
+
+    /// Eagerly validate runtime-only proxy settings artifacts.
+    ///
+    /// Asset-route validation lives here so regex compilation and origin URL
+    /// semantic checks fail fast alongside other runtime-prepared settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns a configuration error if any configured asset route is invalid.
+    pub fn prepare_runtime(&self) -> Result<(), Report<TrustedServerError>> {
+        for route in &self.asset_routes {
+            route.prepare_runtime()?;
+        }
+
+        Ok(())
+    }
+
+    /// Resolve the longest matching asset route for the given request path.
+    #[must_use]
+    pub fn asset_route_for_path(&self, path: &str) -> Option<&ProxyAssetRoute> {
+        let mut best_match: Option<&ProxyAssetRoute> = None;
+
+        for route in &self.asset_routes {
+            if !path.starts_with(&route.prefix) {
+                continue;
+            }
+
+            match best_match {
+                Some(current) if current.prefix.len() >= route.prefix.len() => {}
+                _ => best_match = Some(route),
+            }
+        }
+
+        best_match
     }
 }
 
@@ -674,6 +1678,8 @@ pub struct Settings {
     #[serde(default)]
     pub proxy: Proxy,
     #[serde(default)]
+    pub image_optimizer: ImageOptimizerSettings,
+    #[serde(default)]
     pub debug: DebugConfig,
 }
 
@@ -693,6 +1699,7 @@ impl Settings {
             })?;
 
         settings.proxy.normalize();
+        settings.image_optimizer.normalize();
         settings.consent.validate();
         settings.prepare_runtime()?;
 
@@ -739,6 +1746,7 @@ impl Settings {
 
         settings.integrations.normalize();
         settings.proxy.normalize();
+        settings.image_optimizer.normalize();
         settings.consent.validate();
 
         settings.validate().map_err(|err| {
@@ -760,6 +1768,10 @@ impl Settings {
     ///
     /// Returns a configuration error if any handler path regex does not compile.
     pub fn prepare_runtime(&self) -> Result<(), Report<TrustedServerError>> {
+        self.image_optimizer.prepare_runtime()?;
+        self.proxy.prepare_runtime()?;
+        self.validate_asset_image_optimizer_profile_sets()?;
+
         for handler in &self.handlers {
             handler.prepare_runtime()?;
         }
@@ -795,6 +1807,38 @@ impl Settings {
         Err(Report::new(TrustedServerError::InsecureDefault {
             field: insecure_fields.join(", "),
         }))
+    }
+
+    fn validate_asset_image_optimizer_profile_sets(
+        &self,
+    ) -> Result<(), Report<TrustedServerError>> {
+        for route in &self.proxy.asset_routes {
+            let Some(config) = &route.image_optimizer else {
+                continue;
+            };
+            if !config.enabled {
+                continue;
+            }
+            if !self
+                .image_optimizer
+                .profile_sets
+                .contains_key(&config.profile_set)
+            {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "proxy.asset_routes prefix `{}` references unknown image_optimizer profile_set `{}`",
+                        route.prefix, config.profile_set
+                    ),
+                }));
+            }
+        }
+        Ok(())
+    }
+
+    /// Resolve the longest matching asset route for the request path.
+    #[must_use]
+    pub fn asset_route_for_path(&self, path: &str) -> Option<&ProxyAssetRoute> {
+        self.proxy.asset_route_for_path(path)
     }
 
     /// Resolve the first handler whose regex matches the request path.
@@ -954,9 +1998,24 @@ fn validate_no_trailing_slash(value: &str) -> Result<(), ValidationError> {
     if value.ends_with('/') {
         let mut err = ValidationError::new("trailing_slash");
         err.add_param("value".into(), &value);
-        err.message = Some("origin_url must not end with '/'".into());
+        err.message = Some("origin_url must not include a trailing slash".into());
         return Err(err);
     }
+    Ok(())
+}
+
+fn validate_host_header_override(value: &str) -> Result<(), ValidationError> {
+    if let Err(reason) = validate_host_header_override_value(value) {
+        let mut err = ValidationError::new("invalid_host_header_override");
+        err.add_param("value".into(), &value);
+        err.add_param("reason".into(), &reason);
+        err.message = Some(
+            "origin_host_header_override must be a valid host or host:port without scheme, path, query, or fragment"
+                .into(),
+        );
+        return Err(err);
+    }
+
     Ok(())
 }
 
@@ -964,6 +2023,74 @@ fn validate_redacted_not_empty(value: &Redacted<String>) -> Result<(), Validatio
     if value.expose().is_empty() {
         return Err(ValidationError::new("empty_value"));
     }
+    Ok(())
+}
+
+fn validate_asset_route_prefix(value: &str) -> Result<(), ValidationError> {
+    if !value.starts_with('/') {
+        let mut err = ValidationError::new("invalid_prefix");
+        err.add_param("value".into(), &value);
+        err.message = Some("asset-route prefix must start with '/'".into());
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+fn validate_proxy_origin_url(value: &str) -> Result<(), ValidationError> {
+    validate_no_trailing_slash(value)?;
+
+    let parsed = Url::parse(value).map_err(|parse_error| {
+        let mut err = ValidationError::new("invalid_origin_url");
+        err.add_param("value".into(), &value);
+        err.add_param("message".into(), &parse_error.to_string());
+        err.message = Some("origin_url must be an absolute http or https URL".into());
+        err
+    })?;
+
+    if !matches!(parsed.scheme(), "http" | "https") {
+        let mut err = ValidationError::new("invalid_origin_url_scheme");
+        err.add_param("value".into(), &value);
+        err.message = Some("origin_url must use http or https".into());
+        return Err(err);
+    }
+
+    if parsed.host_str().is_none() {
+        let mut err = ValidationError::new("missing_origin_host");
+        err.add_param("value".into(), &value);
+        err.message = Some("origin_url must include a host".into());
+        return Err(err);
+    }
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        let mut err = ValidationError::new("origin_url_has_userinfo");
+        err.add_param("value".into(), &value);
+        err.message = Some("origin_url must not include username or password".into());
+        return Err(err);
+    }
+
+    if parsed.fragment().is_some() {
+        let mut err = ValidationError::new("origin_url_has_fragment");
+        err.add_param("value".into(), &value);
+        err.message = Some("origin_url must not include a fragment".into());
+        return Err(err);
+    }
+
+    if !matches!(parsed.path(), "" | "/") {
+        let mut err = ValidationError::new("origin_url_has_path");
+        err.add_param("value".into(), &value);
+        err.message =
+            Some("origin_url must not include a path; only scheme/host/port are used".into());
+        return Err(err);
+    }
+
+    if parsed.query().is_some() {
+        let mut err = ValidationError::new("origin_url_has_query");
+        err.add_param("value".into(), &value);
+        err.message = Some("origin_url must not include a query string".into());
+        return Err(err);
+    }
+
     Ok(())
 }
 
@@ -1030,6 +2157,23 @@ where
         JsonValue::Null => Ok(HashMap::new()),
         other => Err(serde::de::Error::custom(format!(
             "expected object or JSON string, got {other}",
+        ))),
+    }
+}
+
+pub(crate) fn bool_from_bool_or_str<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = JsonValue::deserialize(deserializer)?;
+    match value {
+        JsonValue::Bool(value) => Ok(value),
+        JsonValue::String(value) => value
+            .trim()
+            .parse::<bool>()
+            .map_err(serde::de::Error::custom),
+        other => Err(serde::de::Error::custom(format!(
+            "expected bool or parseable bool string, got {other}"
         ))),
     }
 }
@@ -1163,6 +2307,7 @@ mod tests {
             settings.publisher.origin_url,
             "https://origin.test-publisher.com"
         );
+        assert_eq!(settings.publisher.origin_host_header_override, None);
         assert_eq!(
             settings.ec.passphrase.expose(),
             "test-secret-key-32-bytes-minimum"
@@ -1240,6 +2385,73 @@ mod tests {
             assert!(
                 result.is_err(),
                 "should reject invalid source_domain {source_domain:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_accepts_origin_host_header_override() {
+        let toml_str = crate_test_settings_str().replace(
+            r#"origin_url = "https://origin.test-publisher.com""#,
+            r#"origin_url = "https://origin.test-publisher.com"
+origin_host_header_override = "www.example.com:8443""#,
+        );
+
+        let settings = Settings::from_toml(&toml_str).expect("should accept host header override");
+        assert_eq!(
+            settings.publisher.origin_host_header(),
+            "www.example.com:8443",
+            "should use configured host header override"
+        );
+    }
+
+    #[test]
+    fn publisher_rejects_unknown_fields() {
+        let toml_str = crate_test_settings_str().replace(
+            r#"origin_url = "https://origin.test-publisher.com""#,
+            r#"origin_url = "https://origin.test-publisher.com"
+origin_host_header_overide = "www.example.com""#,
+        );
+
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("unknown publisher fields should fail configuration loading");
+        assert!(
+            format!("{err:?}").contains("origin_host_header_overide"),
+            "error should identify the misspelled publisher field: {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_invalid_origin_host_header_overrides() {
+        for override_value in [
+            "",
+            " www.example.com",
+            "www.example.com ",
+            "https://www.example.com",
+            "www.example.com/path",
+            "www.example.com?query=1",
+            "www.example.com#fragment",
+            "www.example.com\n",
+            "www.example.com:",
+            "www.example.com:99999",
+            "example..com",
+            ".",
+            "-",
+            "-example.com",
+            "example-.com",
+            "[::1",
+        ] {
+            let toml_str = crate_test_settings_str().replace(
+                r#"origin_url = "https://origin.test-publisher.com""#,
+                &format!(
+                    "origin_url = \"https://origin.test-publisher.com\"\norigin_host_header_override = {override_value:?}"
+                ),
+            );
+
+            let result = Settings::from_toml(&toml_str);
+            assert!(
+                result.is_err(),
+                "origin_host_header_override {override_value:?} should fail validation"
             );
         }
     }
@@ -1921,12 +3133,53 @@ mod tests {
     }
 
     #[test]
+    fn test_origin_host_header_override_env() {
+        let env_key = format!(
+            "{}{}PUBLISHER{}ORIGIN_HOST_HEADER_OVERRIDE",
+            ENVIRONMENT_VARIABLE_PREFIX,
+            ENVIRONMENT_VARIABLE_SEPARATOR,
+            ENVIRONMENT_VARIABLE_SEPARATOR
+        );
+
+        temp_env::with_var(env_key, Some("www.example.com"), || {
+            let settings = Settings::from_toml_and_env(&crate_test_settings_str())
+                .expect("should load settings with host header override env");
+
+            assert_eq!(
+                settings.publisher.origin_host_header_override.as_deref(),
+                Some("www.example.com")
+            );
+            assert_eq!(settings.publisher.origin_host_header(), "www.example.com");
+        });
+    }
+
+    #[test]
+    fn test_origin_host_header_override_env_typo_fails_closed() {
+        let env_key = format!(
+            "{}{}PUBLISHER{}ORIGIN_HOST_HEADER_OVERIDE",
+            ENVIRONMENT_VARIABLE_PREFIX,
+            ENVIRONMENT_VARIABLE_SEPARATOR,
+            ENVIRONMENT_VARIABLE_SEPARATOR
+        );
+
+        temp_env::with_var(env_key, Some("www.example.com"), || {
+            let err = Settings::from_toml_and_env(&crate_test_settings_str())
+                .expect_err("misspelled host override env var should fail configuration loading");
+            assert!(
+                format!("{err:?}").contains("origin_host_header_overide"),
+                "error should identify the misspelled publisher env field: {err:?}"
+            );
+        });
+    }
+
+    #[test]
     fn test_publisher_origin_host() {
         // Test with full URL including port
         let publisher = Publisher {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "https://origin.example.com:8080".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "origin.example.com:8080");
@@ -1936,6 +3189,7 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "https://origin.example.com".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "origin.example.com");
@@ -1945,6 +3199,7 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://localhost:9090".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "localhost:9090");
@@ -1954,6 +3209,7 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "localhost:9090".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "localhost:9090");
@@ -1963,6 +3219,7 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://192.168.1.1:8080".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "192.168.1.1:8080");
@@ -1972,9 +3229,36 @@ mod tests {
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://[::1]:8080".to_string(),
+            origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
         };
         assert_eq!(publisher.origin_host(), "[::1]:8080");
+    }
+
+    #[test]
+    fn test_publisher_origin_host_header_defaults_to_origin_host() {
+        let publisher = Publisher {
+            domain: "example.com".to_string(),
+            cookie_domain: ".example.com".to_string(),
+            origin_url: "https://origin.example.com:8443".to_string(),
+            origin_host_header_override: None,
+            proxy_secret: Redacted::new("test-secret".to_string()),
+        };
+
+        assert_eq!(publisher.origin_host_header(), "origin.example.com:8443");
+    }
+
+    #[test]
+    fn test_publisher_origin_host_header_uses_override() {
+        let publisher = Publisher {
+            domain: "example.com".to_string(),
+            cookie_domain: ".example.com".to_string(),
+            origin_url: "https://origin.example.com".to_string(),
+            origin_host_header_override: Some("www.example.com".to_string()),
+            proxy_secret: Redacted::new("test-secret".to_string()),
+        };
+
+        assert_eq!(publisher.origin_host_header(), "www.example.com");
     }
 
     #[test]
@@ -2356,6 +3640,7 @@ mod tests {
                 "  AD.EXAMPLE.COM  ".to_string(),
                 "*.Example.Org".to_string(),
             ],
+            asset_routes: vec![],
         };
         proxy.normalize();
         assert_eq!(
@@ -2375,6 +3660,7 @@ mod tests {
                 "".to_string(),
                 "cdn.example.com".to_string(),
             ],
+            asset_routes: vec![],
         };
         proxy.normalize();
         assert_eq!(
@@ -2389,6 +3675,7 @@ mod tests {
         let mut proxy = Proxy {
             certificate_check: true,
             allowed_domains: vec!["*".to_string(), "tracker.com".to_string()],
+            asset_routes: vec![],
         };
         proxy.normalize();
         assert_eq!(
@@ -2403,6 +3690,7 @@ mod tests {
         let mut proxy = Proxy {
             certificate_check: true,
             allowed_domains: vec!["*".to_string()],
+            asset_routes: vec![],
         };
         proxy.normalize();
         assert!(
@@ -2416,11 +3704,532 @@ mod tests {
         let mut proxy = Proxy {
             certificate_check: true,
             allowed_domains: vec!["  ".to_string(), "\t".to_string()],
+            asset_routes: vec![],
         };
         proxy.normalize();
         assert!(
             proxy.allowed_domains.is_empty(),
             "all-blank list should normalize to empty (open mode)"
+        );
+    }
+
+    #[test]
+    fn proxy_normalize_trims_asset_routes() {
+        let mut proxy = Proxy {
+            certificate_check: true,
+            allowed_domains: vec![],
+            asset_routes: vec![ProxyAssetRoute {
+                prefix: "  /.images/  ".to_string(),
+                origin_url: "  https://assets.example.com  ".to_string(),
+                ..Default::default()
+            }],
+        };
+        proxy.normalize();
+        assert_eq!(
+            proxy.asset_routes[0].prefix, "/.images/",
+            "should trim asset-route prefix"
+        );
+        assert_eq!(
+            proxy.asset_routes[0].origin_url, "https://assets.example.com",
+            "should trim asset-route origin_url"
+        );
+    }
+
+    #[test]
+    fn proxy_normalize_trims_asset_route_rewrite_fields() {
+        let mut proxy = Proxy {
+            certificate_check: true,
+            allowed_domains: vec![],
+            asset_routes: vec![ProxyAssetRoute {
+                prefix: "/.images/".to_string(),
+                origin_url: "https://assets.example.com".to_string(),
+                path_pattern: Some("  ^/(.*)$  ".to_string()),
+                target_path: Some("  /rewritten/$1  ".to_string()),
+                ..Default::default()
+            }],
+        };
+        proxy.normalize();
+
+        assert_eq!(
+            proxy.asset_routes[0].path_pattern.as_deref(),
+            Some("^/(.*)$"),
+            "should trim asset-route path_pattern"
+        );
+        assert_eq!(
+            proxy.asset_routes[0].target_path.as_deref(),
+            Some("/rewritten/$1"),
+            "should trim asset-route target_path"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_rewrite_fields_parse_from_toml() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.image/"
+            origin_url = "https://assets.example.com"
+            path_pattern = "^/\\.image/(.*)/[^/]+\\.([^/.]+)$"
+            target_path = "/image/upload/$1.$2"
+            "#;
+        let settings = Settings::from_toml(&toml_str).expect("should parse asset route rewrite");
+        let route = settings
+            .asset_route_for_path("/.image/options/id/example.jpg")
+            .expect("should match configured asset route");
+
+        assert_eq!(
+            route.path_pattern.as_deref(),
+            Some(r"^/\.image/(.*)/[^/]+\.([^/.]+)$"),
+            "should preserve the configured rewrite pattern"
+        );
+        assert_eq!(
+            route.target_path.as_deref(),
+            Some("/image/upload/$1.$2"),
+            "should preserve the configured replacement"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_auth_and_image_optimizer_parse_from_toml() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [image_optimizer.profile_sets.default_images]
+            base_params = "quality=70&resize-filter=bicubic"
+            default_profile = "default"
+            unknown_profile = "use_default"
+
+            [image_optimizer.profile_sets.default_images.profiles]
+            default = "width=1920"
+            medium = "format=auto&width=828"
+
+            [image_optimizer.profile_sets.default_images.aspect_ratios]
+            allowed = ["1-1", "16-9"]
+            profiles = ["medium"]
+
+            [image_optimizer.profile_sets.default_images.crop_offsets]
+            enabled = true
+            buckets = [10, 30, 50, 70, 90]
+            default = 50
+
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.image/"
+            origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+
+            [proxy.asset_routes.auth]
+            type = "s3_sigv4"
+            region = "us-east-1"
+            origin_query = "strip"
+
+            [proxy.asset_routes.image_optimizer]
+            enabled = true
+            region = "us_east"
+            profile_set = "default_images"
+            "#;
+
+        let settings = Settings::from_toml(&toml_str)
+            .expect("should parse S3 auth and image optimizer asset route");
+        let route = settings
+            .asset_route_for_path("/.image/id/example.jpg")
+            .expect("should match configured route");
+        assert!(route.image_optimizer_enabled());
+        assert_eq!(route.origin_query_policy(), OriginQueryPolicy::Strip);
+        match route.auth.as_ref().expect("should configure route auth") {
+            AssetOriginAuth::S3SigV4(config) => {
+                assert_eq!(config.region, "us-east-1");
+                assert_eq!(config.secret_store, "s3-auth");
+                assert_eq!(config.access_key_id, "access_key_id");
+                assert_eq!(config.secret_access_key, "secret_access_key");
+            }
+        }
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_s3_sigv4_http_origin_url() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "http://bucket.s3.us-east-1.amazonaws.com"
+
+            [proxy.asset_routes.auth]
+            type = "s3_sigv4"
+            region = "us-east-1"
+            "#;
+
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject cleartext S3 SigV4 origin URLs");
+
+        assert!(
+            format!("{err:?}").contains("must use https when auth type is s3_sigv4"),
+            "should mention the S3 SigV4 HTTPS requirement: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_invalid_s3_regions() {
+        for region in ["us east 1", "us/east/1", "US-EAST-1", "us-east-\\n1"] {
+            let toml_str = crate_test_settings_str()
+                + &format!(
+                    r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+
+            [proxy.asset_routes.auth]
+            type = "s3_sigv4"
+            region = "{region}"
+            "#
+                );
+
+            let err = Settings::from_toml(&toml_str)
+                .expect_err("should reject malformed S3 region values");
+
+            assert!(
+                format!("{err:?}").contains("region must contain only lowercase letters"),
+                "should mention the S3 region character policy for {region:?}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_unknown_s3_auth_fields() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+
+            [proxy.asset_routes.auth]
+            type = "s3_sigv4"
+            region = "us-east-1"
+            secret_access_key_name = "secret_access_key"
+            "#;
+
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject unknown S3 auth config fields");
+
+        assert!(
+            format!("{err:?}").contains("secret_access_key_name"),
+            "should mention the unknown S3 auth field: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_invalid_image_optimizer_regions() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [image_optimizer.profile_sets.default_images]
+            base_params = "quality=70"
+            default_profile = "default"
+
+            [image_optimizer.profile_sets.default_images.profiles]
+            default = "width=1920"
+
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.image/"
+            origin_url = "https://assets.example.com"
+
+            [proxy.asset_routes.image_optimizer]
+            enabled = true
+            region = "us-east-2"
+            profile_set = "default_images"
+            "#;
+
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject unsupported Image Optimizer regions");
+
+        assert!(
+            format!("{err:?}").contains("image_optimizer region `us-east-2` is not supported"),
+            "should mention the unsupported Image Optimizer region: {err:?}"
+        );
+    }
+
+    #[test]
+    fn image_optimizer_validation_rejects_unknown_aspect_ratio_profile() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [image_optimizer.profile_sets.default_images]
+            default_profile = "default"
+
+            [image_optimizer.profile_sets.default_images.profiles]
+            default = "width=1920"
+
+            [image_optimizer.profile_sets.default_images.aspect_ratios]
+            allowed = ["1-1"]
+            profiles = ["missing"]
+            "#;
+
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject aspect-ratio profiles that are not defined");
+        assert!(
+            format!("{err:?}").contains("aspect ratio profile `missing` is not defined"),
+            "should mention the unknown aspect-ratio profile: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_image_optimizer_env_accepts_nested_bool_strings_and_arrays() {
+        let toml_str = crate_test_settings_str();
+        let separator = ENVIRONMENT_VARIABLE_SEPARATOR;
+        let vars = [
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}PREFIX"),
+                Some("/.image/"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}ORIGIN_URL"),
+                Some("https://bucket.s3.us-west-2.amazonaws.com"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}TYPE"),
+                Some("s3_sigv4"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}REGION"),
+                Some("us-west-2"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}ORIGIN_QUERY"),
+                Some("strip"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}ENABLED"),
+                Some("true"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}REGION"),
+                Some("us_west"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}PROFILE_SET"),
+                Some("default_images"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}BASE_PARAMS"),
+                Some("quality=70&resize-filter=bicubic"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}DEFAULT_PROFILE"),
+                Some("w828"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}PROFILES{separator}W828"),
+                Some("format=auto&width=828"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}PROFILES{separator}W1536"),
+                Some("format=auto&width=1536"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}ASPECT_RATIOS{separator}ALLOWED"),
+                Some("[\"1-1\",\"16-9\"]"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}ASPECT_RATIOS{separator}PROFILES"),
+                Some("[\"w828\",\"w1536\"]"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}CROP_OFFSETS{separator}ENABLED"),
+                Some("true"),
+            ),
+            (
+                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}CROP_OFFSETS{separator}BUCKETS"),
+                Some("[10,30,50,70,90]"),
+            ),
+        ];
+
+        temp_env::with_vars(vars, || {
+            let settings = Settings::from_toml_and_env(&toml_str)
+                .expect("should parse image optimizer env overrides");
+            let route = settings
+                .asset_route_for_path("/.image/id/example.jpg")
+                .expect("should match image optimizer asset route");
+            assert!(route.image_optimizer_enabled());
+
+            let image_optimizer = route
+                .image_optimizer
+                .as_ref()
+                .expect("should configure image optimizer");
+            assert!(image_optimizer.enabled);
+            assert_eq!(image_optimizer.region, "us_west");
+            assert_eq!(image_optimizer.profile_set, "default_images");
+
+            let profile_set = settings
+                .image_optimizer
+                .profile_sets
+                .get("default_images")
+                .expect("should configure default image profiles");
+            assert_eq!(profile_set.profiles["w828"], "format=auto&width=828");
+            let aspect_ratios = profile_set
+                .aspect_ratios
+                .as_ref()
+                .expect("should configure aspect ratios");
+            assert_eq!(aspect_ratios.allowed, vec!["1-1", "16-9"]);
+            assert_eq!(aspect_ratios.profiles, vec!["w828", "w1536"]);
+            let crop_offsets = profile_set
+                .crop_offsets
+                .as_ref()
+                .expect("should configure crop offsets");
+            assert!(crop_offsets.enabled);
+            assert_eq!(crop_offsets.buckets, vec![10, 30, 50, 70, 90]);
+        });
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_image_optimizer_preserve_query() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [image_optimizer.profile_sets.default_images]
+            base_params = "quality=70"
+
+            [image_optimizer.profile_sets.default_images.profiles]
+            default = "width=1920"
+
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.image/"
+            origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+
+            [proxy.asset_routes.image_optimizer]
+            enabled = true
+            region = "us_east"
+            profile_set = "default_images"
+            origin_query = "preserve"
+            "#;
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject preserving arbitrary client query with IO enabled");
+
+        assert!(
+            format!("{err:?}")
+                .contains("cannot preserve origin query while image_optimizer is enabled"),
+            "should mention the rejected IO origin query policy: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_disabled_image_optimizer_does_not_override_origin_query_policy() {
+        let route = ProxyAssetRoute {
+            prefix: "/.image/".to_string(),
+            origin_url: "https://assets.example.com".to_string(),
+            image_optimizer: Some(AssetImageOptimizerConfig {
+                enabled: false,
+                region: "us_east".to_string(),
+                profile_set: "default_images".to_string(),
+                origin_query: Some(OriginQueryPolicy::Strip),
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(route.origin_query_policy(), OriginQueryPolicy::Preserve);
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_incomplete_rewrite() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.image/"
+            origin_url = "https://assets.example.com"
+            path_pattern = "^/\\.image/(.*)$"
+            "#;
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject incomplete asset route rewrite");
+
+        assert!(
+            format!("{err:?}").contains("must configure path_pattern and target_path together"),
+            "should mention the incomplete rewrite configuration: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_invalid_path_pattern() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.image/"
+            origin_url = "https://assets.example.com"
+            path_pattern = "["
+            target_path = "/image/upload/$1"
+            "#;
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject invalid asset route path_pattern");
+
+        assert!(
+            format!("{err:?}").contains("failed to compile"),
+            "should mention the invalid regex: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_for_path_prefers_longest_prefix() {
+        let proxy = Proxy {
+            certificate_check: true,
+            allowed_domains: vec![],
+            asset_routes: vec![
+                ProxyAssetRoute {
+                    prefix: "/.images/".to_string(),
+                    origin_url: "https://a.example.com".to_string(),
+                    ..Default::default()
+                },
+                ProxyAssetRoute {
+                    prefix: "/.images/special/".to_string(),
+                    origin_url: "https://b.example.com".to_string(),
+                    ..Default::default()
+                },
+            ],
+        };
+
+        let route = proxy
+            .asset_route_for_path("/.images/special/banner.png")
+            .expect("should match a configured asset route");
+        assert_eq!(
+            route.origin_url, "https://b.example.com",
+            "should prefer the most specific prefix"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_for_path_keeps_first_duplicate_prefix() {
+        let proxy = Proxy {
+            certificate_check: true,
+            allowed_domains: vec![],
+            asset_routes: vec![
+                ProxyAssetRoute {
+                    prefix: "/.images/".to_string(),
+                    origin_url: "https://first.example.com".to_string(),
+                    ..Default::default()
+                },
+                ProxyAssetRoute {
+                    prefix: "/.images/".to_string(),
+                    origin_url: "https://second.example.com".to_string(),
+                    ..Default::default()
+                },
+            ],
+        };
+
+        let route = proxy
+            .asset_route_for_path("/.images/banner.png")
+            .expect("should match duplicate prefixes deterministically");
+        assert_eq!(
+            route.origin_url, "https://first.example.com",
+            "should keep the first configured duplicate prefix"
         );
     }
 
@@ -2439,6 +4248,132 @@ mod tests {
                 "*.cdn.example.com".to_string()
             ],
             "from_toml should normalize allowed_domains"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_prefix_without_leading_slash() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = ".images/"
+            origin_url = "https://assets.example.com"
+            "#;
+        let err =
+            Settings::from_toml(&toml_str).expect_err("should reject invalid asset-route prefix");
+        assert!(
+            format!("{err:?}").contains("asset-route prefix must start with '/'"),
+            "should mention the prefix validation failure: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_non_http_origin_url() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "ftp://assets.example.com"
+            "#;
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject non-http asset-route origin_url");
+        assert!(
+            format!("{err:?}").contains("origin_url must use http or https"),
+            "should mention the origin_url validation failure: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_origin_url_path() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "https://assets.example.com/api"
+            "#;
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject asset-route origin_url with path");
+        assert!(
+            format!("{err:?}").contains("origin_url must not include a path"),
+            "should mention the origin_url path validation failure: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_origin_url_query() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "https://assets.example.com?token=abc"
+            "#;
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject asset-route origin_url with query");
+        assert!(
+            format!("{err:?}").contains("origin_url must not include a query string"),
+            "should mention the origin_url query validation failure: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_origin_url_userinfo() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "https://user:pass@assets.example.com"
+            "#;
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject asset-route origin_url with userinfo");
+        assert!(
+            format!("{err:?}").contains("origin_url must not include username or password"),
+            "should mention the origin_url userinfo validation failure: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_rejects_origin_url_fragment() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "https://assets.example.com#fragment"
+            "#;
+        let err = Settings::from_toml(&toml_str)
+            .expect_err("should reject asset-route origin_url with fragment");
+        assert!(
+            format!("{err:?}").contains("origin_url must not include a fragment"),
+            "should mention the origin_url fragment validation failure: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_asset_route_validation_accepts_origin_url_host_and_port() {
+        let toml_str = crate_test_settings_str()
+            + r#"
+            [proxy]
+
+            [[proxy.asset_routes]]
+            prefix = "/.images/"
+            origin_url = "https://assets.example.com:8443"
+            "#;
+        let settings =
+            Settings::from_toml(&toml_str).expect("should accept asset-route origin host and port");
+        assert_eq!(
+            settings.proxy.asset_routes[0].origin_url, "https://assets.example.com:8443",
+            "should preserve valid origin URL with non-standard port"
         );
     }
 
@@ -2537,8 +4472,8 @@ mod tests {
             .expect("should check admin coverage");
         assert_eq!(
             uncovered,
-            vec!["/_ts/admin/keys/rotate", "/_ts/admin/keys/deactivate",],
-            "should report all admin endpoints as uncovered"
+            vec!["/_ts/admin/keys/rotate", "/_ts/admin/keys/deactivate"],
+            "should report every admin endpoint as uncovered"
         );
     }
 
@@ -2572,7 +4507,7 @@ mod tests {
         assert_eq!(
             uncovered,
             vec!["/_ts/admin/keys/deactivate"],
-            "should detect endpoints not covered by the rotate-only handler"
+            "should detect the admin endpoints not covered by the narrow handler"
         );
     }
 

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -1776,6 +1776,19 @@ impl Settings {
             handler.prepare_runtime()?;
         }
 
+        for (name, value) in &self.response_headers {
+            http::header::HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
+                Report::new(TrustedServerError::Configuration {
+                    message: format!("Invalid response header name: {name}"),
+                })
+            })?;
+            http::header::HeaderValue::from_str(value).map_err(|_| {
+                Report::new(TrustedServerError::Configuration {
+                    message: format!("Invalid response header value for {name}"),
+                })
+            })?;
+        }
+
         Ok(())
     }
 

--- a/crates/trusted-server-core/src/streaming_processor.rs
+++ b/crates/trusted-server-core/src/streaming_processor.rs
@@ -115,7 +115,7 @@ impl<P: StreamProcessor> StreamingPipeline<P> {
     ///
     /// Handles all supported compression transformations by wrapping the raw
     /// reader/writer in the appropriate decoder/encoder, then delegating to
-    /// [`Self::process_chunks`].
+    /// `Self::process_chunks`.
     ///
     /// # Errors
     ///

--- a/crates/trusted-server-core/src/test_support.rs
+++ b/crates/trusted-server-core/src/test_support.rs
@@ -48,4 +48,8 @@ pub mod tests {
         let toml_str = crate_test_settings_str();
         Settings::from_toml(&toml_str).expect("Invalid config")
     }
+
+    /// A valid EC ID in `{64-hex}.{6-alnum}` format for use in tests.
+    pub const VALID_SYNTHETIC_ID: &str =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.Ab1234";
 }

--- a/crates/trusted-server-core/src/test_support.rs
+++ b/crates/trusted-server-core/src/test_support.rs
@@ -18,7 +18,6 @@ pub mod tests {
             [publisher]
             domain = "test-publisher.com"
             cookie_domain = ".test-publisher.com"
-            origin_backend = "publisher_origin"
             origin_url = "https://origin.test-publisher.com"
             proxy_secret = "unit-test-proxy-secret"
 

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -22,7 +22,7 @@ pub fn tsjs_script_tag(module_ids: &[&str]) -> String {
 /// Hashes all compiled module IDs so the cache invalidates whenever any module
 /// changes. Over-invalidates slightly (includes deferred modules in the hash)
 /// but never serves stale content. Use [`tsjs_script_src`] with exact module
-/// IDs when the [`IntegrationRegistry`] is available.
+/// IDs when `IntegrationRegistry` is available.
 #[must_use]
 pub fn tsjs_unified_script_src() -> String {
     let ids = all_module_ids();

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -64,3 +64,159 @@ pub fn tsjs_deferred_script_tags(module_ids: &[&str]) -> String {
         .map(|id| tsjs_deferred_script_tag(id))
         .collect::<String>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash_query_value(src: &str) -> &str {
+        src.split_once("?v=")
+            .map(|(_, hash)| hash)
+            .expect("should contain cache-busting hash query")
+    }
+
+    fn assert_sha256_hex_hash(value: &str) {
+        assert_eq!(value.len(), 64, "should be a SHA-256 hex digest");
+        assert!(
+            value.chars().all(|ch| ch.is_ascii_hexdigit()),
+            "should contain only ASCII hex digits"
+        );
+    }
+
+    #[test]
+    fn tsjs_script_src_formats_unified_bundle_url_with_hash() {
+        let src = tsjs_script_src(&["creative"]);
+
+        assert!(
+            src.starts_with("/static/tsjs=tsjs-unified.min.js?v="),
+            "should use unified static bundle path"
+        );
+        assert_sha256_hex_hash(hash_query_value(&src));
+    }
+
+    #[test]
+    fn tsjs_script_src_empty_module_list_matches_core_only_bundle() {
+        let empty_src = tsjs_script_src(&[]);
+
+        assert!(
+            empty_src.starts_with("/static/tsjs=tsjs-unified.min.js?v="),
+            "should use unified static bundle path"
+        );
+        assert_sha256_hex_hash(hash_query_value(&empty_src));
+        assert_eq!(
+            empty_src,
+            tsjs_script_src(&["core"]),
+            "should include core exactly once for an empty module list"
+        );
+    }
+
+    #[test]
+    fn tsjs_script_src_hash_changes_with_module_set() {
+        let creative_src = tsjs_script_src(&["creative"]);
+        let creative_prebid_src = tsjs_script_src(&["creative", "prebid"]);
+
+        assert_ne!(
+            creative_src, creative_prebid_src,
+            "should include requested modules in cache-busting hash"
+        );
+    }
+
+    #[test]
+    fn tsjs_script_src_hash_depends_on_module_order() {
+        assert_ne!(
+            tsjs_script_src(&["creative", "prebid"]),
+            tsjs_script_src(&["prebid", "creative"]),
+            "should include module order in cache-busting hash"
+        );
+    }
+
+    #[test]
+    fn tsjs_script_src_deduplicates_core_module() {
+        assert_eq!(
+            tsjs_script_src(&["core", "prebid"]),
+            tsjs_script_src(&["prebid"]),
+            "should not hash core twice when requested explicitly"
+        );
+    }
+
+    #[test]
+    fn tsjs_script_tag_wraps_source_in_single_trustedserver_tag() {
+        let module_ids = ["creative"];
+        let src = tsjs_script_src(&module_ids);
+
+        assert_eq!(
+            tsjs_script_tag(&module_ids),
+            format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>"),
+            "should generate exactly one trusted server script tag"
+        );
+    }
+
+    #[test]
+    fn tsjs_unified_helpers_use_all_module_ids() {
+        let ids = all_module_ids();
+
+        assert_eq!(
+            tsjs_unified_script_src(),
+            tsjs_script_src(&ids),
+            "should hash all module IDs for the unified script source"
+        );
+        assert_eq!(
+            tsjs_unified_script_tag(),
+            tsjs_script_tag(&ids),
+            "should wrap the all-module unified script source"
+        );
+    }
+
+    #[test]
+    fn tsjs_deferred_script_src_formats_known_module_url_with_hash() {
+        let src = tsjs_deferred_script_src("prebid");
+
+        assert!(
+            src.starts_with("/static/tsjs=tsjs-prebid.min.js?v="),
+            "should use per-module static bundle path"
+        );
+        assert_sha256_hex_hash(hash_query_value(&src));
+    }
+
+    #[test]
+    fn tsjs_deferred_script_src_uses_empty_hash_for_unknown_module() {
+        assert_eq!(
+            tsjs_deferred_script_src("unknown-module"),
+            "/static/tsjs=tsjs-unknown-module.min.js?v=",
+            "should document current unknown-module hash behavior"
+        );
+    }
+
+    #[test]
+    fn tsjs_deferred_script_tag_marks_script_defer() {
+        let src = tsjs_deferred_script_src("prebid");
+
+        assert_eq!(
+            tsjs_deferred_script_tag("prebid"),
+            format!("<script src=\"{src}\" defer></script>"),
+            "should generate a deferred script tag"
+        );
+    }
+
+    #[test]
+    fn tsjs_deferred_script_tags_returns_empty_for_empty_input() {
+        assert_eq!(
+            tsjs_deferred_script_tags(&[]),
+            "",
+            "should not emit tags when no deferred modules exist"
+        );
+    }
+
+    #[test]
+    fn tsjs_deferred_script_tags_preserves_input_order() {
+        assert_eq!(
+            tsjs_deferred_script_tags(&["prebid", "creative"]),
+            format!(
+                "{}{}",
+                tsjs_deferred_script_tag("prebid"),
+                tsjs_deferred_script_tag("creative")
+            ),
+            "should preserve caller-provided deferred module order"
+        );
+    }
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -86,6 +86,7 @@ export default withMermaid(
               link: '/guide/auction-orchestration',
             },
             { text: 'First-Party Proxy', link: '/guide/first-party-proxy' },
+            { text: 'Asset Routes', link: '/guide/asset-routes' },
             { text: 'Creative Processing', link: '/guide/creative-processing' },
             {
               text: 'Integrations Overview',

--- a/docs/guide/asset-routes.md
+++ b/docs/guide/asset-routes.md
@@ -1,0 +1,211 @@
+# Asset Routes
+
+Asset routes proxy selected first-party paths to an alternate asset origin. They are useful when a publisher-facing URL should stay stable while the bytes come from a CDN, a static origin, or a private S3 bucket.
+
+Asset routes are separate from signed `/first-party/proxy` URLs. They match configured path prefixes directly, do not require `tstoken`, and are intended for publisher-owned asset paths such as images and static files.
+
+## Request flow
+
+For a matching `GET` or `HEAD` request, Trusted Server runs this sequence:
+
+1. Match the longest configured `proxy.asset_routes` prefix.
+2. Optionally rewrite the request path with `path_pattern` and `target_path`.
+3. Build Image Optimizer metadata from the request query when the route enables it.
+4. Apply the origin query policy.
+5. Add origin authentication headers when the route configures auth.
+6. Send the request to the resolved backend origin.
+7. Return the origin status, body, and safe headers.
+
+The origin query policy runs before S3 signing, so the signature covers the exact URL sent to S3. Image Optimizer metadata stays separate from the origin URL and is translated by the Fastly adapter.
+
+## Basic route
+
+```toml
+[proxy]
+
+[[proxy.asset_routes]]
+prefix = "/assets/"
+origin_url = "https://assets.example.com"
+```
+
+A request for `/assets/logo.png?v=1` is sent to:
+
+```text
+https://assets.example.com/assets/logo.png?v=1
+```
+
+Plain asset routes preserve the incoming query string by default.
+`origin_url` must be only an absolute `http` or `https` origin (scheme, host, and optional port), without userinfo, path, query, or fragment components.
+
+## Path rewrite
+
+Use `path_pattern` and `target_path` when the public path shape differs from the origin object path.
+
+```toml
+[[proxy.asset_routes]]
+prefix = "/.image/"
+origin_url = "https://assets-cdn.example.com"
+path_pattern = "^/\\.image/(.*)/[^/]+\\.([^/.]+)$"
+target_path = "/image/upload/$1.$2"
+```
+
+Both fields must be configured together. The rewritten path must start with `/`.
+
+## Private S3 origins
+
+Add an auth block when the asset origin is a private S3 bucket.
+
+```toml
+[[proxy.asset_routes]]
+prefix = "/.image/"
+origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+
+[proxy.asset_routes.auth]
+type = "s3_sigv4"
+region = "us-east-1"
+origin_query = "strip"
+secret_store = "s3-auth"
+access_key_id = "access_key_id"
+secret_access_key = "secret_access_key"
+# session_token = "session_token"
+```
+
+### S3 requirements
+
+- `origin_url` must be the real S3 host that AWS validates in the SigV4 canonical request.
+- Use `https` origins for authenticated routes. `http` origins are accepted by the generic asset route validator, but they would send SigV4 headers in clear text.
+- S3 support is for `GET` and `HEAD` asset reads.
+- Signing uses header-based AWS SigV4, not presigned URLs.
+- The signer uses `x-amz-content-sha256: UNSIGNED-PAYLOAD`.
+- Credentials are loaded from the configured runtime secret store and cached per process by configured secret names.
+- Successful authenticated S3 responses preserve the origin `Cache-Control`; configure object cache headers intentionally.
+- Existing client `Authorization` and `x-amz-*` signing headers are replaced before signing.
+
+### Secret store values
+
+The default secret store and key names are:
+
+| Config field        | Default value       | Secret value                         |
+| ------------------- | ------------------- | ------------------------------------ |
+| `secret_store`      | `s3-auth`           | Secret store name                    |
+| `access_key_id`     | `access_key_id`     | AWS access key ID                    |
+| `secret_access_key` | `secret_access_key` | AWS secret access key                |
+| `session_token`     | unset               | Optional AWS temporary session token |
+
+Use private deployment configuration for environment-specific store names or profile tables.
+
+## Origin query policy
+
+`origin_query` controls whether the upstream origin receives the browser query string.
+
+| Value      | Behavior                                            |
+| ---------- | --------------------------------------------------- |
+| `preserve` | Keep the incoming query string on the origin URL    |
+| `strip`    | Remove the incoming query string before origin send |
+
+Precedence:
+
+1. `proxy.asset_routes.auth.origin_query`, when auth is configured.
+2. `proxy.asset_routes.image_optimizer.origin_query`, when Image Optimizer is enabled.
+3. The route default.
+
+Defaults:
+
+- Plain asset routes default to `preserve`.
+- Image-optimized asset routes default to `strip`.
+- Enabled Image Optimizer routes reject effective `preserve` to avoid arbitrary client query parameters becoming transformation inputs.
+
+## Fastly Image Optimizer profiles
+
+Image Optimizer support is configured in two places:
+
+1. A top-level reusable profile set under `[image_optimizer.profile_sets.<name>]`.
+2. A route-level `[proxy.asset_routes.image_optimizer]` block that selects the profile set and processing region.
+
+```toml
+[image_optimizer.profile_sets.default_images]
+base_params = "quality=70&resize-filter=bicubic"
+default_profile = "default"
+unknown_profile = "use_default"
+profile_param = "profile"
+aspect_ratio_param = "ar"
+debug_param = "_io_debug"
+
+[image_optimizer.profile_sets.default_images.profiles]
+default = "width=1920"
+medium = "format=auto&width=828"
+thumbnail = "width=150&crop=1:1,smart"
+
+[image_optimizer.profile_sets.default_images.aspect_ratios]
+allowed = ["1-1", "16-9", "4-3"]
+profiles = ["medium"]
+
+[image_optimizer.profile_sets.default_images.crop_offsets]
+enabled = true
+x_param = "x"
+y_param = "y"
+buckets = [10, 30, 50, 70, 90]
+default = 50
+when_missing = "smart"
+
+[[proxy.asset_routes]]
+prefix = "/.image/"
+origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+
+[proxy.asset_routes.auth]
+type = "s3_sigv4"
+region = "us-east-1"
+origin_query = "strip"
+
+[proxy.asset_routes.image_optimizer]
+enabled = true
+region = "us_east"
+profile_set = "default_images"
+```
+
+A request such as:
+
+```text
+/.image/id/example.jpg?profile=medium&ar=1-1&x=44&y=63
+```
+
+uses the `medium` profile, applies the allowed `1-1` crop override, buckets offsets to the configured values, strips the origin query, signs the S3 request if auth is enabled, and sends Fastly IO metadata through the Fastly adapter.
+
+## Supported profile parameters
+
+Profile strings intentionally accept a strict subset of Image Optimizer parameters.
+
+| Parameter       | Example value | Notes                                                                            |
+| --------------- | ------------- | -------------------------------------------------------------------------------- |
+| `quality`       | `70`          | Integer in `0..=100`                                                             |
+| `resize-filter` | `bicubic`     | `nearest`, `bilinear`, `bicubic`, `lanczos2`, `lanczos3`                         |
+| `format`        | `auto`        | Also accepts `avif`, `gif`, `jpeg`, `jpg`, `jxl`, `jpegxl`, `mp4`, `png`, `webp` |
+| `width`         | `828`         | Positive integer pixels                                                          |
+| `height`        | `466`         | Positive integer pixels                                                          |
+| `crop`          | `1:1,smart`   | Aspect ratio, optional `smart`, or paired `offset-xN,offset-yN` suffixes         |
+
+Unknown profile parameters are configuration errors. Arbitrary client query parameters are not forwarded as Image Optimizer options.
+
+## Debug bypass
+
+Set the configured debug parameter to `1` to disable Image Optimizer for one request:
+
+```text
+/.image/id/example.jpg?profile=medium&_io_debug=1
+```
+
+The asset route still matches. Path rewrite, origin query policy, and S3 signing still run. The response comes from the unoptimized origin object.
+
+## Local testing notes
+
+Viceroy does not perform real Fastly Image Optimizer transformations. Local tests can verify routing, query stripping, SigV4 headers, and metadata attachment. End-to-end image transformation verification requires a deployed Fastly Compute service with Image Optimizer enabled.
+
+## Security checklist
+
+- Use a private S3 bucket policy that permits only the configured AWS principal.
+- Store AWS credentials in Fastly Secret Store or an equivalent runtime secret store.
+- Use HTTPS origins for authenticated routes so SigV4 headers are not transmitted in clear text.
+- Set origin `Cache-Control` for authenticated S3 objects based on the intended audience: use public cache headers for public assets in private buckets, and `private` or `no-store` for assets that must not be shared from cache.
+- Keep customer-specific profile names and profile tables in private deployment config when needed.
+- Use `origin_query = "strip"` for image transformation routes unless the query string is part of the S3 object identity.
+- Configure narrow path prefixes so asset routes do not capture unrelated application paths.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -61,7 +61,8 @@ openssl rand -base64 32
 | ------------------- | -------------------------------------------- |
 | `[publisher]`       | Domain, origin, proxy settings               |
 | `[ec]`              | Edge Cookie (EC) ID generation               |
-| `[proxy]`           | Proxy SSRF allowlist                         |
+| `[proxy]`           | Proxy SSRF allowlist and asset routes        |
+| `[image_optimizer]` | Reusable Image Optimizer profile sets        |
 | `[request_signing]` | Ed25519 request signing                      |
 | `[auction]`         | Auction orchestration                        |
 | `[integrations.*]`  | Partner integrations (Prebid, Next.js, etc.) |
@@ -153,12 +154,13 @@ Core publisher settings for domain, origin, and proxy configuration.
 
 ### `[publisher]`
 
-| Field           | Type   | Required | Description                                            |
-| --------------- | ------ | -------- | ------------------------------------------------------ |
-| `domain`        | String | Yes      | Publisher's apex domain name                           |
-| `cookie_domain` | String | Yes      | Domain for non-EC cookies (typically with leading dot) |
-| `origin_url`    | String | Yes      | Full URL of publisher origin server                    |
-| `proxy_secret`  | String | Yes      | Secret key for encrypting/signing proxy URLs           |
+| Field                         | Type   | Required | Description                                                   |
+| ----------------------------- | ------ | -------- | ------------------------------------------------------------- |
+| `domain`                      | String | Yes      | Publisher's apex domain name                                  |
+| `cookie_domain`               | String | Yes      | Domain for non-EC cookies (typically with leading dot)        |
+| `origin_url`                  | String | Yes      | Full URL of publisher origin server                           |
+| `origin_host_header_override` | String | No       | Outbound Host header to send while connecting to `origin_url` |
+| `proxy_secret`                | String | Yes      | Secret key for encrypting/signing proxy URLs                  |
 
 > **Note:** EC cookies (`ts-ec`) derive their domain automatically as `.{domain}` and
 > do not use `cookie_domain`. The `cookie_domain` field is used by other cookie helpers.
@@ -170,6 +172,8 @@ Core publisher settings for domain, origin, and proxy configuration.
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
+# Optional: connect to origin_url but send this outbound Host header.
+# origin_host_header_override = "www.publisher.com"
 proxy_secret = "change-me-to-secure-random-value"
 ```
 
@@ -179,6 +183,7 @@ proxy_secret = "change-me-to-secure-random-value"
 TRUSTED_SERVER__PUBLISHER__DOMAIN=publisher.com
 TRUSTED_SERVER__PUBLISHER__COOKIE_DOMAIN=.publisher.com
 TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.com
+TRUSTED_SERVER__PUBLISHER__ORIGIN_HOST_HEADER_OVERRIDE=www.publisher.com
 TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
 ```
 
@@ -234,6 +239,26 @@ TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
 - ❌ `origin.publisher.com` (missing protocol)
 
 **Port Handling**: Includes port if non-standard (not 80/443).
+
+#### `origin_host_header_override`
+
+**Purpose**: Optional Host header to send to the publisher origin while still
+connecting to the host in `origin_url`.
+
+**Usage**:
+
+- Connects, uses SNI, and checks certificates against `origin_url`
+- Sends the configured value as the outbound HTTP `Host` header
+- Useful when the origin endpoint expects a canonical publisher hostname
+
+**Format**: Hostname with optional port, without protocol, path, query, or fragment
+
+- ✅ `www.publisher.com`
+- ✅ `www.publisher.com:8443`
+- ❌ `https://www.publisher.com`
+- ❌ `www.publisher.com/path`
+
+**Default**: When omitted, Trusted Server sends the host from `origin_url`.
 
 #### `proxy_secret`
 
@@ -628,13 +653,15 @@ See [Creative Processing](/guide/creative-processing#exclude-domains) for detail
 
 ## Proxy Configuration
 
-Controls first-party proxy security settings.
+Controls first-party proxy security settings and path-based asset routes.
 
 ### `[proxy]`
 
-| Field             | Type          | Required           | Description                                            |
-| ----------------- | ------------- | ------------------ | ------------------------------------------------------ |
-| `allowed_domains` | Array[String] | No (default: `[]`) | Redirect destinations the proxy is permitted to follow |
+| Field               | Type          | Required             | Description                                            |
+| ------------------- | ------------- | -------------------- | ------------------------------------------------------ |
+| `allowed_domains`   | Array[String] | No (default: `[]`)   | Redirect destinations the proxy is permitted to follow |
+| `certificate_check` | Boolean       | No (default: `true`) | Verify TLS certificates when proxying HTTPS origins    |
+| `asset_routes`      | Array[Table]  | No (default: `[]`)   | Path prefixes proxied directly to configured origins   |
 
 **Example**:
 
@@ -698,6 +725,177 @@ allowed_domains = [
 :::
 
 See [First-Party Proxy](/guide/first-party-proxy#proxy-allowlist) for usage details.
+
+#### `certificate_check`
+
+**Purpose**: Control TLS certificate verification for HTTPS proxy and asset-route origins.
+
+**Default**: `true`
+
+Set this to `false` only for local development with self-signed certificates.
+
+### `[[proxy.asset_routes]]`
+
+Asset routes proxy selected first-party paths to an alternate asset origin without requiring signed `/first-party/proxy` URLs.
+
+| Field             | Type   | Required | Description                                     |
+| ----------------- | ------ | -------- | ----------------------------------------------- |
+| `prefix`          | String | Yes      | Request path prefix to match                    |
+| `origin_url`      | String | Yes      | Absolute `http` or `https` origin URL           |
+| `path_pattern`    | String | No       | Regex matched against the incoming request path |
+| `target_path`     | String | No       | Replacement path used with `path_pattern`       |
+| `auth`            | Table  | No       | Optional origin authentication                  |
+| `image_optimizer` | Table  | No       | Optional route-level Image Optimizer settings   |
+
+**Example**:
+
+```toml
+[[proxy.asset_routes]]
+prefix = "/assets/"
+origin_url = "https://assets.example.com"
+```
+
+**Path rewrite example**:
+
+```toml
+[[proxy.asset_routes]]
+prefix = "/.image/"
+origin_url = "https://assets-cdn.example.com"
+path_pattern = "^/\\.image/(.*)/[^/]+\\.([^/.]+)$"
+target_path = "/image/upload/$1.$2"
+```
+
+**Behavior**:
+
+- Only `GET` and `HEAD` requests use asset routes.
+- Built-in and integration routes take precedence.
+- The longest matching asset-route prefix wins.
+- `path_pattern` and `target_path` must be configured together.
+- `origin_url` must not include userinfo, a path, a query string, or a fragment.
+- Unsafe origin response headers such as `Set-Cookie` are stripped before the response reaches the browser.
+
+### `[proxy.asset_routes.auth]`
+
+The first supported origin auth type is `s3_sigv4`.
+
+| Field               | Type   | Required | Default             | Description                                     |
+| ------------------- | ------ | -------- | ------------------- | ----------------------------------------------- |
+| `type`              | String | Yes      | none                | Must be `s3_sigv4`                              |
+| `region`            | String | Yes      | none                | AWS region used in the SigV4 credential scope   |
+| `secret_store`      | String | No       | `s3-auth`           | Runtime secret store containing AWS credentials |
+| `access_key_id`     | String | No       | `access_key_id`     | Secret key containing the AWS access key ID     |
+| `secret_access_key` | String | No       | `secret_access_key` | Secret key containing the AWS secret access key |
+| `session_token`     | String | No       | unset               | Optional secret key containing a session token  |
+| `origin_query`      | String | No       | route default       | `preserve` or `strip`                           |
+
+**Example**:
+
+```toml
+[[proxy.asset_routes]]
+prefix = "/.image/"
+origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+
+[proxy.asset_routes.auth]
+type = "s3_sigv4"
+region = "us-east-1"
+origin_query = "strip"
+secret_store = "s3-auth"
+access_key_id = "access_key_id"
+secret_access_key = "secret_access_key"
+# session_token = "session_token"
+```
+
+S3 auth uses header-based AWS SigV4 with `UNSIGNED-PAYLOAD`. It is scoped to read-only asset requests and expects `origin_url` to use the S3 host that AWS validates. Credentials are cached per process by configured secret names after the first successful read.
+
+Effective `origin_query` precedence is auth-level `origin_query`, then enabled Image Optimizer `origin_query`, then the route default.
+
+### `[proxy.asset_routes.image_optimizer]`
+
+Route-level Image Optimizer configuration selects a reusable profile set.
+
+| Field          | Type    | Required         | Default              | Description                                                                 |
+| -------------- | ------- | ---------------- | -------------------- | --------------------------------------------------------------------------- |
+| `enabled`      | Boolean | No               | `true`               | Enable Image Optimizer for the route                                        |
+| `region`       | String  | Yes when enabled | none                 | Fastly IO processing region, such as `us_east`                              |
+| `profile_set`  | String  | Yes when enabled | none                 | Name under `[image_optimizer.profile_sets.*]`                               |
+| `origin_query` | String  | No               | `strip` when enabled | `preserve` or `strip`; effective `preserve` is rejected while IO is enabled |
+
+**Example**:
+
+```toml
+[proxy.asset_routes.image_optimizer]
+enabled = true
+region = "us_east"
+profile_set = "default_images"
+```
+
+### `[image_optimizer.profile_sets.<name>]`
+
+Profile sets convert small request query controls into a closed set of Image Optimizer parameters.
+
+| Field                | Type   | Required | Default       | Description                                      |
+| -------------------- | ------ | -------- | ------------- | ------------------------------------------------ |
+| `base_params`        | String | No       | `""`          | Params applied before profile-specific params    |
+| `default_profile`    | String | No       | `default`     | Profile used when no profile is requested        |
+| `unknown_profile`    | String | No       | `use_default` | `use_default` or `reject`                        |
+| `profile_param`      | String | No       | `profile`     | Query parameter containing the profile name      |
+| `aspect_ratio_param` | String | No       | `ar`          | Query parameter containing aspect ratio          |
+| `debug_param`        | String | No       | `_io_debug`   | Query parameter that disables IO when set to `1` |
+
+Profile values live under `[image_optimizer.profile_sets.<name>.profiles]` and use query-string syntax.
+
+```toml
+[image_optimizer.profile_sets.default_images]
+base_params = "quality=70&resize-filter=bicubic"
+default_profile = "default"
+unknown_profile = "use_default"
+profile_param = "profile"
+aspect_ratio_param = "ar"
+debug_param = "_io_debug"
+
+[image_optimizer.profile_sets.default_images.profiles]
+default = "width=1920"
+medium = "format=auto&width=828"
+thumbnail = "width=150&crop=1:1,smart"
+```
+
+Supported profile parameters are `quality`, `resize-filter`, `format`, `width`, `height`, and `crop`. Unknown profile parameters fail configuration validation.
+
+### `[image_optimizer.profile_sets.<name>.aspect_ratios]`
+
+| Field      | Type          | Required | Description                                         |
+| ---------- | ------------- | -------- | --------------------------------------------------- |
+| `allowed`  | Array[String] | No       | Allowed query values such as `1-1` or `16-9`        |
+| `profiles` | Array[String] | No       | Defined profiles that accept aspect-ratio overrides |
+
+```toml
+[image_optimizer.profile_sets.default_images.aspect_ratios]
+allowed = ["1-1", "16-9", "4-3"]
+profiles = ["medium", "thumbnail"]
+```
+
+### `[image_optimizer.profile_sets.<name>.crop_offsets]`
+
+| Field          | Type           | Required | Default                | Description                                  |
+| -------------- | -------------- | -------- | ---------------------- | -------------------------------------------- |
+| `enabled`      | Boolean        | No       | `true`                 | Enable offset bucketing                      |
+| `x_param`      | String         | No       | `x`                    | Query parameter for x-axis offset            |
+| `y_param`      | String         | No       | `y`                    | Query parameter for y-axis offset            |
+| `buckets`      | Array[Integer] | No       | `[10, 30, 50, 70, 90]` | Offset buckets in `0..=100`                  |
+| `default`      | Integer        | No       | `50`                   | Offset used when input is missing or invalid |
+| `when_missing` | String         | No       | `smart`                | `smart` or `none` when neither offset exists |
+
+```toml
+[image_optimizer.profile_sets.default_images.crop_offsets]
+enabled = true
+x_param = "x"
+y_param = "y"
+buckets = [10, 30, 50, 70, 90]
+default = 50
+when_missing = "smart"
+```
+
+See [Asset Routes](/guide/asset-routes) for request flow, S3 auth details, and Image Optimizer behavior.
 
 ## Integration Configurations
 

--- a/docs/guide/fastly.md
+++ b/docs/guide/fastly.md
@@ -112,7 +112,7 @@ Configure in `trusted-server.toml`:
 
 ```toml
 [ec]
-passphrase = "replace-with-32-plus-byte-random-secret"}]}},{
+passphrase = "replace-with-32-plus-byte-random-secret"
 ec_store = "ec_identity_store"
 ```
 

--- a/docs/guide/first-party-proxy.md
+++ b/docs/guide/first-party-proxy.md
@@ -25,9 +25,11 @@ flowchart TD
 
 ## Core Endpoints
 
-### `/first-party/proxy` - Asset Proxy
+### `/first-party/proxy` - Signed Asset Proxy
 
 Proxies third-party assets with automatic HTML/CSS rewriting.
+
+For publisher-owned asset paths that should route directly to a configured origin without `tstoken`, use [Asset Routes](/guide/asset-routes). Asset routes support path-prefix matching, private S3 origins, and Fastly Image Optimizer profile tables.
 
 **Request**:
 
@@ -423,6 +425,18 @@ cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
 proxy_secret = "your-secure-random-secret"
 ```
+
+### Asset Routes
+
+Use `[[proxy.asset_routes]]` when a first-party path prefix should proxy directly to another asset origin.
+
+```toml
+[[proxy.asset_routes]]
+prefix = "/assets/"
+origin_url = "https://assets.example.com"
+```
+
+Asset routes are intended for publisher-owned paths, not third-party creative URLs. They support optional path rewrites, private S3 origin signing, and Fastly Image Optimizer metadata. See [Asset Routes](/guide/asset-routes) for full configuration and operational guidance.
 
 ### Proxy Allowlist
 

--- a/docs/guide/first-party-proxy.md
+++ b/docs/guide/first-party-proxy.md
@@ -59,7 +59,7 @@ GET /first-party/proxy?tsurl=https://example.com/ad.html&tstoken=signature
 4. **Processes** response based on content type:
    - **HTML** (`text/html`) - Rewrites all URLs, returns `text/html`
    - **CSS** (`text/css`) - Rewrites `url()` values, returns `text/css`
-   - **Images** - Detects pixels, sets `image/*` if missing
+   - **Images** - Detects pixels, sets `application/octet-stream` if missing
    - **Other** - Passthrough without modification
 
 **Example**:
@@ -293,12 +293,12 @@ For the detailed signing algorithm, validation steps, and security notes, see [P
 
 **Triggers**:
 
-- Response `Content-Type: image/*`, OR
+- Response `Content-Type` starts with `image/`, OR
 - Request `Accept` header contains `image/`
 
 **Process**:
 
-1. Set `Content-Type: image/*` if missing
+1. Set `Content-Type: application/octet-stream` if missing
 2. Detect likely pixels with heuristics:
    - `Content-Length` ≤ 256 bytes
    - URL contains `/pixel`, `/p.gif`, `/1x1`, `/track`

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -4,10 +4,11 @@ Get up and running with Trusted Server quickly.
 
 ## Prerequisites
 
-Before you begin, ensure you have:
+Before you begin, ensure you have the following installed (versions are pinned in `.tool-versions`):
 
-- Rust 1.91.1 (see `.tool-versions`)
-- Fastly CLI installed
+- Rust {{RUST_VERSION}}
+- NodeJS {{NODEJS_VERSION}}
+- Fastly {{FASTLY_VERSION}} CLI installed
 - A Fastly account and API key
 - Basic familiarity with WebAssembly
 

--- a/docs/guide/integrations/didomi.md
+++ b/docs/guide/integrations/didomi.md
@@ -56,19 +56,50 @@ api_origin = "https://api.privacy-center.org"
 
 ### Configuration Options
 
-| Field        | Type    | Required | Default                          | Description                |
-| ------------ | ------- | -------- | -------------------------------- | -------------------------- |
-| `enabled`    | boolean | No       | `false`                          | Enable/disable integration |
-| `sdk_origin` | string  | Yes      | `https://sdk.privacy-center.org` | Didomi SDK backend URL     |
-| `api_origin` | string  | Yes      | `https://api.privacy-center.org` | Didomi API backend URL     |
+| Field        | Type    | Required | Default                          | Description                              |
+| ------------ | ------- | -------- | -------------------------------- | ---------------------------------------- |
+| `enabled`    | boolean | No       | `false`                          | Enable/disable integration               |
+| `proxy_path` | string  | No       | `integrations/didomi/consent`    | Custom proxy URL path prefix (see below) |
+| `sdk_origin` | string  | Yes      | `https://sdk.privacy-center.org` | Didomi SDK backend URL                   |
+| `api_origin` | string  | Yes      | `https://api.privacy-center.org` | Didomi API backend URL                   |
 
 ### Environment Variables
 
 ```bash
 TRUSTED_SERVER__INTEGRATIONS__DIDOMI__ENABLED=true
+TRUSTED_SERVER__INTEGRATIONS__DIDOMI__PROXY_PATH=my-custom-consent
 TRUSTED_SERVER__INTEGRATIONS__DIDOMI__SDK_ORIGIN=https://sdk.privacy-center.org
 TRUSTED_SERVER__INTEGRATIONS__DIDOMI__API_ORIGIN=https://api.privacy-center.org
 ```
+
+### Custom Proxy Path
+
+By default, Didomi requests are served at `/integrations/didomi/consent/*`. Since this path is predictable, ad blockers may add it to their block lists. Use `proxy_path` to set a customer-specific path that is harder to target:
+
+```toml
+[integrations.didomi]
+enabled = true
+proxy_path = "my-custom-consent"
+```
+
+With this configuration, requests are served at `/my-custom-consent/*` instead of the default.
+
+**Format rules:**
+
+- Must not be empty or just `/`
+- Must not end with a trailing slash
+- May contain only ASCII letters, numbers, `-`, `_`, `.`, `~`, and `/` path separators
+- Must not contain dot-only path segments (`.` or `..`)
+- Must not contain percent escapes or consecutive slashes (`//`)
+- Leading slash is optional (it is normalized internally)
+
+**Examples of valid values:**
+
+- `"consent-proxy"` → serves at `/consent-proxy/*`
+- `"privacy/manage"` → serves at `/privacy/manage/*`
+- `"/my-cmp-path"` → serves at `/my-cmp-path/*`
+
+The custom path is automatically passed to the client-side JavaScript bundle via `window.__tsjs_didomi.proxyPath`, so the Didomi SDK URL rewriting continues to work without additional frontend configuration.
 
 ## Endpoints
 

--- a/docs/superpowers/specs/2026-04-28-multi-backend-asset-proxy-design.md
+++ b/docs/superpowers/specs/2026-04-28-multi-backend-asset-proxy-design.md
@@ -1,0 +1,704 @@
+# Multi-backend Asset Proxy Design
+
+> Proposed design for path-based first-party asset proxy routing.
+> Date: 2026-04-28.
+
+---
+
+## Goal
+
+Allow Trusted Server to proxy selected first-party asset paths to a different
+backend origin than `publisher.origin_url`.
+
+Example:
+
+- incoming URL: `https://www.example.com/.images/foo.jpg?w=1200`
+- matched rule: `prefix = "/.images/"`
+- asset origin: `https://some.fastly-service.com`
+- upstream URL: `https://some.fastly-service.com/.images/foo.jpg?w=1200`
+
+This should happen transparently for normal inbound requests, without requiring
+`/first-party/proxy` signed URLs.
+
+---
+
+## Problem
+
+Today, unknown routes fall through to the publisher proxy path and always go to
+one backend:
+
+- `settings.publisher.origin_url`
+
+That works for HTML and general publisher-origin traffic, but it does not allow
+specific first-party asset namespaces to be served by a separate backend such
+as an image CDN, Fastly service, or dedicated asset origin.
+
+Publishers need to keep asset URLs on their first-party domain while routing
+certain path prefixes to a different backend.
+
+---
+
+## Scope
+
+### In scope
+
+- Path-prefix-based routing for first-party asset requests
+- Multiple configured asset-route rules
+- Per-rule alternate `origin_url`
+- Transparent proxying for ordinary inbound `GET`/`HEAD` requests
+- Preservation of the incoming path and query string by default
+- Optional regex-based path rewrite after prefix route selection
+- Raw response pass-through from the matched asset origin, except unsafe publisher-domain state/security headers
+- Deterministic longest-prefix route selection
+- Request routing that happens after built-in and integration routes, but
+  before publisher-origin fallback
+
+### Out of scope
+
+- Regex-based route selection
+- Cookie, consent, HTML, CSS, or JS rewriting on asset-route responses
+- Redirect following for asset routes
+- Special cache policy overrides
+- Non-`GET` / non-`HEAD` methods
+- Per-route header customization
+- Health checks, fallback chains, or origin failover
+
+---
+
+## Product Requirements
+
+### 1. Transparent inbound routing
+
+The feature applies to normal inbound requests handled by Trusted Server.
+
+It is **not** an extension of `/first-party/proxy` and does **not** require URL
+signing.
+
+If an incoming request path matches a configured asset route, Trusted Server
+proxies it directly to that route's configured origin.
+
+### 2. Match on simple path prefixes
+
+Routes are selected by simple prefixes, not regexes. Optional regexes may rewrite the upstream path only after a prefix route has already matched.
+
+Examples:
+
+- valid: `/.images/`
+- valid: `/static/`
+- invalid: `.images/`
+- invalid: `images/`
+
+Rule matching is performed against the request path only. Query strings are
+ignored for matching.
+
+### 3. Preserve path and query by default, with optional path rewrite
+
+When a rule matches without rewrite settings, Trusted Server replaces only the
+upstream origin (scheme/host/port) and preserves the rest of the request URL
+exactly.
+
+Example:
+
+- inbound: `/.images/foo/bar.jpg?auto=webp&width=1200`
+- upstream path/query: `/.images/foo/bar.jpg?auto=webp&width=1200`
+
+Routes may optionally configure `path_pattern` and `target_path` together. In
+that case, `path_pattern` is matched against the incoming request path after the
+prefix route has been selected, and `target_path` is used as the regex
+replacement for the upstream path. The incoming query string is still preserved.
+
+Example:
+
+- inbound: `/.images/foo/bar.jpg?auto=webp&width=1200`
+- `path_pattern`: `^/\.images/(.*)$`
+- `target_path`: `/cdn/$1`
+- upstream path/query: `/cdn/foo/bar.jpg?auto=webp&width=1200`
+
+### 4. Multiple rules supported
+
+Configuration supports multiple asset-route entries.
+
+Example use cases:
+
+- `/.images/` → image CDN
+- `/static/assets/` → static asset backend
+- `/_next/image/` → specialized image transformer
+
+### 5. Longest matching prefix wins
+
+If multiple routes match a path, the most specific route wins.
+
+Example:
+
+- `/.images/` → backend A
+- `/.images/special/` → backend B
+- request `/.images/special/x.jpg` → backend B
+
+### 6. Only `GET` and `HEAD`
+
+Asset-route matching only applies to `GET` and `HEAD` requests.
+
+All other methods continue through existing route handling and publisher
+fallback behavior unchanged.
+
+### 7. Explicit routes win first
+
+Built-in Trusted Server routes and registered integration routes must retain
+higher precedence than asset-route matching.
+
+Asset routes act only inside the fallback proxy space. They must not shadow:
+
+- `/auction`
+- `/first-party/*`
+- `/.well-known/*`
+- admin routes
+- registered integration routes
+
+### 8. Raw pass-through behavior
+
+Matched asset routes bypass the publisher-page processing pipeline.
+
+Specifically, asset-route handling does **not** perform:
+
+- EC generation / consent pipeline work
+- cookie mutation
+- HTML rewriting
+- CSS rewriting
+- URL rewriting
+- RSC processing
+- post-processing
+- redirect following
+
+The route behaves as a lean transport proxy.
+
+### 9. Upstream errors are not masked
+
+If the matched asset origin returns a response, that response is returned to the
+client as-is.
+
+If the asset origin cannot be reached or backend setup fails, Trusted Server
+returns the existing error behavior for that failure class.
+
+It must **not** silently fall back to `publisher.origin_url`.
+
+### 10. Preserve upstream cache semantics
+
+Trusted Server passes through upstream cache headers unchanged, including:
+
+- `Cache-Control`
+- `ETag`
+- `Last-Modified`
+- `Expires`
+- `Vary`
+
+There is no v1 cache override layer.
+
+### 11. Preserve redirect semantics
+
+If the asset origin returns a redirect (`301`, `302`, `303`, `307`, `308`),
+Trusted Server returns that redirect to the client as-is.
+
+It does not follow redirects server-side.
+
+### 12. Preserve `HEAD` semantics
+
+A `HEAD` request to a matched asset route is proxied upstream as `HEAD` and
+returned without body synthesis.
+
+---
+
+## Configuration Design
+
+Asset routes live under `[proxy]` in `trusted-server.toml`.
+
+### Proposed shape
+
+```toml
+[proxy]
+certificate_check = true
+
+[[proxy.asset_routes]]
+prefix = "/.images/"
+origin_url = "https://some.fastly-service.com"
+
+[[proxy.asset_routes]]
+prefix = "/static/assets/"
+origin_url = "https://assets.example.net"
+```
+
+### Field definitions
+
+#### `prefix`
+
+- required
+- string
+- must start with `/`
+- matched against the request path only
+- case-sensitive, using normal request-path semantics
+
+#### `origin_url`
+
+- required
+- string
+- absolute `http` or `https` URL
+- must not include userinfo, a trailing slash, path, query, or fragment
+- used as the upstream scheme/host/port base
+- request query is preserved from the incoming request
+- request path is preserved unless `path_pattern` / `target_path` rewrite it
+
+#### `path_pattern`
+
+- optional
+- string
+- regex matched against the incoming request path after prefix route selection
+- must be configured together with `target_path`
+- does not participate in route selection
+
+#### `target_path`
+
+- optional
+- string
+- regex replacement applied to `path_pattern` matches
+- must be configured together with `path_pattern`
+- replacement output must start with `/`
+
+### Validation rules
+
+#### Hard validation errors
+
+These should fail configuration loading:
+
+- `prefix` missing
+- `prefix` does not start with `/`
+- `origin_url` missing
+- `origin_url` is not an absolute `http`/`https` URL
+- `origin_url` has userinfo, a trailing slash, path, query, or fragment
+- `path_pattern` is configured without `target_path`, or vice versa
+- `path_pattern` does not compile as a regex
+- `target_path` rewrite output does not start with `/`
+
+#### Warning-only validation
+
+Duplicate exact prefixes should not fail startup.
+
+Instead:
+
+- log a warning for later duplicates
+- keep behavior deterministic
+- exact duplicate prefixes use the **first configured rule**
+
+This preserves production availability while surfacing misconfiguration.
+
+---
+
+## Proposed Data Model
+
+Add a new route type under proxy settings.
+
+```rust
+pub struct ProxyAssetRoute {
+    pub prefix: String,
+    pub origin_url: String,
+}
+
+pub struct Proxy {
+    pub certificate_check: bool,
+    pub allowed_domains: Vec<String>,
+    pub asset_routes: Vec<ProxyAssetRoute>,
+}
+```
+
+### Runtime helper behavior
+
+A helper should normalize and validate asset routes during settings preparation.
+
+Recommended responsibilities:
+
+- validate each route
+- warn on duplicate exact prefixes
+- provide longest-prefix matching for a path
+- provide deterministic duplicate behavior
+
+---
+
+## Request Routing Design
+
+### Current baseline
+
+Today the top-level request router behaves roughly as follows:
+
+1. match built-in routes
+2. match integration routes
+3. otherwise proxy to `publisher.origin_url`
+
+### Proposed routing order
+
+1. match built-in Trusted Server routes
+2. match integration routes
+3. if method is `GET` or `HEAD`, try asset-route match
+4. if asset route matched, proxy to that asset origin
+5. otherwise fall through to existing publisher-origin proxy path
+
+### Why this placement
+
+This preserves current application route behavior while allowing targeted
+origin overrides for fallback asset paths.
+
+Asset routes should not become a general-purpose top-level router that can
+interfere with core product endpoints.
+
+---
+
+## Matching Algorithm
+
+### Inputs
+
+- HTTP method
+- request path
+- configured `asset_routes`
+
+### Matching rules
+
+1. Ignore all asset routes unless method is `GET` or `HEAD`
+2. Compare request path against each configured `prefix`
+3. A route matches when `request_path.starts_with(prefix)`
+4. Select the match with the longest `prefix`
+5. If multiple routes have the same exact prefix, the first configured route
+   wins and later duplicates only warn
+
+### Examples
+
+#### Example 1: simple match
+
+Rules:
+
+- `/.images/` → `https://img.fastly.example`
+
+Request:
+
+- `GET /.images/photo.jpg?w=1000`
+
+Result:
+
+- proxy to `https://img.fastly.example/.images/photo.jpg?w=1000`
+
+#### Example 2: longest prefix
+
+Rules:
+
+- `/.images/` → A
+- `/.images/special/` → B
+
+Request:
+
+- `GET /.images/special/banner.png`
+
+Result:
+
+- route B wins
+
+#### Example 3: wrong method
+
+Rules:
+
+- `/.images/` → A
+
+Request:
+
+- `POST /.images/upload`
+
+Result:
+
+- no asset-route match; continue existing routing behavior
+
+---
+
+## Proxy Behavior
+
+### Upstream URL construction
+
+For a matched asset route:
+
+1. take the matched rule's `origin_url`
+2. preserve the incoming request path exactly
+3. preserve the incoming query string exactly
+4. build the upstream request URL from those components
+
+Example:
+
+- origin: `https://some.fastly-service.com`
+- path: `/.images/foo.jpg`
+- query: `auto=webp&width=800`
+- upstream: `https://some.fastly-service.com/.images/foo.jpg?auto=webp&width=800`
+
+### Backend selection
+
+The route should use the existing dynamic-backend mechanism already used
+elsewhere in Trusted Server.
+
+Backend creation should be derived from the matched `origin_url` and
+`settings.proxy.certificate_check`.
+
+### Host header
+
+The upstream `Host` header must be set to the matched asset origin host,
+not the original first-party host.
+
+This is necessary for CDN and origin correctness.
+
+### Method forwarding
+
+- incoming `GET` → upstream `GET`
+- incoming `HEAD` → upstream `HEAD`
+
+No method rewriting.
+
+### Header forwarding
+
+Forward a minimal curated set of request headers, aligned with existing proxy
+helper behavior where possible.
+
+Recommended v1 header set:
+
+- `Accept`
+- `Accept-Encoding`
+- `Accept-Language`
+- `User-Agent`
+- `Referer`
+- `X-Forwarded-For`
+
+Avoid broad header tunneling in v1.
+
+### Redirects
+
+Do not follow redirects.
+
+If upstream returns a redirect, return it to the client.
+
+### Response handling
+
+Treat the response as raw pass-through except for publisher-domain state and
+security headers that asset origins must not control:
+
+- preserve status code
+- preserve response body bytes
+- preserve response headers, including cache headers
+- strip `Set-Cookie`
+- strip `Strict-Transport-Security`
+- strip `Clear-Site-Data`
+- do not inspect content type for rewriting
+- do not run creative, HTML, CSS, or RSC processors
+
+---
+
+## Interaction with Existing Publisher Proxy
+
+The existing publisher proxy path is HTML-aware and consent-aware. It includes:
+
+- cookie parsing
+- EC generation / forwarding
+- consent context construction
+- response rewriting and post-processing
+- origin fallback through `publisher.origin_url`
+
+The new asset-route path is intentionally separate.
+
+### Design principle
+
+Use the publisher proxy for pages and general publisher-origin traffic.
+Use asset-route proxying for configured static/asset namespaces.
+
+This separation keeps the asset path lean and avoids introducing page-proxy
+behavior into CDN-style traffic.
+
+---
+
+## Failure Semantics
+
+### Upstream returns HTTP response
+
+Return it as-is.
+
+Examples:
+
+- `404 Not Found` → return `404`
+- `500 Internal Server Error` → return `500`
+- `302 Found` → return `302`
+
+### Upstream unreachable / backend failure
+
+Return the normal Trusted Server error behavior for backend/proxy failure.
+
+Do **not** retry against `publisher.origin_url`.
+Do **not** silently fall back.
+
+### Misconfiguration
+
+- invalid `prefix` / invalid `origin_url` → configuration error
+- duplicate exact `prefix` → warning only
+
+---
+
+## Observability
+
+At minimum, log enough information to diagnose routing decisions.
+
+Recommended log points:
+
+- asset route matched: request path, matched prefix, target origin
+- duplicate exact prefix detected at startup
+- asset proxy backend creation failure
+- asset upstream request failure
+- asset route skipped due to unsupported method
+
+Logging should use the project's normal `log` macros.
+
+---
+
+## Security Considerations
+
+### 1. Limited scope
+
+This feature is not an arbitrary open proxy. It only routes to origins that are
+statically configured in `trusted-server.toml`.
+
+### 2. No redirect following
+
+Returning redirects as-is avoids introducing redirect-chain SSRF concerns for
+this feature.
+
+### 3. Minimal header forwarding
+
+Forwarding a curated header set reduces risk from hop-by-hop headers or
+unexpected application headers being tunneled upstream.
+
+### 4. No signed-URL trust expansion
+
+This feature does not reuse `/first-party/proxy` URL-signing behavior. It is a
+separate static routing mechanism.
+
+### 5. Asset origins cannot mutate publisher browser state
+
+Because responses are served on the publisher first-party domain, asset origins
+must not be able to set cookies, alter transport-security policy, or clear
+publisher storage. Asset responses therefore strip `Set-Cookie`,
+`Strict-Transport-Security`, and `Clear-Site-Data`.
+
+---
+
+## Acceptance Criteria
+
+### Configuration
+
+- `trusted-server.toml` accepts `[[proxy.asset_routes]]`
+- each route requires `prefix` and `origin_url`
+- invalid `prefix` fails config load
+- invalid `origin_url` fails config load
+- duplicate exact prefixes log warnings but do not fail startup
+
+### Routing
+
+- built-in routes still win over asset routes
+- integration routes still win over asset routes
+- asset routes are evaluated before publisher-origin fallback
+- only `GET` and `HEAD` requests participate
+- longest matching prefix wins
+- exact duplicate prefixes resolve deterministically to the first configured rule
+
+### Proxy semantics
+
+- matched requests preserve path and query exactly unless optional rewrite settings change the path
+- matched requests use the asset origin's scheme/host/port
+- upstream `Host` header matches asset origin host
+- redirects are returned to the client, not followed
+- cache headers pass through unchanged
+- no fallback to `publisher.origin_url` on asset origin failure
+- `HEAD` remains `HEAD`
+
+### Response processing
+
+- matched asset routes bypass publisher consent/cookie/rewriting logic
+- matched asset routes behave as raw pass-through except unsafe publisher-domain state/security headers are stripped
+
+---
+
+## Recommended Tests
+
+### Settings tests
+
+- parses multiple `[[proxy.asset_routes]]` entries
+- rejects prefix without leading `/`
+- rejects `origin_url` with trailing slash
+- rejects non-absolute `origin_url`
+- warns on duplicate exact prefixes
+- rejects invalid `path_pattern` / `target_path` combinations
+
+### Route-selection tests
+
+- no match for unsupported method
+- match by prefix
+- longest-prefix wins
+- exact duplicate prefix resolves to first rule
+- query string does not affect matching
+
+### Adapter/router tests
+
+- built-in route precedence over asset route
+- integration route precedence over asset route
+- unmatched path still falls through to publisher proxy
+
+### Proxy-construction tests
+
+- path preserved exactly without rewrite settings
+- path rewritten when `path_pattern` and `target_path` are configured
+- query preserved exactly
+- upstream host header uses asset origin host
+- `HEAD` preserved
+- redirect response returned as-is
+
+---
+
+## Implementation Notes
+
+A minimal implementation should avoid changing the existing publisher proxy
+behavior more than necessary.
+
+Recommended implementation outline:
+
+1. Add `ProxyAssetRoute` and `Proxy.asset_routes` to settings
+2. Add normalization / validation / duplicate-warning logic
+3. Add a path-matching helper that selects the longest prefix
+4. Add a lean asset-proxy handler that:
+   - builds a backend from matched `origin_url`
+   - preserves path + query by default
+   - applies optional path rewrite while preserving query
+   - forwards a minimal header set
+   - does not follow redirects
+   - returns raw upstream response after stripping unsafe publisher-domain state/security headers
+5. Insert asset-route handling into top-level routing after explicit routes and
+   before publisher fallback
+6. Add focused tests for config, matching, precedence, and proxy construction
+
+---
+
+## Future Extensions
+
+Potential future work, intentionally excluded from v1:
+
+- regex route selection
+- per-route custom headers
+- per-route cache overrides
+- per-route certificate-check options
+- per-route method allowlists
+- route metrics / counters
+- fallback chains across multiple origins
+
+---
+
+## Open Questions
+
+None blocking for v1.
+
+The only follow-up item already identified is broader project-wide work to make
+misconfiguration handling more consistent across Trusted Server, but that is not
+required to implement this feature.

--- a/docs/superpowers/specs/2026-05-19-asset-s3-auth-fastly-io-design.md
+++ b/docs/superpowers/specs/2026-05-19-asset-s3-auth-fastly-io-design.md
@@ -1,0 +1,488 @@
+# Asset S3 Auth and Fastly IO Design
+
+## Problem
+
+Issue #695 requires authenticated S3 bucket support for path-based asset
+proxying. The asset proxy work in #668 routes selected first-party asset paths
+to alternate origins, but private S3 buckets return `403` unless upstream
+requests are signed.
+
+Issue #696 requires Fastly Image Optimizer (IO) support for those image asset
+routes. These concerns must compose without tightly coupling the asset proxy to
+S3, Fastly IO, or any customer-specific URL/profile convention.
+
+The migration target includes production-style image URLs such as:
+
+```text
+/.image/<public-id>/<basename>.jpg?profile=w828&ar=1-1
+```
+
+where query parameters describe image transformation intent, not the S3 object
+identity. For private S3 + IO, the origin request usually needs to be signed for
+the final object path with origin query parameters stripped.
+
+## Goals
+
+- Support private S3 buckets as asset route origins using AWS Signature Version
+  4 header authentication.
+- Keep asset routes generic: routes may use no auth, S3 auth, public S3, a CDN,
+  Fastly IO, or no IO in any combination.
+- Keep S3 signing platform-neutral and independent from Fastly APIs.
+- Keep Fastly IO platform-neutral at the core boundary; only the Fastly adapter
+  should translate to `fastly::image_optimizer::ImageOptimizerOptions`.
+- Support configurable profile-table image transformations equivalent to common
+  VCL table-based IO setups.
+- Avoid committing customer-specific names, profile sets, or URL semantics.
+- Reuse existing path-prefix and path rewrite behavior from asset routes; S3
+  signing signs the final rewritten origin URL.
+- Fail fast on invalid configuration where possible.
+
+## Non-Goals
+
+- Full AWS SDK integration or AWS default credential-provider support.
+- Uploads or signed request bodies. Initial support is read-only `GET` and
+  `HEAD` asset access.
+- Presigned S3 URLs in query parameters.
+- Arbitrary IO query DSL support. Initial profile-table values support a strict
+  subset of IO params.
+- Legacy path-parameter normalization such as
+  `/.image/w_828,ar_1:1/<id>/<file>`. Query-profile URLs are handled first;
+  legacy path normalization can be added later if traffic requires it.
+- Local end-to-end IO transformation verification. Viceroy currently does not
+  perform real image optimization.
+
+## Proposed Configuration Model
+
+### Asset route capabilities
+
+Asset route auth and image optimization are independent optional capabilities:
+
+```toml
+[[proxy.asset_routes]]
+prefix = "/.image/"
+origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+# Existing #668 path rewrite behavior remains available and unchanged.
+# path_pattern = "^/\\.image/(.*)$"
+# target_path = "/images/$1"
+
+[proxy.asset_routes.auth]
+type = "s3_sigv4"
+region = "us-east-1"
+origin_query = "strip"
+# Optional secret lookup overrides; these default if omitted.
+# secret_store = "s3-auth"
+# access_key_id = "access_key_id"
+# secret_access_key = "secret_access_key"
+# session_token = "session_token"
+
+[proxy.asset_routes.image_optimizer]
+enabled = true
+region = "us_east"
+profile_set = "default_images"
+```
+
+Other supported combinations:
+
+```toml
+# Public non-IO asset origin.
+[[proxy.asset_routes]]
+prefix = "/static/"
+origin_url = "https://cdn.example.com"
+
+# Private S3, no IO.
+[[proxy.asset_routes]]
+prefix = "/private-assets/"
+origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+auth = { type = "s3_sigv4", region = "us-east-1" }
+
+# Public image origin with IO.
+[[proxy.asset_routes]]
+prefix = "/images/"
+origin_url = "https://images.example.com"
+image_optimizer = { enabled = true, region = "us_east", profile_set = "default_images" }
+```
+
+### S3 auth defaults
+
+`auth.type = "s3_sigv4"` uses route-scoped config with default secret names:
+
+| Field               | Default                                | Meaning                                          |
+| ------------------- | -------------------------------------- | ------------------------------------------------ |
+| `secret_store`      | `s3-auth`                              | Runtime secret store name                        |
+| `access_key_id`     | `access_key_id`                        | Secret key containing AWS access key ID          |
+| `secret_access_key` | `secret_access_key`                    | Secret key containing AWS secret access key      |
+| `session_token`     | unset                                  | Optional secret key containing AWS session token |
+| `origin_query`      | `preserve` without IO, `strip` with IO | Query behavior for the origin/S3 request         |
+
+Credential fields name secret-store entries, not literal credential values.
+
+### Image optimizer profile sets
+
+Profile tables are reusable and defined globally in `trusted-server.toml`:
+
+```toml
+[image_optimizer.profile_sets.default_images]
+base_params = "quality=70&resize-filter=bicubic"
+default_profile = "default"
+unknown_profile = "use_default" # "use_default" | "reject"
+profile_param = "profile"
+aspect_ratio_param = "ar"
+debug_param = "_io_debug"
+
+[image_optimizer.profile_sets.default_images.profiles]
+default = "width=1920"
+thumbnail = "width=150&crop=1:1,smart"
+medium = "format=auto&width=828"
+large = "format=auto&width=1536"
+
+[image_optimizer.profile_sets.default_images.aspect_ratios]
+allowed = ["1-1", "16-9", "4-3"]
+profiles = ["medium", "large"]
+
+[image_optimizer.profile_sets.default_images.crop_offsets]
+enabled = true
+x_param = "x"
+y_param = "y"
+buckets = [10, 30, 50, 70, 90]
+default = 50
+when_missing = "smart"
+```
+
+Only a small generic commented example should be committed to
+`trusted-server.toml`. Customer-specific profile set names and tables belong in
+private deployment configuration or environment overrides.
+
+## Runtime Semantics
+
+### Route handling order
+
+Asset routes are evaluated after explicit built-in and integration routes and
+before publisher fallback, as designed in #668. Only `GET` and `HEAD` requests
+participate.
+
+### Asset request pipeline
+
+For a matched asset route:
+
+```text
+incoming request
+  -> build final origin URL using existing path_pattern/target_path behavior
+  -> evaluate image_optimizer profile table from the original client query
+  -> determine origin query policy
+  -> build platform-neutral upstream request
+  -> apply origin auth, if configured
+  -> attach platform-neutral IO metadata, if enabled and not debug-bypassed
+  -> PlatformHttpClient::send()
+```
+
+S3 signing happens after path rewrite and after origin query policy is applied,
+so the signature always covers the exact URL that the origin should see.
+
+### Origin query policy
+
+`origin_query` controls whether the origin request includes the inbound query:
+
+- `strip`: origin URL query is empty.
+- `preserve`: origin URL query preserves the inbound query string.
+
+For S3-authenticated routes with IO enabled, default to `strip`. This matches
+the common shape where `profile`, `ar`, `x`, and `y` are transformation inputs
+rather than S3 object identity.
+
+Initial implementation rejects `origin_query = "preserve"` when IO is enabled.
+Fastly treats request query parameters as possible IO transformation inputs, so
+preserving arbitrary client query parameters would bypass the closed profile set
+and can also change the URL Fastly ultimately sends to the origin. A future
+explicit allowlist can relax this if origin query preservation is needed.
+
+### Debug bypass
+
+If the configured `debug_param` is present with value `1`, image optimization is
+disabled for that request. The asset route still applies, and origin auth still
+applies if configured. The response is the original source object.
+
+This provides a simple way to compare optimized vs. origin images.
+
+## S3 SigV4 Auth
+
+### Signing method
+
+Use header-based AWS Signature Version 4. Do not generate presigned query URLs.
+
+For `GET` and `HEAD`, add or overwrite:
+
+```http
+Host: <origin-host>
+x-amz-date: <YYYYMMDDTHHMMSSZ>
+x-amz-content-sha256: UNSIGNED-PAYLOAD
+x-amz-security-token: <token> # only when configured and present
+Authorization: AWS4-HMAC-SHA256 Credential=..., SignedHeaders=..., Signature=...
+```
+
+Use:
+
+- service: `s3`
+- payload hash: `UNSIGNED-PAYLOAD`
+- method: `GET` or `HEAD`
+- canonical URI/query from the final origin URL
+- canonical headers including at least `host`, `x-amz-content-sha256`,
+  `x-amz-date`, and `x-amz-security-token` when present
+
+### Credential loading
+
+Read credentials from `RuntimeServices::secret_store()` using the configured
+runtime `StoreName`. The core signer receives strings/bytes and does not depend
+on Fastly Secret Store directly.
+
+Missing access key or secret key is a request-time proxy error. Missing session
+token is allowed when `session_token` is absent. When `session_token` is
+configured, the named secret must be present. Do not log secret values.
+
+### Endpoint assumptions
+
+For `s3_sigv4`, `origin_url` must be the real S3 or S3-compatible endpoint host
+that the origin will validate in the signature, for example:
+
+```toml
+origin_url = "https://my-bucket.s3.us-east-1.amazonaws.com"
+```
+
+or path-style/S3-compatible usage:
+
+```toml
+origin_url = "https://s3.us-east-1.amazonaws.com"
+path_pattern = "^/\\.image/(.*)$"
+target_path = "/my-bucket/$1"
+```
+
+Do not sign for one host while sending to a different vanity host.
+
+## Platform-Neutral Image Optimizer Metadata
+
+Extend the platform HTTP abstraction so core can request image optimization
+without importing Fastly SDK types.
+
+Suggested core shape:
+
+```rust
+pub struct PlatformHttpRequest {
+    pub request: EdgeRequest,
+    pub backend_name: String,
+    pub image_optimizer: Option<PlatformImageOptimizerOptions>,
+    pub stream_response: bool,
+}
+
+pub struct PlatformImageOptimizerOptions {
+    pub region: PlatformImageOptimizerRegion,
+    pub preserve_query_string_on_origin_request: bool,
+    pub params: PlatformImageOptimizerParams,
+}
+```
+
+`PlatformImageOptimizerParams` initially needs only the strict subset produced
+by profile tables:
+
+- `quality`
+- `resize_filter`
+- `format`
+- `width`
+- `height`
+- `crop`
+
+The Fastly adapter maps these neutral options to
+`fastly::image_optimizer::ImageOptimizerOptions` and calls
+`Request::set_image_optimizer()` in `send()`.
+
+`FastlyPlatformHttpClient::send_async()` must reject requests that carry image
+optimizer metadata because the Fastly Rust SDK does not support IO with
+`send_async` or `send_async_streaming`.
+
+Test platform clients should record the metadata so core tests can assert that
+IO would be requested without needing real Fastly IO locally. Asset routes should
+set `stream_response` for final origin responses so large images/static assets are
+not materialized into WASM memory as a single buffer.
+
+## Profile Table Conversion
+
+### Supported profile parameters
+
+The profile parser is intentionally strict in v1. Profile strings may contain:
+
+- `quality=<0..100>`
+- `resize-filter=bicubic` initially, plus any Fastly SDK resize filters we map
+- `format=auto|avif|gif|jpeg|jxl|mp4|png|webp` as supported by the SDK/version
+- `width=<pixels>`
+- `height=<pixels>`
+- `crop=<w>:<h>`
+- `crop=<w>:<h>,smart`
+- `crop=<w>:<h>,offset-x<N>,offset-y<N>` as generated by offset handling
+
+Unknown keys or invalid values fail config preparation.
+
+### Profile lookup
+
+For a request query:
+
+```text
+?profile=medium&ar=1-1&x=70&y=30
+```
+
+1. Read `profile_param` from the query.
+2. Look up the profile in the configured profile set.
+3. If missing/unknown and `unknown_profile = "use_default"`, use
+   `default_profile`.
+4. If missing/unknown and `unknown_profile = "reject"`, return a bad request or
+   proxy error before sending upstream.
+5. Merge `base_params` and the selected profile params, with profile params
+   overriding base params if the same key appears.
+
+### Aspect ratio override
+
+If `aspect_ratio_param` is present and valid:
+
+- the value must be in `aspect_ratios.allowed`
+- the selected profile must be in `aspect_ratios.profiles`
+
+Then set/replace `crop` to the requested aspect ratio. Convert `1-1` to `1:1`.
+Invalid or unsupported aspect ratio values are ignored to match tolerant VCL
+behavior and avoid breaking images.
+
+### Crop offset bucketing
+
+When crop offsets are enabled and the final crop is a bare aspect ratio:
+
+- if either `x_param` or `y_param` is present, normalize each value to the
+  configured bucket list and append `offset-xN,offset-yN`
+- invalid, missing, non-numeric, or out-of-range values normalize to the
+  configured default
+- if neither offset is present and `when_missing = "smart"`, append `smart`
+
+Default bucket behavior should match the common VCL pattern:
+
+```text
+<20 => 10
+<40 => 30
+<60 => 50
+<80 => 70
+else => 90
+```
+
+The configured bucket list must be sorted and bounded to a safe range to avoid
+variant explosion.
+
+### Closed output set
+
+The profile mapper consumes `profile`, `ar`, `x`, and `y`. It does not pass the
+client query through as raw IO params. The generated IO metadata is the only
+transformation request, unless debug bypass disables IO.
+
+## Local Development and Verification
+
+Local development can validate:
+
+- config parsing and validation
+- asset route matching and path rewrite behavior
+- profile table conversion
+- S3 SigV4 canonical request/signature generation
+- platform-neutral IO metadata attachment
+- Fastly adapter rejection of IO metadata on async sends
+
+Local Viceroy cannot prove real image resizing/format conversion. Current
+Viceroy source returns unsupported for the Image Optimizer hostcall. End-to-end
+acceptance requires a Fastly Compute service with IO enabled for the account and
+service.
+
+## Testing Strategy
+
+### Settings tests
+
+- parse `auth = { type = "s3_sigv4", ... }`
+- default S3 secret store/key names
+- reject invalid S3 region/empty credential key names
+- parse top-level `image_optimizer.profile_sets`
+- reject route `image_optimizer.profile_set` references that do not exist
+- reject unsupported profile-table params
+- reject invalid crop/quality/width/height values
+- accept generic commented-example-equivalent config
+
+### Profile conversion tests
+
+- missing profile uses default profile
+- unknown profile uses default when configured
+- unknown profile rejects when configured
+- `profile=medium` produces base + profile IO params
+- valid aspect ratio override appends/replaces crop only for configured profiles
+- invalid aspect ratio is ignored
+- no offsets appends `smart` for bare crops
+- `x`/`y` offsets normalize to configured buckets
+- debug param disables IO metadata
+- arbitrary query params are not passed into generated IO metadata
+
+### S3 signer tests
+
+- canonical request uses final rewritten path
+- origin query is stripped when configured
+- origin query is preserved when configured
+- generated `Authorization` matches a stable fixture
+- session token is added and signed when present
+- unsigned payload header is present
+- inbound `Authorization` and `x-amz-*` headers are overwritten/not trusted
+- secret values are not logged or surfaced in error text
+
+### Asset proxy tests
+
+- public asset route still works without auth or IO
+- S3 auth route signs before sending
+- IO route attaches platform-neutral metadata
+- S3 + IO route strips origin query by default
+- S3 + IO rejects preserve-query configuration while profile-table IO is enabled
+- path rewrite occurs before signing
+- `GET` and `HEAD` are supported
+- non-`GET`/`HEAD` skip asset route and fall through as existing behavior
+- upstream `Set-Cookie` and HSTS stripping remains unchanged from #668
+
+### Fastly adapter tests
+
+- `send()` maps neutral IO options to Fastly SDK options
+- `send_async()` fails when IO metadata is present
+- request headers from S3 signing survive Fastly request conversion
+- Host/backend behavior remains consistent with signed host expectations
+
+## Implementation Plan
+
+1. Add config structs for:
+   - `AssetOriginAuth`
+   - `S3SigV4AuthConfig`
+   - top-level `ImageOptimizerSettings`
+   - `ImageOptimizerProfileSet`
+   - route-level `AssetImageOptimizerConfig`
+2. Add profile-set normalization and validation during settings preparation.
+3. Extend `PlatformHttpRequest` with optional `PlatformImageOptimizerOptions`.
+4. Add Fastly adapter mapping for neutral IO metadata in `send()` and explicit
+   rejection in `send_async()`.
+5. Implement strict profile-table parser/converter.
+6. Implement internal lightweight S3 SigV4 signer using existing crypto crates.
+7. Wire asset route handling:
+   - build final origin URL using existing rewrite behavior
+   - compute IO metadata or debug bypass
+   - apply origin query policy
+   - build outbound request
+   - apply S3 signing if configured
+   - send synchronously
+8. Add generic commented config examples to `trusted-server.toml`.
+9. Run:
+   - `cargo test --workspace`
+   - `cargo fmt --all -- --check`
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+   - wasm build for `trusted-server-adapter-fastly`
+
+## Open Questions
+
+- What exact S3 object key mapping will production deployments need? Keep this
+  configurable through the existing path rewrite fields.
+- `session_token` is optional by default; if a route config names a session-token
+  secret, that secret must exist at request time.
+- Which Fastly IO region should production configs use? It should be close to
+  the S3/image origin.
+- Should a later phase add legacy path-parameter normalization? Defer until
+  active traffic requires it.

--- a/docs/superpowers/specs/2026-05-28-edgezero-image-optimizer-primitive-design.md
+++ b/docs/superpowers/specs/2026-05-28-edgezero-image-optimizer-primitive-design.md
@@ -1,0 +1,272 @@
+# EdgeZero Image Optimizer Primitive Design
+
+> Proposed extraction shape for moving Trusted Server's Fastly Image Optimizer
+> request metadata into EdgeZero.
+> Date: 2026-05-28.
+
+---
+
+## Goal
+
+Make the Image Optimizer support introduced for asset routes easy to extract
+into `~/Projects/stackpop/edgezero` without moving Trusted Server-specific asset
+routing, S3 authentication, or profile-table behavior.
+
+The extraction should let a Trusted Server asset route produce a closed image
+transformation request, attach it to an EdgeZero proxy request, and rely on the
+Fastly adapter to translate that request into `fastly::image_optimizer` calls.
+
+---
+
+## Keep in Trusted Server
+
+These pieces are product/application policy and should not move to EdgeZero:
+
+- `proxy.asset_routes` configuration and route matching.
+- Path rewrite behavior for asset origins.
+- Top-level image profile tables and query controls such as `profile`, `ar`,
+  `x`, `y`, and debug bypass.
+- Origin query strip/preserve policy.
+- S3 SigV4 credential loading and request signing.
+- S3 preflight behavior used to avoid Image Optimizer masking origin errors.
+- Response-header stripping for publisher-domain safety.
+
+Trusted Server should continue converting route config plus request query into a
+small platform-neutral options object.
+
+---
+
+## Move to EdgeZero
+
+Move only the generic proxy capability shape:
+
+```text
+edgezero-core
+  src/proxy/image_optimizer.rs
+    ImageOptimizerOptions
+    ImageOptimizerParams
+    ImageOptimizerCrop
+    ImageOptimizerCropMode
+```
+
+Then expose it through `edgezero_core::proxy`:
+
+```rust
+use edgezero_core::proxy::{ImageOptimizerOptions, ProxyRequest};
+
+let request = ProxyRequest::new(method, uri).with_image_optimizer(options);
+```
+
+Recommended API shape:
+
+```rust
+pub struct ProxyRequest {
+    // existing fields
+    image_optimizer: Option<ImageOptimizerOptions>,
+}
+
+impl ProxyRequest {
+    pub fn with_image_optimizer(mut self, options: ImageOptimizerOptions) -> Self;
+    pub fn image_optimizer(&self) -> Option<&ImageOptimizerOptions>;
+}
+```
+
+A first-class field/method is preferred over raw `Extensions` because adapters
+must not silently ignore requested transformations.
+
+---
+
+## Adapter Contract
+
+Adapters that support the capability should translate it at send time.
+Adapters that do not support it should return an unsupported/internal proxy error
+before sending the origin request.
+
+Silent fallback is not acceptable: returning the unoptimized origin image would
+make a successful HTTP response hide a platform capability failure.
+
+### Fastly adapter
+
+`edgezero-adapter-fastly` should map `ImageOptimizerOptions` to
+`fastly::image_optimizer::ImageOptimizerOptions` and call
+`FastlyRequest::set_image_optimizer()` before sending.
+
+The current Fastly proxy path uses `send_async_streaming()`. Fastly IO requires a
+separate branch because the request must be decorated before send:
+
+```text
+ProxyRequest without ImageOptimizerOptions
+  -> existing send_async_streaming path
+
+ProxyRequest with ImageOptimizerOptions
+  -> build FastlyRequest
+  -> set_image_optimizer(...)
+  -> send(...)
+  -> return streaming response body when supported
+```
+
+The initial Fastly IO branch may reject streaming request bodies if the Fastly SDK
+path cannot combine request-body streaming with Image Optimizer. Asset image
+routes currently send empty `GET`/`HEAD` bodies, so that limitation is acceptable
+for the extraction.
+
+### Cloudflare adapter
+
+Cloudflare is compatible with the same EdgeZero proxy-capability direction, but
+it should not be treated as identical to Fastly IO.
+
+Cloudflare Workers expose image transformations by passing options on a fetch
+subrequest:
+
+```javascript
+fetch(imageURL, {
+  cf: { image: { fit: 'scale-down', width: 800, height: 600 } },
+})
+```
+
+Relevant documented capabilities:
+
+- custom Worker URL schemes and hidden origins are supported;
+- origin access can be controlled in Worker code;
+- width, height, fit, quality, and format are supported;
+- `fit=cover`/`fit=crop` plus `gravity` provide crop behavior;
+- `gravity=auto` provides saliency-based smart cropping;
+- Worker coordinate gravity uses `{ x, y }` values from `0.0` to `1.0`;
+- authenticated origins can be fetched with signed headers and
+  `origin-auth = "share-publicly"` when caching privately-authenticated images
+  as public variants is acceptable.
+
+Sources:
+
+- <https://developers.cloudflare.com/images/optimization/transformations/transform-via-workers/>
+- <https://developers.cloudflare.com/images/optimization/features/>
+- <https://developers.cloudflare.com/images/optimization/transformations/control-origin-access/>
+
+Mapping notes for a future `edgezero-adapter-cloudflare` implementation:
+
+| EdgeZero option                                | Cloudflare mapping                                                                              |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `quality = Some(n)`                            | `cf.image.quality = n`                                                                          |
+| `format = "avif"`, `"webp"`, `"jpeg"`, `"png"` | `cf.image.format = ...`                                                                         |
+| `format = "auto"`                              | inspect the request `Accept` header and choose AVIF/WebP, matching Cloudflare's Worker guidance |
+| `width` / `height`                             | `cf.image.width` / `cf.image.height`                                                            |
+| bare aspect-ratio crop plus width              | derive target height and use `fit = "cover"` or `fit = "crop"`                                  |
+| `Smart` crop mode                              | `gravity = "auto"`                                                                              |
+| offset `x` / `y` in `0..=100`                  | `gravity = { x: x / 100.0, y: y / 100.0 }`                                                      |
+
+The current Trusted Server DTO also contains Fastly-shaped fields:
+
+- `region` has no Cloudflare equivalent.
+- `preserve_query_string_on_origin_request` has no direct Cloudflare equivalent;
+  Cloudflare fetches the exact source URL the adapter/request builder provides,
+  so origin query policy should stay in Trusted Server's URL construction.
+- `resize_filter` has no Cloudflare equivalent in the documented Worker image
+  options.
+
+For a Fastly-first extraction, keeping these fields is still acceptable because
+unsupported adapters can reject metadata. If Cloudflare support is added soon,
+prefer splitting common transform parameters from provider-specific options
+before making the EdgeZero API public/stable.
+
+### Other non-Fastly adapters
+
+Spin and Axum adapters should initially reject `ImageOptimizerOptions` with a
+clear unsupported-capability error. They can add provider-specific
+implementations later without changing Trusted Server route logic.
+
+---
+
+## Type Shape
+
+The current Trusted Server DTOs are intentionally close to the future EdgeZero
+shape:
+
+```rust
+pub struct ImageOptimizerOptions {
+    pub region: String,
+    pub preserve_query_string_on_origin_request: bool,
+    pub params: ImageOptimizerParams,
+}
+
+pub struct ImageOptimizerParams {
+    pub format: Option<String>,
+    pub quality: Option<u32>,
+    pub resize_filter: Option<String>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub crop: Option<ImageOptimizerCrop>,
+}
+
+pub struct ImageOptimizerCrop {
+    pub width: u32,
+    pub height: u32,
+    pub mode: Option<ImageOptimizerCropMode>,
+    pub offset_x: Option<u32>,
+    pub offset_y: Option<u32>,
+}
+
+pub enum ImageOptimizerCropMode {
+    Smart,
+}
+```
+
+For the first EdgeZero extraction, copying this shape is acceptable if the
+primitive is explicitly Fastly-first and unsupported adapters reject it. Before
+shipping Cloudflare support or treating the EdgeZero API as stable, split common
+fields from provider-specific fields:
+
+```rust
+pub struct ImageOptimizerOptions {
+    pub params: ImageOptimizerParams,
+    pub provider: ImageOptimizerProviderOptions,
+}
+
+pub enum ImageOptimizerProviderOptions {
+    Fastly {
+        region: String,
+        preserve_query_string_on_origin_request: bool,
+    },
+    Cloudflare {
+        origin_auth: Option<CloudflareOriginAuth>,
+    },
+    None,
+}
+```
+
+A later public API cleanup can also replace stringly fields with enums/builders
+once the primitive's cross-provider story is clearer.
+
+---
+
+## Trusted Server Migration Steps
+
+1. Move the DTO file from `trusted-server-core::platform::image_optimizer` to
+   `edgezero_core::proxy::image_optimizer`.
+2. Replace `PlatformHttpRequest::image_optimizer` with
+   `edgezero_core::proxy::ProxyRequest::image_optimizer` or the equivalent
+   EdgeZero proxy request field.
+3. Move the Fastly translation helpers from
+   `trusted-server-adapter-fastly/src/platform.rs` into
+   `edgezero-adapter-fastly/src/proxy.rs`.
+4. Keep `asset_image_optimizer.rs`, `s3_sigv4.rs`, and asset-route handling in
+   Trusted Server.
+5. Make non-Fastly EdgeZero proxy clients reject requests carrying image
+   optimizer metadata.
+
+---
+
+## Current PR Seam
+
+This PR keeps runtime behavior in Trusted Server but isolates the future move by
+placing the neutral DTOs in:
+
+```text
+crates/trusted-server-core/src/platform/image_optimizer.rs
+```
+
+That file is the primary extraction candidate for EdgeZero. The Fastly-specific
+mapping remains isolated in:
+
+```text
+crates/trusted-server-adapter-fastly/src/platform.rs
+```

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -12,6 +12,8 @@ password = "replace-with-admin-password-32-bytes"
 domain = "test-publisher.com"
 cookie_domain = ".test-publisher.com"
 origin_url = "https://origin.test-publisher.com"
+# Optional: override outbound Host header while connecting to origin_url.
+# origin_host_header_override = "www.example.com"
 proxy_secret = "change-me-proxy-secret"
 
 [ec]
@@ -185,6 +187,36 @@ rewrite_script = true
 #     "*.edgecompute.app",
 # ]
 
+# Reusable Fastly Image Optimizer profile sets for asset routes.
+# Keep production/customer-specific profile names and tables in private deployment config.
+# Profile values intentionally support a strict subset of IO params: quality,
+# resize-filter, format, width, height, and crop. Client query parameters are
+# mapped through this table instead of being passed through as arbitrary IO options.
+# [image_optimizer.profile_sets.default_images]
+# base_params = "quality=70&resize-filter=bicubic"
+# default_profile = "default"
+# unknown_profile = "use_default" # "use_default" or "reject"
+# profile_param = "profile"
+# aspect_ratio_param = "ar"
+# debug_param = "_io_debug" # _io_debug=1 bypasses IO for one request
+#
+# [image_optimizer.profile_sets.default_images.profiles]
+# default = "width=1920"
+# thumbnail = "width=150&crop=1:1,smart"
+# medium = "format=auto&width=828"
+# large = "format=auto&width=1536"
+#
+# [image_optimizer.profile_sets.default_images.aspect_ratios]
+# allowed = ["1-1", "16-9", "4-3"]
+# profiles = ["medium", "large"]
+#
+# [image_optimizer.profile_sets.default_images.crop_offsets]
+# enabled = true
+# x_param = "x"
+# y_param = "y"
+# buckets = [10, 30, 50, 70, 90]
+# default = 50
+# when_missing = "smart"
 
 # Proxy configuration
 [proxy]
@@ -192,6 +224,53 @@ rewrite_script = true
 # Defaults to true. Set to false only for local development with self-signed certificates.
 # certificate_check = true
 
+# Configure first-party asset paths that should proxy to a different backend origin.
+# Matching is path-prefix-based and the longest matching prefix wins.
+# Include a trailing / unless you intentionally want /static to also match paths such as /staticfile.js.
+# Only GET/HEAD requests participate. Built-in and integration routes still take precedence.
+# Trusted Server preserves the incoming query string. By default it also preserves
+# the incoming path, but path_pattern/target_path can generically rewrite paths
+# before sending them upstream.
+#
+# [[proxy.asset_routes]]
+# prefix = "/.images/"
+# origin_url = "https://some.fastly-service.example.com"
+#
+# Example: private S3 origin with Fastly IO profile-table conversion.
+# [[proxy.asset_routes]]
+# prefix = "/.image/"
+# origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
+#
+# [proxy.asset_routes.auth]
+# type = "s3_sigv4"
+# region = "us-east-1"
+# origin_query = "strip" # Strip transform query params before S3 signing
+# secret_store = "s3-auth"
+# access_key_id = "access_key_id"
+# secret_access_key = "secret_access_key"
+# # session_token = "session_token"
+#
+# [proxy.asset_routes.image_optimizer]
+# enabled = true
+# region = "us_east"
+# profile_set = "default_images"
+# # Enabled IO routes strip origin queries by default. origin_query = "preserve"
+# # is rejected while IO is enabled because Fastly can treat query params as transforms.
+#
+# Example: CDN-style first-party image path rewrite.
+# [[proxy.asset_routes]]
+# prefix = "/.image/"
+# origin_url = "https://assets-cdn.example.com"
+# path_pattern = "^/\\.image/(.*)/[^/]+\\.([^/.]+)$"
+# target_path = "/image/upload/$1.$2"
+#
+# Example: shared static assets stored under an upstream /_network prefix.
+# [[proxy.asset_routes]]
+# prefix = "/_next/static/"
+# origin_url = "https://static-assets.example.com"
+# path_pattern = "^(.*)$"
+# target_path = "/_network$1"
+#
 # Restrict redirect destinations for the first-party proxy to an explicit domain allowlist.
 # Supports exact match ("example.com") and subdomain wildcard prefix ("*.example.com").
 # Wildcard prefix also matches the apex domain ("*.example.com" matches "example.com").


### PR DESCRIPTION
## Summary

- Adds direct unit coverage for bare-host rewrite boundary behavior.
- Fixes standalone `host:port` bare-host rewrites while preserving the port and following path/query/fragment.
- Locks down negative cases for subdomains, embedded tokens, larger hostnames, and invalid colon suffixes.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/host_rewrite.rs` | Documented numeric port handling, allowed valid `:port` suffixes as safe rewrite boundaries, and added focused unit tests for boundary behavior. |

## Closes

Closes #449

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] JS tests: `cd crates/js/lib && npx vitest run`
- [ ] JS format: `cd crates/js/lib && npm run format`
- [ ] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: `cargo test -p trusted-server-core host_rewrite`; `cargo test -p trusted-server-core nextjs::shared`; `cargo test -p trusted-server-core rsc_flight`; `cargo test -p trusted-server-core`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
