### PR TITLE
Fix malformed TOML example in Fastly setup guide

### DIFF
--- a/docs/guide/fastly.md
+++ b/docs/guide/fastly.md
@@ -112,7 +112,7 @@ Configure in `trusted-server.toml`:
 
 ```toml
 [ec]
-passphrase = "replace-with-32-plus-byte-random-secret"}]}},{
+passphrase = "replace-with-32-plus-byte-random-secret"
 ec_store = "ec_identity_store"
 ```
 


### PR DESCRIPTION
The `[ec]` configuration example in `docs/guide/fastly.md` carries stray characters from a copy-paste artifact, leaving the snippet invalid TOML:

```
passphrase = "replace-with-32-plus-byte-random-secret"}]}},{
```

This removes the trailing characters so the example parses:

```toml
[ec]
passphrase = "replace-with-32-plus-byte-random-secret"
ec_store = "ec_identity_store"
```

No other changes. The rest of the file was scanned for similar artifacts and is clean.
