### PR TITLE
Stop forwarding Authorization header to third-party integration APIs

### DIFF
--- a/crates/trusted-server-core/src/integrations/didomi.rs
+++ b/crates/trusted-server-core/src/integrations/didomi.rs
@@ -164,6 +164,10 @@ impl DidomiIntegration {
             );
         }
 
+        // `Authorization` is intentionally NOT forwarded: it carries the
+        // publisher site's own credential (e.g. staging basic-auth), which would
+        // leak to the third-party upstream and can break APIs that reject an
+        // unexpected `Authorization` header.
         for header_name in [
             header::ACCEPT,
             header::ACCEPT_LANGUAGE,
@@ -172,7 +176,6 @@ impl DidomiIntegration {
             header::USER_AGENT,
             header::REFERER,
             header::ORIGIN,
-            header::AUTHORIZATION,
         ] {
             if let Some(value) = original_headers.get(&header_name) {
                 proxy_headers.insert(header_name, value.clone());

--- a/crates/trusted-server-core/src/integrations/didomi.rs
+++ b/crates/trusted-server-core/src/integrations/didomi.rs
@@ -451,6 +451,46 @@ mod tests {
     }
 
     #[test]
+    fn copy_headers_strips_authorization() {
+        // Security regression guard: the publisher's Authorization header must
+        // not be forwarded to the Didomi upstream (credential leak).
+        let integration = DidomiIntegration::new(Arc::new(config(true)));
+        let backend = DidomiBackend::Api;
+        let original_req = http::Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/test")
+            .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+            .header(header::USER_AGENT, "test-agent")
+            .body(EdgeBody::empty())
+            .expect("should build original request");
+        let mut proxy_req = http::Request::builder()
+            .method(Method::POST)
+            .uri("https://api.privacy-center.org/test")
+            .body(EdgeBody::empty())
+            .expect("should build proxy request");
+
+        integration.copy_headers(
+            &backend,
+            None,
+            original_req.headers(),
+            proxy_req.headers_mut(),
+        );
+
+        assert!(
+            proxy_req.headers().get(header::AUTHORIZATION).is_none(),
+            "should NOT forward the publisher's Authorization header to Didomi"
+        );
+        assert_eq!(
+            proxy_req
+                .headers()
+                .get(header::USER_AGENT)
+                .and_then(|v| v.to_str().ok()),
+            Some("test-agent"),
+            "should still forward required headers (user-agent)"
+        );
+    }
+
+    #[test]
     fn registers_custom_proxy_path() {
         let mut settings = create_test_settings();
         let custom_config = DidomiIntegrationConfig {

--- a/crates/trusted-server-core/src/integrations/lockr.rs
+++ b/crates/trusted-server-core/src/integrations/lockr.rs
@@ -248,11 +248,14 @@ impl LockrIntegration {
         from: &HeaderMap<HeaderValue>,
         to: &mut HeaderMap<HeaderValue>,
     ) -> Result<(), Report<TrustedServerError>> {
+        // NOTE: `Authorization` is intentionally NOT forwarded. It carries the
+        // publisher site's own credential (e.g. staging basic-auth), which the
+        // Lockr API rejects with `{"code":400,"message":"Invalid request"}` —
+        // and forwarding it would leak the publisher credential to a third party.
         let headers_to_copy = [
             header::CONTENT_TYPE,
             header::ACCEPT,
             header::USER_AGENT,
-            header::AUTHORIZATION,
             header::ACCEPT_LANGUAGE,
             header::ACCEPT_ENCODING,
         ];
@@ -598,6 +601,62 @@ mod tests {
             stub.recorded_backend_names().len(),
             1,
             "should route one outbound request through PlatformHttpClient"
+        );
+    }
+
+    #[test]
+    fn lockr_proxy_forwards_body_and_strips_authorization() {
+        // Regression guard for two upstream-rejection causes:
+        // 1. The POST body (and content-type) must be forwarded, otherwise the
+        //    Lockr API returns `{"code":400,"message":"Invalid request"}`.
+        // 2. The publisher's `Authorization` header (e.g. site basic-auth) must
+        //    NOT be forwarded — the Lockr API rejects it with the same 400, and
+        //    forwarding it would leak the publisher credential to a third party.
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, br#"{"success":true,"data":{}}"#.to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let integration = LockrIntegration::new(test_config());
+
+        let payload = br#"{"appID":"test-app-id"}"#;
+        let req = http::Request::builder()
+            .method(HttpMethod::POST)
+            .uri("https://publisher.example/integrations/lockr/api/publisher/app/v2/identityLockr/settings")
+            .header(header::CONTENT_TYPE, "application/json;charset=UTF-8")
+            .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+            .body(EdgeBody::from(payload.to_vec()))
+            .expect("should build request");
+
+        let response = futures::executor::block_on(integration.handle(&settings, &services, req))
+            .expect("should proxy request");
+        assert_eq!(response.status(), http::StatusCode::OK, "should return OK");
+
+        let bodies = stub.recorded_request_bodies();
+        assert_eq!(
+            bodies.len(),
+            1,
+            "should forward exactly one upstream request"
+        );
+        assert_eq!(
+            bodies[0], payload,
+            "should forward the POST body unchanged to the Lockr API"
+        );
+
+        let headers = stub.recorded_request_headers();
+        assert!(
+            headers[0]
+                .iter()
+                .any(|(name, value)| name == "content-type"
+                    && value == "application/json;charset=UTF-8"),
+            "should forward the content-type header to the Lockr API"
+        );
+        assert!(
+            !headers[0]
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("authorization")),
+            "should NOT forward the publisher's Authorization header to the Lockr API"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/lockr.rs
+++ b/crates/trusted-server-core/src/integrations/lockr.rs
@@ -18,7 +18,6 @@ use serde::Deserialize;
 use validator::Validate;
 
 use crate::constants::INTERNAL_HEADERS;
-use crate::cookies::{strip_cookies, CONSENT_COOKIE_NAMES};
 use crate::error::TrustedServerError;
 use crate::integrations::{
     collect_body_bounded, collect_response_bounded, ensure_integration_backend,
@@ -248,10 +247,15 @@ impl LockrIntegration {
         from: &HeaderMap<HeaderValue>,
         to: &mut HeaderMap<HeaderValue>,
     ) -> Result<(), Report<TrustedServerError>> {
-        // NOTE: `Authorization` is intentionally NOT forwarded. It carries the
-        // publisher site's own credential (e.g. staging basic-auth), which the
-        // Lockr API rejects with `{"code":400,"message":"Invalid request"}` —
-        // and forwarding it would leak the publisher credential to a third party.
+        // NOTE: `Authorization` and `Cookie` are intentionally NOT forwarded.
+        // Under the first-party proxy the browser attaches the publisher's own
+        // credentials to `/integrations/lockr/api/...` — `Authorization` (e.g.
+        // staging basic-auth) and every publisher session/auth cookie. Both
+        // would leak to the third-party upstream, and the Lockr API rejects an
+        // unexpected `Authorization` with `{"code":400,"message":"Invalid
+        // request"}`. The SDK already passes the identity cookie data it needs
+        // in the request body (`firstPartyCookies`), so no `Cookie` header is
+        // required upstream.
         let headers_to_copy = [
             header::CONTENT_TYPE,
             header::ACCEPT,
@@ -265,9 +269,6 @@ impl LockrIntegration {
                 to.insert(header_name, value.clone());
             }
         }
-
-        // Always strip consent cookies — consent travels through the OpenRTB body
-        self.copy_cookie_header(from, to)?;
 
         // Use origin override if configured, otherwise forward original
         let origin = self.config.origin_override.as_deref().or_else(|| {
@@ -289,34 +290,6 @@ impl LockrIntegration {
             let name_str = name.as_str();
             if name_str.starts_with("x-") && !INTERNAL_HEADERS.contains(&name_str) {
                 to.append(name.clone(), value.clone());
-            }
-        }
-
-        Ok(())
-    }
-
-    fn copy_cookie_header(
-        &self,
-        from: &HeaderMap<HeaderValue>,
-        to: &mut HeaderMap<HeaderValue>,
-    ) -> Result<(), Report<TrustedServerError>> {
-        let Some(cookie_value) = from.get(header::COOKIE) else {
-            return Ok(());
-        };
-
-        match cookie_value.to_str() {
-            Ok(value) => {
-                let stripped = strip_cookies(value, CONSENT_COOKIE_NAMES);
-                if stripped.is_empty() {
-                    return Ok(());
-                }
-
-                let cookie_header = HeaderValue::from_str(&stripped)
-                    .change_context(Self::error("Failed to rebuild stripped cookie header"))?;
-                to.insert(header::COOKIE, cookie_header);
-            }
-            Err(_) => {
-                to.insert(header::COOKIE, cookie_value.clone());
             }
         }
 
@@ -605,13 +578,15 @@ mod tests {
     }
 
     #[test]
-    fn lockr_proxy_forwards_body_and_strips_authorization() {
-        // Regression guard for two upstream-rejection causes:
+    fn lockr_proxy_forwards_body_and_strips_publisher_credentials() {
+        // Regression guard for the upstream-rejection / credential-leak causes:
         // 1. The POST body (and content-type) must be forwarded, otherwise the
         //    Lockr API returns `{"code":400,"message":"Invalid request"}`.
         // 2. The publisher's `Authorization` header (e.g. site basic-auth) must
         //    NOT be forwarded — the Lockr API rejects it with the same 400, and
         //    forwarding it would leak the publisher credential to a third party.
+        // 3. The publisher's `Cookie` header (session/auth cookies the browser
+        //    attaches to the first-party route) must NOT be forwarded either.
         let stub = Arc::new(StubHttpClient::new());
         stub.push_response(200, br#"{"success":true,"data":{}}"#.to_vec());
         let services = build_services_with_http_client(
@@ -626,6 +601,7 @@ mod tests {
             .uri("https://publisher.example/integrations/lockr/api/publisher/app/v2/identityLockr/settings")
             .header(header::CONTENT_TYPE, "application/json;charset=UTF-8")
             .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+            .header(header::COOKIE, "session_id=secret; euconsent-v2=tcf")
             .body(EdgeBody::from(payload.to_vec()))
             .expect("should build request");
 
@@ -657,6 +633,12 @@ mod tests {
                 .iter()
                 .any(|(name, _)| name.eq_ignore_ascii_case("authorization")),
             "should NOT forward the publisher's Authorization header to the Lockr API"
+        );
+        assert!(
+            !headers[0]
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("cookie")),
+            "should NOT forward the publisher's Cookie header to the Lockr API"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/permutive.rs
+++ b/crates/trusted-server-core/src/integrations/permutive.rs
@@ -663,4 +663,55 @@ mod tests {
             "should route outbound request through PlatformHttpClient"
         );
     }
+
+    #[test]
+    fn permutive_proxy_strips_authorization() {
+        // Security regression guard: the publisher's Authorization header must
+        // not be forwarded to the Permutive upstream (credential leak).
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, b"ok".to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = create_test_settings();
+        let integration = PermutiveIntegration::new(PermutiveConfig {
+            enabled: true,
+            organization_id: "myorg".to_string(),
+            workspace_id: "workspace-123".to_string(),
+            project_id: String::new(),
+            api_endpoint: default_api_endpoint(),
+            secure_signals_endpoint: default_secure_signals_endpoint(),
+            cache_ttl_seconds: 3600,
+            rewrite_sdk: true,
+        });
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://publisher.example/integrations/permutive/api/v2.0/events")
+            .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+            .header(header::USER_AGENT, "test-agent")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let response = futures::executor::block_on(integration.handle(&settings, &services, req))
+            .expect("should proxy request");
+        assert_eq!(
+            response.status(),
+            http::StatusCode::OK,
+            "should return stubbed response"
+        );
+
+        let headers = stub.recorded_request_headers();
+        assert!(
+            !headers[0]
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("authorization")),
+            "should NOT forward the publisher's Authorization header to Permutive"
+        );
+        assert!(
+            headers[0]
+                .iter()
+                .any(|(name, value)| name == "user-agent" && value == "test-agent"),
+            "should still forward required headers (user-agent)"
+        );
+    }
 }

--- a/crates/trusted-server-core/src/integrations/permutive.rs
+++ b/crates/trusted-server-core/src/integrations/permutive.rs
@@ -257,11 +257,14 @@ impl PermutiveIntegration {
 
     /// Copy relevant request headers for proxying.
     fn copy_request_headers(&self, from: &HeaderMap<HeaderValue>, to: &mut HeaderMap<HeaderValue>) {
+        // `Authorization` is intentionally NOT forwarded: it carries the
+        // publisher site's own credential (e.g. staging basic-auth), which would
+        // leak to the third-party upstream and can break APIs that reject an
+        // unexpected `Authorization` header.
         let headers_to_copy = [
             header::CONTENT_TYPE,
             header::ACCEPT,
             header::USER_AGENT,
-            header::AUTHORIZATION,
             header::ACCEPT_LANGUAGE,
             header::ACCEPT_ENCODING,
         ];

--- a/crates/trusted-server-core/src/platform/test_support.rs
+++ b/crates/trusted-server-core/src/platform/test_support.rs
@@ -214,6 +214,9 @@ struct StubPendingResponse {
 /// exercising the code under test, then inspect
 /// [`recorded_backend_names`](Self::recorded_backend_names) to assert call
 /// sites.
+/// Upper bound on the request body bytes captured per `send` call.
+const MAX_RECORDED_BODY_BYTES: usize = 64 * 1024 * 1024;
+
 pub(crate) struct StubHttpClient {
     calls: Mutex<Vec<String>>,
     responses: Mutex<VecDeque<StubHttpResponse>>,
@@ -228,6 +231,8 @@ pub(crate) struct StubHttpClient {
     stream_response_flags: Mutex<Vec<bool>>,
     request_methods: Mutex<Vec<String>>,
     request_uris: Mutex<Vec<String>>,
+    // Outgoing request bodies captured per send call, collected to bytes.
+    request_bodies: Mutex<Vec<Vec<u8>>>,
 }
 
 struct StubHttpResponse {
@@ -248,6 +253,7 @@ impl StubHttpClient {
             stream_response_flags: Mutex::new(Vec::new()),
             request_methods: Mutex::new(Vec::new()),
             request_uris: Mutex::new(Vec::new()),
+            request_bodies: Mutex::new(Vec::new()),
         }
     }
 
@@ -339,6 +345,17 @@ impl StubHttpClient {
             .expect("should lock request URIs")
             .clone()
     }
+
+    /// Return request bodies captured per `send` call, in order.
+    ///
+    /// Each entry is the outgoing request body collected to bytes. Bodies are
+    /// only captured by [`send`](PlatformHttpClient::send).
+    pub fn recorded_request_bodies(&self) -> Vec<Vec<u8>> {
+        self.request_bodies
+            .lock()
+            .expect("should lock request bodies")
+            .clone()
+    }
 }
 
 // ?Send matches PlatformHttpClient. See http.rs for the full rationale.
@@ -390,6 +407,18 @@ impl PlatformHttpClient for StubHttpClient {
             .lock()
             .expect("should lock request_headers")
             .push(headers);
+
+        // Capture the outgoing request body so tests can assert it is forwarded.
+        let (_, body) = request.request.into_parts();
+        let body_bytes = body
+            .into_bytes_bounded(MAX_RECORDED_BODY_BYTES)
+            .await
+            .map(|bytes| bytes.to_vec())
+            .unwrap_or_default();
+        self.request_bodies
+            .lock()
+            .expect("should lock request bodies")
+            .push(body_bytes);
 
         let response = self
             .responses

--- a/crates/trusted-server-core/src/platform/test_support.rs
+++ b/crates/trusted-server-core/src/platform/test_support.rs
@@ -409,12 +409,15 @@ impl PlatformHttpClient for StubHttpClient {
             .push(headers);
 
         // Capture the outgoing request body so tests can assert it is forwarded.
+        // Propagate collection failures instead of recording an empty body, so
+        // tests cannot mistake a capture failure for an intentionally empty body.
         let (_, body) = request.request.into_parts();
         let body_bytes = body
             .into_bytes_bounded(MAX_RECORDED_BODY_BYTES)
             .await
-            .map(|bytes| bytes.to_vec())
-            .unwrap_or_default();
+            .change_context(PlatformError::HttpClient)
+            .attach("failed to capture StubHttpClient request body")?
+            .to_vec();
         self.request_bodies
             .lock()
             .expect("should lock request bodies")


### PR DESCRIPTION
## Root cause (verified with a local `fastly compute serve` reproduction)

The integration API proxies forward the publisher site's **`Authorization`** header (e.g. a staging basic-auth credential) to the third-party upstream. The Lockr API rejects any request carrying an unexpected `Authorization`:

```json
{"success":false,"error":{"code":400,"message":"Invalid request"}}
```

This short-circuits the SDK's `getAIMSettings()` init (which gates on `success && data`) — **no settings data, no `pvStatus`, no `page-view`, no identity tokens** — on any deployment served behind site auth. It also **leaks the publisher credential** to the third party.

### How it was confirmed

- Direct upstream replay: a fully-correct request (Origin + content-type + body) returns `success`; **adding only an `Authorization` header flips it to the exact `400 Invalid request`**. Missing Origin returns `500`, missing body/content-type returns `400` from a *different* cause — both ruled out.
- Local `fastly compute serve` (legacy path, lockr enabled) reproduced the `400`; debug logging showed the proxy putting `authorization` on the outbound wire. Removing it → upstream no longer returns the `400`.

This corrects two earlier misdiagnoses (Origin — PR #831, closed; POST body — the original framing of this PR). The body and content-type were always forwarded correctly.

## Fix

Stop forwarding `Authorization` in **lockr**, **permutive**, and **didomi**.

Audit of all integration proxies:
| Integration | Forwarded `Authorization`? | Action |
|---|---|---|
| lockr | yes | **stopped** |
| permutive | yes | **stopped** |
| didomi | yes | **stopped** |
| sourcepoint | no (already omitted, with comment) | — |
| datadome, prebid, gpt | no | — |

## Tests

- New `lockr_proxy_forwards_body_and_strips_authorization`: asserts the proxy forwards the POST body + content-type but **strips `Authorization`**. Extends the stub HTTP client to record outgoing request bodies.
- `cargo test -p trusted-server-core` — 1455 passed; `fmt` + `clippy` clean.

Fixes #832