### PR TITLE
Make first-party integration URLs root-relative

### DIFF
--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -52,7 +52,7 @@
 //! automatically rewrite `DataDome` script URLs in HTML responses:
 //!
 //! - `<script src="https://js.datadome.co/tags.js">` becomes
-//!   `<script src="https://publisher.com/integrations/datadome/tags.js">`
+//!   `<script src="/integrations/datadome/tags.js">`
 //! - Handles both `src` and `href` attributes (for preload/prefetch links)
 
 use std::sync::{Arc, LazyLock};
@@ -815,6 +815,10 @@ impl IntegrationAttributeRewriter for DataDomeIntegration {
 
         let path = Self::extract_datadome_path(attr_value);
         // Root-relative so the browser resolves it against the page host.
+        // Note: a page-level `<base href>` participates in this resolution, so
+        // on pages that set an external base URL these resolve against that base
+        // rather than the address-bar origin — an accepted tradeoff, matching
+        // GTM/Didomi/Testlight which are also relative.
         let new_url = format!("/integrations/datadome{path}");
 
         log::info!(

--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -803,7 +803,7 @@ impl IntegrationAttributeRewriter for DataDomeIntegration {
         &self,
         _attr_name: &str,
         attr_value: &str,
-        ctx: &IntegrationAttributeContext<'_>,
+        _ctx: &IntegrationAttributeContext<'_>,
     ) -> AttributeRewriteAction {
         // Check if this is a DataDome script URL
         let is_datadome =
@@ -814,10 +814,8 @@ impl IntegrationAttributeRewriter for DataDomeIntegration {
         }
 
         let path = Self::extract_datadome_path(attr_value);
-        let new_url = format!(
-            "{}://{}/integrations/datadome{}",
-            ctx.request_scheme, ctx.request_host, path
-        );
+        // Root-relative so the browser resolves it against the page host.
+        let new_url = format!("/integrations/datadome{path}");
 
         log::info!(
             "[datadome] Rewriting script src from {} to {}",
@@ -1328,10 +1326,7 @@ mod tests {
         let action = integration.rewrite("src", "https://js.datadome.co/tags.js", &ctx);
         match action {
             AttributeRewriteAction::Replace(new_url) => {
-                assert_eq!(
-                    new_url,
-                    "https://publisher.com/integrations/datadome/tags.js"
-                );
+                assert_eq!(new_url, "/integrations/datadome/tags.js");
             }
             _ => panic!("Expected Replace action"),
         }
@@ -1340,10 +1335,7 @@ mod tests {
         let action = integration.rewrite("href", "https://js.datadome.co/tags.js", &ctx);
         match action {
             AttributeRewriteAction::Replace(new_url) => {
-                assert_eq!(
-                    new_url,
-                    "https://publisher.com/integrations/datadome/tags.js"
-                );
+                assert_eq!(new_url, "/integrations/datadome/tags.js");
             }
             _ => panic!("Expected Replace action for href"),
         }
@@ -1368,10 +1360,7 @@ mod tests {
         let action = integration.rewrite("src", "https://js.datadome.co/js/check", &ctx);
         match action {
             AttributeRewriteAction::Replace(new_url) => {
-                assert_eq!(
-                    new_url,
-                    "https://publisher.com/integrations/datadome/js/check"
-                );
+                assert_eq!(new_url, "/integrations/datadome/js/check");
             }
             _ => panic!("Expected Replace action"),
         }
@@ -1380,10 +1369,7 @@ mod tests {
         let action = integration.rewrite("href", "//js.datadome.co/js/signal", &ctx);
         match action {
             AttributeRewriteAction::Replace(new_url) => {
-                assert_eq!(
-                    new_url,
-                    "https://publisher.com/integrations/datadome/js/signal"
-                );
+                assert_eq!(new_url, "/integrations/datadome/js/signal");
             }
             _ => panic!("Expected Replace action for protocol-relative URL"),
         }
@@ -1392,10 +1378,7 @@ mod tests {
         let action = integration.rewrite("src", "https://js.datadome.co", &ctx);
         match action {
             AttributeRewriteAction::Replace(new_url) => {
-                assert_eq!(
-                    new_url,
-                    "https://publisher.com/integrations/datadome/tags.js"
-                );
+                assert_eq!(new_url, "/integrations/datadome/tags.js");
             }
             _ => panic!("Expected Replace action for bare domain"),
         }

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -435,17 +435,15 @@ impl IntegrationAttributeRewriter for GptIntegration {
         &self,
         _attr_name: &str,
         attr_value: &str,
-        ctx: &IntegrationAttributeContext<'_>,
+        _ctx: &IntegrationAttributeContext<'_>,
     ) -> AttributeRewriteAction {
         if !self.config.rewrite_script {
             return AttributeRewriteAction::keep();
         }
 
         if Self::is_gpt_script_url(attr_value) {
-            AttributeRewriteAction::replace(format!(
-                "{}://{}/integrations/gpt/script",
-                ctx.request_scheme, ctx.request_host
-            ))
+            // Root-relative so the browser resolves it against the page host.
+            AttributeRewriteAction::replace("/integrations/gpt/script".to_string())
         } else {
             AttributeRewriteAction::keep()
         }
@@ -587,8 +585,8 @@ mod tests {
         match result {
             AttributeRewriteAction::Replace(url) => {
                 assert_eq!(
-                    url, "https://edge.example.com/integrations/gpt/script",
-                    "should rewrite to first-party script endpoint"
+                    url, "/integrations/gpt/script",
+                    "should rewrite to root-relative first-party script endpoint"
                 );
             }
             other => panic!("Expected Replace action, got {:?}", other),

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -443,6 +443,10 @@ impl IntegrationAttributeRewriter for GptIntegration {
 
         if Self::is_gpt_script_url(attr_value) {
             // Root-relative so the browser resolves it against the page host.
+            // Note: a page-level `<base href>` participates in this resolution,
+            // so on pages that set an external base URL these resolve against
+            // that base rather than the address-bar origin — an accepted
+            // tradeoff, matching GTM/Didomi/Testlight which are also relative.
             AttributeRewriteAction::replace("/integrations/gpt/script".to_string())
         } else {
             AttributeRewriteAction::keep()

--- a/crates/trusted-server-core/src/integrations/lockr.rs
+++ b/crates/trusted-server-core/src/integrations/lockr.rs
@@ -412,17 +412,15 @@ impl IntegrationAttributeRewriter for LockrIntegration {
         &self,
         _attr_name: &str,
         attr_value: &str,
-        ctx: &IntegrationAttributeContext<'_>,
+        _ctx: &IntegrationAttributeContext<'_>,
     ) -> AttributeRewriteAction {
         if !self.config.rewrite_sdk {
             return AttributeRewriteAction::Keep;
         }
 
         if self.is_lockr_sdk_url(attr_value) {
-            let replacement = format!(
-                "{}://{}/integrations/lockr/sdk",
-                ctx.request_scheme, ctx.request_host
-            );
+            // Root-relative so the browser resolves it against the page host.
+            let replacement = "/integrations/lockr/sdk".to_string();
             log::debug!("Rewriting Lockr SDK URL to {}", replacement);
             AttributeRewriteAction::Replace(replacement)
         } else {
@@ -532,10 +530,8 @@ mod tests {
 
         assert_eq!(
             result,
-            AttributeRewriteAction::Replace(
-                "https://edge.example.com/integrations/lockr/sdk".to_string()
-            ),
-            "should rewrite Lockr SDK URL to first-party proxy"
+            AttributeRewriteAction::Replace("/integrations/lockr/sdk".to_string()),
+            "should rewrite Lockr SDK URL to root-relative first-party proxy"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/lockr.rs
+++ b/crates/trusted-server-core/src/integrations/lockr.rs
@@ -420,6 +420,10 @@ impl IntegrationAttributeRewriter for LockrIntegration {
 
         if self.is_lockr_sdk_url(attr_value) {
             // Root-relative so the browser resolves it against the page host.
+            // Note: a page-level `<base href>` participates in this resolution,
+            // so on pages that set an external base URL these resolve against
+            // that base rather than the address-bar origin — an accepted
+            // tradeoff, matching GTM/Didomi/Testlight which are also relative.
             let replacement = "/integrations/lockr/sdk".to_string();
             log::debug!("Rewriting Lockr SDK URL to {}", replacement);
             AttributeRewriteAction::Replace(replacement)

--- a/crates/trusted-server-core/src/integrations/permutive.rs
+++ b/crates/trusted-server-core/src/integrations/permutive.rs
@@ -425,18 +425,16 @@ impl IntegrationAttributeRewriter for PermutiveIntegration {
         &self,
         _attr_name: &str,
         attr_value: &str,
-        ctx: &IntegrationAttributeContext<'_>,
+        _ctx: &IntegrationAttributeContext<'_>,
     ) -> AttributeRewriteAction {
         if !self.config.rewrite_sdk {
             return AttributeRewriteAction::keep();
         }
 
         if self.is_permutive_sdk_url(attr_value) {
-            // Rewrite to first-party SDK endpoint
-            AttributeRewriteAction::replace(format!(
-                "{}://{}/integrations/permutive/sdk",
-                ctx.request_scheme, ctx.request_host
-            ))
+            // Rewrite to first-party SDK endpoint.
+            // Root-relative so the browser resolves it against the page host.
+            AttributeRewriteAction::replace("/integrations/permutive/sdk".to_string())
         } else {
             AttributeRewriteAction::keep()
         }
@@ -547,7 +545,7 @@ mod tests {
 
         assert!(matches!(rewritten, AttributeRewriteAction::Replace(_)));
         if let AttributeRewriteAction::Replace(url) = rewritten {
-            assert_eq!(url, "https://edge.example.com/integrations/permutive/sdk");
+            assert_eq!(url, "/integrations/permutive/sdk");
         }
     }
 

--- a/crates/trusted-server-core/src/integrations/permutive.rs
+++ b/crates/trusted-server-core/src/integrations/permutive.rs
@@ -434,6 +434,10 @@ impl IntegrationAttributeRewriter for PermutiveIntegration {
         if self.is_permutive_sdk_url(attr_value) {
             // Rewrite to first-party SDK endpoint.
             // Root-relative so the browser resolves it against the page host.
+            // Note: a page-level `<base href>` participates in this resolution,
+            // so on pages that set an external base URL these resolve against
+            // that base rather than the address-bar origin — an accepted
+            // tradeoff, matching GTM/Didomi/Testlight which are also relative.
             AttributeRewriteAction::replace("/integrations/permutive/sdk".to_string())
         } else {
             AttributeRewriteAction::keep()

--- a/crates/trusted-server-core/src/integrations/sourcepoint.rs
+++ b/crates/trusted-server-core/src/integrations/sourcepoint.rs
@@ -285,11 +285,7 @@ impl SourcepointIntegration {
         Ok(target.to_string())
     }
 
-    fn build_first_party_url(
-        &self,
-        source_url: &str,
-        ctx: &IntegrationAttributeContext<'_>,
-    ) -> Option<String> {
+    fn build_first_party_url(&self, source_url: &str) -> Option<String> {
         let parsed = parse_sourcepoint_url(source_url)?;
         if parsed.host_str()? != SOURCEPOINT_CDN_HOST {
             return None;
@@ -301,10 +297,8 @@ impl SourcepointIntegration {
             .map(|value| format!("?{value}"))
             .unwrap_or_default();
 
-        Some(format!(
-            "{}://{}{}{}{}",
-            ctx.request_scheme, ctx.request_host, SOURCEPOINT_CDN_PREFIX, path, query
-        ))
+        // Root-relative so the browser resolves it against the page host.
+        Some(format!("{SOURCEPOINT_CDN_PREFIX}{path}{query}"))
     }
 
     fn copy_headers(
@@ -851,11 +845,11 @@ impl IntegrationAttributeRewriter for SourcepointIntegration {
         &self,
         _attr_name: &str,
         attr_value: &str,
-        ctx: &IntegrationAttributeContext<'_>,
+        _ctx: &IntegrationAttributeContext<'_>,
     ) -> AttributeRewriteAction {
         // `handles_attribute()` already gates on `rewrite_sdk`, so this
         // method is only called when rewriting is enabled.
-        if let Some(rewritten) = self.build_first_party_url(attr_value, ctx) {
+        if let Some(rewritten) = self.build_first_party_url(attr_value) {
             return AttributeRewriteAction::replace(rewritten);
         }
 
@@ -986,7 +980,7 @@ mod tests {
         assert_eq!(
             rewritten,
             AttributeRewriteAction::replace(
-                "https://edge.example.com/integrations/sourcepoint/cdn/mms/v2/get_site_data?account_id=821",
+                "/integrations/sourcepoint/cdn/mms/v2/get_site_data?account_id=821",
             )
         );
     }

--- a/crates/trusted-server-core/src/integrations/sourcepoint.rs
+++ b/crates/trusted-server-core/src/integrations/sourcepoint.rs
@@ -298,6 +298,10 @@ impl SourcepointIntegration {
             .unwrap_or_default();
 
         // Root-relative so the browser resolves it against the page host.
+        // Note: a page-level `<base href>` participates in this resolution, so
+        // on pages that set an external base URL these resolve against that base
+        // rather than the address-bar origin — an accepted tradeoff, matching
+        // GTM/Didomi/Testlight which are also relative.
         Some(format!("{SOURCEPOINT_CDN_PREFIX}{path}{query}"))
     }
 


### PR DESCRIPTION
Closes #820

## Problem

The **GPT, DataDome, Permutive, Lockr, and Sourcepoint** attribute rewriters rewrite a publisher's `<script src>` / `<link href>` to an **absolute** first-party URL built from `request_host`:

```rust
format!("{}://{}/integrations/gpt/script", ctx.request_scheme, ctx.request_host)
```

`ctx.request_host` is the host TS derived for the request (`extract_request_host` → `Host`/`X-Forwarded-Host`). When that isn't the page's own host, these URLs leak the wrong host into the HTML — e.g. the page renders `https://ts.example.com/integrations/gpt/script` while the address bar shows `www.example.com`. This shows up behind a host-rewriting dev proxy, and anywhere `request_host` resolves to the routing host rather than the production domain.

## Fix

Emit these URLs **root-relative** (`/integrations/...`) so the **browser** resolves them against the page's own host:

```rust
"/integrations/gpt/script".to_string()
```

Correct both in production and behind a proxy, and it removes the dependency on `request_host` / `X-Forwarded-Host` derivation entirely. This matches what GTM, Didomi, Testlight, and these integrations' own inline-script rewriters already do.

## Scope — full integration audit

Audited **every** integration's page-facing URL emission (attribute rewriters, head injectors, inline-script rewriters, config-rendered URLs):

| Verdict | Integrations |
|---|---|
| **Fixed** (were absolute from `request_host`) | gpt, datadome, permutive, lockr, sourcepoint |
| Already root-relative | google_tag_manager, didomi, testlight, datadome `client_side_tag_url` (default), sourcepoint trap prefix |
| Correctly absolute (real external/upstream origin) | GPT/GTM/Permutive/Sourcepoint upstream fetch targets |
| Intentionally absolute — **left unchanged** | NextJS RSC/flight payload host rewriting |
| Server-side only — not page-facing | DataDome protection module's raw-`Host` read (validation API body) |

These five were the only page-facing first-party URLs built from a host.

## Tests

Unit tests asserting the old absolute form updated to the root-relative form (no weakening). `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -D warnings`, and `cargo test --workspace` all pass.
