### PR TITLE
Add tester cookie clear endpoint

### DIFF
--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -24,6 +24,7 @@
 //! | POST | `/_ts/api/v1/batch-sync` | [`handle_batch_sync`] |
 //! | GET | `/_ts/api/v1/identify` | [`handle_identify`] |
 //! | GET | `/_ts/set-tester` | [`handle_set_tester`] |
+//! | GET | `/_ts/clear-tester` | [`handle_clear_tester`] |
 //! | OPTIONS | `/_ts/api/v1/identify` | [`cors_preflight_identify`] |
 //! | POST | `/auction` | [`handle_auction`] |
 //! | GET | `/first-party/proxy` | [`handle_first_party_proxy`] |
@@ -120,7 +121,7 @@ use trusted_server_core::request_signing::{
 };
 use trusted_server_core::settings::{ProxyAssetRoute, Settings};
 use trusted_server_core::settings_data::get_settings;
-use trusted_server_core::tester_cookie::handle_set_tester;
+use trusted_server_core::tester_cookie::{handle_clear_tester, handle_set_tester};
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware};
 use crate::platform::{
@@ -552,6 +553,7 @@ async fn run_named_route(
             }
         }
         NamedRouteHandler::SetTester => handle_set_tester(&state.settings),
+        NamedRouteHandler::ClearTester => handle_clear_tester(&state.settings),
         NamedRouteHandler::Auction => {
             // The auction reads consent data, so the consent KV store must be
             // available — fail closed with 503 when it is configured but
@@ -909,6 +911,7 @@ enum NamedRouteHandler {
     BatchSync,
     Identify,
     SetTester,
+    ClearTester,
     Auction,
     FirstPartyProxy,
     FirstPartyClick,
@@ -970,6 +973,11 @@ const NAMED_ROUTES: &[NamedRoute] = &[
         path: "/_ts/set-tester",
         primary_methods: &[Method::GET],
         handler: NamedRouteHandler::SetTester,
+    },
+    NamedRoute {
+        path: "/_ts/clear-tester",
+        primary_methods: &[Method::GET],
+        handler: NamedRouteHandler::ClearTester,
     },
     NamedRoute {
         path: "/auction",
@@ -1526,6 +1534,48 @@ mod tests {
         assert_eq!(
             set_cookie, "ts-tester=true; Domain=.test-publisher.com; Path=/; Secure; SameSite=Lax",
             "tester cookie should use publisher.cookie_domain"
+        );
+    }
+
+    #[test]
+    fn dispatch_clear_tester_is_disabled_by_default() {
+        let router = test_router();
+        let response = block_on(router.oneshot(empty_request(Method::GET, "/_ts/clear-tester")));
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "disabled clear tester-cookie route should return 404"
+        );
+        assert!(
+            response.headers().get(header::SET_COOKIE).is_none(),
+            "disabled clear tester-cookie route should not set a cookie"
+        );
+    }
+
+    #[test]
+    fn dispatch_clear_tester_clears_cookie_on_configured_domain() {
+        let mut settings = test_settings();
+        settings.tester_cookie.enabled = true;
+        let state = app_state_for_settings(settings);
+        let router = TrustedServerApp::routes_for_state(&state);
+        let response = block_on(router.oneshot(empty_request(Method::GET, "/_ts/clear-tester")));
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NO_CONTENT,
+            "enabled clear tester-cookie route should return no content"
+        );
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("should clear tester cookie")
+            .to_str()
+            .expect("should render set-cookie as utf-8");
+        assert_eq!(
+            set_cookie,
+            "ts-tester=; Domain=.test-publisher.com; Path=/; Secure; SameSite=Lax; Max-Age=0",
+            "tester cookie clear should use publisher.cookie_domain"
         );
     }
 

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -51,7 +51,7 @@ use trusted_server_core::request_signing::{
 };
 use trusted_server_core::settings::Settings;
 use trusted_server_core::settings_data::get_settings;
-use trusted_server_core::tester_cookie::handle_set_tester;
+use trusted_server_core::tester_cookie::{handle_clear_tester, handle_set_tester};
 
 mod app;
 mod backend;
@@ -866,6 +866,7 @@ async fn route_request(
             (outcome, false)
         }
         (Method::GET, "/_ts/set-tester") => (handle_set_tester(settings), false),
+        (Method::GET, "/_ts/clear-tester") => (handle_clear_tester(settings), false),
 
         // Unified auction endpoint.
         (Method::POST, "/auction") => {

--- a/crates/trusted-server-adapter-fastly/src/route_tests.rs
+++ b/crates/trusted-server-adapter-fastly/src/route_tests.rs
@@ -1082,6 +1082,63 @@ fn set_tester_route_sets_cookie_on_configured_domain_when_enabled() {
 }
 
 #[test]
+fn clear_tester_route_is_disabled_by_default() {
+    let settings = create_test_settings();
+    let (orchestrator, integration_registry) = build_route_stack(&settings);
+    let req = Request::get("https://test.com/_ts/clear-tester");
+    let services = test_runtime_services(&req);
+
+    let response = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route disabled clear tester-cookie request",
+    );
+
+    assert_eq!(
+        response.get_status(),
+        StatusCode::NOT_FOUND,
+        "disabled clear tester-cookie route should return 404"
+    );
+    assert_eq!(
+        response.get_header_str(header::SET_COOKIE),
+        None,
+        "disabled clear tester-cookie route should not set a cookie"
+    );
+}
+
+#[test]
+fn clear_tester_route_clears_cookie_on_configured_domain_when_enabled() {
+    let mut settings = create_test_settings();
+    settings.tester_cookie.enabled = true;
+    let (orchestrator, integration_registry) = build_route_stack(&settings);
+    let req = Request::get("https://test.com/_ts/clear-tester");
+    let services = test_runtime_services(&req);
+
+    let response = route_buffered_response(
+        &settings,
+        &orchestrator,
+        &integration_registry,
+        &services,
+        req,
+        "should route enabled clear tester-cookie request",
+    );
+
+    assert_eq!(
+        response.get_status(),
+        StatusCode::NO_CONTENT,
+        "enabled clear tester-cookie route should return no content"
+    );
+    assert_eq!(
+        response.get_header_str(header::SET_COOKIE),
+        Some("ts-tester=; Domain=.test-publisher.com; Path=/; Secure; SameSite=Lax; Max-Age=0"),
+        "tester cookie clear should use publisher.cookie_domain"
+    );
+}
+
+#[test]
 fn malformed_auction_json_returns_bad_request() {
     let settings = create_auction_test_settings(r#"["prebid"]"#);
 

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -1702,7 +1702,7 @@ pub struct DebugConfig {
 /// Tester-cookie endpoint configuration.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct TesterCookieConfig {
-    /// Enable `GET /_ts/set-tester`, which sets `ts-tester=true`.
+    /// Enable tester-cookie endpoints that set and clear `ts-tester`.
     #[serde(default)]
     pub enabled: bool,
 }

--- a/crates/trusted-server-core/src/tester_cookie.rs
+++ b/crates/trusted-server-core/src/tester_cookie.rs
@@ -1,7 +1,7 @@
 //! Tester-cookie endpoint helpers.
 //!
-//! The tester route is intentionally disabled unless configured. When enabled,
-//! it sets a first-party `ts-tester=true` cookie scoped to the configured
+//! The tester routes are intentionally disabled unless configured. When enabled,
+//! they set or clear a first-party `ts-tester` cookie scoped to the configured
 //! publisher cookie domain.
 
 use edgezero_core::body::Body as EdgeBody;
@@ -16,6 +16,14 @@ use crate::settings::Settings;
 fn format_tester_cookie(domain: &str) -> String {
     format!(
         "{}=true; Domain={}; Path=/; Secure; SameSite=Lax",
+        COOKIE_TS_TESTER, domain,
+    )
+}
+
+/// Formats the tester cookie clearing `Set-Cookie` header value.
+fn format_clear_tester_cookie(domain: &str) -> String {
+    format!(
+        "{}=; Domain={}; Path=/; Secure; SameSite=Lax; Max-Age=0",
         COOKIE_TS_TESTER, domain,
     )
 }
@@ -44,6 +52,44 @@ pub fn handle_set_tester(
             .change_context(TrustedServerError::InvalidHeaderValue {
                 message: "tester cookie contains invalid header value".to_string(),
             })?;
+
+    let mut response = Response::new(EdgeBody::empty());
+    *response.status_mut() = StatusCode::NO_CONTENT;
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, private"),
+    );
+    response
+        .headers_mut()
+        .insert(header::SET_COOKIE, set_cookie);
+    Ok(response)
+}
+
+/// Handles `GET /_ts/clear-tester`.
+///
+/// Returns `404 Not Found` while `[tester_cookie].enabled` is false. When the
+/// feature is enabled, returns `204 No Content` with `Set-Cookie` expiring the
+/// `ts-tester` cookie scoped to `publisher.cookie_domain`.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError::InvalidHeaderValue`] if the configured cookie
+/// domain cannot be rendered as an HTTP header value.
+pub fn handle_clear_tester(
+    settings: &Settings,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    if !settings.tester_cookie.enabled {
+        let mut response = Response::new(EdgeBody::empty());
+        *response.status_mut() = StatusCode::NOT_FOUND;
+        return Ok(response);
+    }
+
+    let set_cookie = HeaderValue::from_str(&format_clear_tester_cookie(
+        &settings.publisher.cookie_domain,
+    ))
+    .change_context(TrustedServerError::InvalidHeaderValue {
+        message: "tester cookie clear contains invalid header value".to_string(),
+    })?;
 
     let mut response = Response::new(EdgeBody::empty());
     *response.status_mut() = StatusCode::NO_CONTENT;
@@ -109,6 +155,58 @@ mod tests {
         assert!(
             response.headers().get(header::SET_COOKIE).is_none(),
             "disabled tester route should not set a cookie"
+        );
+    }
+
+    #[test]
+    fn clear_tester_cookie_uses_configured_cookie_domain() {
+        let mut settings = create_test_settings();
+        settings.tester_cookie.enabled = true;
+        settings.publisher.cookie_domain = ".tester.example".to_string();
+
+        let response = handle_clear_tester(&settings).expect("should build clear tester response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NO_CONTENT,
+            "enabled clear tester route should return no content"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-store, private"),
+            "clear tester route should not be cacheable"
+        );
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("should clear tester cookie")
+            .to_str()
+            .expect("should render set-cookie as utf-8");
+        assert_eq!(
+            set_cookie,
+            "ts-tester=; Domain=.tester.example; Path=/; Secure; SameSite=Lax; Max-Age=0",
+            "tester cookie clear should use publisher.cookie_domain"
+        );
+    }
+
+    #[test]
+    fn clear_tester_cookie_route_is_disabled_by_default() {
+        let settings = create_test_settings();
+
+        let response =
+            handle_clear_tester(&settings).expect("should build disabled clear tester response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "disabled clear tester route should return not found"
+        );
+        assert!(
+            response.headers().get(header::SET_COOKIE).is_none(),
+            "disabled clear tester route should not set a cookie"
         );
     }
 }

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -49,6 +49,35 @@ The cookie domain comes from `[publisher].cookie_domain`.
 curl -i "https://edge.example.com/_ts/set-tester"
 ```
 
+### GET /\_ts/clear-tester
+
+Clears the first-party tester marker cookie for QA or troubleshooting workflows.
+
+**Configuration:** Uses the same `[tester_cookie].enabled` flag as `/_ts/set-tester`.
+
+**Response when enabled:**
+
+- **Status:** `204 No Content`
+- **Headers:**
+
+```http
+Set-Cookie: ts-tester=; Domain=<publisher.cookie_domain>; Path=/; Secure; SameSite=Lax; Max-Age=0
+Cache-Control: no-store, private
+```
+
+The cookie domain comes from `[publisher].cookie_domain`.
+
+**Response when disabled:**
+
+- **Status:** `404 Not Found`
+- **Set-Cookie:** none
+
+**Example:**
+
+```bash
+curl -i "https://edge.example.com/_ts/clear-tester"
+```
+
 ---
 
 ## First-Party Endpoints

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -326,14 +326,14 @@ TRUSTED_SERVER__PUBLISHER__MAX_BUFFERED_BODY_BYTES=16777216
 
 ## Tester Cookie Configuration
 
-Settings for the optional tester-cookie endpoint. This feature is disabled by
+Settings for the optional tester-cookie endpoints. This feature is disabled by
 default and should only be enabled for intentional QA or troubleshooting flows.
 
 ### `[tester_cookie]`
 
-| Field     | Type    | Required | Description                                                  |
-| --------- | ------- | -------- | ------------------------------------------------------------ |
-| `enabled` | Boolean | No       | Enables `GET /_ts/set-tester` to set `ts-tester=true` cookie |
+| Field     | Type    | Required | Description                                        |
+| --------- | ------- | -------- | -------------------------------------------------- |
+| `enabled` | Boolean | No       | Enables routes to set and clear `ts-tester` cookie |
 
 When enabled, `GET /_ts/set-tester` returns `204 No Content` and sets:
 
@@ -342,7 +342,14 @@ Set-Cookie: ts-tester=true; Domain=<publisher.cookie_domain>; Path=/; Secure; Sa
 Cache-Control: no-store, private
 ```
 
-When disabled, the route returns `404 Not Found` and does not set a cookie.
+`GET /_ts/clear-tester` returns `204 No Content` and clears the cookie:
+
+```http
+Set-Cookie: ts-tester=; Domain=<publisher.cookie_domain>; Path=/; Secure; SameSite=Lax; Max-Age=0
+Cache-Control: no-store, private
+```
+
+When disabled, both routes return `404 Not Found` and do not set a cookie.
 
 ::: warning
 The cookie is scoped with `[publisher].cookie_domain`, not the EC-specific

--- a/trusted-server.toml
+++ b/trusted-server.toml
@@ -21,8 +21,8 @@ proxy_secret = "change-me-proxy-secret"
 # Raise it for deployments serving larger publisher pages:
 # max_buffered_body_bytes = 16777216  # 16 MiB
 
-# Tester-cookie endpoint. When enabled, GET /_ts/set-tester sets
-# ts-tester=true on publisher.cookie_domain.
+# Tester-cookie endpoints. When enabled, GET /_ts/set-tester sets
+# ts-tester=true and GET /_ts/clear-tester clears it on publisher.cookie_domain.
 [tester_cookie]
 enabled = false
 


### PR DESCRIPTION
## Summary

- Add `GET /_ts/clear-tester` to clear the optional tester marker cookie.
- Reuse the existing `[tester_cookie].enabled` gate across EdgeZero and legacy routing paths.
- Update tests, config comments, and publisher-facing docs for set/clear tester-cookie workflows.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/tester_cookie.rs` | Added clear-cookie formatting and `handle_clear_tester`, plus enabled/disabled unit tests. |
| `crates/trusted-server-adapter-fastly/src/app.rs` | Registered the EdgeZero `GET /_ts/clear-tester` route and dispatch tests. |
| `crates/trusted-server-adapter-fastly/src/main.rs` | Registered the legacy Fastly `GET /_ts/clear-tester` route. |
| `crates/trusted-server-adapter-fastly/src/route_tests.rs` | Added legacy route tests for disabled and enabled clear behavior. |
| `crates/trusted-server-core/src/settings.rs` | Updated tester-cookie config doc comment to mention set and clear endpoints. |
| `trusted-server.toml` | Documented the new clear endpoint in sample config comments. |
| `docs/guide/api-reference.md` | Added API reference docs for `GET /_ts/clear-tester`. |
| `docs/guide/configuration.md` | Updated tester-cookie configuration docs for both routes. |

## Closes

Closes #796

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] JS tests: `cd crates/js/lib && npx vitest run`
- [ ] JS format: `cd crates/js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: `cargo test --workspace tester_cookie -- --nocapture`; `cargo test --workspace clear_tester -- --nocapture`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
