### PR TITLE
Add Trusted Server audit command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # env
 .env*
 trusted-server.toml
+js-assets.toml
 
 # backup
 **/*.rs.bk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc405d38be14342132609f06f02acaf825ddccfe76c4824a69281e0458ebd4"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,10 +379,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cast"
@@ -419,6 +445,71 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chromiumoxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ed067eb6c1f660bdb87c05efb964421d2ca262bae0296cdfe38cf0cd949a3e"
+dependencies = [
+ "async-tungstenite",
+ "base64",
+ "bytes",
+ "chromiumoxide_cdp",
+ "chromiumoxide_types",
+ "dunce",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "which",
+ "windows-registry",
+]
+
+[[package]]
+name = "chromiumoxide_cdp"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a6a03a7ebac4ea85308f285d6959a3e6b2ce32a0c9465dc7a7b1db0144eec7"
+dependencies = [
+ "chromiumoxide_pdl",
+ "chromiumoxide_types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_pdl"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c602dea92337bc4d824668d78c5b79c3b4ddb29b40dd7218282bbe8fd3fc2091"
+dependencies = [
+ "chromiumoxide_types",
+ "either",
+ "heck",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_types"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678d5146e74f16fc4a41978b275af572cd913de1f10270d2b93b6c276bc57d80"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -737,6 +828,19 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
@@ -744,7 +848,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -829,6 +933,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1182,6 +1292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1526,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1630,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1647,15 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1656,6 +1806,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever",
+ "match_token",
 ]
 
 [[package]]
@@ -2215,14 +2376,14 @@ checksum = "00aad58f6ec3990e795943872f13651e7a5fa59dca2c8f31a74faf8a0e0fb652"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cssparser",
+ "cssparser 0.36.0",
  "encoding_rs",
  "foldhash",
  "hashbrown 0.17.1",
  "memchr",
  "mime",
  "precomputed-hash",
- "selectors",
+ "selectors 0.37.0",
  "thiserror 2.0.18",
 ]
 
@@ -2231,6 +2392,34 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "matchit"
@@ -2525,13 +2714,33 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2540,8 +2749,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2551,7 +2770,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2560,11 +2792,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3193,6 +3434,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f3a24d916e78954af99281a455168d4a9515d65eca99a18da1b813689c4ad9"
+dependencies = [
+ "cssparser 0.35.0",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors 0.31.0",
+ "tendril",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,17 +3486,36 @@ dependencies = [
 
 [[package]]
 name = "selectors"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser 0.35.0",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
 dependencies = [
  "bitflags 2.13.0",
- "cssparser",
+ "cssparser 0.36.0",
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
- "phf_codegen",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
  "precomputed-hash",
  "rustc-hash",
  "servo_arc",
@@ -3370,6 +3645,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3541,6 +3827,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,6 +3946,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -4033,11 +4355,20 @@ dependencies = [
 name = "trusted-server-cli"
 version = "0.1.0"
 dependencies = [
+ "chromiumoxide",
  "clap",
  "edgezero-cli",
+ "futures",
  "log",
+ "regex",
+ "scraper",
+ "serde",
  "tempfile",
+ "tokio",
+ "toml",
  "trusted-server-core",
+ "url",
+ "which",
 ]
 
 [[package]]
@@ -4112,6 +4443,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,6 +4488,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -4180,6 +4534,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4416,6 +4776,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,6 +4863,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ build-print = "1.0.1"
 bytes = "1.11"
 chacha20poly1305 = "0.10"
 chrono = "0.4.44"
+chromiumoxide = "0.9.1"
 clap = { version = "4", features = ["derive"] }
 config = "0.15.19"
 cookie = "0.18.1"
@@ -73,6 +74,7 @@ mime = "0.3"
 rand = "0.8"
 regex = "1.12.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+scraper = "0.24.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 simple_logger = "5"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ ts config init
 # Edit trusted-server.toml
 ts config validate
 
+# Audit a public page with Chrome/Chromium to bootstrap a draft config
+ts audit https://publisher.example
+
 # Run tests (Fastly/WASM crates — requires Viceroy)
 cargo test-fastly
 

--- a/crates/trusted-server-cli/Cargo.toml
+++ b/crates/trusted-server-cli/Cargo.toml
@@ -14,10 +14,20 @@ path = "src/main.rs"
 workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+chromiumoxide = { workspace = true }
 clap = { workspace = true }
 edgezero-cli = { workspace = true }
+futures = { workspace = true }
 log = { workspace = true }
+regex = { workspace = true }
+scraper = { workspace = true }
+serde = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+toml = { workspace = true }
 trusted-server-core = { workspace = true }
+url = { workspace = true }
+which = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/trusted-server-cli/src/audit.rs
+++ b/crates/trusted-server-cli/src/audit.rs
@@ -1,0 +1,685 @@
+mod analyzer;
+pub(crate) mod browser_collector;
+pub(crate) mod collector;
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use url::Url;
+
+use crate::audit::collector::AuditCollector;
+use crate::config_init::EXAMPLE_CONFIG;
+use crate::error::{cli_error, report_error, CliResult};
+use crate::run::AuditArgs;
+
+use analyzer::{analyze_collected_page, extract_gtm_container_id};
+
+const DEFAULT_JS_ASSETS_PATH: &str = "js-assets.toml";
+const DEFAULT_CONFIG_PATH: &str = "trusted-server.toml";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum AssetParty {
+    FirstParty,
+    ThirdParty,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct AuditedAsset {
+    pub(crate) kind: String,
+    pub(crate) url: String,
+    pub(crate) host: String,
+    pub(crate) party: AssetParty,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) integration: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct DetectedIntegration {
+    pub(crate) id: String,
+    pub(crate) evidence: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct AuditArtifact {
+    pub(crate) audited_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) page_title: Option<String>,
+    pub(crate) js_asset_count: usize,
+    pub(crate) third_party_asset_count: usize,
+    pub(crate) detected_integrations: Vec<DetectedIntegration>,
+    pub(crate) assets: Vec<AuditedAsset>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AuditOutputs {
+    pub(crate) artifact: AuditArtifact,
+    pub(crate) js_assets_toml: String,
+    pub(crate) draft_config_toml: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AuditOutputPlan {
+    js_assets_path: Option<PathBuf>,
+    config_path: Option<PathBuf>,
+}
+
+pub(crate) fn run_audit(
+    args: &AuditArgs,
+    collector: &dyn AuditCollector,
+    out: &mut dyn Write,
+) -> CliResult<()> {
+    let target_url = parse_audit_url(&args.url)?;
+    let plan = resolve_output_plan(args)?;
+    let collected = collector.collect_page(&target_url)?;
+    let outputs = build_audit_outputs(&collected)?;
+    let wrote_config = plan.config_path.is_some();
+    let written = write_audit_outputs(&outputs, &plan)?;
+    write_success_summary(&outputs, &written, wrote_config, out)
+}
+
+fn parse_audit_url(value: &str) -> CliResult<Url> {
+    let url = Url::parse(value)
+        .map_err(|error| report_error(format!("invalid audit URL `{value}`: {error}")))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return cli_error(format!(
+            "`ts audit` only supports http/https URLs, got `{}`",
+            url.scheme()
+        ));
+    }
+    Ok(url)
+}
+
+fn resolve_output_plan(args: &AuditArgs) -> CliResult<AuditOutputPlan> {
+    if args.no_js_assets && args.no_config {
+        return cli_error("nothing to do: both --no-js-assets and --no-config were set");
+    }
+
+    let js_assets_path = if args.no_js_assets {
+        None
+    } else {
+        Some(resolve_output_path(
+            args.js_assets.as_deref(),
+            DEFAULT_JS_ASSETS_PATH,
+        )?)
+    };
+    let config_path = if args.no_config {
+        None
+    } else {
+        Some(resolve_output_path(
+            args.config.as_deref(),
+            DEFAULT_CONFIG_PATH,
+        )?)
+    };
+
+    if js_assets_path.is_some() && js_assets_path == config_path {
+        return cli_error("audit output paths must be distinct");
+    }
+
+    for path in [&js_assets_path, &config_path].into_iter().flatten() {
+        if path.exists() && !args.force {
+            return cli_error(format!(
+                "refusing to overwrite existing file `{}`; re-run with --force",
+                path.display()
+            ));
+        }
+    }
+
+    Ok(AuditOutputPlan {
+        js_assets_path,
+        config_path,
+    })
+}
+
+fn resolve_output_path(path: Option<&Path>, default: &str) -> CliResult<PathBuf> {
+    let candidate = path.unwrap_or_else(|| Path::new(default));
+    if candidate.is_absolute() {
+        Ok(candidate.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()
+            .map_err(|error| report_error(format!("failed to read current directory: {error}")))?
+            .join(candidate))
+    }
+}
+
+fn build_audit_outputs(collected: &collector::CollectedPage) -> CliResult<AuditOutputs> {
+    let artifact = analyze_collected_page(collected)?;
+    let final_url = collected
+        .final_url()
+        .map_err(|error| report_error(format!("invalid final URL: {error}")))?;
+    let js_assets_toml = toml::to_string_pretty(&artifact)
+        .map_err(|error| report_error(format!("failed to serialize audit artifact: {error}")))?;
+    let draft_config_toml = build_draft_config(&final_url, &artifact)?;
+
+    Ok(AuditOutputs {
+        artifact,
+        js_assets_toml,
+        draft_config_toml,
+    })
+}
+
+fn write_audit_outputs(outputs: &AuditOutputs, plan: &AuditOutputPlan) -> CliResult<Vec<String>> {
+    let selected_paths = [&plan.js_assets_path, &plan.config_path]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    for path in &selected_paths {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).map_err(|error| {
+                report_error(format!(
+                    "failed to create parent directory {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+    }
+
+    let mut written_paths = Vec::new();
+    if let Some(path) = &plan.js_assets_path {
+        fs::write(path, &outputs.js_assets_toml).map_err(|error| {
+            report_error(format!(
+                "failed to write JS asset audit {}: {error}",
+                path.display()
+            ))
+        })?;
+        written_paths.push(path.display().to_string());
+    }
+    if let Some(path) = &plan.config_path {
+        fs::write(path, &outputs.draft_config_toml).map_err(|error| {
+            report_error(format!(
+                "failed to write draft config {}: {error}",
+                path.display()
+            ))
+        })?;
+        written_paths.push(path.display().to_string());
+    }
+
+    Ok(written_paths)
+}
+
+fn write_success_summary(
+    outputs: &AuditOutputs,
+    written: &[String],
+    wrote_config: bool,
+    out: &mut dyn Write,
+) -> CliResult<()> {
+    let integrations = outputs
+        .artifact
+        .detected_integrations
+        .iter()
+        .map(|integration| integration.id.as_str())
+        .collect::<Vec<_>>();
+    let draft_note = if wrote_config {
+        "\nDraft config: review before validation and push"
+    } else {
+        ""
+    };
+    writeln!(
+        out,
+        "Audited {}\nTitle: {}\nJS assets: {}\nThird-party assets: {}\nDetected integrations: {}\nWrote: {}{}",
+        outputs.artifact.audited_url,
+        outputs
+            .artifact
+            .page_title
+            .as_deref()
+            .unwrap_or("<unknown>"),
+        outputs.artifact.js_asset_count,
+        outputs.artifact.third_party_asset_count,
+        if integrations.is_empty() {
+            "none".to_string()
+        } else {
+            integrations.join(", ")
+        },
+        if written.is_empty() {
+            "none".to_string()
+        } else {
+            written.join(", ")
+        },
+        draft_note
+    )
+    .map_err(|error| report_error(format!("failed to write command output: {error}")))
+}
+
+fn build_draft_config(target_url: &Url, artifact: &AuditArtifact) -> CliResult<String> {
+    let host = target_url
+        .host_str()
+        .ok_or_else(|| report_error("audited URL is missing a host"))?;
+    let origin = target_url.origin().ascii_serialization();
+    let mut draft = EXAMPLE_CONFIG.to_string();
+
+    draft = replace_key_in_section(
+        &draft,
+        "publisher",
+        "domain",
+        &format!("domain = \"{host}\""),
+    )?;
+    draft = replace_key_in_section(
+        &draft,
+        "publisher",
+        "cookie_domain",
+        &format!("cookie_domain = \".{host}\""),
+    )?;
+    draft = replace_key_in_section(
+        &draft,
+        "publisher",
+        "origin_url",
+        &format!("origin_url = \"{origin}\""),
+    )?;
+
+    let detected = artifact
+        .detected_integrations
+        .iter()
+        .map(|integration| integration.id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    if detected.contains("gpt") {
+        draft = replace_key_in_section(&draft, "integrations.gpt", "enabled", "enabled = true")?;
+    }
+    if detected.contains("didomi") {
+        draft = replace_key_in_section(&draft, "integrations.didomi", "enabled", "enabled = true")?;
+    }
+    if detected.contains("datadome") {
+        draft =
+            replace_key_in_section(&draft, "integrations.datadome", "enabled", "enabled = true")?;
+    }
+
+    let mut manual_review = Vec::new();
+    if detected.contains("google_tag_manager") {
+        if let Some(gtm_id) = extract_gtm_container_id(artifact) {
+            draft = replace_key_in_section(
+                &draft,
+                "integrations.google_tag_manager",
+                "enabled",
+                "enabled = true",
+            )?;
+            draft = replace_key_in_section(
+                &draft,
+                "integrations.google_tag_manager",
+                "container_id",
+                &format!("container_id = \"{gtm_id}\""),
+            )?;
+        } else {
+            manual_review.push("google_tag_manager");
+        }
+    }
+
+    for integration in detected {
+        if !matches!(
+            integration,
+            "gpt" | "didomi" | "datadome" | "google_tag_manager"
+        ) {
+            manual_review.push(integration);
+        }
+    }
+
+    if !manual_review.is_empty() {
+        if !draft.ends_with('\n') {
+            draft.push('\n');
+        }
+        draft.push_str("\n# Audit findings requiring manual review\n");
+        for integration in manual_review {
+            draft.push_str(&format!(
+                "# - Detected {integration}; review the corresponding [integrations.{integration}] section before enabling it.\n"
+            ));
+        }
+    }
+
+    Ok(draft)
+}
+
+fn replace_key_in_section(
+    document: &str,
+    section: &str,
+    key: &str,
+    replacement_line: &str,
+) -> CliResult<String> {
+    let section_header = format!("[{section}]");
+    let mut in_section = false;
+    let mut replaced = false;
+    let mut saw_section = false;
+    let mut lines = Vec::new();
+
+    for line in document.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_section = trimmed == section_header;
+            saw_section |= in_section;
+        }
+
+        if in_section && !replaced && is_key_line(trimmed, key) {
+            lines.push(replacement_line.to_string());
+            replaced = true;
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+
+    if !saw_section {
+        return cli_error(format!(
+            "failed to update starter config because section `{section_header}` was not found"
+        ));
+    }
+    if !replaced {
+        return cli_error(format!(
+            "failed to update starter config because key `{key}` was not found in `{section_header}`"
+        ));
+    }
+
+    let mut output = lines.join("\n");
+    if document.ends_with('\n') {
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+fn is_key_line(trimmed_line: &str, key: &str) -> bool {
+    trimmed_line
+        .strip_prefix(key)
+        .and_then(|remaining| remaining.trim_start().strip_prefix('='))
+        .is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::audit::collector::{CollectedPage, CollectedRequest, CollectedScriptTag};
+
+    struct FakeCollector {
+        collected: CollectedPage,
+        calls: Cell<usize>,
+    }
+
+    impl FakeCollector {
+        fn new(collected: CollectedPage) -> Self {
+            Self {
+                collected,
+                calls: Cell::new(0),
+            }
+        }
+    }
+
+    impl AuditCollector for FakeCollector {
+        fn collect_page(&self, _target_url: &Url) -> CliResult<CollectedPage> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(self.collected.clone())
+        }
+    }
+
+    fn collected_page() -> CollectedPage {
+        CollectedPage {
+            requested_url: "https://publisher.example/page".to_string(),
+            final_url: "https://publisher.example/page".to_string(),
+            page_title: Some("Example Publisher".to_string()),
+            html: r#"<html><head><title>Example Publisher</title><script src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script></head></html>"#.to_string(),
+            script_tags: vec![CollectedScriptTag {
+                src: Some("https://www.googletagmanager.com/gtm.js?id=GTM-ABC123".to_string()),
+                inline_text: None,
+            }],
+            network_requests: vec![CollectedRequest {
+                url: "https://cdn.publisher.example/app.js".to_string(),
+                method: "GET".to_string(),
+                resource_type: Some("script".to_string()),
+                status: None,
+            }],
+            warnings: Vec::new(),
+        }
+    }
+
+    fn audit_args(url: &str) -> AuditArgs {
+        AuditArgs {
+            url: url.to_string(),
+            js_assets: None,
+            config: None,
+            no_js_assets: false,
+            no_config: false,
+            force: false,
+        }
+    }
+
+    #[test]
+    fn parse_audit_url_accepts_http_and_https() {
+        assert!(parse_audit_url("http://publisher.example").is_ok());
+        assert!(parse_audit_url("https://publisher.example").is_ok());
+    }
+
+    #[test]
+    fn parse_audit_url_rejects_non_http_schemes() {
+        for url in [
+            "file:///etc/passwd",
+            "data:text/html,hello",
+            "chrome://version",
+        ] {
+            let error = parse_audit_url(url).expect_err("should reject non-http URL");
+            assert!(
+                format!("{error:?}").contains("only supports http/https"),
+                "should explain scheme restriction"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_output_plan_rejects_no_outputs() {
+        let mut args = audit_args("https://publisher.example");
+        args.no_js_assets = true;
+        args.no_config = true;
+
+        let error = resolve_output_plan(&args).expect_err("should reject empty output set");
+
+        assert!(
+            format!("{error:?}").contains("nothing to do"),
+            "should explain no-output error"
+        );
+    }
+
+    #[test]
+    fn resolve_output_plan_rejects_existing_files_without_force() {
+        let temp = TempDir::new().expect("should create temp dir");
+        let path = temp.path().join("js-assets.toml");
+        fs::write(&path, "existing").expect("should write existing file");
+        let mut args = audit_args("https://publisher.example");
+        args.js_assets = Some(path);
+        args.no_config = true;
+
+        let error = resolve_output_plan(&args).expect_err("should reject overwrite");
+
+        assert!(
+            format!("{error:?}").contains("refusing to overwrite"),
+            "should explain overwrite refusal"
+        );
+    }
+
+    #[test]
+    fn resolve_output_plan_allows_existing_files_with_force() {
+        let temp = TempDir::new().expect("should create temp dir");
+        let path = temp.path().join("js-assets.toml");
+        fs::write(&path, "existing").expect("should write existing file");
+        let mut args = audit_args("https://publisher.example");
+        args.js_assets = Some(path.clone());
+        args.no_config = true;
+        args.force = true;
+
+        let plan = resolve_output_plan(&args).expect("should allow forced overwrite");
+
+        assert_eq!(plan.js_assets_path.as_deref(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn run_audit_writes_selected_outputs_and_summary() {
+        let temp = TempDir::new().expect("should create temp dir");
+        let js_assets = temp.path().join("audit/js-assets.toml");
+        let config = temp.path().join("audit/trusted-server.toml");
+        let args = AuditArgs {
+            url: "https://publisher.example/page".to_string(),
+            js_assets: Some(js_assets.clone()),
+            config: Some(config.clone()),
+            no_js_assets: false,
+            no_config: false,
+            force: false,
+        };
+        let collector = FakeCollector::new(collected_page());
+        let mut out = Vec::new();
+
+        run_audit(&args, &collector, &mut out).expect("should run audit");
+
+        assert_eq!(collector.calls.get(), 1, "should collect page once");
+        assert!(js_assets.exists(), "should write JS assets");
+        assert!(config.exists(), "should write draft config");
+        let summary = String::from_utf8(out).expect("summary should be UTF-8");
+        assert!(summary.contains("Audited https://publisher.example/page"));
+        assert!(summary.contains("Detected integrations: google_tag_manager, gpt"));
+        assert!(summary.contains("Draft config: review before validation and push"));
+    }
+
+    #[test]
+    fn run_audit_respects_no_config() {
+        let temp = TempDir::new().expect("should create temp dir");
+        let js_assets = temp.path().join("js-assets.toml");
+        let mut args = audit_args("https://publisher.example/page");
+        args.js_assets = Some(js_assets.clone());
+        args.no_config = true;
+        let collector = FakeCollector::new(collected_page());
+
+        run_audit(&args, &collector, &mut Vec::new()).expect("should run audit");
+
+        assert!(js_assets.exists(), "should write assets");
+        assert!(
+            !temp.path().join("trusted-server.toml").exists(),
+            "should not write config"
+        );
+    }
+
+    #[test]
+    fn run_audit_respects_no_js_assets() {
+        let temp = TempDir::new().expect("should create temp dir");
+        let config = temp.path().join("trusted-server.toml");
+        let mut args = audit_args("https://publisher.example/page");
+        args.config = Some(config.clone());
+        args.no_js_assets = true;
+        let collector = FakeCollector::new(collected_page());
+        let mut out = Vec::new();
+
+        run_audit(&args, &collector, &mut out).expect("should run audit");
+
+        assert!(config.exists(), "should write config");
+        assert!(
+            !temp.path().join("js-assets.toml").exists(),
+            "should not write JS assets"
+        );
+        let summary = String::from_utf8(out).expect("summary should be UTF-8");
+        assert!(summary.contains("Draft config: review before validation and push"));
+    }
+
+    #[test]
+    fn run_audit_writes_collector_warnings_to_asset_artifact() {
+        let temp = TempDir::new().expect("should create temp dir");
+        let js_assets = temp.path().join("js-assets.toml");
+        let mut args = audit_args("https://publisher.example/page");
+        args.js_assets = Some(js_assets.clone());
+        args.no_config = true;
+        let mut collected = collected_page();
+        collected.warnings.push(
+            "browser audit timed out while waiting for the page to settle; results may be partial"
+                .to_string(),
+        );
+        let collector = FakeCollector::new(collected);
+
+        run_audit(&args, &collector, &mut Vec::new()).expect("should run audit");
+
+        let artifact = fs::read_to_string(js_assets).expect("should read artifact");
+        assert!(
+            artifact.contains("results may be partial"),
+            "should persist collector warning"
+        );
+    }
+
+    #[test]
+    fn run_audit_conflict_prevents_collection() {
+        let temp = TempDir::new().expect("should create temp dir");
+        let js_assets = temp.path().join("js-assets.toml");
+        fs::write(&js_assets, "existing").expect("should write existing file");
+        let mut args = audit_args("https://publisher.example/page");
+        args.js_assets = Some(js_assets);
+        args.no_config = true;
+        let collector = FakeCollector::new(collected_page());
+
+        let error = run_audit(&args, &collector, &mut Vec::new())
+            .expect_err("should reject existing output");
+
+        assert_eq!(collector.calls.get(), 0, "should not collect page");
+        assert!(
+            format!("{error:?}").contains("refusing to overwrite"),
+            "should report overwrite conflict"
+        );
+    }
+
+    #[test]
+    fn build_draft_config_uses_final_url_and_detected_integrations() {
+        let url = Url::parse("https://www.publisher.example:8443/path").expect("should parse URL");
+        let artifact = AuditArtifact {
+            audited_url: url.to_string(),
+            page_title: Some("Example".to_string()),
+            js_asset_count: 2,
+            third_party_asset_count: 2,
+            detected_integrations: vec![
+                DetectedIntegration {
+                    id: "google_tag_manager".to_string(),
+                    evidence: "GTM-ABC123".to_string(),
+                },
+                DetectedIntegration {
+                    id: "gpt".to_string(),
+                    evidence: "https://securepubads.g.doubleclick.net/tag/js/gpt.js".to_string(),
+                },
+                DetectedIntegration {
+                    id: "prebid".to_string(),
+                    evidence: "inline script matched `prebid`".to_string(),
+                },
+            ],
+            assets: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let draft = build_draft_config(&url, &artifact).expect("should build draft config");
+
+        assert!(draft.contains("domain = \"www.publisher.example\""));
+        assert!(draft.contains("cookie_domain = \".www.publisher.example\""));
+        assert!(draft.contains("origin_url = \"https://www.publisher.example:8443\""));
+        assert!(draft.contains("[integrations.gpt]\nenabled = true"));
+        assert!(draft.contains("[integrations.google_tag_manager]\nenabled = true"));
+        assert!(draft.contains("container_id = \"GTM-ABC123\""));
+        assert!(draft.contains("Detected prebid"));
+        toml::from_str::<toml::Value>(&draft).expect("draft should parse as TOML");
+    }
+
+    #[test]
+    fn build_draft_config_does_not_enable_gtm_without_container_id() {
+        let url = Url::parse("https://publisher.example/path").expect("should parse URL");
+        let artifact = AuditArtifact {
+            audited_url: url.to_string(),
+            page_title: None,
+            js_asset_count: 1,
+            third_party_asset_count: 1,
+            detected_integrations: vec![DetectedIntegration {
+                id: "google_tag_manager".to_string(),
+                evidence: "https://www.googletagmanager.com/gtm.js".to_string(),
+            }],
+            assets: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let draft = build_draft_config(&url, &artifact).expect("should build draft config");
+
+        assert!(draft.contains("[integrations.google_tag_manager]\nenabled = false"));
+        assert!(draft.contains("Detected google_tag_manager"));
+    }
+}

--- a/crates/trusted-server-cli/src/audit.rs
+++ b/crates/trusted-server-cli/src/audit.rs
@@ -421,16 +421,20 @@ mod tests {
             requested_url: "https://publisher.example/page".to_string(),
             final_url: "https://publisher.example/page".to_string(),
             page_title: Some("Example Publisher".to_string()),
-            html: r#"<html><head><title>Example Publisher</title><script src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script></head></html>"#.to_string(),
-            script_tags: vec![CollectedScriptTag {
-                src: Some("https://www.googletagmanager.com/gtm.js?id=GTM-ABC123".to_string()),
-                inline_text: None,
-            }],
+            html: r#"<html><head><title>Example Publisher</title></head></html>"#.to_string(),
+            script_tags: vec![
+                CollectedScriptTag {
+                    src: Some("https://www.googletagmanager.com/gtm.js?id=GTM-ABC123".to_string()),
+                    inline_text: None,
+                },
+                CollectedScriptTag {
+                    src: Some("https://securepubads.g.doubleclick.net/tag/js/gpt.js".to_string()),
+                    inline_text: None,
+                },
+            ],
             network_requests: vec![CollectedRequest {
                 url: "https://cdn.publisher.example/app.js".to_string(),
-                method: "GET".to_string(),
                 resource_type: Some("script".to_string()),
-                status: None,
             }],
             warnings: Vec::new(),
         }

--- a/crates/trusted-server-cli/src/audit/analyzer.rs
+++ b/crates/trusted-server-cli/src/audit/analyzer.rs
@@ -11,6 +11,24 @@ use crate::error::{report_error, CliResult};
 
 static GTM_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\bGTM-[A-Z0-9]+\b").expect("should compile GTM regex"));
+static GPT_INLINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\b(?:googletag|gpt\.js|googletagservices|securepubads)\b")
+        .expect("should compile GPT inline regex")
+});
+static DIDOMI_INLINE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\bdidomi\b").expect("should compile Didomi inline regex"));
+static DATADOME_INLINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\bdatadome\b").expect("should compile DataDome inline regex")
+});
+static PERMUTIVE_INLINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\bpermutive\b").expect("should compile Permutive inline regex")
+});
+static LOCKR_INLINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?:\blockr\b|\bloc\.kr\b)").expect("should compile Lockr inline regex")
+});
+static PREBID_INLINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?:\bprebid\b|\bpbjs\b)").expect("should compile Prebid inline regex")
+});
 
 pub(crate) fn analyze_collected_page(collected: &CollectedPage) -> CliResult<AuditArtifact> {
     let final_url = collected
@@ -22,7 +40,6 @@ pub(crate) fn analyze_collected_page(collected: &CollectedPage) -> CliResult<Aud
 
     let document = Html::parse_document(&collected.html);
     let title_selector = Selector::parse("title").expect("should parse title selector");
-    let script_selector = Selector::parse("script").expect("should parse script selector");
     let derived_title = document
         .select(&title_selector)
         .next()
@@ -46,29 +63,14 @@ pub(crate) fn analyze_collected_page(collected: &CollectedPage) -> CliResult<Aud
         ));
     }
 
-    for element in document.select(&script_selector) {
-        if let Some(src) = element.value().attr("src") {
+    for tag in &collected.script_tags {
+        if let Some(src) = &tag.src {
             if let Ok(asset_url) = final_url.join(src) {
                 let integration = detect_integration_from_url(&asset_url);
                 record_integration(&mut integrations, &integration, asset_url.as_str());
                 insert_asset(&mut assets_by_url, &final_url, &asset_url, integration);
             } else {
                 warnings.push(format!("could not resolve script URL `{src}`"));
-            }
-        } else {
-            let inline_text = element.text().collect::<Vec<_>>().join(" ");
-            for (integration_id, evidence) in detect_integrations_from_inline_script(&inline_text) {
-                integrations.entry(integration_id).or_insert(evidence);
-            }
-        }
-    }
-
-    for tag in &collected.script_tags {
-        if let Some(src) = &tag.src {
-            if let Ok(asset_url) = Url::parse(src) {
-                let integration = detect_integration_from_url(&asset_url);
-                record_integration(&mut integrations, &integration, asset_url.as_str());
-                insert_asset(&mut assets_by_url, &final_url, &asset_url, integration);
             }
         }
 
@@ -167,6 +169,7 @@ pub(crate) fn classify_party(page_url: &Url, asset_url: &Url) -> AssetParty {
 }
 
 fn host_matches(page_host: &str, asset_host: &str) -> bool {
+    // This is an advisory heuristic, not public-suffix-aware eTLD+1 classification.
     asset_host == page_host
         || asset_host
             .strip_suffix(page_host)
@@ -213,9 +216,15 @@ pub(crate) fn detect_integrations_from_inline_script(script: &str) -> Vec<(Strin
         ));
     }
 
-    let lowered = script.to_ascii_lowercase();
-    for integration in ["gpt", "didomi", "datadome", "permutive", "lockr", "prebid"] {
-        if lowered.contains(integration) {
+    for (integration, regex) in [
+        ("gpt", &*GPT_INLINE_REGEX),
+        ("didomi", &*DIDOMI_INLINE_REGEX),
+        ("datadome", &*DATADOME_INLINE_REGEX),
+        ("permutive", &*PERMUTIVE_INLINE_REGEX),
+        ("lockr", &*LOCKR_INLINE_REGEX),
+        ("prebid", &*PREBID_INLINE_REGEX),
+    ] {
+        if regex.is_match(script) {
             matches.push((
                 integration.to_string(),
                 format!("inline script matched `{integration}`"),
@@ -259,16 +268,20 @@ mod tests {
             requested_url: "https://publisher.example/page".to_string(),
             final_url: "https://publisher.example/page".to_string(),
             page_title: Some("Browser Title".to_string()),
-            html: r#"<html><head><title>HTML Title</title><script src="https://www.googletagmanager.com/gtm.js?id=GTM-ABCD123"></script></head></html>"#.to_string(),
-            script_tags: vec![CollectedScriptTag {
-                src: Some("https://securepubads.g.doubleclick.net/tag/js/gpt.js".to_string()),
-                inline_text: None,
-            }],
+            html: r#"<html><head><title>HTML Title</title></head></html>"#.to_string(),
+            script_tags: vec![
+                CollectedScriptTag {
+                    src: Some("https://www.googletagmanager.com/gtm.js?id=GTM-ABCD123".to_string()),
+                    inline_text: None,
+                },
+                CollectedScriptTag {
+                    src: Some("https://securepubads.g.doubleclick.net/tag/js/gpt.js".to_string()),
+                    inline_text: None,
+                },
+            ],
             network_requests: vec![CollectedRequest {
                 url: "https://cdn.example.com/dynamic.js".to_string(),
-                method: "GET".to_string(),
                 resource_type: Some("Script".to_string()),
-                status: Some(200),
             }],
             warnings: vec!["partial settle".to_string()],
         };
@@ -345,9 +358,7 @@ mod tests {
             }],
             network_requests: vec![CollectedRequest {
                 url: "https://cdn.example.com/prebid.js".to_string(),
-                method: "GET".to_string(),
                 resource_type: Some("script".to_string()),
-                status: Some(200),
             }],
             warnings: Vec::new(),
         };
@@ -371,8 +382,17 @@ mod tests {
             requested_url: "https://publisher.example/page".to_string(),
             final_url: "https://publisher.example/path/page".to_string(),
             page_title: None,
-            html: r#"<html><head><script src="/static/app.js"></script><script src="http://[invalid"></script></head></html>"#.to_string(),
-            script_tags: Vec::new(),
+            html: "<html><head></head></html>".to_string(),
+            script_tags: vec![
+                CollectedScriptTag {
+                    src: Some("/static/app.js".to_string()),
+                    inline_text: None,
+                },
+                CollectedScriptTag {
+                    src: Some("http://[invalid".to_string()),
+                    inline_text: None,
+                },
+            ],
             network_requests: Vec::new(),
             warnings: Vec::new(),
         };
@@ -461,6 +481,22 @@ mod tests {
         assert!(matches
             .iter()
             .any(|(integration, _)| integration == "didomi"));
+    }
+
+    #[test]
+    fn detect_integrations_from_inline_script_avoids_short_substring_matches() {
+        let matches = detect_integrations_from_inline_script("const svgptimize = blockrResult;");
+
+        assert!(
+            !matches.iter().any(|(integration, _)| integration == "gpt"),
+            "should not match incidental GPT substrings"
+        );
+        assert!(
+            !matches
+                .iter()
+                .any(|(integration, _)| integration == "lockr"),
+            "should not match lockr inside a larger token"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-cli/src/audit/analyzer.rs
+++ b/crates/trusted-server-cli/src/audit/analyzer.rs
@@ -1,0 +1,547 @@
+use std::collections::BTreeMap;
+use std::sync::LazyLock;
+
+use regex::Regex;
+use scraper::{Html, Selector};
+use url::Url;
+
+use crate::audit::collector::CollectedPage;
+use crate::audit::{AssetParty, AuditArtifact, AuditedAsset, DetectedIntegration};
+use crate::error::{report_error, CliResult};
+
+static GTM_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bGTM-[A-Z0-9]+\b").expect("should compile GTM regex"));
+
+pub(crate) fn analyze_collected_page(collected: &CollectedPage) -> CliResult<AuditArtifact> {
+    let final_url = collected
+        .final_url()
+        .map_err(|error| report_error(format!("invalid final URL: {error}")))?;
+    let requested_url = collected
+        .requested_url()
+        .map_err(|error| report_error(format!("invalid requested URL: {error}")))?;
+
+    let document = Html::parse_document(&collected.html);
+    let title_selector = Selector::parse("title").expect("should parse title selector");
+    let script_selector = Selector::parse("script").expect("should parse script selector");
+    let derived_title = document
+        .select(&title_selector)
+        .next()
+        .map(|element| {
+            element
+                .text()
+                .collect::<Vec<_>>()
+                .join(" ")
+                .trim()
+                .to_string()
+        })
+        .filter(|title| !title.is_empty());
+
+    let mut assets_by_url = BTreeMap::<String, AuditedAsset>::new();
+    let mut integrations = BTreeMap::<String, String>::new();
+    let mut warnings = collected.warnings.clone();
+
+    if requested_url != final_url {
+        warnings.push(format!(
+            "page redirected from `{requested_url}` to `{final_url}`"
+        ));
+    }
+
+    for element in document.select(&script_selector) {
+        if let Some(src) = element.value().attr("src") {
+            if let Ok(asset_url) = final_url.join(src) {
+                let integration = detect_integration_from_url(&asset_url);
+                record_integration(&mut integrations, &integration, asset_url.as_str());
+                insert_asset(&mut assets_by_url, &final_url, &asset_url, integration);
+            } else {
+                warnings.push(format!("could not resolve script URL `{src}`"));
+            }
+        } else {
+            let inline_text = element.text().collect::<Vec<_>>().join(" ");
+            for (integration_id, evidence) in detect_integrations_from_inline_script(&inline_text) {
+                integrations.entry(integration_id).or_insert(evidence);
+            }
+        }
+    }
+
+    for tag in &collected.script_tags {
+        if let Some(src) = &tag.src {
+            if let Ok(asset_url) = Url::parse(src) {
+                let integration = detect_integration_from_url(&asset_url);
+                record_integration(&mut integrations, &integration, asset_url.as_str());
+                insert_asset(&mut assets_by_url, &final_url, &asset_url, integration);
+            }
+        }
+
+        if let Some(inline_text) = &tag.inline_text {
+            for (integration_id, evidence) in detect_integrations_from_inline_script(inline_text) {
+                integrations.entry(integration_id).or_insert(evidence);
+            }
+        }
+    }
+
+    for request in &collected.network_requests {
+        let is_script = request
+            .resource_type
+            .as_deref()
+            .is_some_and(|resource_type| resource_type.eq_ignore_ascii_case("script"));
+        if !is_script {
+            continue;
+        }
+        if let Ok(asset_url) = Url::parse(&request.url) {
+            let integration = detect_integration_from_url(&asset_url);
+            record_integration(&mut integrations, &integration, asset_url.as_str());
+            insert_asset(&mut assets_by_url, &final_url, &asset_url, integration);
+        }
+    }
+
+    let assets = assets_by_url.into_values().collect::<Vec<_>>();
+    let third_party_asset_count = assets
+        .iter()
+        .filter(|asset| asset.party == AssetParty::ThirdParty)
+        .count();
+
+    let page_title = collected
+        .page_title
+        .as_deref()
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToOwned::to_owned)
+        .or(derived_title);
+
+    Ok(AuditArtifact {
+        audited_url: final_url.to_string(),
+        page_title,
+        js_asset_count: assets.len(),
+        third_party_asset_count,
+        detected_integrations: integrations
+            .into_iter()
+            .map(|(id, evidence)| DetectedIntegration { id, evidence })
+            .collect(),
+        assets,
+        warnings,
+    })
+}
+
+fn insert_asset(
+    assets_by_url: &mut BTreeMap<String, AuditedAsset>,
+    page_url: &Url,
+    asset_url: &Url,
+    integration: Option<String>,
+) {
+    let asset = assets_by_url
+        .entry(asset_url.to_string())
+        .or_insert_with(|| AuditedAsset {
+            kind: "script".to_string(),
+            url: asset_url.to_string(),
+            host: asset_url.host_str().unwrap_or_default().to_string(),
+            party: classify_party(page_url, asset_url),
+            integration: None,
+        });
+
+    if asset.integration.is_none() {
+        asset.integration = integration;
+    }
+}
+
+fn record_integration(
+    integrations: &mut BTreeMap<String, String>,
+    integration: &Option<String>,
+    evidence: &str,
+) {
+    if let Some(integration_id) = integration {
+        integrations
+            .entry(integration_id.clone())
+            .or_insert_with(|| evidence.to_string());
+    }
+}
+
+pub(crate) fn classify_party(page_url: &Url, asset_url: &Url) -> AssetParty {
+    let page_host = page_url.host_str().unwrap_or_default();
+    let asset_host = asset_url.host_str().unwrap_or_default();
+
+    if host_matches(page_host, asset_host) {
+        AssetParty::FirstParty
+    } else {
+        AssetParty::ThirdParty
+    }
+}
+
+fn host_matches(page_host: &str, asset_host: &str) -> bool {
+    asset_host == page_host
+        || asset_host
+            .strip_suffix(page_host)
+            .is_some_and(|prefix| prefix.ends_with('.'))
+        || page_host
+            .strip_suffix(asset_host)
+            .is_some_and(|prefix| prefix.ends_with('.'))
+}
+
+pub(crate) fn detect_integration_from_url(url: &Url) -> Option<String> {
+    let host = url.host_str().unwrap_or_default();
+    let path = url.path();
+    let value = format!("{host}{path}").to_ascii_lowercase();
+
+    if value.contains("googletagmanager.com") {
+        Some("google_tag_manager".to_string())
+    } else if value.contains("securepubads.g.doubleclick.net")
+        || value.contains("googletagservices.com")
+        || value.contains("doubleclick.net/tag/js/gpt")
+    {
+        Some("gpt".to_string())
+    } else if value.contains("privacy-center.org") {
+        Some("didomi".to_string())
+    } else if value.contains("datadome.co") {
+        Some("datadome".to_string())
+    } else if value.contains("permutive") {
+        Some("permutive".to_string())
+    } else if value.contains("loc.kr") {
+        Some("lockr".to_string())
+    } else if value.contains("prebid") {
+        Some("prebid".to_string())
+    } else {
+        None
+    }
+}
+
+pub(crate) fn detect_integrations_from_inline_script(script: &str) -> Vec<(String, String)> {
+    let mut matches = Vec::new();
+
+    if let Some(container_id) = GTM_REGEX.find(script) {
+        matches.push((
+            "google_tag_manager".to_string(),
+            container_id.as_str().to_string(),
+        ));
+    }
+
+    let lowered = script.to_ascii_lowercase();
+    for integration in ["gpt", "didomi", "datadome", "permutive", "lockr", "prebid"] {
+        if lowered.contains(integration) {
+            matches.push((
+                integration.to_string(),
+                format!("inline script matched `{integration}`"),
+            ));
+        }
+    }
+
+    matches
+}
+
+pub(crate) fn extract_gtm_container_id(artifact: &AuditArtifact) -> Option<String> {
+    for integration in &artifact.detected_integrations {
+        if integration.id == "google_tag_manager" && GTM_REGEX.is_match(&integration.evidence) {
+            return Some(integration.evidence.clone());
+        }
+    }
+
+    for asset in &artifact.assets {
+        if asset.integration.as_deref() == Some("google_tag_manager") {
+            if let Some(matched) = GTM_REGEX.find(asset.url.as_str()) {
+                return Some(matched.as_str().to_string());
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::collector::{CollectedRequest, CollectedScriptTag};
+
+    fn page_url() -> Url {
+        Url::parse("https://publisher.example/page").expect("should parse URL")
+    }
+
+    #[test]
+    fn analyze_collected_page_merges_dom_and_network_scripts() {
+        let collected = CollectedPage {
+            requested_url: "https://publisher.example/page".to_string(),
+            final_url: "https://publisher.example/page".to_string(),
+            page_title: Some("Browser Title".to_string()),
+            html: r#"<html><head><title>HTML Title</title><script src="https://www.googletagmanager.com/gtm.js?id=GTM-ABCD123"></script></head></html>"#.to_string(),
+            script_tags: vec![CollectedScriptTag {
+                src: Some("https://securepubads.g.doubleclick.net/tag/js/gpt.js".to_string()),
+                inline_text: None,
+            }],
+            network_requests: vec![CollectedRequest {
+                url: "https://cdn.example.com/dynamic.js".to_string(),
+                method: "GET".to_string(),
+                resource_type: Some("Script".to_string()),
+                status: Some(200),
+            }],
+            warnings: vec!["partial settle".to_string()],
+        };
+
+        let artifact = analyze_collected_page(&collected).expect("should analyze collected page");
+
+        assert_eq!(artifact.page_title.as_deref(), Some("Browser Title"));
+        assert_eq!(
+            artifact.js_asset_count, 3,
+            "should merge all script evidence"
+        );
+        assert_eq!(artifact.warnings, vec!["partial settle".to_string()]);
+        assert!(
+            artifact
+                .detected_integrations
+                .iter()
+                .any(|integration| integration.id == "google_tag_manager"),
+            "should preserve GTM detection"
+        );
+        assert!(
+            artifact
+                .detected_integrations
+                .iter()
+                .any(|integration| integration.id == "gpt"),
+            "should detect GPT from browser collected scripts"
+        );
+    }
+
+    #[test]
+    fn analyze_collected_page_uses_html_title_when_browser_title_absent() {
+        let collected = CollectedPage {
+            requested_url: "https://publisher.example/page".to_string(),
+            final_url: "https://publisher.example/page".to_string(),
+            page_title: None,
+            html: "<html><head><title>HTML Title</title></head></html>".to_string(),
+            script_tags: Vec::new(),
+            network_requests: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let artifact = analyze_collected_page(&collected).expect("should analyze collected page");
+
+        assert_eq!(artifact.page_title.as_deref(), Some("HTML Title"));
+    }
+
+    #[test]
+    fn analyze_collected_page_uses_html_title_when_browser_title_is_empty() {
+        let collected = CollectedPage {
+            requested_url: "https://publisher.example/page".to_string(),
+            final_url: "https://publisher.example/page".to_string(),
+            page_title: Some("   ".to_string()),
+            html: "<html><head><title>HTML Title</title></head></html>".to_string(),
+            script_tags: Vec::new(),
+            network_requests: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let artifact = analyze_collected_page(&collected).expect("should analyze collected page");
+
+        assert_eq!(artifact.page_title.as_deref(), Some("HTML Title"));
+    }
+
+    #[test]
+    fn analyze_collected_page_deduplicates_scripts_and_updates_integration() {
+        let collected = CollectedPage {
+            requested_url: "https://publisher.example/page".to_string(),
+            final_url: "https://publisher.example/page".to_string(),
+            page_title: None,
+            html: r#"<html><head><script src="https://cdn.example.com/prebid.js"></script></head></html>"#
+                .to_string(),
+            script_tags: vec![CollectedScriptTag {
+                src: Some("https://cdn.example.com/prebid.js".to_string()),
+                inline_text: None,
+            }],
+            network_requests: vec![CollectedRequest {
+                url: "https://cdn.example.com/prebid.js".to_string(),
+                method: "GET".to_string(),
+                resource_type: Some("script".to_string()),
+                status: Some(200),
+            }],
+            warnings: Vec::new(),
+        };
+
+        let artifact = analyze_collected_page(&collected).expect("should analyze collected page");
+
+        assert_eq!(
+            artifact.js_asset_count, 1,
+            "should deduplicate identical script URLs"
+        );
+        assert_eq!(
+            artifact.assets[0].integration.as_deref(),
+            Some("prebid"),
+            "should preserve detected integration on deduped asset"
+        );
+    }
+
+    #[test]
+    fn analyze_collected_page_resolves_relative_scripts_and_warns_on_invalid_src() {
+        let collected = CollectedPage {
+            requested_url: "https://publisher.example/page".to_string(),
+            final_url: "https://publisher.example/path/page".to_string(),
+            page_title: None,
+            html: r#"<html><head><script src="/static/app.js"></script><script src="http://[invalid"></script></head></html>"#.to_string(),
+            script_tags: Vec::new(),
+            network_requests: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let artifact = analyze_collected_page(&collected).expect("should analyze collected page");
+
+        assert!(
+            artifact
+                .assets
+                .iter()
+                .any(|asset| asset.url == "https://publisher.example/static/app.js"),
+            "should resolve relative URL against final URL"
+        );
+        assert!(
+            artifact
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("could not resolve script URL")),
+            "should warn about malformed script URL"
+        );
+    }
+
+    #[test]
+    fn analyze_collected_page_uses_final_url_and_records_redirect_warning() {
+        let collected = CollectedPage {
+            requested_url: "http://publisher.example/page".to_string(),
+            final_url: "https://www.publisher.example/landing".to_string(),
+            page_title: Some("Example Publisher".to_string()),
+            html: "<html><head></head></html>".to_string(),
+            script_tags: Vec::new(),
+            network_requests: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let artifact = analyze_collected_page(&collected).expect("should analyze collected page");
+
+        assert_eq!(
+            artifact.audited_url, "https://www.publisher.example/landing",
+            "should report the final audited URL"
+        );
+        assert!(
+            artifact.warnings.iter().any(|warning| warning.contains(
+                "page redirected from `http://publisher.example/page` to `https://www.publisher.example/landing`"
+            )),
+            "should preserve redirect context in warnings"
+        );
+    }
+
+    #[test]
+    fn classify_party_uses_host_relationship() {
+        let page = page_url();
+        let exact = Url::parse("https://publisher.example/app.js").expect("should parse URL");
+        let subdomain =
+            Url::parse("https://cdn.publisher.example/app.js").expect("should parse URL");
+        let parent = Url::parse("https://example/app.js").expect("should parse URL");
+        let unrelated = Url::parse("https://cdn.example.com/app.js").expect("should parse URL");
+
+        assert_eq!(classify_party(&page, &exact), AssetParty::FirstParty);
+        assert_eq!(classify_party(&page, &subdomain), AssetParty::FirstParty);
+        assert_eq!(classify_party(&page, &parent), AssetParty::FirstParty);
+        assert_eq!(classify_party(&page, &unrelated), AssetParty::ThirdParty);
+    }
+
+    #[test]
+    fn detect_integrations_from_inline_script_reads_standard_gtm_snippet() {
+        let matches = detect_integrations_from_inline_script(
+            r#"(function(w,d,s,l,i){w[l]=w[l]||[];})(window,document,'script','dataLayer','GTM-ABC123');"#,
+        );
+
+        assert!(
+            matches.iter().any(
+                |(integration, evidence)| integration == "google_tag_manager"
+                    && evidence == "GTM-ABC123"
+            ),
+            "should detect GTM IDs followed by snippet punctuation"
+        );
+    }
+
+    #[test]
+    fn detect_integrations_from_inline_script_reads_case_insensitive_markers() {
+        let matches = detect_integrations_from_inline_script("window.PREBID = window.Didomi;");
+
+        assert!(matches
+            .iter()
+            .any(|(integration, _)| integration == "prebid"));
+        assert!(matches
+            .iter()
+            .any(|(integration, _)| integration == "didomi"));
+    }
+
+    #[test]
+    fn detect_integration_from_url_recognizes_known_patterns() {
+        let cases = [
+            (
+                "https://www.googletagmanager.com/gtm.js?id=GTM-ABC123",
+                "google_tag_manager",
+            ),
+            (
+                "https://securepubads.g.doubleclick.net/tag/js/gpt.js",
+                "gpt",
+            ),
+            ("https://sdk.privacy-center.org/sdk.js", "didomi"),
+            ("https://js.datadome.co/tags.js", "datadome"),
+            ("https://cdn.permutive.com/sdk.js", "permutive"),
+            ("https://identity.loc.kr/sdk.js", "lockr"),
+            ("https://cdn.example.com/prebid.js", "prebid"),
+        ];
+
+        for (url, expected) in cases {
+            let parsed = Url::parse(url).expect("should parse URL");
+            assert_eq!(
+                detect_integration_from_url(&parsed).as_deref(),
+                Some(expected),
+                "should detect {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_gtm_container_id_reads_query_parameter_urls() {
+        let artifact = AuditArtifact {
+            audited_url: "https://publisher.example".to_string(),
+            page_title: None,
+            js_asset_count: 1,
+            third_party_asset_count: 1,
+            detected_integrations: Vec::new(),
+            assets: vec![AuditedAsset {
+                kind: "script".to_string(),
+                url: "https://www.googletagmanager.com/gtm.js?id=GTM-ABC123&l=dataLayer"
+                    .to_string(),
+                host: "www.googletagmanager.com".to_string(),
+                party: AssetParty::ThirdParty,
+                integration: Some("google_tag_manager".to_string()),
+            }],
+            warnings: Vec::new(),
+        };
+
+        assert_eq!(
+            extract_gtm_container_id(&artifact).as_deref(),
+            Some("GTM-ABC123"),
+            "should extract GTM container IDs before query separators"
+        );
+    }
+
+    #[test]
+    fn artifact_serialization_uses_expected_shape() {
+        let artifact = AuditArtifact {
+            audited_url: "https://publisher.example".to_string(),
+            page_title: None,
+            js_asset_count: 1,
+            third_party_asset_count: 1,
+            detected_integrations: vec![DetectedIntegration {
+                id: "gpt".to_string(),
+                evidence: "https://securepubads.g.doubleclick.net/tag/js/gpt.js".to_string(),
+            }],
+            assets: vec![AuditedAsset {
+                kind: "script".to_string(),
+                url: "https://securepubads.g.doubleclick.net/tag/js/gpt.js".to_string(),
+                host: "securepubads.g.doubleclick.net".to_string(),
+                party: AssetParty::ThirdParty,
+                integration: Some("gpt".to_string()),
+            }],
+            warnings: Vec::new(),
+        };
+
+        let toml = toml::to_string_pretty(&artifact).expect("should serialize artifact");
+
+        assert!(toml.contains("audited_url = \"https://publisher.example\""));
+        assert!(toml.contains("party = \"third-party\""));
+        assert!(!toml.contains("page_title"));
+    }
+}

--- a/crates/trusted-server-cli/src/audit/browser_collector.rs
+++ b/crates/trusted-server-cli/src/audit/browser_collector.rs
@@ -7,7 +7,7 @@ use futures::StreamExt as _;
 use serde::Deserialize;
 use tempfile::TempDir;
 use tokio::runtime::Builder;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 use url::Url;
 use which::which;
 
@@ -19,6 +19,9 @@ use crate::error::{report_error, CliResult};
 const SETTLE_QUIET_PERIOD: Duration = Duration::from_millis(750);
 const SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const SETTLE_MAX_WAIT: Duration = Duration::from_secs(6);
+const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
+const BROWSER_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
+const RESOURCE_TIMING_BUFFER_WARNING_THRESHOLD: usize = 250;
 
 #[derive(Default)]
 pub(crate) struct BrowserAuditCollector;
@@ -72,10 +75,14 @@ async fn collect_page_via_browser_async(target_url: &Url) -> CliResult<Collected
 
     let result = collect_page_from_browser(&mut browser, target_url).await;
 
-    let close_result = browser
-        .close()
+    let close_result = timeout(BROWSER_CLOSE_TIMEOUT, browser.close())
         .await
-        .map_err(|error| report_error(format!("failed to close browser after audit: {error}")));
+        .map_err(|_| report_error("timed out closing browser after audit"))
+        .and_then(|result| {
+            result.map_err(|error| {
+                report_error(format!("failed to close browser after audit: {error}"))
+            })
+        });
     if close_result.is_err() {
         handler_task.abort();
     }
@@ -95,18 +102,28 @@ async fn collect_page_from_browser(
         report_error(format!("failed to create browser page for audit: {error}"))
     })?;
 
-    page.goto(target_url.as_str())
+    timeout(NAVIGATION_TIMEOUT, page.goto(target_url.as_str()))
         .await
+        .map_err(|_| report_error(format!("timed out navigating to `{target_url}`")))?
         .map_err(|error| report_error(format!("failed to navigate to `{target_url}`: {error}")))?;
 
-    let navigation_response = page.wait_for_navigation_response().await.map_err(|error| {
-        report_error(format!(
-            "failed to read main document navigation response: {error}"
-        ))
-    })?;
-    validate_navigation_response(navigation_response)?;
+    let navigation_response = timeout(NAVIGATION_TIMEOUT, page.wait_for_navigation_response())
+        .await
+        .map_err(|_| {
+            report_error(format!(
+                "timed out waiting for main document navigation response from `{target_url}`"
+            ))
+        })?
+        .map_err(|error| {
+            report_error(format!(
+                "failed to read main document navigation response: {error}"
+            ))
+        })?;
 
     let mut warnings = Vec::new();
+    if let Some(warning) = validate_navigation_response(navigation_response)? {
+        warnings.push(warning);
+    }
     if !wait_for_page_settle(&page).await? {
         warnings.push(
             "browser audit timed out while waiting for the page to settle; results may be partial"
@@ -164,6 +181,13 @@ async fn collect_page_from_browser(
             ))
         })?;
 
+    if network_requests.len() >= RESOURCE_TIMING_BUFFER_WARNING_THRESHOLD {
+        warnings.push(
+            "browser resource timing buffer reached its default size; some network assets may be missing"
+                .to_string(),
+        );
+    }
+
     Ok(CollectedPage {
         requested_url: target_url.to_string(),
         final_url,
@@ -180,9 +204,7 @@ async fn collect_page_from_browser(
             .into_iter()
             .map(|entry| CollectedRequest {
                 url: entry.url,
-                method: "GET".to_string(),
                 resource_type: entry.initiator_type,
-                status: None,
             })
             .collect(),
         warnings,
@@ -230,7 +252,7 @@ async fn wait_for_page_settle(page: &chromiumoxide::Page) -> CliResult<bool> {
     Ok(false)
 }
 
-fn validate_navigation_response(navigation_response: ArcHttpRequest) -> CliResult<()> {
+fn validate_navigation_response(navigation_response: ArcHttpRequest) -> CliResult<Option<String>> {
     let request = navigation_response
         .ok_or_else(|| report_error("browser audit did not capture the main document response"))?;
 
@@ -245,11 +267,11 @@ fn validate_navigation_response(navigation_response: ArcHttpRequest) -> CliResul
     })?;
 
     if is_successful_navigation_status(response.status) {
-        return Ok(());
+        return Ok(None);
     }
 
-    Err(report_error(format!(
-        "audit request returned HTTP {} {} for `{}`",
+    Ok(Some(format!(
+        "audit request returned HTTP {} {} for `{}`; results may be partial",
         response.status, response.status_text, response.url
     )))
 }

--- a/crates/trusted-server-cli/src/audit/browser_collector.rs
+++ b/crates/trusted-server-cli/src/audit/browser_collector.rs
@@ -1,0 +1,353 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chromiumoxide::browser::{Browser, BrowserConfig};
+use chromiumoxide::ArcHttpRequest;
+use futures::StreamExt as _;
+use serde::Deserialize;
+use tempfile::TempDir;
+use tokio::runtime::Builder;
+use tokio::time::sleep;
+use url::Url;
+use which::which;
+
+use crate::audit::collector::{
+    AuditCollector, CollectedPage, CollectedRequest, CollectedScriptTag,
+};
+use crate::error::{report_error, CliResult};
+
+const SETTLE_QUIET_PERIOD: Duration = Duration::from_millis(750);
+const SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const SETTLE_MAX_WAIT: Duration = Duration::from_secs(6);
+
+#[derive(Default)]
+pub(crate) struct BrowserAuditCollector;
+
+impl AuditCollector for BrowserAuditCollector {
+    fn collect_page(&self, target_url: &Url) -> CliResult<CollectedPage> {
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                report_error(format!(
+                    "failed to build Tokio runtime for browser audit: {error}"
+                ))
+            })?;
+
+        runtime.block_on(collect_page_via_browser_async(target_url))
+    }
+}
+
+async fn collect_page_via_browser_async(target_url: &Url) -> CliResult<CollectedPage> {
+    let chrome_executable = find_browser_executable()?;
+    let user_data_dir = TempDir::new().map_err(|error| {
+        report_error(format!(
+            "failed to create temporary browser profile for audit: {error}"
+        ))
+    })?;
+    let config = BrowserConfig::builder()
+        .chrome_executable(chrome_executable)
+        .user_data_dir(user_data_dir.path())
+        .new_headless_mode()
+        .build()
+        .map_err(|error| {
+            report_error(format!(
+                "failed to build Chromium configuration for audit: {error}"
+            ))
+        })?;
+
+    let (mut browser, mut handler) = Browser::launch(config).await.map_err(|error| {
+        report_error(format!(
+            "failed to launch Chrome/Chromium for audit: {error}"
+        ))
+    })?;
+
+    let handler_task = tokio::spawn(async move {
+        while let Some(event) = handler.next().await {
+            if event.is_err() {
+                break;
+            }
+        }
+    });
+
+    let result = collect_page_from_browser(&mut browser, target_url).await;
+
+    let close_result = browser
+        .close()
+        .await
+        .map_err(|error| report_error(format!("failed to close browser after audit: {error}")));
+    if close_result.is_err() {
+        handler_task.abort();
+    }
+    let _ = handler_task.await;
+
+    match (result, close_result) {
+        (Ok(collected), Ok(_)) => Ok(collected),
+        (Ok(_), Err(error)) | (Err(error), _) => Err(error),
+    }
+}
+
+async fn collect_page_from_browser(
+    browser: &mut Browser,
+    target_url: &Url,
+) -> CliResult<CollectedPage> {
+    let page = browser.new_page("about:blank").await.map_err(|error| {
+        report_error(format!("failed to create browser page for audit: {error}"))
+    })?;
+
+    page.goto(target_url.as_str())
+        .await
+        .map_err(|error| report_error(format!("failed to navigate to `{target_url}`: {error}")))?;
+
+    let navigation_response = page.wait_for_navigation_response().await.map_err(|error| {
+        report_error(format!(
+            "failed to read main document navigation response: {error}"
+        ))
+    })?;
+    validate_navigation_response(navigation_response)?;
+
+    let mut warnings = Vec::new();
+    if !wait_for_page_settle(&page).await? {
+        warnings.push(
+            "browser audit timed out while waiting for the page to settle; results may be partial"
+                .to_string(),
+        );
+    }
+
+    let final_url = page
+        .url()
+        .await
+        .map_err(|error| report_error(format!("failed to read final page URL: {error}")))?
+        .ok_or_else(|| report_error("browser page URL was empty after navigation"))?;
+    let page_title = page
+        .get_title()
+        .await
+        .map_err(|error| report_error(format!("failed to read page title: {error}")))?;
+    let html = page
+        .content()
+        .await
+        .map_err(|error| report_error(format!("failed to read rendered page HTML: {error}")))?;
+
+    let script_tags: Vec<BrowserScriptTag> = page
+        .evaluate(
+            r#"() => Array.from(document.scripts).map((script) => ({
+                src: script.src || null,
+                inline_text: script.src ? null : (script.textContent || null),
+            }))"#,
+        )
+        .await
+        .map_err(|error| report_error(format!("failed to read rendered script tags: {error}")))?
+        .into_value()
+        .map_err(|error| {
+            report_error(format!(
+                "failed to decode rendered script tag data: {error}"
+            ))
+        })?;
+
+    let network_requests: Vec<BrowserPerformanceEntry> = page
+        .evaluate(
+            r#"() => performance.getEntriesByType('resource').map((entry) => ({
+                url: entry.name,
+                initiator_type: entry.initiatorType || null,
+            }))"#,
+        )
+        .await
+        .map_err(|error| {
+            report_error(format!(
+                "failed to read browser performance resource entries: {error}"
+            ))
+        })?
+        .into_value()
+        .map_err(|error| {
+            report_error(format!(
+                "failed to decode browser performance resource data: {error}"
+            ))
+        })?;
+
+    Ok(CollectedPage {
+        requested_url: target_url.to_string(),
+        final_url,
+        page_title: page_title.filter(|title| !title.trim().is_empty()),
+        html,
+        script_tags: script_tags
+            .into_iter()
+            .map(|script| CollectedScriptTag {
+                src: script.src,
+                inline_text: script.inline_text.filter(|text| !text.trim().is_empty()),
+            })
+            .collect(),
+        network_requests: network_requests
+            .into_iter()
+            .map(|entry| CollectedRequest {
+                url: entry.url,
+                method: "GET".to_string(),
+                resource_type: entry.initiator_type,
+                status: None,
+            })
+            .collect(),
+        warnings,
+    })
+}
+
+async fn wait_for_page_settle(page: &chromiumoxide::Page) -> CliResult<bool> {
+    let mut elapsed = Duration::ZERO;
+    let mut previous_count = None;
+    let mut stable_for = Duration::ZERO;
+
+    while elapsed < SETTLE_MAX_WAIT {
+        let ready_state: String = page
+            .evaluate("document.readyState")
+            .await
+            .map_err(|error| report_error(format!("failed to read document ready state: {error}")))?
+            .into_value()
+            .map_err(|error| {
+                report_error(format!("failed to decode document ready state: {error}"))
+            })?;
+        let resource_count: usize = page
+            .evaluate("performance.getEntriesByType('resource').length")
+            .await
+            .map_err(|error| report_error(format!("failed to read resource count: {error}")))?
+            .into_value()
+            .map_err(|error| report_error(format!("failed to decode resource count: {error}")))?;
+
+        if ready_state == "complete" {
+            if previous_count == Some(resource_count) {
+                stable_for += SETTLE_POLL_INTERVAL;
+            } else {
+                stable_for = Duration::ZERO;
+            }
+
+            if stable_for >= SETTLE_QUIET_PERIOD {
+                return Ok(true);
+            }
+        }
+
+        previous_count = Some(resource_count);
+        sleep(SETTLE_POLL_INTERVAL).await;
+        elapsed += SETTLE_POLL_INTERVAL;
+    }
+
+    Ok(false)
+}
+
+fn validate_navigation_response(navigation_response: ArcHttpRequest) -> CliResult<()> {
+    let request = navigation_response
+        .ok_or_else(|| report_error("browser audit did not capture the main document response"))?;
+
+    if let Some(failure_text) = &request.failure_text {
+        return Err(report_error(format!(
+            "main document request failed: {failure_text}"
+        )));
+    }
+
+    let response = request.response.as_ref().ok_or_else(|| {
+        report_error("browser audit did not capture the main document HTTP response")
+    })?;
+
+    if is_successful_navigation_status(response.status) {
+        return Ok(());
+    }
+
+    Err(report_error(format!(
+        "audit request returned HTTP {} {} for `{}`",
+        response.status, response.status_text, response.url
+    )))
+}
+
+fn is_successful_navigation_status(status: i64) -> bool {
+    (200..400).contains(&status)
+}
+
+fn find_browser_executable() -> CliResult<PathBuf> {
+    for candidate in browser_executable_path_candidates() {
+        if let Ok(path) = which(candidate) {
+            return Ok(path);
+        }
+    }
+
+    for candidate in browser_executable_fallbacks() {
+        let candidate_path = Path::new(candidate);
+        if candidate_path.is_file() {
+            return Ok(candidate_path.to_path_buf());
+        }
+    }
+
+    Err(report_error(
+        "Chrome/Chromium was not found on PATH or in the standard local install locations checked by `ts audit`. Install a local Chrome or Chromium binary before running `ts audit`.",
+    ))
+}
+
+fn browser_executable_path_candidates() -> &'static [&'static str] {
+    &[
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+        "chrome",
+        "Google Chrome",
+        "Google Chrome for Testing",
+    ]
+}
+
+fn browser_executable_fallbacks() -> &'static [&'static str] {
+    #[cfg(target_os = "macos")]
+    {
+        &[
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+        ]
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        &[
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+            "/usr/bin/chromium",
+            "/usr/bin/chromium-browser",
+            "/snap/bin/chromium",
+        ]
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        &[]
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BrowserScriptTag {
+    src: Option<String>,
+    inline_text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BrowserPerformanceEntry {
+    url: String,
+    initiator_type: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_navigation_status_allows_redirects_but_rejects_errors() {
+        assert!(is_successful_navigation_status(200));
+        assert!(is_successful_navigation_status(302));
+        assert!(is_successful_navigation_status(399));
+        assert!(!is_successful_navigation_status(199));
+        assert!(!is_successful_navigation_status(400));
+        assert!(!is_successful_navigation_status(500));
+    }
+
+    #[test]
+    fn browser_path_candidates_include_common_names() {
+        let candidates = browser_executable_path_candidates();
+
+        assert!(candidates.contains(&"google-chrome"));
+        assert!(candidates.contains(&"chromium"));
+        assert!(candidates.contains(&"Google Chrome for Testing"));
+    }
+}

--- a/crates/trusted-server-cli/src/audit/browser_collector.rs
+++ b/crates/trusted-server-cli/src/audit/browser_collector.rs
@@ -22,6 +22,8 @@ const SETTLE_MAX_WAIT: Duration = Duration::from_secs(6);
 const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
 const BROWSER_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 const RESOURCE_TIMING_BUFFER_WARNING_THRESHOLD: usize = 250;
+const RESOURCE_TIMING_BUFFER_WARNING: &str =
+    "browser resource timing buffer reached its default size; some network assets may be missing";
 
 #[derive(Default)]
 pub(crate) struct BrowserAuditCollector;
@@ -181,11 +183,8 @@ async fn collect_page_from_browser(
             ))
         })?;
 
-    if network_requests.len() >= RESOURCE_TIMING_BUFFER_WARNING_THRESHOLD {
-        warnings.push(
-            "browser resource timing buffer reached its default size; some network assets may be missing"
-                .to_string(),
-        );
+    if let Some(warning) = resource_timing_buffer_warning(network_requests.len()) {
+        warnings.push(warning.to_string());
     }
 
     Ok(CollectedPage {
@@ -280,6 +279,11 @@ fn is_successful_navigation_status(status: i64) -> bool {
     (200..400).contains(&status)
 }
 
+fn resource_timing_buffer_warning(resource_count: usize) -> Option<&'static str> {
+    (resource_count >= RESOURCE_TIMING_BUFFER_WARNING_THRESHOLD)
+        .then_some(RESOURCE_TIMING_BUFFER_WARNING)
+}
+
 fn find_browser_executable() -> CliResult<PathBuf> {
     for candidate in browser_executable_path_candidates() {
         if let Ok(path) = which(candidate) {
@@ -352,6 +356,12 @@ struct BrowserPerformanceEntry {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use chromiumoxide::cdp::browser_protocol::network::{Headers, RequestId, Response};
+    use chromiumoxide::cdp::browser_protocol::security::SecurityState;
+    use chromiumoxide::handler::http::HttpRequest;
+
     use super::*;
 
     #[test]
@@ -365,11 +375,61 @@ mod tests {
     }
 
     #[test]
+    fn navigation_response_returns_warning_for_http_error_status() {
+        let warning =
+            validate_navigation_response(navigation_response_with_status(403, "Forbidden"))
+                .expect("should validate navigation response")
+                .expect("should return warning for HTTP error status");
+
+        assert_eq!(
+            warning,
+            "audit request returned HTTP 403 Forbidden for `https://example.com/`; results may be partial",
+            "should warn and continue when the main document returns an HTTP error"
+        );
+    }
+
+    #[test]
+    fn resource_timing_buffer_warning_starts_at_threshold() {
+        assert_eq!(
+            resource_timing_buffer_warning(RESOURCE_TIMING_BUFFER_WARNING_THRESHOLD - 1),
+            None,
+            "should not warn before the resource timing buffer threshold"
+        );
+        assert_eq!(
+            resource_timing_buffer_warning(RESOURCE_TIMING_BUFFER_WARNING_THRESHOLD),
+            Some(RESOURCE_TIMING_BUFFER_WARNING),
+            "should warn when the resource timing buffer reaches the threshold"
+        );
+    }
+
+    #[test]
     fn browser_path_candidates_include_common_names() {
         let candidates = browser_executable_path_candidates();
 
         assert!(candidates.contains(&"google-chrome"));
         assert!(candidates.contains(&"chromium"));
         assert!(candidates.contains(&"Google Chrome for Testing"));
+    }
+
+    fn navigation_response_with_status(status: i64, status_text: &str) -> ArcHttpRequest {
+        let mut request =
+            HttpRequest::new(RequestId::new("request-1"), None, None, false, Vec::new());
+        request.response = Some(
+            Response::builder()
+                .url("https://example.com/")
+                .status(status)
+                .status_text(status_text)
+                .headers(Headers::default())
+                .mime_type("text/html")
+                .charset("utf-8")
+                .connection_reused(false)
+                .connection_id(1.0)
+                .encoded_data_length(0.0)
+                .security_state(SecurityState::Secure)
+                .build()
+                .expect("should build navigation response"),
+        );
+
+        Some(Arc::new(request))
     }
 }

--- a/crates/trusted-server-cli/src/audit/collector.rs
+++ b/crates/trusted-server-cli/src/audit/collector.rs
@@ -27,9 +27,7 @@ pub(crate) struct CollectedScriptTag {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub(crate) struct CollectedRequest {
     pub(crate) url: String,
-    pub(crate) method: String,
     pub(crate) resource_type: Option<String>,
-    pub(crate) status: Option<u16>,
 }
 
 impl CollectedPage {

--- a/crates/trusted-server-cli/src/audit/collector.rs
+++ b/crates/trusted-server-cli/src/audit/collector.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::error::CliResult;
+
+pub(crate) trait AuditCollector {
+    fn collect_page(&self, target_url: &Url) -> CliResult<CollectedPage>;
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct CollectedPage {
+    pub(crate) requested_url: String,
+    pub(crate) final_url: String,
+    pub(crate) page_title: Option<String>,
+    pub(crate) html: String,
+    pub(crate) script_tags: Vec<CollectedScriptTag>,
+    pub(crate) network_requests: Vec<CollectedRequest>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct CollectedScriptTag {
+    pub(crate) src: Option<String>,
+    pub(crate) inline_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct CollectedRequest {
+    pub(crate) url: String,
+    pub(crate) method: String,
+    pub(crate) resource_type: Option<String>,
+    pub(crate) status: Option<u16>,
+}
+
+impl CollectedPage {
+    pub(crate) fn requested_url(&self) -> Result<Url, url::ParseError> {
+        Url::parse(&self.requested_url)
+    }
+
+    pub(crate) fn final_url(&self) -> Result<Url, url::ParseError> {
+        Url::parse(&self.final_url)
+    }
+}

--- a/crates/trusted-server-cli/src/config_init.rs
+++ b/crates/trusted-server-cli/src/config_init.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
-const EXAMPLE_CONFIG: &str = include_str!(concat!(
+pub(crate) const EXAMPLE_CONFIG: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../trusted-server.example.toml"
 ));

--- a/crates/trusted-server-cli/src/error.rs
+++ b/crates/trusted-server-cli/src/error.rs
@@ -5,5 +5,7 @@ pub(crate) fn cli_error<T>(message: impl Into<String>) -> CliResult<T> {
 }
 
 pub(crate) fn report_error(message: impl Into<String>) -> String {
-    message.into()
+    let message = message.into();
+    log::error!("{message}");
+    message
 }

--- a/crates/trusted-server-cli/src/error.rs
+++ b/crates/trusted-server-cli/src/error.rs
@@ -1,0 +1,9 @@
+pub(crate) type CliResult<T> = Result<T, String>;
+
+pub(crate) fn cli_error<T>(message: impl Into<String>) -> CliResult<T> {
+    Err(message.into())
+}
+
+pub(crate) fn report_error(message: impl Into<String>) -> String {
+    message.into()
+}

--- a/crates/trusted-server-cli/src/lib.rs
+++ b/crates/trusted-server-cli/src/lib.rs
@@ -11,7 +11,11 @@
 )]
 
 #[cfg(not(target_arch = "wasm32"))]
+mod audit;
+#[cfg(not(target_arch = "wasm32"))]
 mod config_init;
+#[cfg(not(target_arch = "wasm32"))]
+mod error;
 #[cfg(not(target_arch = "wasm32"))]
 mod run;
 

--- a/crates/trusted-server-cli/src/run.rs
+++ b/crates/trusted-server-cli/src/run.rs
@@ -7,6 +7,7 @@ use edgezero_cli::args::{
 };
 use trusted_server_core::config::TrustedServerAppConfig;
 
+use crate::audit::browser_collector::BrowserAuditCollector;
 use crate::config_init::{run_config_init, ConfigInitArgs};
 
 #[derive(Debug, Parser)]
@@ -18,6 +19,8 @@ struct Args {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Audit a public page and write draft Trusted Server artifacts.
+    Audit(AuditArgs),
     /// Sign in / out / status against an `EdgeZero` adapter.
     Auth(AuthArgs),
     /// Build the project for a target adapter.
@@ -31,6 +34,27 @@ enum Command {
     Provision(ProvisionArgs),
     /// Serve the project locally through a target adapter.
     Serve(ServeArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct AuditArgs {
+    /// Public HTTP(S) URL to audit.
+    pub(crate) url: String,
+    /// JavaScript asset audit output path.
+    #[arg(long)]
+    pub(crate) js_assets: Option<std::path::PathBuf>,
+    /// Draft Trusted Server config output path.
+    #[arg(long)]
+    pub(crate) config: Option<std::path::PathBuf>,
+    /// Do not write the JavaScript asset audit file.
+    #[arg(long)]
+    pub(crate) no_js_assets: bool,
+    /// Do not write the draft Trusted Server config file.
+    #[arg(long)]
+    pub(crate) no_config: bool,
+    /// Overwrite existing output files.
+    #[arg(long)]
+    pub(crate) force: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -50,13 +74,19 @@ enum ConfigCommand {
 /// # Errors
 ///
 /// Returns an error when command parsing, config validation, `EdgeZero`
-/// delegation, or config initialization fails.
+/// delegation, audit collection, or config initialization fails.
 pub fn run_from_env() -> Result<(), String> {
     dispatch(Args::parse())
 }
 
 fn dispatch(args: Args) -> Result<(), String> {
     match args.command {
+        Command::Audit(args) => {
+            let stdout = std::io::stdout();
+            let mut out = stdout.lock();
+            let collector = BrowserAuditCollector;
+            crate::audit::run_audit(&args, &collector, &mut out)
+        }
         Command::Auth(args) => edgezero_cli::run_auth(&args),
         Command::Build(args) => edgezero_cli::run_build(&args),
         Command::Config(ConfigCommand::Init(args)) => run_config_init(&args),
@@ -90,6 +120,64 @@ mod tests {
 
     fn parse(args: &[&str]) -> Args {
         Args::try_parse_from(args).expect("should parse args")
+    }
+
+    #[test]
+    fn parses_audit_with_default_outputs() {
+        let args = parse(&["ts", "audit", "https://publisher.example"]);
+        let Command::Audit(audit) = args.command else {
+            panic!("expected audit command");
+        };
+        assert_eq!(audit.url, "https://publisher.example");
+        assert_eq!(audit.js_assets, None);
+        assert_eq!(audit.config, None);
+        assert!(!audit.no_js_assets);
+        assert!(!audit.no_config);
+        assert!(!audit.force);
+    }
+
+    #[test]
+    fn parses_audit_with_custom_outputs() {
+        let args = parse(&[
+            "ts",
+            "audit",
+            "https://publisher.example",
+            "--js-assets",
+            "audit/js-assets.toml",
+            "--config",
+            "audit/trusted-server.toml",
+            "--no-js-assets",
+            "--no-config",
+            "--force",
+        ]);
+        let Command::Audit(audit) = args.command else {
+            panic!("expected audit command");
+        };
+        assert_eq!(audit.js_assets, Some(PathBuf::from("audit/js-assets.toml")));
+        assert_eq!(
+            audit.config,
+            Some(PathBuf::from("audit/trusted-server.toml"))
+        );
+        assert!(audit.no_js_assets);
+        assert!(audit.no_config);
+        assert!(audit.force);
+    }
+
+    #[test]
+    fn audit_does_not_accept_adapter_option() {
+        let error = Args::try_parse_from([
+            "ts",
+            "audit",
+            "https://publisher.example",
+            "--adapter",
+            "fastly",
+        ])
+        .expect_err("should reject audit adapter option");
+        assert!(
+            error.to_string().contains("unexpected argument")
+                || error.to_string().contains("Found argument"),
+            "error should explain unsupported option"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-integration-tests/Cargo.lock
+++ b/crates/trusted-server-integration-tests/Cargo.lock
@@ -19,19 +19,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -869,17 +856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -1109,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "ego-tree"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -1540,12 +1516,11 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
  "match_token",
 ]
@@ -2171,23 +2146,20 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.14.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
 ]
 
 [[package]]
 name = "match_token"
-version = "0.1.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3340,17 +3312,16 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e749d29b2064585327af5038a5a8eb73aeebad4a3472e83531a436563f7208"
+checksum = "e5f3a24d916e78954af99281a455168d4a9515d65eca99a18da1b813689c4ad9"
 dependencies = [
- "ahash",
- "cssparser 0.34.0",
+ "cssparser 0.35.0",
  "ego-tree",
  "getopts",
  "html5ever",
  "precomputed-hash",
- "selectors 0.26.0",
+ "selectors 0.31.0",
  "tendril",
 ]
 
@@ -3392,13 +3363,13 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.26.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
 dependencies = [
  "bitflags 2.13.0",
- "cssparser 0.34.0",
- "derive_more 0.99.20",
+ "cssparser 0.35.0",
+ "derive_more",
  "fxhash",
  "log",
  "new_debug_unreachable",
@@ -3417,7 +3388,7 @@ checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser 0.36.0",
- "derive_more 2.1.1",
+ "derive_more",
  "log",
  "new_debug_unreachable",
  "phf 0.13.1",
@@ -4306,7 +4277,7 @@ dependencies = [
  "chacha20poly1305",
  "chrono",
  "cookie",
- "derive_more 2.1.1",
+ "derive_more",
  "ed25519-dalek",
  "edgezero-core",
  "error-stack",
@@ -4344,7 +4315,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "bytes",
- "derive_more 2.1.1",
+ "derive_more",
  "edgezero-adapter-axum",
  "edgezero-core",
  "env_logger",
@@ -4738,6 +4709,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/crates/trusted-server-integration-tests/Cargo.toml
+++ b/crates/trusted-server-integration-tests/Cargo.toml
@@ -22,7 +22,7 @@ trusted-server-core = { path = "../trusted-server-core" }
 [dev-dependencies]
 testcontainers = { version = "0.25", features = ["blocking"] }
 reqwest = { version = "0.12", features = ["blocking", "cookies", "json"] }
-scraper = "0.21"
+scraper = "0.24.0"
 log = "0.4.33"
 error-stack = "0.6"
 derive_more = { version = "2.0", features = ["display"] }

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,7 +1,7 @@
 # Trusted Server CLI
 
 The Trusted Server CLI binary is `ts`. It is a host-target operator tool for
-configuration and EdgeZero-backed lifecycle commands.
+configuration, page audits, and EdgeZero-backed lifecycle commands.
 
 ## Install from source
 
@@ -68,3 +68,54 @@ ts provision --adapter fastly
 ts deploy --adapter fastly
 ts serve --adapter fastly
 ```
+
+## Audit a public page
+
+`ts audit` loads a public page in a fresh headless Chrome/Chromium session,
+collects rendered JavaScript asset evidence, detects known Trusted Server
+integrations, and writes local draft artifacts.
+
+Chrome or Chromium must be installed locally. The command checks common PATH
+names and standard macOS/Linux install locations.
+
+```bash
+ts audit https://publisher.example
+```
+
+By default, the command writes:
+
+| File                  | Purpose                                                                  |
+| --------------------- | ------------------------------------------------------------------------ |
+| `js-assets.toml`      | JavaScript asset inventory, detected integrations, counts, and warnings. |
+| `trusted-server.toml` | Draft Trusted Server config based on the starter template and final URL. |
+
+The generated config is a draft. Review it, replace placeholders/secrets, adjust
+publisher-specific settings, then run:
+
+```bash
+ts config validate
+```
+
+If a config already exists, avoid overwriting it:
+
+```bash
+ts audit https://publisher.example --no-config
+```
+
+Use custom output paths when reviewing artifacts first:
+
+```bash
+ts audit https://publisher.example \
+  --js-assets audit/js-assets.toml \
+  --config audit/trusted-server.toml
+```
+
+Use `--force` only when replacing existing output files is intentional:
+
+```bash
+ts audit https://publisher.example --force
+```
+
+`ts audit` is not an EdgeZero adapter command. It has no `--adapter` option and
+it does not provision resources, push config, build, deploy, or contact platform
+APIs.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -13,6 +13,7 @@ Before you begin, ensure you have the following installed (versions are pinned i
 **For Fastly deployment** (optional for local dev):
 
 - Fastly {{FASTLY_VERSION}} CLI installed
+- Chrome or Chromium, required for `ts audit`
 - A Fastly account and API key
 
 ## Installation
@@ -108,6 +109,15 @@ Create a starter Trusted Server config with the `ts` CLI:
 ```bash
 ts config init
 ```
+
+To bootstrap from a public publisher page, run an audit first:
+
+```bash
+ts audit https://publisher.example
+```
+
+The audit command writes `js-assets.toml` plus a draft `trusted-server.toml`.
+Review the draft, replace placeholders/secrets, then validate it.
 
 Edit `trusted-server.toml` to configure:
 

--- a/docs/superpowers/plans/2026-06-16-edgezero-based-ts-audit-implementation-plan.md
+++ b/docs/superpowers/plans/2026-06-16-edgezero-based-ts-audit-implementation-plan.md
@@ -1,0 +1,820 @@
+# EdgeZero-Based Trusted Server Audit CLI Implementation Plan
+
+**Date:** 2026-06-16
+**Status:** Approved implementation plan
+**Spec:** `docs/superpowers/specs/2026-06-16-edgezero-based-ts-audit-design.md`
+**Depends on:** base CLI pass from
+`docs/superpowers/specs/2026-06-16-edgezero-based-ts-cli-design.md`
+
+## Current baseline
+
+The base CLI pass has added the host-target `trusted-server-cli` crate with:
+
+```text
+crates/trusted-server-cli/
+  Cargo.toml
+  src/args.rs
+  src/config_command.rs
+  src/edgezero_delegate.rs
+  src/error.rs
+  src/lib.rs
+  src/main.rs
+  src/run.rs
+```
+
+Important existing shapes to preserve:
+
+- The binary is `ts`.
+- The implementation is gated to non-wasm targets in `lib.rs` and `main.rs`.
+- `run_from_env()` parses process args and wires production services.
+- `run_with_io()` supports testable invocation with injected writers.
+- `run::dispatch()` currently injects an `EdgeZeroDelegate` for lifecycle/config
+  push tests.
+- `config_command.rs` already embeds `trusted-server.example.toml` for
+  `config init`.
+- `trusted-server.example.toml` now uses `example.com` sentinel values rather
+  than the old `test-publisher.com` values.
+- `.gitignore` already ignores `trusted-server.toml`, but does not yet ignore
+  `js-assets.toml`.
+
+The old implementation to port from is on `feature/ts-cli`:
+
+```text
+crates/trusted-server-cli/src/audit.rs
+crates/trusted-server-cli/src/audit/analyzer.rs
+crates/trusted-server-cli/src/audit/browser_collector.rs
+crates/trusted-server-cli/src/audit/collector.rs
+```
+
+This plan recreates that behavior on top of the new base CLI structure, while
+applying the spec's tightening around output preflight, deterministic merge
+behavior, and EdgeZero separation.
+
+## Decisions locked for this plan
+
+- `ts audit` is Trusted Server-owned, not an EdgeZero delegate.
+- No `--adapter`, `--manifest`, `--store`, `--local`, `--dry-run`, or `--json`
+  options are added to audit v1.
+- The command writes local draft artifacts only; it never provisions, pushes,
+  deploys, or contacts platform APIs.
+- Preserve the old command surface:
+  - `ts audit <url>`;
+  - `--js-assets <path>`;
+  - `--config <path>`;
+  - `--no-js-assets`;
+  - `--no-config`;
+  - `--force`.
+- Preserve the old artifact schema exactly enough that existing
+  `js-assets.toml` readers do not need a migration.
+- Improve over the old implementation by preflighting selected output paths
+  before launching the browser and before writing any file.
+- Use a fake collector in tests; unit tests must not require Chrome/Chromium.
+- Browser smoke tests, if added, must be ignored by default or feature-gated.
+- Generated `trusted-server.toml` is a draft. It may still fail production
+  validation until the operator replaces placeholders and reviews settings.
+- Do not write rendered HTML, inline script bodies, cookies, storage, request
+  bodies, or response bodies to artifacts.
+- Keep all browser automation dependencies host-only under
+  `trusted-server-cli`.
+- Follow repository error/logging style: `error-stack::Report`, no `println!`,
+  output through injected `Write` handles in testable code.
+
+## Definition of done
+
+- `ts audit [options] <url>` appears in clap help and dispatches correctly.
+- URL validation accepts only `http` and `https` URLs.
+- Default outputs are `js-assets.toml` and `trusted-server.toml`.
+- `--no-js-assets` and `--no-config` work individually.
+- Passing both no-output flags fails before browser collection.
+- Existing outputs are rejected without `--force` before browser collection.
+- If any selected output path conflicts, no selected file is written.
+- Browser collector launches an isolated headless Chrome/Chromium session.
+- Browser collector captures final URL, title, rendered HTML, DOM scripts, and
+  script resource timing entries.
+- Navigation failures and non-`200..399` main-document statuses fail clearly.
+- Page settle timeout continues with a warning.
+- Analyzer merges HTML, DOM, and resource-timing script evidence.
+- Assets and detected integrations are deduplicated and sorted deterministically.
+- First-party/third-party classification matches the spec's host relationship
+  heuristic.
+- Integration detectors match the old v1 detector set.
+- `js-assets.toml` serializes the specified schema.
+- Draft config generation patches current `trusted-server.example.toml`
+  sentinels, uses the final redirected URL, and appends manual-review comments.
+- `ts audit` does not invoke any `EdgeZeroDelegate` or platform API.
+- `.gitignore` ignores the default `js-assets.toml` artifact.
+- CLI guide / getting-started docs mention the audit command and Chrome
+  requirement.
+- Focused unit tests pass.
+- Host-target CLI tests pass.
+- Formatting passes.
+
+## Proposed module layout
+
+Add audit as an internal host-only module under the existing CLI crate:
+
+```text
+crates/trusted-server-cli/src/
+  audit.rs
+  audit/
+    analyzer.rs
+    browser_collector.rs
+    collector.rs
+```
+
+Responsibilities:
+
+| File                         | Responsibility                                                                |
+| ---------------------------- | ----------------------------------------------------------------------------- |
+| `args.rs`                    | Add `Command::Audit(AuditArgs)` and parse audit flags.                        |
+| `run.rs`                     | Dispatch audit via an injectable collector and stdout writer.                 |
+| `audit.rs`                   | Command orchestration, output planning, file writes, draft config generation. |
+| `audit/collector.rs`         | `CollectedPage` data structs and `AuditCollector` trait.                      |
+| `audit/analyzer.rs`          | Convert `CollectedPage` to `AuditArtifact`; detection/classification.         |
+| `audit/browser_collector.rs` | Production Chrome/Chromium collector.                                         |
+| `Cargo.toml`                 | Add host-only audit dependencies.                                             |
+| `.gitignore`                 | Ignore default `js-assets.toml`.                                              |
+| docs                         | Document command usage and draft status.                                      |
+
+## Data model sketch
+
+Port these old public/internal shapes with doc comments as needed for clippy:
+
+```rust
+pub struct AuditArgs {
+    pub url: String,
+    pub js_assets: Option<PathBuf>,
+    pub config: Option<PathBuf>,
+    pub no_js_assets: bool,
+    pub no_config: bool,
+    pub force: bool,
+}
+
+pub trait AuditCollector {
+    fn collect_page(&self, target_url: &Url) -> CliResult<CollectedPage>;
+}
+
+pub struct CollectedPage {
+    pub requested_url: String,
+    pub final_url: String,
+    pub page_title: Option<String>,
+    pub html: String,
+    pub script_tags: Vec<CollectedScriptTag>,
+    pub network_requests: Vec<CollectedRequest>,
+    pub warnings: Vec<String>,
+}
+
+pub struct AuditArtifact {
+    pub audited_url: String,
+    pub page_title: Option<String>,
+    pub js_asset_count: usize,
+    pub third_party_asset_count: usize,
+    pub detected_integrations: Vec<DetectedIntegration>,
+    pub assets: Vec<AuditedAsset>,
+    pub warnings: Vec<String>,
+}
+```
+
+Keep serialization compatible with the old artifact:
+
+- `AssetParty` serializes with `#[serde(rename_all = "kebab-case")]`.
+- `AuditedAsset.integration` remains `Option<String>`.
+- `page_title` remains `Option<String>`.
+- No `schema_version` in v1.
+
+## Service injection shape
+
+The current `dispatch()` injects only an `EdgeZeroDelegate`. To test audit
+without launching Chrome, extend the dispatcher to inject both platform and audit
+services.
+
+Preferred shape:
+
+```rust
+struct CliServices<'a> {
+    edgezero: &'a mut dyn EdgeZeroDelegate,
+    audit: &'a dyn AuditCollector,
+}
+
+fn dispatch(
+    args: Args,
+    services: &mut CliServices<'_>,
+    out: &mut dyn Write,
+    err: &mut dyn Write,
+) -> CliResult<()>;
+```
+
+Production setup in `run_from_env()` and `run_with_io()`:
+
+```rust
+let mut edgezero = ProductionEdgeZeroDelegate;
+let audit = BrowserAuditCollector;
+let mut services = CliServices {
+    edgezero: &mut edgezero,
+    audit: &audit,
+};
+```
+
+Tests can use:
+
+```rust
+let mut edgezero = FakeEdgeZeroDelegate::default();
+let audit = FakeAuditCollector::new(collected_page);
+let mut services = CliServices {
+    edgezero: &mut edgezero,
+    audit: &audit,
+};
+```
+
+This keeps the no-EdgeZero requirement testable: after dispatching `Command::Audit`,
+assert fake EdgeZero lifecycle/push calls are empty.
+
+If introducing `CliServices` feels too large, an acceptable smaller alternative
+is `dispatch_with_audit_collector(args, delegate, collector, out, err)` used by
+production and tests. Avoid global mutable test hooks.
+
+## Dependencies
+
+Add only host-target CLI dependencies.
+
+Likely additions to root `[workspace.dependencies]`:
+
+```toml
+chromiumoxide = "<chosen-compatible-version>"
+scraper = "0.21" # or current compatible version
+```
+
+Likely additions to `crates/trusted-server-cli/Cargo.toml` under
+`target.'cfg(not(target_arch = "wasm32"))'.dependencies`:
+
+```toml
+chromiumoxide = { workspace = true }
+futures = { workspace = true }
+regex = { workspace = true }
+scraper = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+which = { workspace = true }
+```
+
+Existing workspace dependencies already include `futures`, `regex`, `tokio`,
+`url`, and `which`. Confirm `tokio` features are sufficient for the browser
+collector:
+
+- current workspace features include `rt`, `time`, `macros`, `io-util`, and
+  `sync`;
+- browser collector needs current-thread runtime and timers;
+- if `chromiumoxide` requires extra Tokio features, add only the minimum
+  host-safe features needed.
+
+Dependency constraints:
+
+- Do not add these dependencies to runtime crates.
+- Do not make `trusted-server-core` depend on browser automation or HTML
+  scraping crates.
+- Keep the CLI crate wasm stub compiling by leaving all real audit modules under
+  `#[cfg(not(target_arch = "wasm32"))]` via `lib.rs` module gating.
+
+## Stage 1 — Add CLI argument surface
+
+Files:
+
+- `crates/trusted-server-cli/src/args.rs`
+- `crates/trusted-server-cli/src/run.rs`
+
+Steps:
+
+1. Add `Command::Audit(AuditArgs)` to `args.rs`.
+2. Add `AuditArgs` with:
+   - positional `url: String`;
+   - `#[arg(long)] js_assets: Option<PathBuf>`;
+   - `#[arg(long)] config: Option<PathBuf>`;
+   - `#[arg(long)] no_js_assets: bool`;
+   - `#[arg(long)] no_config: bool`;
+   - `#[arg(long)] force: bool`.
+3. Use clap's default kebab-case flag names, so the struct field `js_assets`
+   maps to `--js-assets`.
+4. Add parser tests:
+   - parses default audit URL;
+   - parses all custom options;
+   - `--no-js-assets` and `--no-config` can each parse;
+   - audit does not accept `--adapter`.
+5. Add a dispatch match arm that calls `audit::run_audit()` with the injected
+   collector.
+6. Ensure existing delegate command parser tests remain unchanged.
+
+Do not implement browser collection in this stage.
+
+## Stage 2 — Add audit module scaffold and output planning
+
+Files:
+
+- `crates/trusted-server-cli/src/lib.rs`
+- `crates/trusted-server-cli/src/audit.rs`
+- `crates/trusted-server-cli/src/audit/collector.rs`
+
+Steps:
+
+1. Register `mod audit;` in `lib.rs` under the existing non-wasm module gate.
+2. Add collector data structs and `AuditCollector` trait.
+3. Add `AuditOutputPlan` in `audit.rs`:
+
+   ```rust
+   struct AuditOutputPlan {
+       js_assets_path: Option<PathBuf>,
+       config_path: Option<PathBuf>,
+   }
+   ```
+
+4. Add `parse_audit_url(value: &str) -> CliResult<Url>`.
+5. Add `resolve_output_plan(args: &AuditArgs) -> CliResult<AuditOutputPlan>`.
+6. Rules for `resolve_output_plan()`:
+   - reject both `no_js_assets` and `no_config`;
+   - default JS asset path to `js-assets.toml` unless disabled;
+   - default config path to `trusted-server.toml` unless disabled;
+   - resolve relative paths against `std::env::current_dir()`;
+   - preserve absolute paths;
+   - reject existing selected paths unless `force`;
+   - create no directories yet, or create only after all selected paths pass the
+     conflict check.
+7. Add `prepare_output_paths(plan)` or integrate directory creation after
+   successful preflight.
+8. Tests:
+   - URL parsing accepts HTTP/HTTPS;
+   - URL parsing rejects `file:`, `data:`, `chrome:`;
+   - both no-output flags reject with a clear message;
+   - default and custom paths resolve as expected;
+   - existing file fails without `--force`;
+   - existing file passes with `--force`;
+   - one conflicting path prevents all writes.
+
+Implementation note: keep path planning separate from browser collection so a
+fake collector can record whether it was called. Use that to prove conflicts
+short-circuit before collection.
+
+## Stage 3 — Port analyzer and artifact schema
+
+Files:
+
+- `crates/trusted-server-cli/src/audit.rs`
+- `crates/trusted-server-cli/src/audit/analyzer.rs`
+
+Steps:
+
+1. Add serializable artifact structs in `audit.rs`:
+   - `AssetParty`;
+   - `AuditedAsset`;
+   - `DetectedIntegration`;
+   - `AuditArtifact`;
+   - `AuditOutputs`.
+2. Port `analyze_collected_page()` from the old branch.
+3. Preserve these analysis inputs:
+   - rendered HTML `<script>` tags;
+   - browser-collected `document.scripts` entries;
+   - browser resource timing entries with resource type `script`,
+     case-insensitive.
+4. Preserve these analysis outputs:
+   - final audited URL;
+   - title from browser title or rendered `<title>` fallback;
+   - sorted/deduplicated assets;
+   - sorted detected integrations;
+   - warnings.
+5. Implement deterministic merge behavior:
+   - key assets by absolute URL string in `BTreeMap`;
+   - if an existing asset has `integration = None` and a later source detects an
+     integration, update the existing row;
+   - if an existing asset already has an integration, keep the first detected
+     integration.
+6. Preserve host-party classification:
+   - exact host match is first-party;
+   - dot-boundary subdomain relationship in either direction is first-party;
+   - otherwise third-party.
+7. Preserve warning behavior:
+   - carry collector warnings through;
+   - add redirect warning when requested and final URL differ;
+   - add malformed HTML script URL warnings;
+   - ignore malformed browser/resource URLs.
+8. Serialize artifact with `toml::to_string_pretty()`.
+9. Tests:
+   - title fallback/preference;
+   - redirect warning;
+   - HTML + DOM + resource timing merge;
+   - dedupe;
+   - dedupe updates integration from later evidence;
+   - relative script resolution against final URL;
+   - malformed HTML script URL warning;
+   - non-script resource timing ignored;
+   - party classification cases;
+   - deterministic order;
+   - TOML serialization has expected fields and kebab-case parties.
+
+## Stage 4 — Port integration detection
+
+Files:
+
+- `crates/trusted-server-cli/src/audit/analyzer.rs`
+
+Steps:
+
+1. Port URL detector behavior for:
+   - `google_tag_manager`;
+   - `gpt`;
+   - `didomi`;
+   - `datadome`;
+   - `permutive`;
+   - `lockr`;
+   - `prebid`.
+2. Port inline detector behavior:
+   - GTM regex: `\bGTM-[A-Z0-9]+\b`;
+   - case-insensitive markers for the other v1 integration IDs.
+3. Keep the detector implementation small and easy to extend. Prefer constants
+   or focused helper functions over spreading string literals through the
+   analyzer loop.
+4. Add `extract_gtm_container_id(artifact: &AuditArtifact) -> Option<String>`.
+5. Evidence precedence:
+   - first evidence per integration ID wins;
+   - GTM container ID evidence is preferred naturally when encountered first;
+   - if only URL evidence exists, extract GTM ID from the asset URL when
+     possible.
+6. Tests:
+   - GTM inline snippet detection;
+   - GTM URL ID extraction;
+   - GPT URL detection;
+   - Didomi URL detection;
+   - DataDome URL detection;
+   - Permutive URL detection;
+   - Lockr URL detection;
+   - Prebid URL detection;
+   - inline marker detection is case-insensitive;
+   - unrelated URLs/scripts do not detect integrations.
+
+Testing note: detector tests may use public vendor host/path patterns only where
+needed to prove the detector constants. Do not use real publisher/customer
+domains.
+
+## Stage 5 — Implement draft config generation against current template
+
+Files:
+
+- `crates/trusted-server-cli/src/audit.rs`
+- maybe `crates/trusted-server-cli/src/config_command.rs`
+
+Steps:
+
+1. Reuse the same embedded `trusted-server.example.toml` content as
+   `config init`.
+   - Current constant is private in `config_command.rs`.
+   - Either make a small `pub(crate) const EXAMPLE_CONFIG` available, or create a
+     tiny shared `template` helper to avoid duplicate `include_str!` paths.
+2. Generate draft config from the final audited URL, not the requested URL.
+3. Patch current template sentinels:
+
+   ```toml
+   domain = "example.com"
+   cookie_domain = ".example.com"
+   origin_url = "https://origin.example.com"
+   ```
+
+4. Set:
+   - `publisher.domain = <final host without port>`;
+   - `publisher.cookie_domain = ".<final host>"`;
+   - `publisher.origin_url = <final origin with non-default port preserved>`.
+5. Auto-enable only these integrations:
+   - GPT: set `[integrations.gpt].enabled = true`;
+   - Didomi: set `[integrations.didomi].enabled = true`;
+   - DataDome: set `[integrations.datadome].enabled = true`;
+   - GTM: set `[integrations.google_tag_manager].enabled = true` and replace
+     `container_id` only when a usable `GTM-...` ID is extracted.
+6. For GTM without a container ID, do not enable. Add a manual-review comment.
+7. For Permutive, Lockr, and Prebid, add manual-review comments.
+8. Do not add platform/provider/EdgeZero sections.
+9. Do not infer secrets, consent, auction bidders, request signing, stores, or
+   EdgeZero environment overlays.
+10. Keep the generated config readable and parseable TOML.
+
+Implementation detail for robust replacements:
+
+- Avoid global `enabled = false` replacement.
+- Use section-aware replacement helpers, for example:
+  - find `[integrations.gpt]` section and replace that section's first
+    `enabled = false` line;
+  - find `[integrations.google_tag_manager]` and replace both `enabled` and
+    `container_id` lines while preserving `upstream_url`.
+- If a required sentinel/section is missing, fail with an audit error explaining
+  which template section could not be updated.
+
+Tests:
+
+- final redirected URL drives config fields;
+- non-default port is preserved in `origin_url`;
+- GPT/Didomi/DataDome auto-enable;
+- GTM with ID auto-enables and sets container ID;
+- GTM without ID adds manual-review comment and stays disabled;
+- Prebid/Permutive/Lockr manual-review comments;
+- generated config parses as TOML;
+- no EdgeZero/provider sections are added.
+
+## Stage 6 — Implement production browser collector
+
+Files:
+
+- `crates/trusted-server-cli/src/audit/browser_collector.rs`
+
+Steps:
+
+1. Add `BrowserAuditCollector` implementing `AuditCollector`.
+2. Inside the sync trait method, create a current-thread Tokio runtime:
+
+   ```rust
+   tokio::runtime::Builder::new_current_thread()
+       .enable_all()
+       .build()
+   ```
+
+3. Find browser executable:
+   - PATH candidates:
+     - `google-chrome`;
+     - `google-chrome-stable`;
+     - `chromium`;
+     - `chromium-browser`;
+     - `chrome`;
+     - `Google Chrome`;
+     - `Google Chrome for Testing`.
+   - macOS fallback paths:
+     - `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`;
+     - `/Applications/Chromium.app/Contents/MacOS/Chromium`;
+     - `/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`.
+   - Linux fallback paths:
+     - `/usr/bin/google-chrome`;
+     - `/usr/bin/google-chrome-stable`;
+     - `/usr/bin/chromium`;
+     - `/usr/bin/chromium-browser`;
+     - `/snap/bin/chromium`.
+4. Launch headless Chrome/Chromium with a fresh profile.
+5. Spawn the chromiumoxide handler task and drain events until completion/error.
+6. Navigate to the target URL.
+7. Wait for the main document response.
+8. Validate navigation response:
+   - missing request => error;
+   - failure text => error;
+   - missing response => error;
+   - status in `200..400` => ok;
+   - otherwise error with status, status text, and response URL.
+9. Wait for settle:
+   - poll interval `250ms`;
+   - quiet period `750ms`;
+   - max wait `6s`;
+   - ready state must be `complete`;
+   - resource count must be stable for the quiet period.
+10. On settle timeout, push warning and continue.
+11. Collect:
+    - `page.url()`;
+    - `page.get_title()`;
+    - `page.content()`;
+    - `document.scripts` with `src` and inline text;
+    - `performance.getEntriesByType('resource')` with URL and initiator type.
+12. Map DOM scripts into `CollectedScriptTag`, filtering empty inline text.
+13. Map resource entries into `CollectedRequest` with `method = "GET"` and
+    `status = None`.
+14. Close the browser and surface close errors.
+15. Abort/await the handler task as in the old implementation.
+
+Tests:
+
+- keep helper functions small enough to unit-test without launching a browser;
+- test successful/failed navigation status helper;
+- test browser fallback list helpers if practical;
+- do not run real browser launch in default unit tests.
+
+Watch point: the spec requires an isolated fresh session. Confirm the chosen
+chromiumoxide config uses a temporary profile or does not reuse the user's
+profile. If needed, explicitly create a `TempDir` user data directory that lives
+for the browser session.
+
+## Stage 7 — Command orchestration and writes
+
+Files:
+
+- `crates/trusted-server-cli/src/audit.rs`
+- `crates/trusted-server-cli/src/run.rs`
+
+Steps:
+
+1. Implement:
+
+   ```rust
+   pub fn run_audit(
+       args: &AuditArgs,
+       collector: &dyn AuditCollector,
+       out: &mut dyn Write,
+   ) -> CliResult<()>;
+   ```
+
+2. Order of operations:
+   - validate no-output flags;
+   - parse URL;
+   - resolve/preflight output plan;
+   - collect page via injected collector;
+   - analyze collected page;
+   - serialize `js-assets.toml`;
+   - build draft config;
+   - create parent dirs for selected outputs;
+   - write selected outputs;
+   - print success summary.
+3. Use a helper `write_audit_outputs()` that receives already-built content and
+   selected paths.
+4. If directory creation or file write fails for one output, return an IO-flavored
+   CLI error with the path context.
+5. Success summary must match the spec:
+
+   ```text
+   Audited <final-url>
+   Title: <title-or-unknown>
+   JS assets: <count>
+   Third-party assets: <count>
+   Detected integrations: <none-or-comma-list>
+   Wrote: <paths>
+   ```
+
+6. Ensure integrations in summary are sorted by ID because artifact generation
+   is sorted.
+7. Keep warnings in `js-assets.toml`; no need to print warning list in v1.
+8. Add orchestration tests with a fake collector:
+   - writes both default outputs;
+   - writes only config with `--no-js-assets`;
+   - writes only assets with `--no-config`;
+   - output conflict prevents collector call;
+   - collector error writes no files;
+   - summary includes expected values;
+   - fake EdgeZero delegate remains unused.
+
+## Stage 8 — Docs and gitignore
+
+Files likely touched:
+
+- `.gitignore`
+- `README.md`
+- `docs/guide/getting-started.md`
+- possibly create or update `docs/guide/cli.md` if the base CLI pass added it
+- `docs/superpowers/specs/2026-06-16-edgezero-based-ts-audit-design.md` only if
+  implementation reveals a spec correction is needed
+
+Steps:
+
+1. Add `js-assets.toml` to `.gitignore` next to `trusted-server.toml`.
+2. Update README quick start only if it currently documents the new CLI command
+   set.
+3. Add operator docs for:
+   - Chrome/Chromium requirement;
+   - default generated files;
+   - `--no-config`, `--no-js-assets`, `--force`;
+   - draft config status and need to run `ts config validate` after editing;
+   - audit has no `--adapter` and does not push config.
+4. Ensure docs use example domains only.
+5. Run docs formatting for touched Markdown.
+
+## Stage 9 — Verification plan
+
+Run focused checks after implementing audit:
+
+```bash
+cargo fmt --all -- --check
+HOST_TARGET="$(rustc -vV | sed -n 's/^host: //p')"
+cargo test --package trusted-server-cli --target "$HOST_TARGET"
+cargo check --package trusted-server-cli --target "$HOST_TARGET"
+```
+
+Then run broader checks required by repository policy as time permits / before
+handoff:
+
+```bash
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+If docs are touched:
+
+```bash
+cd docs && npx prettier --check .
+```
+
+If adding `chromiumoxide` or changing workspace dependencies causes wasm-target
+resolution issues, first verify the host CLI target, then verify the workspace
+wasm/default target to make sure host-only dependencies do not leak into runtime
+crates.
+
+No default verification command should require Chrome/Chromium to be installed.
+
+## Test matrix summary
+
+| Area            | Tests                                                                                |
+| --------------- | ------------------------------------------------------------------------------------ |
+| Args            | parse audit URL/options; reject unsupported audit flags via clap.                    |
+| URL validation  | accept HTTP/HTTPS; reject file/data/chrome/malformed.                                |
+| Output planning | defaults, custom paths, absolute/relative, force, conflicts, no-output reject.       |
+| Analyzer        | title, redirects, merge, dedupe, sorting, party classification, warnings.            |
+| Detection       | GTM, GPT, Didomi, DataDome, Permutive, Lockr, Prebid URL/inline evidence.            |
+| Artifact        | TOML shape, optional fields, kebab-case party, deterministic output.                 |
+| Draft config    | final URL fields, integration edits, manual-review comments, parseable TOML.         |
+| Browser helpers | browser discovery fallback helpers, status validation, settle helper where possible. |
+| Orchestration   | fake collector writes selected outputs, summary, no EdgeZero calls.                  |
+
+## File-by-file implementation checklist
+
+### `crates/trusted-server-cli/Cargo.toml`
+
+- [ ] Add host-only audit dependencies.
+- [ ] Add dev dependencies only if tests need them beyond existing `tempfile`.
+
+### Root `Cargo.toml`
+
+- [ ] Add workspace dependencies for `chromiumoxide` and `scraper` if chosen.
+- [ ] Confirm dependency features remain host-only through crate-level target
+      dependency declarations.
+
+### `crates/trusted-server-cli/src/lib.rs`
+
+- [ ] Add `mod audit;` behind `#[cfg(not(target_arch = "wasm32"))]`.
+
+### `crates/trusted-server-cli/src/args.rs`
+
+- [ ] Add `AuditArgs`.
+- [ ] Add `Command::Audit(AuditArgs)`.
+- [ ] Add parser tests.
+
+### `crates/trusted-server-cli/src/run.rs`
+
+- [ ] Add `CliServices` or equivalent multi-service dispatch injection.
+- [ ] Wire production `BrowserAuditCollector`.
+- [ ] Dispatch `Command::Audit` to `audit::run_audit()`.
+- [ ] Add fake-collector orchestration tests.
+
+### `crates/trusted-server-cli/src/config_command.rs`
+
+- [ ] Expose the example config template as `pub(crate)` or move to a shared
+      helper so audit and config init use the same bytes.
+
+### `crates/trusted-server-cli/src/audit.rs`
+
+- [ ] Define artifact structs.
+- [ ] Implement URL parsing.
+- [ ] Implement output planning/preflight.
+- [ ] Implement draft config generation.
+- [ ] Implement output writes and success summary.
+- [ ] Add unit tests for config generation and output planning.
+
+### `crates/trusted-server-cli/src/audit/collector.rs`
+
+- [ ] Define collected page structs.
+- [ ] Define `AuditCollector` trait.
+- [ ] Add URL parsing helpers on `CollectedPage` if useful.
+
+### `crates/trusted-server-cli/src/audit/analyzer.rs`
+
+- [ ] Port analysis from old implementation.
+- [ ] Port/organize integration detectors.
+- [ ] Add analyzer and detector tests.
+
+### `crates/trusted-server-cli/src/audit/browser_collector.rs`
+
+- [ ] Implement browser discovery.
+- [ ] Implement headless browser collection.
+- [ ] Implement settle wait.
+- [ ] Implement navigation response validation.
+- [ ] Add browser-independent tests.
+
+### `.gitignore`
+
+- [ ] Add `js-assets.toml`.
+
+### Docs
+
+- [ ] Add/update CLI usage docs.
+- [ ] Add Chrome/Chromium requirement.
+- [ ] Add generated-file warnings.
+
+## Risk register
+
+| Risk                                                              | Mitigation                                                                                               |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `chromiumoxide` API/version drift from old branch                 | Pin a compatible version, port in a small stage, and keep browser code isolated.                         |
+| Browser deps leak into wasm/default builds                        | Keep deps under CLI host-target dependency table and modules under non-wasm gate.                        |
+| Output preflight still allows partial writes on late IO failure   | Preflight known conflicts first; document v1 does not require atomic replacement.                        |
+| Text replacement breaks when template changes                     | Use section-aware replacement helpers and fail with explicit missing-section errors.                     |
+| GTM is enabled without usable container ID                        | Implement explicit GTM ID extraction gate before enabling.                                               |
+| Detector string literals use real publisher/customer data         | Use only public vendor detector constants and example domains in tests/docs.                             |
+| Tests accidentally require Chrome                                 | Use fake collector for orchestration and unit-test helpers only.                                         |
+| Existing base CLI dispatch tests become awkward with two services | Introduce a small `CliServices` wrapper and adapt tests once rather than adding globals.                 |
+| Clippy warns about public items missing docs                      | Keep audit modules private where possible; add doc comments for any public crate-visible APIs as needed. |
+
+## Approved implementation choices
+
+The following choices were confirmed before implementation:
+
+1. Use `chromiumoxide` again for v1 browser collection.
+2. Add `js-assets.toml` to `.gitignore`.
+3. Keep no `--browser` override in v1.
+4. Use section-aware text edits against `trusted-server.example.toml` rather than
+   parsed-TOML rewriting.
+5. Add `CliServices` or equivalent service injection in `run.rs` so audit command
+   tests can use a fake collector.

--- a/docs/superpowers/specs/2026-06-16-edgezero-based-ts-audit-design.md
+++ b/docs/superpowers/specs/2026-06-16-edgezero-based-ts-audit-design.md
@@ -1,0 +1,1063 @@
+# Trusted Server CLI — Page Audit and Config Bootstrap
+
+**Date:** 2026-06-16
+**Status:** Draft design
+**Scope:** `ts audit` in the EdgeZero-backed Trusted Server product CLI
+**Related context:**
+
+- `docs/superpowers/specs/2026-06-16-edgezero-based-ts-cli-design.md`
+- `docs/superpowers/plans/2026-06-16-trusted-server-cli-respec-context.md`
+- Prior implementation on `feature/ts-cli`:
+  - `crates/trusted-server-cli/src/lib.rs`
+  - `crates/trusted-server-cli/src/audit.rs`
+  - `crates/trusted-server-cli/src/audit/analyzer.rs`
+  - `crates/trusted-server-cli/src/audit/browser_collector.rs`
+  - `crates/trusted-server-cli/src/audit/collector.rs`
+  - `docs/guide/cli.md`
+
+---
+
+## 1. Goal
+
+Add `ts audit` back to the new EdgeZero-backed Trusted Server CLI as a
+Trusted Server-specific browser audit and config-bootstrap command.
+
+`ts audit` loads a public publisher page in a real headless Chrome/Chromium
+browser, collects rendered script evidence, classifies JavaScript assets,
+detects known Trusted Server integrations, and writes local draft artifacts:
+
+```text
+js-assets.toml       # page/script audit artifact
+trusted-server.toml  # draft Trusted Server app config
+```
+
+The command is intentionally **not** an EdgeZero lifecycle command. It does not
+provision, push config, deploy, build, serve, authenticate, or resolve platform
+adapters. It runs inside the `ts` product CLI because its behavior is specific
+to Trusted Server onboarding and integration discovery.
+
+The rebuilt command should preserve the old `feature/ts-cli` user-facing
+behavior unless this spec explicitly tightens it:
+
+```bash
+ts audit https://publisher.example
+
+ts audit https://publisher.example --no-config
+
+ts audit https://publisher.example \
+  --js-assets audit/js-assets.toml \
+  --config audit/trusted-server.toml
+```
+
+The audit output is a **starter draft**, not a production-ready deployment. The
+operator must review the generated config, replace placeholders/secrets, validate
+it with `ts config validate`, then push it through the separate EdgeZero-backed
+config workflow.
+
+---
+
+## 2. Non-goals
+
+The initial `ts audit` does **not** do any of the following:
+
+- delegate to EdgeZero adapters;
+- require `--adapter`;
+- read, validate, generate, or modify `edgezero.toml`;
+- push config-store entries;
+- write secret-store entries;
+- provision platform resources;
+- infer platform store names or runtime config-store settings;
+- validate that the generated `trusted-server.toml` is production-ready;
+- replace manual publisher configuration review;
+- crawl more than the requested page;
+- run Lighthouse or performance scoring;
+- inspect non-script asset classes as first-class artifacts;
+- capture request/response bodies, cookies, local storage, session storage, or
+  arbitrary page data;
+- support authenticated pages, user profiles, or inherited browser cookies;
+- provide a browser UI/headful mode;
+- support remote browser execution;
+- add a plugin system for third-party audit detectors;
+- create tickets, docs pages, or reports beyond the local TOML artifacts;
+- support JSON command output in v1.
+
+---
+
+## 3. Relationship to the EdgeZero-backed CLI
+
+`ts audit` is a product-level onboarding command that lives beside the
+EdgeZero-backed command surface defined in the base CLI spec:
+
+```text
+ts config init
+ts config validate
+ts config push --adapter <adapter>
+ts auth login --adapter <adapter>
+ts provision --adapter <adapter>
+ts serve --adapter <adapter>
+ts build --adapter <adapter>
+ts deploy --adapter <adapter>
+ts audit <url>
+```
+
+The boundary is:
+
+| Command family                         | Owner                                     | Platform behavior |
+| -------------------------------------- | ----------------------------------------- | ----------------- |
+| `ts auth/provision/serve/build/deploy` | EdgeZero delegates                        | Yes               |
+| `ts config push`                       | Trusted Server transform + EdgeZero write | Yes               |
+| `ts audit`                             | Trusted Server CLI                        | No                |
+
+`ts audit` may share generic CLI infrastructure with the base CLI crate:
+argument parsing, path resolution, output helpers, error formatting, and
+`trusted-server.example.toml` access. It must not share or introduce platform
+adapter logic.
+
+Implementation rule:
+
+> Adding or changing `ts audit` must not require changes to EdgeZero adapter
+> traits, EdgeZero platform manifests, or runtime platform stores.
+
+---
+
+## 4. Command surface
+
+```bash
+ts audit [options] <url>
+```
+
+| Argument / option    | Default               | Description                                             |
+| -------------------- | --------------------- | ------------------------------------------------------- |
+| `<url>`              | required              | Public `http` or `https` page URL to audit.             |
+| `--js-assets <path>` | `js-assets.toml`      | Write the JavaScript asset audit artifact to this path. |
+| `--config <path>`    | `trusted-server.toml` | Write the draft Trusted Server config to this path.     |
+| `--no-js-assets`     | `false`               | Do not write the JavaScript asset audit artifact.       |
+| `--no-config`        | `false`               | Do not write the draft Trusted Server config.           |
+| `--force`            | `false`               | Overwrite existing output files.                        |
+
+Rules:
+
+- `<url>` must parse as a URL and must use the `http` or `https` scheme.
+- Relative output paths resolve from the current working directory.
+- Absolute output paths are used as-is.
+- Parent directories are created for selected outputs.
+- Existing output files are not overwritten unless `--force` is passed.
+- `--no-js-assets` and `--no-config` may each be used alone.
+- Passing both `--no-js-assets` and `--no-config` is an argument error because
+  the command would have no local output to write.
+- `--force` applies to every selected output path.
+- There is no `--adapter`, `--manifest`, `--store`, `--local`, `--dry-run`, or
+  `--json` option for audit in v1.
+
+Recommended fail-fast order:
+
+1. Parse arguments.
+2. Validate `<url>`.
+3. Resolve the selected output paths.
+4. Preflight all selected output paths for overwrite conflicts.
+5. Run the browser audit.
+6. Build all output content in memory.
+7. Write selected output files.
+8. Print the success summary.
+
+This improves the old implementation by avoiding a long browser run when output
+paths are already known to be unwritable, and by avoiding partial writes when one
+selected path conflicts.
+
+---
+
+## 5. Output file model
+
+### 5.1 Generated files
+
+By default, `ts audit` writes:
+
+```text
+js-assets.toml
+trusted-server.toml
+```
+
+`js-assets.toml` is a local audit artifact. It contains URL inventory and
+integration evidence for the audited page.
+
+`trusted-server.toml` is a draft app config generated from
+`trusted-server.example.toml` and patched with values inferred from the final
+audited page URL and detected integrations.
+
+### 5.2 Source control expectations
+
+The default output paths may contain publisher hostnames, vendor inventory, and
+configuration placeholders. They are operator-owned artifacts, not generic sample
+files.
+
+The repository should ignore the default operator-owned outputs:
+
+```text
+trusted-server.toml
+js-assets.toml
+```
+
+Custom paths under an `audit/` directory are allowed. Project documentation
+should warn operators to review generated audit artifacts before committing them,
+because they may describe a real publisher page.
+
+### 5.3 Draft config status
+
+The generated config is expected to be syntactically valid TOML, but it is not
+required to pass production validation immediately.
+
+Reasons it may still fail `ts config validate`:
+
+- the starter template can include placeholder secrets;
+- detected integrations may need publisher-specific IDs or endpoints;
+- non-detected integrations may still need manual enablement or disablement;
+- publisher-specific consent, auction, proxy, and request-signing fields cannot
+  be inferred reliably from one page load.
+
+The success summary and docs must call it a draft.
+
+---
+
+## 6. Browser collection pipeline
+
+`ts audit` uses a real headless Chrome/Chromium browser because a static HTML
+fetch misses scripts injected by tag managers, consent managers, ad stacks, and
+other runtime code.
+
+The v1 collector preserves the old `feature/ts-cli` behavior:
+
+1. Locate a local Chrome/Chromium executable.
+2. Launch a fresh headless browser session.
+3. Open a new page at `about:blank`.
+4. Navigate to the requested URL.
+5. Wait for the main document navigation response.
+6. Reject failed navigations and non-success HTTP statuses.
+7. Wait for the page to settle.
+8. Read the final page URL.
+9. Read the page title.
+10. Read the rendered HTML.
+11. Read `document.scripts` from the rendered DOM.
+12. Read browser resource timing entries.
+13. Close the browser.
+14. Analyze the collected page data.
+
+### 6.1 Browser executable resolution
+
+The collector checks common Chrome/Chromium executable names on `PATH`, then
+standard local install locations for supported host operating systems.
+
+The old implementation checked PATH names equivalent to:
+
+```text
+google-chrome
+google-chrome-stable
+chromium
+chromium-browser
+chrome
+Google Chrome
+Google Chrome for Testing
+```
+
+It also checked common macOS and Linux application paths.
+
+The rebuilt implementation should preserve that behavior. Windows-specific
+fallback paths are not required for v1, but PATH discovery may work on Windows if
+the chosen browser automation dependency supports the host.
+
+If no browser is found, fail with a clear hint:
+
+```text
+Chrome/Chromium was not found on PATH or in the standard local install locations checked by `ts audit`. Install a local Chrome or Chromium binary before running `ts audit`.
+```
+
+### 6.2 Browser session isolation
+
+The browser session must be fresh and isolated:
+
+- do not use the user's normal browser profile;
+- do not reuse persistent cookies or local storage;
+- do not load extensions;
+- do not require interactive login;
+- do not persist browser state after the command exits.
+
+This keeps `ts audit` suitable for public-page onboarding and reduces the chance
+of writing user-specific data into artifacts.
+
+### 6.3 Navigation validation
+
+The main document navigation is successful when the browser reports a status in
+this range:
+
+```text
+200 <= status < 400
+```
+
+Redirects are allowed. The final URL after redirects is the canonical audited URL
+for output artifacts and draft config generation.
+
+Failures are fatal when:
+
+- the browser does not report a main document response;
+- the main request has browser failure text;
+- the main response is missing;
+- the main response status is outside `200..399`;
+- browser launch, navigation, evaluation, or close fails.
+
+Subresource failures do not fail the command in v1 because the old collector only
+read resource timing data and did not capture reliable per-resource status codes.
+
+### 6.4 Page settle heuristic
+
+After navigation, wait for the page to settle using the old constants:
+
+| Constant            | Value   |
+| ------------------- | ------- |
+| settle quiet period | `750ms` |
+| poll interval       | `250ms` |
+| max wait            | `6s`    |
+
+At each poll:
+
+1. Read `document.readyState`.
+2. Read `performance.getEntriesByType('resource').length`.
+3. If `readyState == "complete"` and the resource count has remained stable for
+   the quiet period, the page is settled.
+
+If the page does not settle before the max wait, continue with a warning instead
+of failing:
+
+```text
+browser audit timed out while waiting for the page to settle; results may be partial
+```
+
+No CLI flags are defined for these timings in v1.
+
+### 6.5 Collected page data
+
+The collector produces this internal data model:
+
+```rust
+struct CollectedPage {
+    requested_url: String,
+    final_url: String,
+    page_title: Option<String>,
+    html: String,
+    script_tags: Vec<CollectedScriptTag>,
+    network_requests: Vec<CollectedRequest>,
+    warnings: Vec<String>,
+}
+
+struct CollectedScriptTag {
+    src: Option<String>,
+    inline_text: Option<String>,
+}
+
+struct CollectedRequest {
+    url: String,
+    method: String,
+    resource_type: Option<String>,
+    status: Option<u16>,
+}
+```
+
+For browser resource timing entries:
+
+- `url` is the resource entry name;
+- `method` is `GET` in v1;
+- `resource_type` is the resource entry initiator type;
+- `status` is `None` in v1.
+
+The public `js-assets.toml` artifact must not include raw rendered HTML or raw
+inline script text.
+
+---
+
+## 7. Analysis pipeline
+
+The analyzer converts `CollectedPage` into an `AuditArtifact`.
+
+Pipeline:
+
+1. Parse `requested_url` and `final_url` as URLs.
+2. Parse rendered HTML as a document.
+3. Derive a title from the HTML `<title>` element.
+4. Prefer the browser-reported title when it is non-empty; otherwise use the
+   derived HTML title.
+5. Start with collector warnings.
+6. If requested URL and final URL differ, append a redirect warning.
+7. Inspect script elements from rendered HTML.
+8. Inspect browser-collected `document.scripts` entries.
+9. Inspect resource timing entries whose type is `script`, case-insensitive.
+10. Resolve, classify, detect, and deduplicate script assets.
+11. Sort assets and integrations deterministically.
+12. Count total JavaScript assets and third-party assets.
+
+### 7.1 Script sources
+
+Use three evidence sources because each catches different browser behavior:
+
+| Source                       | Purpose                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| Rendered HTML `<script src>` | Captures scripts present in final DOM markup.                               |
+| Browser `document.scripts`   | Captures normalized script URLs and inline scripts after runtime mutations. |
+| Resource timing entries      | Captures dynamically loaded script network resources.                       |
+
+For HTML `<script src>` values:
+
+- resolve relative URLs against the final page URL;
+- if resolution fails, append a warning and continue.
+
+For browser `document.scripts` values:
+
+- `src` should normally already be absolute;
+- parse absolute script URLs;
+- ignore malformed entries rather than failing the whole audit.
+
+For resource timing entries:
+
+- only entries with resource type `script`, case-insensitive, are treated as JS
+  assets;
+- parse absolute resource URLs;
+- ignore malformed entries rather than failing the whole audit.
+
+### 7.2 Deduplication and ordering
+
+Assets are deduplicated by their absolute URL string after resolution/parsing.
+
+Output order must be deterministic:
+
+- assets sorted lexicographically by URL;
+- detected integrations sorted lexicographically by integration ID;
+- warnings preserved in append order.
+
+If the same asset URL is observed from multiple sources, write one asset row. If
+any source identifies the asset's integration, the final row should contain that
+integration ID.
+
+The last sentence is a slight tightening over the old implementation, which kept
+the first inserted row unchanged. The user-visible intent is still the same:
+produce one best-effort row per script URL.
+
+### 7.3 Party classification
+
+Each asset is classified as either:
+
+```text
+first-party
+third-party
+```
+
+Classification is based only on the final page host and asset host.
+
+An asset is first-party when any of these are true:
+
+- `asset_host == page_host`;
+- `asset_host` is a dot-boundary subdomain of `page_host`;
+- `page_host` is a dot-boundary subdomain of `asset_host`.
+
+Otherwise it is third-party.
+
+This intentionally preserves the old lightweight host relationship heuristic. It
+does not use the Public Suffix List and can be imperfect for complex delegated
+subdomain setups. Those cases should be corrected manually by the operator when
+reviewing `js-assets.toml`.
+
+---
+
+## 8. Integration detection
+
+`ts audit` detects integrations from two evidence types:
+
+1. script URL host/path patterns;
+2. inline script text markers.
+
+The initial detector set matches the old implementation:
+
+| Integration ID       | URL evidence                          | Inline evidence                     | Draft config action                           |
+| -------------------- | ------------------------------------- | ----------------------------------- | --------------------------------------------- |
+| `google_tag_manager` | Known tag-manager script URL patterns | `GTM-...` container ID pattern      | Enable only when a container ID is extracted. |
+| `gpt`                | Known GPT script URL patterns         | Case-insensitive `gpt` marker       | Enable `[integrations.gpt]`.                  |
+| `didomi`             | Known Didomi script URL patterns      | Case-insensitive `didomi` marker    | Enable `[integrations.didomi]`.               |
+| `datadome`           | Known DataDome script URL patterns    | Case-insensitive `datadome` marker  | Enable `[integrations.datadome]`.             |
+| `permutive`          | Known Permutive script URL patterns   | Case-insensitive `permutive` marker | Add manual-review comment.                    |
+| `lockr`              | Known Lockr script URL patterns       | Case-insensitive `lockr` marker     | Add manual-review comment.                    |
+| `prebid`             | Known Prebid script URL patterns      | Case-insensitive `prebid` marker    | Add manual-review comment.                    |
+
+The exact public vendor host/path substrings should be ported from the old
+`feature/ts-cli` analyzer into runtime detector constants. Documentation and
+examples should use `example` hostnames unless they are testing detector
+constants directly.
+
+### 8.1 URL detection
+
+URL detection is best-effort and case-insensitive over the URL host and path.
+Query strings can still be inspected separately for IDs such as a GTM container
+ID.
+
+When URL detection finds an integration:
+
+- set `asset.integration` to that integration ID;
+- add a `detected_integrations` entry if one does not already exist;
+- use the script URL string as evidence.
+
+### 8.2 Inline detection
+
+Inline script text is inspected only for small integration markers. It is not
+written to the audit artifact.
+
+GTM container IDs are detected with the old shape:
+
+```text
+GTM-[A-Z0-9]+
+```
+
+Other v1 inline detectors are case-insensitive substring checks for the
+integration IDs listed above.
+
+When inline detection finds an integration:
+
+- add a `detected_integrations` entry if one does not already exist;
+- use the container ID as GTM evidence when available;
+- otherwise use a concise marker such as `inline script matched <integration>`.
+
+### 8.3 Evidence precedence
+
+For each integration ID, keep the first evidence string encountered in the
+analysis pipeline. Because output is sorted by integration ID, the evidence order
+should not affect TOML ordering, only the evidence value.
+
+### 8.4 Extensibility
+
+The detector implementation should be a small data-driven table or a set of
+focused helper functions so future integrations can be added without changing the
+collector.
+
+Do not add sourcepoint, APS, ad server, consent-string, ad slot, or bidder
+configuration inference in v1 unless there is an explicit follow-up spec. The v1
+requirement is to preserve the old detector set.
+
+---
+
+## 9. Audit artifact schema
+
+`js-assets.toml` is the pretty TOML serialization of this schema:
+
+```rust
+struct AuditArtifact {
+    audited_url: String,
+    page_title: Option<String>,
+    js_asset_count: usize,
+    third_party_asset_count: usize,
+    detected_integrations: Vec<DetectedIntegration>,
+    assets: Vec<AuditedAsset>,
+    warnings: Vec<String>,
+}
+
+struct DetectedIntegration {
+    id: String,
+    evidence: String,
+}
+
+struct AuditedAsset {
+    kind: String,
+    url: String,
+    host: String,
+    party: AssetParty,
+    integration: Option<String>,
+}
+
+enum AssetParty {
+    FirstParty,  // serialized as "first-party"
+    ThirdParty, // serialized as "third-party"
+}
+```
+
+Field rules:
+
+- `audited_url` is the final URL after redirects.
+- `page_title` is omitted when unknown.
+- `js_asset_count` is `assets.len()`.
+- `third_party_asset_count` counts assets whose `party` is `third-party`.
+- `detected_integrations` contains one row per detected integration ID.
+- `assets` contains one row per deduplicated script URL.
+- `kind` is `script` for every v1 asset row.
+- `host` is the asset URL host, or an empty string when unavailable.
+- `integration` is omitted when no integration is detected for the asset.
+- `warnings` is an array of human-readable warning strings.
+
+No `schema_version` field is included in v1 so the artifact remains compatible
+with the old `feature/ts-cli` shape. If a future schema version is added, it
+should be additive and documented in a migration note.
+
+Example shape using non-real hosts:
+
+```toml
+audited_url = "https://www.publisher.example/article"
+page_title = "Example Publisher"
+js_asset_count = 2
+third_party_asset_count = 1
+warnings = []
+
+[[detected_integrations]]
+id = "gpt"
+evidence = "https://ads-vendor.example/tag/js/gpt.js"
+
+[[detected_integrations]]
+id = "google_tag_manager"
+evidence = "GTM-ABC123"
+
+[[assets]]
+kind = "script"
+url = "https://www.publisher.example/app.js"
+host = "www.publisher.example"
+party = "first-party"
+
+[[assets]]
+kind = "script"
+url = "https://ads-vendor.example/tag/js/gpt.js"
+host = "ads-vendor.example"
+party = "third-party"
+integration = "gpt"
+```
+
+---
+
+## 10. Draft config generation
+
+`trusted-server.toml` output is produced by taking the
+`trusted-server.example.toml` starter template and applying audit-derived edits.
+
+The generated file should preserve the starter template's comments and ordering
+as much as possible. Text replacement is acceptable if the template has stable
+sentinel values. A parsed-TOML implementation is also acceptable if it preserves
+all required fields and produces a readable draft.
+
+### 10.1 URL-derived fields
+
+Use the final audited URL, not the originally requested URL.
+
+From final URL:
+
+| Config field              | Value                                        |
+| ------------------------- | -------------------------------------------- |
+| `publisher.domain`        | final URL host without port                  |
+| `publisher.cookie_domain` | `.<host>`                                    |
+| `publisher.origin_url`    | final URL origin, including non-default port |
+
+Examples:
+
+| Final URL                                 | `publisher.domain`      | `publisher.cookie_domain` | `publisher.origin_url`               |
+| ----------------------------------------- | ----------------------- | ------------------------- | ------------------------------------ |
+| `https://publisher.example/page`          | `publisher.example`     | `.publisher.example`      | `https://publisher.example`          |
+| `https://www.publisher.example:8443/path` | `www.publisher.example` | `.www.publisher.example`  | `https://www.publisher.example:8443` |
+
+If the final URL is missing a host, fail the audit as an internal audit error.
+This should not happen after `<url>` validation for normal `http`/`https` URLs.
+
+The command does not try to infer an apex cookie domain. Operators must review
+and adjust `publisher.cookie_domain` for their domain policy.
+
+### 10.2 Integration-derived edits
+
+Detected integrations update only known starter-template sections.
+
+| Detection                                 | Draft config edit                                                                   |
+| ----------------------------------------- | ----------------------------------------------------------------------------------- |
+| `gpt`                                     | Set `[integrations.gpt].enabled = true`.                                            |
+| `didomi`                                  | Set `[integrations.didomi].enabled = true`.                                         |
+| `datadome`                                | Set `[integrations.datadome].enabled = true`.                                       |
+| `google_tag_manager` with container ID    | Set `[integrations.google_tag_manager].enabled = true` and `container_id = "<id>"`. |
+| `google_tag_manager` without container ID | Do not enable automatically; add manual-review comment.                             |
+| `permutive`                               | Add manual-review comment.                                                          |
+| `lockr`                                   | Add manual-review comment.                                                          |
+| `prebid`                                  | Add manual-review comment.                                                          |
+
+Manual-review comments are appended near the end of the draft config:
+
+```toml
+# Audit findings requiring manual review
+# - Detected prebid; review the corresponding [integrations.prebid] section before enabling it.
+# - Detected permutive; review the corresponding [integrations.permutive] section before enabling it.
+```
+
+This preserves the old behavior for Permutive, Lockr, and Prebid while tightening
+GTM handling: GTM should only be enabled when a usable container ID was actually
+extracted.
+
+### 10.3 What audit must not change
+
+`ts audit` must not:
+
+- remove starter-template sections;
+- disable starter-template defaults;
+- invent auction bidder settings;
+- infer consent policy;
+- infer request-signing settings;
+- infer secret values;
+- infer platform store names;
+- add `[providers]` sections;
+- write EdgeZero manifest fields;
+- write environment overlays.
+
+The command may only patch the fields listed in this section and append
+manual-review comments.
+
+---
+
+## 11. Human output
+
+On success, print a concise summary to stdout:
+
+```text
+Audited https://www.publisher.example/article
+Title: Example Publisher
+JS assets: 12
+Third-party assets: 8
+Detected integrations: google_tag_manager, gpt, prebid
+Wrote: /path/to/js-assets.toml, /path/to/trusted-server.toml
+```
+
+Rules:
+
+- `Audited` uses the final URL after redirects.
+- `Title` uses `<unknown>` when no page title is found.
+- `JS assets` is the artifact `js_asset_count`.
+- `Third-party assets` is the artifact `third_party_asset_count`.
+- `Detected integrations` is `none` when empty, otherwise comma-separated IDs in
+  deterministic order.
+- `Wrote` is `none` only if future command variants allow no files; in v1, both
+  `--no-js-assets` and `--no-config` are rejected, so success should write at
+  least one file.
+
+Warnings are written into `js-assets.toml`. The success summary does not need to
+print them unless a future UX pass adds a warning count.
+
+---
+
+## 12. Error behavior and exit codes
+
+`ts audit` follows the base CLI exit code policy:
+
+| Exit code | Meaning                                          |
+| --------- | ------------------------------------------------ |
+| `0`       | Audit completed and selected files were written. |
+| `1`       | Audit failed.                                    |
+
+No cancellation exit code is needed because `ts audit` has no interactive prompt.
+
+### 12.1 Argument errors
+
+| Failure                              | Message guidance                                |
+| ------------------------------------ | ----------------------------------------------- |
+| invalid URL                          | include the invalid value and parser error      |
+| unsupported scheme                   | say `ts audit` only supports `http` and `https` |
+| both outputs disabled                | say there is nothing to do                      |
+| output path exists without `--force` | say refusing to overwrite and suggest `--force` |
+
+### 12.2 Browser/audit errors
+
+| Failure                    | Message guidance                                           |
+| -------------------------- | ---------------------------------------------------------- |
+| browser missing            | install Chrome or Chromium locally                         |
+| browser launch failed      | include browser automation error context                   |
+| navigation failed          | include requested URL context                              |
+| main response missing      | say the browser did not capture the main document response |
+| main status not `200..399` | include status, status text, and response URL              |
+| page evaluation failed     | include which data collection step failed                  |
+| browser close failed       | report close failure; do not silently ignore it            |
+
+### 12.3 Non-fatal warnings
+
+Warnings do not cause a non-zero exit:
+
+- page settle timeout;
+- requested URL redirected to final URL;
+- individual malformed script URLs in rendered HTML.
+
+Warnings are stored in the artifact and should be visible during review.
+
+---
+
+## 13. Security and privacy notes
+
+`ts audit` intentionally loads a real public web page and allows that page's
+scripts to execute in headless Chromium. Treat it as an operator-controlled
+onboarding tool, not an unattended crawler.
+
+Required safeguards:
+
+- use an isolated temporary browser profile;
+- do not use the operator's personal browser profile;
+- do not persist cookies or storage;
+- do not write raw inline script bodies;
+- do not write rendered HTML;
+- do not write request or response bodies;
+- do not write browser cookies, local storage, session storage, or form values;
+- do not print generated config values that may contain secrets;
+- do not contact any platform APIs;
+- do not upload artifacts anywhere.
+
+The artifact still contains URL inventory. Operators should treat it as
+potentially sensitive publisher/vendor information.
+
+Docs, tests, and committed fixtures should use `example` domains and fictional
+publisher data. Runtime detector constants may contain the public vendor
+host/path patterns required for actual detection.
+
+---
+
+## 14. Implementation architecture
+
+The base CLI spec owns the crate and binary. `ts audit` should be implemented as
+an internal module of the host-target CLI crate, not as part of
+`trusted-server-core` or any wasm-target adapter crate.
+
+Suggested module layout:
+
+```text
+crates/trusted-server-cli/src/
+  audit.rs              # public command orchestration and output writing
+  audit/
+    collector.rs        # collected data structs and collector trait
+    browser_collector.rs# Chrome/Chromium implementation
+    analyzer.rs         # artifact analysis and integration detection
+```
+
+### 14.1 Host-only dependencies
+
+Host-only browser dependencies are allowed in `trusted-server-cli` only.
+
+Do not add browser automation, Tokio runtime, `which`, or scraper dependencies to
+runtime crates that build for `wasm32-wasip1`.
+
+The prior implementation used:
+
+- `chromiumoxide` for browser automation;
+- `tokio` current-thread runtime inside the sync command handler;
+- `scraper` for rendered HTML parsing;
+- `regex` for GTM ID detection;
+- `url` for URL parsing/resolution;
+- `toml`/`serde` for artifact serialization.
+
+Reusing those dependencies is acceptable. Replacing `chromiumoxide` is also
+acceptable if the command preserves the same collection behavior and tests can
+run without a real browser.
+
+### 14.2 Testability boundary
+
+Use a collector abstraction so unit tests can feed synthetic `CollectedPage`
+values directly into the analyzer and draft-config generator.
+
+Unit tests must not require a real browser. Browser smoke tests, if added, should
+be ignored by default or feature-gated.
+
+Recommended orchestration shape:
+
+```rust
+trait AuditCollector {
+    fn collect_page(&self, target_url: &Url) -> Result<CollectedPage, Report<CliError>>;
+}
+
+fn perform_audit_with_collector(
+    collector: &dyn AuditCollector,
+    target_url: &Url,
+) -> Result<AuditOutputs, Report<CliError>>;
+```
+
+The production command uses the browser collector. Tests use a fake collector.
+
+### 14.3 Output preflight and writes
+
+Build an `AuditOutputPlan` before launching the browser:
+
+```rust
+struct AuditOutputPlan {
+    js_assets_path: Option<PathBuf>,
+    config_path: Option<PathBuf>,
+    force: bool,
+}
+```
+
+The plan should:
+
+- reject both paths disabled;
+- resolve defaults;
+- check overwrite conflicts for all selected paths;
+- avoid writing anything until all output content is ready.
+
+Atomic file replacement is not required in v1, but avoiding partial writes from
+known path conflicts is required.
+
+---
+
+## 15. Tests
+
+### 15.1 CLI arguments and path planning
+
+- `ts audit <http-url>` parses.
+- `ts audit <https-url>` parses.
+- non-HTTP schemes are rejected.
+- malformed URLs are rejected.
+- both `--no-js-assets` and `--no-config` are rejected.
+- default paths resolve to `js-assets.toml` and `trusted-server.toml` under the
+  current working directory.
+- custom `--js-assets` and `--config` paths are honored.
+- parent directories are created for selected outputs.
+- existing outputs are rejected without `--force`.
+- existing outputs are overwritten with `--force`.
+- if one selected output exists and another does not, no file is written before
+  the command reports the overwrite conflict.
+
+### 15.2 Browser collector units
+
+- browser executable discovery finds PATH candidates.
+- browser executable discovery checks supported fallback paths.
+- missing browser produces the install hint.
+- navigation statuses `200`, `302`, and `399` are accepted.
+- navigation statuses below `200` and at or above `400` are rejected.
+- missing main document response is rejected.
+- failed main document request is rejected.
+- settle timeout returns a warning, not an error.
+
+Browser-launch integration tests should be opt-in and skipped by default.
+
+### 15.3 Analyzer
+
+- rendered HTML `<title>` is used when browser title is absent.
+- browser title wins over rendered HTML title when present.
+- requested-to-final URL redirect adds a warning.
+- relative script URLs resolve against the final URL.
+- malformed script URLs add warnings and do not fail the audit.
+- HTML script tags, browser script tags, and script resource timing entries are
+  merged.
+- duplicate script URLs produce one asset row.
+- duplicate script URLs preserve detected integration when any source detects it.
+- assets are sorted by URL.
+- integrations are sorted by ID.
+- first-party exact host match is classified as `first-party`.
+- first-party subdomain relationship is classified as `first-party`.
+- unrelated host is classified as `third-party`.
+- non-script resource timing entries are ignored.
+
+### 15.4 Integration detection
+
+- GTM container IDs are extracted from inline script evidence.
+- GTM container IDs are extracted from script URLs when present.
+- GPT URL evidence detects `gpt`.
+- Didomi URL evidence detects `didomi`.
+- DataDome URL evidence detects `datadome`.
+- Permutive URL evidence detects `permutive`.
+- Lockr URL evidence detects `lockr`.
+- Prebid URL evidence detects `prebid`.
+- inline markers detect `gpt`, `didomi`, `datadome`, `permutive`, `lockr`, and
+  `prebid` case-insensitively.
+- detector tests should avoid real publisher domains.
+
+### 15.5 Artifact serialization
+
+- `js-assets.toml` includes `audited_url`, counts, integrations, assets, and
+  warnings.
+- `page_title` is omitted when unknown.
+- `asset.integration` is omitted when unknown.
+- `party` serializes as `first-party` or `third-party`.
+- `js_asset_count` equals the number of asset rows.
+- `third_party_asset_count` equals the number of third-party asset rows.
+- output is deterministic for the same collected input.
+
+### 15.6 Draft config generation
+
+- final redirected URL is used for config fields.
+- `publisher.domain` uses final host without port.
+- `publisher.cookie_domain` uses `.<host>`.
+- `publisher.origin_url` preserves non-default port.
+- GPT detection enables `[integrations.gpt]`.
+- Didomi detection enables `[integrations.didomi]`.
+- DataDome detection enables `[integrations.datadome]`.
+- GTM detection with container ID enables Google Tag Manager and sets
+  `container_id`.
+- GTM detection without container ID does not enable Google Tag Manager and adds
+  a manual-review comment.
+- Permutive, Lockr, and Prebid detections add manual-review comments.
+- no platform/provider/EdgeZero sections are added.
+- generated TOML parses successfully.
+
+### 15.7 Command orchestration
+
+Using a fake collector:
+
+- selected outputs are written on success.
+- `--no-js-assets` writes only config.
+- `--no-config` writes only assets.
+- stdout summary includes final URL, title, counts, integrations, and paths.
+- collector warnings are present in `js-assets.toml`.
+- no EdgeZero delegate is invoked.
+- no platform API is contacted.
+
+---
+
+## 16. Implementation plan
+
+### Stage 1 — Wire command into the base CLI
+
+- Add `AuditArgs` to the new `ts` command tree.
+- Add `Command::Audit(AuditArgs)` dispatch.
+- Reuse base CLI output and error formatting helpers.
+- Add URL parsing/validation.
+- Add output-path planning and overwrite preflight.
+
+### Stage 2 — Port audit data model and analyzer
+
+- Add `CollectedPage`, `CollectedScriptTag`, and `CollectedRequest`.
+- Add `AuditArtifact`, `AuditedAsset`, `DetectedIntegration`, and `AssetParty`.
+- Port analyzer behavior from `feature/ts-cli`.
+- Port integration detector behavior from `feature/ts-cli`.
+- Add deterministic sorting/deduplication.
+- Add analyzer and artifact serialization tests.
+
+### Stage 3 — Port draft config generation
+
+- Read from the new `trusted-server.example.toml` template.
+- Patch URL-derived publisher fields from the final URL.
+- Enable only the supported auto-enable integrations.
+- Append manual-review comments for inferred-only integrations.
+- Keep generated config as a draft.
+- Add draft config tests.
+
+### Stage 4 — Port browser collector
+
+- Add host-only browser automation dependencies to `trusted-server-cli`.
+- Implement browser discovery.
+- Implement fresh headless browser launch.
+- Implement navigation validation and settle wait.
+- Collect final URL, title, rendered HTML, script tags, and resource timing
+  entries.
+- Ensure browser close errors are surfaced.
+- Add unit tests around browser-independent helper functions.
+
+### Stage 5 — Docs and verification
+
+- Document `ts audit` in the CLI guide.
+- Document Chrome/Chromium requirement.
+- Document generated files and draft-config caveat.
+- Add default generated artifact path to `.gitignore` if not already ignored.
+- Run host-target CLI tests.
+- Run workspace formatting and linting required by the base CLI implementation
+  work.
+
+---
+
+## 17. Open follow-ups outside this spec
+
+- Add `--browser <path>` or `TS_AUDIT_BROWSER` override for non-standard Chrome
+  installs.
+- Add `--timeout` or named audit profiles for slow pages.
+- Add `--json` machine-readable command summary.
+- Add schema versioning for `js-assets.toml`.
+- Add Sourcepoint, APS, ad server, or additional integration detectors.
+- Add optional HAR export with explicit user opt-in.
+- Add authenticated audit support using an explicitly provided isolated browser
+  profile.
+- Add multi-page crawl support.
+- Add richer config bootstrap for consent, auction, bidder, and proxy settings.
+- Add a command to merge audit findings into an existing config instead of
+  writing a fresh draft.


### PR DESCRIPTION
## Summary

- Adds `ts audit` as a Trusted Server-specific page audit command on top of the base CLI.
- Collects rendered page/script evidence with Chrome/Chromium and writes draft audit/config artifacts.
- Adds audit-specific docs, specs, tests, and host dependencies.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-cli/src/audit.rs` | Adds audit orchestration, output planning, artifact writing, and draft config generation. |
| `crates/trusted-server-cli/src/audit/analyzer.rs` | Detects JS assets, first/third-party classification, redirects, titles, and known integrations. |
| `crates/trusted-server-cli/src/audit/browser_collector.rs` | Adds headless Chrome/Chromium collection for DOM scripts and network requests. |
| `crates/trusted-server-cli/src/audit/collector.rs` | Defines audit collection traits/data shapes for testability. |
| `crates/trusted-server-cli/src/args.rs`, `src/run.rs`, `src/lib.rs` | Wires `ts audit` into CLI parsing and dispatch. |
| `Cargo.toml`, `crates/trusted-server-cli/Cargo.toml`, `Cargo.lock` | Adds audit-only dependencies. |
| `README.md`, `docs/guide/cli.md`, `docs/guide/getting-started.md` | Documents audit workflow and Chrome/Chromium prerequisite. |
| `docs/superpowers/...audit...` | Adds audit design and implementation plan artifacts. |

## Closes

No issue provided; this PR is split out from the combined `feature/ts-cli-next` branch.

## Test plan

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] JS tests: `cd crates/js/lib && npx vitest run`
- [ ] JS format: `cd crates/js/lib && npm run format`
- [ ] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: `cargo test --package trusted-server-cli --target aarch64-apple-darwin` — 42 passed

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses tracing/log macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
