### PR TITLE
Document CLI installation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -49,7 +49,8 @@ clippy-spin-native = ["clippy", "-p", "trusted-server-adapter-spin", "--all-targ
 clippy-spin-wasm = ["clippy", "-p", "trusted-server-adapter-spin", "--target", "wasm32-wasip1", "--features", "spin", "--lib", "--", "-D", "warnings"]
 test-spin = ["test", "-p", "trusted-server-adapter-spin"]
 
-# --- ts operator CLI (native host; per-OS target overrides the wasm default) ---
+# --- ts operator CLI (native host; install uses the current host platform) ---
+install-cli = ["install", "--path", "crates/trusted-server-cli", "--bin", "ts", "--locked", "--force"]
 build_cli_linux = ["build", "--package", "trusted-server-cli", "--target", "x86_64-unknown-linux-gnu"]
 build_cli_macos = ["build", "--package", "trusted-server-cli", "--target", "aarch64-apple-darwin"]
 run_cli_linux = ["run", "--package", "trusted-server-cli", "--target", "x86_64-unknown-linux-gnu", "--"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The guide in `docs/guide/` (published at the link below) is the source of truth 
 | [Getting Started](https://iabtechlab.github.io/trusted-server/guide/getting-started)    | Installation and setup                     |
 | [Architecture](https://iabtechlab.github.io/trusted-server/guide/architecture)          | System architecture overview               |
 | [Configuration](https://iabtechlab.github.io/trusted-server/guide/configuration)        | Configuration reference                    |
+| [Trusted Server CLI](https://iabtechlab.github.io/trusted-server/guide/cli)             | `ts` CLI install and command reference     |
 | [Integrations](https://iabtechlab.github.io/trusted-server/guide/integrations-overview) | Partner integrations (Prebid, Lockr, etc.) |
 
 ## Quick Start
@@ -27,9 +28,12 @@ cargo build-fastly       # Fastly adapter + core (wasm32-wasip1)
 cargo build-axum         # Axum dev server (native)
 cargo build-cloudflare   # Cloudflare Workers (wasm32-unknown-unknown)
 
-# Build the host-target CLI
-HOST_TARGET="$(rustc -vV | sed -n 's/^host: //p')"
-cargo build --package trusted-server-cli --target "$HOST_TARGET"
+# Install the host-target CLI for your current platform
+cargo install-cli
+
+# If your shell cannot find `ts`, add Cargo's bin directory to PATH
+export PATH="$HOME/.cargo/bin:$PATH"
+ts --help
 
 # Create local config, then edit placeholders before validation
 ts config init

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5,12 +5,27 @@ configuration, page audits, and EdgeZero-backed lifecycle commands.
 
 ## Install from source
 
-The workspace default target is `wasm32-wasip1`, so build or test the CLI with
-your host target:
+From the repository root, install the `ts` binary with the workspace Cargo alias:
 
 ```bash
-HOST_TARGET="$(rustc -vV | sed -n 's/^host: //p')"
-cargo build --package trusted-server-cli --target "$HOST_TARGET"
+cargo install-cli
+```
+
+The alias runs `cargo install --path crates/trusted-server-cli --bin ts --locked --force`.
+Because it does not pass an explicit `--target`, Cargo builds the CLI for your
+current host platform. The binary is installed into Cargo's bin directory,
+usually `~/.cargo/bin`; make sure that directory is on your `PATH`.
+
+For example, add Cargo's bin directory to your current shell session:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+Verify the install:
+
+```bash
+ts --help
 ```
 
 ## Common workflow

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,6 +25,20 @@ git clone https://github.com/IABTechLab/trusted-server.git
 cd trusted-server
 ```
 
+### Install the CLI
+
+Install the `ts` operator CLI for your current platform:
+
+```bash
+cargo install-cli
+
+# If your shell cannot find `ts`, add Cargo's bin directory to PATH
+export PATH="$HOME/.cargo/bin:$PATH"
+ts --help
+```
+
+See [Trusted Server CLI](/guide/cli) for command details.
+
 ## Local Development
 
 Trusted Server supports two local development modes:


### PR DESCRIPTION
## Summary
- add `cargo install-cli` for installing the host-target `ts` CLI
- document CLI installation in the README, getting started guide, and CLI guide
- include a `~/.cargo/bin` PATH example and `ts --help` verification

## Testing
- `cargo install-cli --help`
- `cd docs && npm run format`
- `cd docs && ./node_modules/.bin/prettier --check ../README.md`

Closes #875