### PR TITLE
Rename Sync docs to Edge Cookie External Sync

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -118,7 +118,10 @@ export default withMermaid(
               text: 'Proxy Signing',
               link: '/guide/proxy-signing',
             },
-            { text: 'Collective Sync', link: '/guide/collective-sync' },
+            {
+              text: 'Edge Cookie External Sync',
+              link: '/guide/collective-sync',
+            },
           ],
         },
         {

--- a/docs/guide/collective-sync.md
+++ b/docs/guide/collective-sync.md
@@ -1,6 +1,6 @@
-# Collective Sync Architecture
+# Edge Cookie External Sync Architecture
 
-Trusted Server supports cross-publisher data sharing through a **Collective Sync** model. Publishers who share the same EC secret key can synchronize user data across their properties, enabling privacy-preserving audience insights without third-party cookies.
+Trusted Server supports ID syncing. Publishers who have engaged in an agreement with identity partners can use our sync endpoints found below.
 
 ## Overview
 
@@ -31,11 +31,11 @@ sequenceDiagram
 
 ## Architecture Principles
 
-| Component        | Role            | Characteristics                                        |
-| ---------------- | --------------- | ------------------------------------------------------ |
-| **KV Store**     | Hot cache       | Fast reads (~1ms), edge-local, eventually consistent   |
-| **Object Store** | Source of truth | Durable, supports range queries, sync endpoint         |
-| **Secret Key**   | Shared salt     | Distributed out-of-band, enables collective membership |
+| Component        | Role            | Characteristics                                           |
+| ---------------- | --------------- | --------------------------------------------------------- |
+| **KV Store**     | Hot cache       | Fast reads (~1ms), edge-local, eventually consistent      |
+| **Object Store** | Source of truth | Durable, supports range queries, sync endpoint            |
+| **Secret Key**   | Shared salt     | Distributed out-of-band, enables a data sharing agreement |
 
 ## Configuration
 
@@ -105,7 +105,7 @@ The Object Store maintains a richer record with full history:
 
 ### Initial Sync
 
-When a new publisher joins the collective, they perform a full sync:
+When a new publisher has a new agreement, they perform a full sync:
 
 ```http
 GET /sync?type=full


### PR DESCRIPTION
Renames the Collective Sync guide page to **Edge Cookie External Sync** and reworks the language.

## Changes
- Page H1 and sidebar label -> "Edge Cookie External Sync"
- Rewrote the opening paragraph (ID syncing framing, identity-partner agreement)
- Replaced "collective membership" / "joins the collective" phrasing with data sharing agreement language

## Notes
- Page URL/filename (`/guide/collective-sync`) is unchanged, so existing inbound links keep resolving.
- Config/code examples (`[collective]`, store name, token placeholder) left untouched.
- Docs prettier format check passes.