### PR TITLE
Use .tool-versions variables in getting-started prerequisites

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -4,10 +4,11 @@ Get up and running with Trusted Server quickly.
 
 ## Prerequisites
 
-Before you begin, ensure you have:
+Before you begin, ensure you have the following installed (versions are pinned in `.tool-versions`):
 
-- Rust 1.91.1 (see `.tool-versions`)
-- Fastly CLI installed
+- Rust {{RUST_VERSION}}
+- NodeJS {{NODEJS_VERSION}}
+- Fastly {{FASTLY_VERSION}} CLI installed
 - A Fastly account and API key
 - Basic familiarity with WebAssembly
 
@@ -72,6 +73,5 @@ fastly compute publish
 ## Next Steps
 
 - Learn about [Edge Cookies](/guide/edge-cookies)
-- Follow the [EC Setup Guide](/guide/ec-setup-guide)
 - Understand [GDPR Compliance](/guide/gdpr-compliance)
 - Configure [Ad Serving](/guide/ad-serving)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -73,5 +73,6 @@ fastly compute publish
 ## Next Steps
 
 - Learn about [Edge Cookies](/guide/edge-cookies)
+- Follow the [EC Setup Guide](/guide/ec-setup-guide)
 - Understand [GDPR Compliance](/guide/gdpr-compliance)
 - Configure [Ad Serving](/guide/ad-serving)


### PR DESCRIPTION
Fixes #747. Supersedes #758.

## Problem

The Getting Started prerequisites listed Rust with a hardcoded version and omitted Node.js/npm entirely. Contributors without Node installed hit a confusing `build.rs` failure when the JS build runs during `cargo build`.

## Approach

Rather than hardcode versions (which drift from the source of truth), this uses the version-substitution mechanism already present in `docs/.vitepress/config.mts`, which parses `.tool-versions` and replaces `{{TOOL_VERSION}}` placeholders at markdown-parse time.

## Changes

| File | Change |
| ---- | ------ |
| `docs/guide/getting-started.md` | Prerequisites now use `{{RUST_VERSION}}`, `{{NODEJS_VERSION}}`, and `{{FASTLY_VERSION}}`; adds NodeJS as an explicit prerequisite |

Renders as:

- Rust 1.91.1
- NodeJS 24.12.0
- Fastly 13.3.0 CLI installed

Versions now stay in sync with `.tool-versions` automatically — no future doc edits needed when toolchain versions bump.

## Test plan

- [x] `cd docs && npm run build` — substitution renders real versions in `dist/guide/getting-started.html`
- [x] `cd docs && npm run format` — passes