### PR TITLE
Add sccache to Rust CI jobs

### DIFF
--- a/.github/actions/setup-integration-test-env/action.yml
+++ b/.github/actions/setup-integration-test-env/action.yml
@@ -58,6 +58,15 @@ runs:
         target: wasm32-wasip1
         cache-shared-key: cargo-${{ runner.os }}
 
+    - name: Set up sccache
+      uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Configure sccache for Rust
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
     - name: Cache Viceroy binary
       if: ${{ inputs.install-viceroy == 'true' }}
       id: cache-viceroy

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,6 +29,14 @@ jobs:
           components: "clippy, rustfmt"
           cache-shared-key: cargo-${{ runner.os }}
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache for Rust
+        run: |
+          echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Run cargo fmt
         uses: actions-rust-lang/rustfmt@v1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,14 @@ jobs:
           target: wasm32-wasip1
           cache-shared-key: cargo-${{ runner.os }}
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache for Rust
+        run: |
+          echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Cache Viceroy binary
         id: cache-viceroy
         uses: actions/cache@v4
@@ -68,6 +76,14 @@ jobs:
           # build" step below; the axum build and tests are native.
           target: wasm32-wasip1
           cache-shared-key: cargo-${{ runner.os }}
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache for Rust
+        run: |
+          echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Build Axum adapter
         run: cargo build -p trusted-server-adapter-axum
@@ -103,6 +119,14 @@ jobs:
           target: wasm32-unknown-unknown
           cache-shared-key: cargo-${{ runner.os }}
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache for Rust
+        run: |
+          echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Check Cloudflare adapter (native host)
         run: cargo check -p trusted-server-adapter-cloudflare
 
@@ -129,6 +153,14 @@ jobs:
           toolchain: ${{ steps.rust-version.outputs.rust-version }}
           target: wasm32-wasip1
           cache-shared-key: cargo-${{ runner.os }}
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache for Rust
+        run: |
+          echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Check Spin adapter (native host)
         run: cargo check -p trusted-server-adapter-spin
@@ -169,6 +201,14 @@ jobs:
           components: clippy, rustfmt
           cache-shared-key: cargo-${{ runner.os }}
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache for Rust
+        run: |
+          echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Format check (parity test crate)
         run: cargo fmt --manifest-path crates/trusted-server-integration-tests/Cargo.toml -- --check
 
@@ -200,6 +240,14 @@ jobs:
           toolchain: ${{ steps.rust-version.outputs.rust-version }}
           components: "clippy, rustfmt"
           cache-shared-key: cargo-cli-${{ runner.os }}
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache for Rust
+        run: |
+          echo "SCCACHE_GHA_ENABLED=on" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       # No separate `cargo fmt` here: `trusted-server-cli` is a workspace member,
       # so the main `cargo fmt --all` job already formats it. Clippy still needs a


### PR DESCRIPTION
## Summary
- add `mozilla-actions/sccache-action@v0.0.10` to Rust CI jobs
- configure `SCCACHE_GHA_ENABLED=on` and `RUSTC_WRAPPER=sccache` for subsequent Cargo steps
- include the integration test environment composite action while leaving existing rust-cache setup in place

## Validation
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml", ".github/actions/**/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`
- `grep -R "mozilla-actions/sccache-action" -n .github/workflows .github/actions`
- `grep -R "RUSTC_WRAPPER\|SCCACHE_GHA_ENABLED" -n .github/workflows .github/actions`

Note: `actionlint` was not installed locally.
