### PR TITLE
docs: add Node.js/npm as prerequisite in getting-started guide

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -7,6 +7,7 @@ Get up and running with Trusted Server quickly.
 Before you begin, ensure you have:
 
 - Rust 1.91.1 (see `.tool-versions`)
+- Node.js >= 18 and npm >= 7 (required for building client-side JS bundles)
 - Fastly CLI installed
 - A Fastly account and API key
 - Basic familiarity with WebAssembly


### PR DESCRIPTION
Fixes #747

The trusted-server-js crate requires npm to run `npm ci` and `npm run build` during cargo build. The package-lock.json uses lockfileVersion 3, which requires npm >= 7. Node.js >= 18 is the minimum LTS version that ships with npm 7+.

Without Node.js/npm installed, the build fails with a confusing error from the build.rs script in crates/js.

## Summary

- Adds Node.js >= 18 and npm >= 7 to the Prerequisites section of the Getting Started guide
- Prevents new contributors from hitting a confusing `build.rs` panic when npm is missing

## Changes

| File | Change |
| ---- | ------ |
| `docs/guide/getting-started.md` | Added "Node.js >= 18 and npm >= 7 (required for building client-side JS bundles)" to Prerequisites list |

## Closes

Closes #747

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/js/lib && npx vitest run`
- [x] JS format: `cd crates/js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [x] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: Verified build panics at `build.rs:81` without npm, succeeds with npm (1,250 Rust tests + 318 JS tests pass)

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code -- use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed