### PR TITLE
Add configurable tester cookie route

### DIFF
--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -23,6 +23,7 @@
 //! | POST | `/admin/keys/deactivate` (legacy alias) | [`handle_deactivate_key`] |
 //! | POST | `/_ts/api/v1/batch-sync` | [`handle_batch_sync`] |
 //! | GET | `/_ts/api/v1/identify` | [`handle_identify`] |
+//! | GET | `/_ts/set-tester` | [`handle_set_tester`] |
 //! | OPTIONS | `/_ts/api/v1/identify` | [`cors_preflight_identify`] |
 //! | POST | `/auction` | [`handle_auction`] |
 //! | GET | `/first-party/proxy` | [`handle_first_party_proxy`] |
@@ -119,6 +120,7 @@ use trusted_server_core::request_signing::{
 };
 use trusted_server_core::settings::{ProxyAssetRoute, Settings};
 use trusted_server_core::settings_data::get_settings;
+use trusted_server_core::tester_cookie::handle_set_tester;
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware};
 use crate::platform::{
@@ -549,6 +551,7 @@ async fn run_named_route(
                 )
             }
         }
+        NamedRouteHandler::SetTester => handle_set_tester(&state.settings),
         NamedRouteHandler::Auction => {
             // The auction reads consent data, so the consent KV store must be
             // available — fail closed with 503 when it is configured but
@@ -905,6 +908,7 @@ enum NamedRouteHandler {
     DeactivateKey,
     BatchSync,
     Identify,
+    SetTester,
     Auction,
     FirstPartyProxy,
     FirstPartyClick,
@@ -961,6 +965,11 @@ const NAMED_ROUTES: &[NamedRoute] = &[
         path: "/_ts/api/v1/identify",
         primary_methods: &[Method::GET, Method::OPTIONS],
         handler: NamedRouteHandler::Identify,
+    },
+    NamedRoute {
+        path: "/_ts/set-tester",
+        primary_methods: &[Method::GET],
+        handler: NamedRouteHandler::SetTester,
     },
     NamedRoute {
         path: "/auction",
@@ -1476,6 +1485,47 @@ mod tests {
             response.status(),
             StatusCode::SERVICE_UNAVAILABLE,
             "POST batch-sync without ec_store should fail with the KvStore error, not reach the publisher"
+        );
+    }
+
+    #[test]
+    fn dispatch_set_tester_is_disabled_by_default() {
+        let router = test_router();
+        let response = block_on(router.oneshot(empty_request(Method::GET, "/_ts/set-tester")));
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "disabled tester-cookie route should return 404"
+        );
+        assert!(
+            response.headers().get(header::SET_COOKIE).is_none(),
+            "disabled tester-cookie route should not set a cookie"
+        );
+    }
+
+    #[test]
+    fn dispatch_set_tester_sets_cookie_on_configured_domain() {
+        let mut settings = test_settings();
+        settings.tester_cookie.enabled = true;
+        let state = app_state_for_settings(settings);
+        let router = TrustedServerApp::routes_for_state(&state);
+        let response = block_on(router.oneshot(empty_request(Method::GET, "/_ts/set-tester")));
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NO_CONTENT,
+            "enabled tester-cookie route should return no content"
+        );
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("should set tester cookie")
+            .to_str()
+            .expect("should render set-cookie as utf-8");
+        assert_eq!(
+            set_cookie, "ts-tester=true; Domain=.test-publisher.com; Path=/; Secure; SameSite=Lax",
+            "tester cookie should use publisher.cookie_domain"
         );
     }
 

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -51,6 +51,7 @@ use trusted_server_core::request_signing::{
 };
 use trusted_server_core::settings::Settings;
 use trusted_server_core::settings_data::get_settings;
+use trusted_server_core::tester_cookie::handle_set_tester;
 
 mod app;
 mod backend;
@@ -864,6 +865,7 @@ async fn route_request(
             let outcome = cors_preflight_identify(settings, &req);
             (outcome, false)
         }
+        (Method::GET, "/_ts/set-tester") => (handle_set_tester(settings), false),
 
         // Unified auction endpoint.
         (Method::POST, "/auction") => {

--- a/crates/trusted-server-adapter-fastly/src/route_tests.rs
+++ b/crates/trusted-server-adapter-fastly/src/route_tests.rs
@@ -1025,6 +1025,63 @@ fn routes_use_request_local_consent() {
 }
 
 #[test]
+fn set_tester_route_is_disabled_by_default() {
+    let settings = create_test_settings();
+    let (orchestrator, integration_registry) = build_route_stack(&settings);
+    let req = Request::get("https://test.com/_ts/set-tester");
+    let services = test_runtime_services(&req);
+
+    let response = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route disabled tester-cookie request",
+    );
+
+    assert_eq!(
+        response.get_status(),
+        StatusCode::NOT_FOUND,
+        "disabled tester-cookie route should return 404"
+    );
+    assert_eq!(
+        response.get_header_str(header::SET_COOKIE),
+        None,
+        "disabled tester-cookie route should not set a cookie"
+    );
+}
+
+#[test]
+fn set_tester_route_sets_cookie_on_configured_domain_when_enabled() {
+    let mut settings = create_test_settings();
+    settings.tester_cookie.enabled = true;
+    let (orchestrator, integration_registry) = build_route_stack(&settings);
+    let req = Request::get("https://test.com/_ts/set-tester");
+    let services = test_runtime_services(&req);
+
+    let response = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route enabled tester-cookie request",
+    );
+
+    assert_eq!(
+        response.get_status(),
+        StatusCode::NO_CONTENT,
+        "enabled tester-cookie route should return no content"
+    );
+    assert_eq!(
+        response.get_header_str(header::SET_COOKIE),
+        Some("ts-tester=true; Domain=.test-publisher.com; Path=/; Secure; SameSite=Lax"),
+        "tester cookie should use publisher.cookie_domain"
+    );
+}
+
+#[test]
 fn malformed_auction_json_returns_bad_request() {
     let settings = create_auction_test_settings(r#"["prebid"]"#);
 

--- a/crates/trusted-server-core/src/constants.rs
+++ b/crates/trusted-server-core/src/constants.rs
@@ -2,6 +2,7 @@ use http::header::HeaderName;
 
 pub const COOKIE_TS_EC: &str = "ts-ec";
 pub const COOKIE_TS_EIDS: &str = "ts-eids";
+pub const COOKIE_TS_TESTER: &str = "ts-tester";
 pub const COOKIE_SHAREDID: &str = "sharedId";
 
 pub const HEADER_X_PUB_USER_ID: HeaderName = HeaderName::from_static("x-pub-user-id");

--- a/crates/trusted-server-core/src/lib.rs
+++ b/crates/trusted-server-core/src/lib.rs
@@ -17,6 +17,7 @@
 //! - [`streaming_replacer`]: Streaming URL replacement for large responses
 //! - [`ec`]: Edge Cookie (EC) identity subsystem — ID generation, consent gating, lifecycle
 //! - [`test_support`]: Testing utilities and mocks
+//! - [`tester_cookie`]: Optional tester-cookie endpoint helpers
 
 #![cfg_attr(
     test,
@@ -62,6 +63,7 @@ pub mod storage;
 pub mod streaming_processor;
 pub mod streaming_replacer;
 pub mod test_support;
+pub mod tester_cookie;
 pub mod tsjs;
 
 #[cfg(test)]

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -1699,10 +1699,20 @@ pub struct DebugConfig {
     pub ja4_endpoint_enabled: bool,
 }
 
+/// Tester-cookie endpoint configuration.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct TesterCookieConfig {
+    /// Enable `GET /_ts/set-tester`, which sets `ts-tester=true`.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
 #[derive(Debug, Default, Clone, Deserialize, Serialize, Validate)]
 pub struct Settings {
     #[validate(nested)]
     pub publisher: Publisher,
+    #[serde(default)]
+    pub tester_cookie: TesterCookieConfig,
     #[serde(default)]
     #[validate(nested)]
     pub ec: Ec,
@@ -2361,6 +2371,10 @@ mod tests {
         );
         assert_eq!(settings.publisher.domain, "test-publisher.com");
         assert_eq!(settings.publisher.cookie_domain, ".test-publisher.com");
+        assert!(
+            !settings.tester_cookie.enabled,
+            "tester-cookie route should default to disabled"
+        );
         assert_eq!(
             settings.publisher.ec_cookie_domain(),
             ".test-publisher.com",
@@ -2377,6 +2391,25 @@ mod tests {
         );
 
         settings.validate().expect("Failed to validate settings");
+    }
+
+    #[test]
+    fn tester_cookie_enabled_parses_from_toml() {
+        let toml_str = format!(
+            r#"{}
+
+            [tester_cookie]
+            enabled = true
+        "#,
+            crate_test_settings_str()
+        );
+
+        let settings = Settings::from_toml(&toml_str).expect("should parse tester-cookie config");
+
+        assert!(
+            settings.tester_cookie.enabled,
+            "tester-cookie config should enable the route"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/tester_cookie.rs
+++ b/crates/trusted-server-core/src/tester_cookie.rs
@@ -1,0 +1,114 @@
+//! Tester-cookie endpoint helpers.
+//!
+//! The tester route is intentionally disabled unless configured. When enabled,
+//! it sets a first-party `ts-tester=true` cookie scoped to the configured
+//! publisher cookie domain.
+
+use edgezero_core::body::Body as EdgeBody;
+use error_stack::{Report, ResultExt};
+use http::{header, HeaderValue, Response, StatusCode};
+
+use crate::constants::COOKIE_TS_TESTER;
+use crate::error::TrustedServerError;
+use crate::settings::Settings;
+
+/// Formats the tester cookie `Set-Cookie` header value.
+fn format_tester_cookie(domain: &str) -> String {
+    format!(
+        "{}=true; Domain={}; Path=/; Secure; SameSite=Lax",
+        COOKIE_TS_TESTER, domain,
+    )
+}
+
+/// Handles `GET /_ts/set-tester`.
+///
+/// Returns `404 Not Found` while `[tester_cookie].enabled` is false. When the
+/// feature is enabled, returns `204 No Content` with `Set-Cookie: ts-tester=true`
+/// scoped to `publisher.cookie_domain`.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError::InvalidHeaderValue`] if the configured cookie
+/// domain cannot be rendered as an HTTP header value.
+pub fn handle_set_tester(
+    settings: &Settings,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    if !settings.tester_cookie.enabled {
+        let mut response = Response::new(EdgeBody::empty());
+        *response.status_mut() = StatusCode::NOT_FOUND;
+        return Ok(response);
+    }
+
+    let set_cookie =
+        HeaderValue::from_str(&format_tester_cookie(&settings.publisher.cookie_domain))
+            .change_context(TrustedServerError::InvalidHeaderValue {
+                message: "tester cookie contains invalid header value".to_string(),
+            })?;
+
+    let mut response = Response::new(EdgeBody::empty());
+    *response.status_mut() = StatusCode::NO_CONTENT;
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, private"),
+    );
+    response
+        .headers_mut()
+        .insert(header::SET_COOKIE, set_cookie);
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::tests::create_test_settings;
+
+    #[test]
+    fn tester_cookie_uses_configured_cookie_domain() {
+        let mut settings = create_test_settings();
+        settings.tester_cookie.enabled = true;
+        settings.publisher.cookie_domain = ".tester.example".to_string();
+
+        let response = handle_set_tester(&settings).expect("should build tester response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NO_CONTENT,
+            "enabled tester route should return no content"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-store, private"),
+            "tester route should not be cacheable"
+        );
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("should set tester cookie")
+            .to_str()
+            .expect("should render set-cookie as utf-8");
+        assert_eq!(
+            set_cookie, "ts-tester=true; Domain=.tester.example; Path=/; Secure; SameSite=Lax",
+            "tester cookie should use publisher.cookie_domain"
+        );
+    }
+
+    #[test]
+    fn tester_cookie_route_is_disabled_by_default() {
+        let settings = create_test_settings();
+
+        let response = handle_set_tester(&settings).expect("should build disabled tester response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "disabled tester route should return not found"
+        );
+        assert!(
+            response.headers().get(header::SET_COOKIE).is_none(),
+            "disabled tester route should not set a cookie"
+        );
+    }
+}

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -8,7 +8,46 @@ Quick reference for all Trusted Server HTTP endpoints.
 - [Edge Cookie Endpoints](#edge-cookie-endpoints) - Identity sync and enrichment
 - [Request Signing](#request-signing-endpoints) - Cryptographic signing and key management
 - [TSJS Library](#tsjs-library-endpoint) - JavaScript library serving
+- [Utility Endpoints](#utility-endpoints) - Optional operational helpers
 - [Integration Endpoints](#integration-endpoints) - Third-party service proxying
+
+---
+
+## Utility Endpoints
+
+### GET /\_ts/set-tester
+
+Sets a first-party tester marker cookie for QA or troubleshooting workflows.
+
+**Configuration:** Disabled by default. Enable with:
+
+```toml
+[tester_cookie]
+enabled = true
+```
+
+**Response when enabled:**
+
+- **Status:** `204 No Content`
+- **Headers:**
+
+```http
+Set-Cookie: ts-tester=true; Domain=<publisher.cookie_domain>; Path=/; Secure; SameSite=Lax
+Cache-Control: no-store, private
+```
+
+The cookie domain comes from `[publisher].cookie_domain`.
+
+**Response when disabled:**
+
+- **Status:** `404 Not Found`
+- **Set-Cookie:** none
+
+**Example:**
+
+```bash
+curl -i "https://edge.example.com/_ts/set-tester"
+```
 
 ---
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -61,6 +61,7 @@ openssl rand -base64 32
 | ------------------- | -------------------------------------------- |
 | `[publisher]`       | Domain, origin, proxy settings               |
 | `[ec]`              | Edge Cookie (EC) ID generation               |
+| `[tester_cookie]`   | Optional tester-cookie endpoint              |
 | `[proxy]`           | Proxy SSRF allowlist and asset routes        |
 | `[image_optimizer]` | Reusable Image Optimizer profile sets        |
 | `[request_signing]` | Ed25519 request signing                      |
@@ -321,6 +322,45 @@ a zero-byte cap fails every non-empty buffered response.
 
 ```bash
 TRUSTED_SERVER__PUBLISHER__MAX_BUFFERED_BODY_BYTES=16777216
+```
+
+## Tester Cookie Configuration
+
+Settings for the optional tester-cookie endpoint. This feature is disabled by
+default and should only be enabled for intentional QA or troubleshooting flows.
+
+### `[tester_cookie]`
+
+| Field     | Type    | Required | Description                                                  |
+| --------- | ------- | -------- | ------------------------------------------------------------ |
+| `enabled` | Boolean | No       | Enables `GET /_ts/set-tester` to set `ts-tester=true` cookie |
+
+When enabled, `GET /_ts/set-tester` returns `204 No Content` and sets:
+
+```http
+Set-Cookie: ts-tester=true; Domain=<publisher.cookie_domain>; Path=/; Secure; SameSite=Lax
+Cache-Control: no-store, private
+```
+
+When disabled, the route returns `404 Not Found` and does not set a cookie.
+
+::: warning
+The cookie is scoped with `[publisher].cookie_domain`, not the EC-specific
+computed domain. Keep `cookie_domain` aligned with the browser scope where your
+QA tooling expects to read `ts-tester`.
+:::
+
+**Example**:
+
+```toml
+[tester_cookie]
+enabled = true
+```
+
+**Environment Override**:
+
+```bash
+TRUSTED_SERVER__TESTER_COOKIE__ENABLED=true
 ```
 
 ## EC Configuration

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -21,6 +21,11 @@ proxy_secret = "change-me-proxy-secret"
 # Raise it for deployments serving larger publisher pages:
 # max_buffered_body_bytes = 16777216  # 16 MiB
 
+# Tester-cookie endpoint. When enabled, GET /_ts/set-tester sets
+# ts-tester=true on publisher.cookie_domain.
+[tester_cookie]
+enabled = false
+
 [ec]
 passphrase = "local-dev-passphrase-32-bytes-min"
 ec_store = "ec_identity_store"


### PR DESCRIPTION
## Summary

- Adds an opt-in `GET /_ts/set-tester` route that sets `ts-tester=true` for QA/tester workflows.
- Scopes the tester cookie to `publisher.cookie_domain` and keeps the feature disabled by default.
- Covers legacy and EdgeZero routing paths with tests and docs.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/settings.rs` | Adds `[tester_cookie].enabled` config with default-off behavior and parsing coverage. |
| `crates/trusted-server-core/src/tester_cookie.rs` | Adds shared tester-cookie handler that returns 404 when disabled and 204 + `Set-Cookie` when enabled. |
| `crates/trusted-server-core/src/constants.rs` | Adds `COOKIE_TS_TESTER`. |
| `crates/trusted-server-core/src/lib.rs` | Exposes tester-cookie helper module. |
| `crates/trusted-server-adapter-fastly/src/main.rs` | Registers legacy `GET /_ts/set-tester` route. |
| `crates/trusted-server-adapter-fastly/src/app.rs` | Registers EdgeZero `GET /_ts/set-tester` route and dispatch tests. |
| `crates/trusted-server-adapter-fastly/src/route_tests.rs` | Adds legacy route tests for enabled and disabled behavior. |
| `trusted-server.toml` | Documents default-off tester-cookie config. |
| `docs/guide/api-reference.md` | Documents the utility endpoint behavior. |
| `docs/guide/configuration.md` | Documents tester-cookie configuration and env override. |

## Closes

Closes #794

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] JS tests: `cd crates/js/lib && npx vitest run`
- [ ] JS format: `cd crates/js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: `cargo test -p trusted-server-adapter-fastly set_tester`; `cargo test -p trusted-server-core tester_cookie --lib`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
