### PR TITLE
Optimize dev proxy upstream performance

### DIFF
--- a/crates/trusted-server-cli/Cargo.toml
+++ b/crates/trusted-server-cli/Cargo.toml
@@ -57,6 +57,7 @@ tokio-rustls = { workspace = true }
 webpki-roots = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 x509-parser = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/crates/trusted-server-cli/src/commands/dev/proxy/browser.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/browser.rs
@@ -738,6 +738,19 @@ fn restore_auto_proxy(
 mod tests {
     use super::*;
     use crate::commands::dev::proxy::rewrite::{Authority, Rule, RuleTable};
+    use crate::commands::dev::proxy::upstream::key::AddressPolicy;
+
+    fn rule(from: &str, to: &str) -> Rule {
+        Rule::new(
+            from.to_string(),
+            Authority::parse(to, false).expect("should parse authority"),
+            false,
+            false,
+            false,
+            AddressPolicy::Dns,
+        )
+        .expect("should build rule")
+    }
 
     #[test]
     fn shell_quote_wraps_and_escapes() {
@@ -826,12 +839,10 @@ mod tests {
 
     #[test]
     fn pac_uses_normalized_connect_address_for_wildcard_bind() {
-        let rules = RuleTable(vec![Rule {
-            from: "www.example-publisher.com".into(),
-            to: Authority::parse("to.edgecompute.app", false).expect("should parse authority"),
-            rewrite_host: false,
-            plaintext: false,
-        }]);
+        let rules = RuleTable(vec![rule(
+            "www.example-publisher.com",
+            "to.edgecompute.app",
+        )]);
         let pac = generate_pac(&rules, "0.0.0.0:18080".parse().expect("addr"));
         assert!(
             pac.contains("PROXY 127.0.0.1:18080"),
@@ -845,12 +856,10 @@ mod tests {
 
     #[test]
     fn pac_proxies_only_https_for_from_hosts() {
-        let rules = RuleTable(vec![Rule {
-            from: "www.example-publisher.com".into(),
-            to: Authority::parse("to.edgecompute.app", false).expect("should parse authority"),
-            rewrite_host: false,
-            plaintext: false,
-        }]);
+        let rules = RuleTable(vec![rule(
+            "www.example-publisher.com",
+            "to.edgecompute.app",
+        )]);
         let pac = generate_pac(
             &rules,
             "127.0.0.1:18080".parse().expect("should parse addr"),

--- a/crates/trusted-server-cli/src/commands/dev/proxy/ca.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/ca.rs
@@ -130,6 +130,8 @@ impl CertAuthority {
     ///
     /// Panics if the leaf-cache mutex is poisoned by a prior panic while held.
     pub fn server_config(&self, host: &str) -> Result<Arc<ServerConfig>, Report<CaError>> {
+        let normalized = host.to_ascii_lowercase();
+        let host = normalized.as_str();
         // Fast path: return a cached config without holding the lock during minting.
         {
             let cache = self
@@ -150,6 +152,19 @@ impl CertAuthority {
         // Double-check: another task may have minted concurrently.
         let entry = cache.entry(host.to_string()).or_insert(config);
         Ok(Arc::clone(entry))
+    }
+
+    /// Reports whether a normalized leaf identity is already cached.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the leaf-cache mutex was poisoned by an earlier panic.
+    #[must_use]
+    pub fn is_cached(&self, host: &str) -> bool {
+        self.leaves
+            .lock()
+            .expect("should be able to acquire leaf cache lock")
+            .contains_key(&host.to_ascii_lowercase())
     }
 
     fn mint(&self, host: &str) -> Result<ServerConfig, Report<CaError>> {
@@ -303,6 +318,19 @@ mod tests {
             .server_config("other.example.com")
             .expect("should mint other");
         assert!(!Arc::ptr_eq(&a, &c), "different host mints a new config");
+    }
+
+    #[test]
+    fn leaf_cache_normalizes_dns_case() {
+        let dir = tempfile::tempdir().expect("should create tempdir");
+        let ca = CertAuthority::load_or_generate(dir.path()).expect("should generate");
+        let lower = ca
+            .server_config("www.example.com")
+            .expect("mint lowercase leaf");
+        let mixed = ca
+            .server_config("WWW.Example.COM")
+            .expect("reuse mixed-case leaf");
+        assert!(Arc::ptr_eq(&lower, &mixed));
     }
 
     #[test]

--- a/crates/trusted-server-cli/src/commands/dev/proxy/config.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/config.rs
@@ -355,7 +355,7 @@ mod tests {
     use super::*;
     use crate::commands::dev::proxy::rewrite::rewrite_for;
     use crate::commands::dev::proxy::upstream::key::{
-        AddressPolicy, ApplicationMode, OriginKey, ReferenceIdentity, Transport, VerifyMode,
+        AddressPolicy, OriginKey, ReferenceIdentity, Transport, VerifyMode,
     };
 
     fn base_args() -> crate::commands::dev::proxy::ProxyArgs {
@@ -594,7 +594,6 @@ mod tests {
                 ReferenceIdentity::dns("to.example.com"),
                 8443,
                 VerifyMode::Insecure,
-                ApplicationMode::Http2Eligible,
                 AddressPolicy::Resolve("192.0.2.10".parse().expect("should parse pin")),
             ),
             "should precompute the complete transport identity"
@@ -620,7 +619,6 @@ mod tests {
                 ReferenceIdentity::ip("127.0.0.1".parse().expect("should parse IP")),
                 443,
                 VerifyMode::Secure,
-                ApplicationMode::Http1Required,
                 AddressPolicy::Dns,
             ),
             "IP identities should validate as IP and remain HTTP/1-only"

--- a/crates/trusted-server-cli/src/commands/dev/proxy/config.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/config.rs
@@ -6,9 +6,11 @@ use std::path::PathBuf;
 
 use base64::Engine as _;
 use error_stack::{Report, ResultExt as _};
+use hyper::header::HeaderValue;
 
 use super::ProxyArgs;
 use super::rewrite::{Authority, Rule, RuleTable};
+use super::upstream::key::AddressPolicy;
 
 /// Errors from configuration resolution.
 #[derive(Debug, derive_more::Display)]
@@ -52,27 +54,40 @@ pub enum ConfigError {
 impl core::error::Error for ConfigError {}
 
 /// Basic-auth credentials to inject upstream.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BasicAuth {
-    pub user: String,
-    pub pass: String,
+    header: HeaderValue,
 }
 
 impl BasicAuth {
-    /// The `Authorization` header value (`Basic base64(user:pass)`).
+    /// Precomputes a validated `Authorization` header.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::BasicAuth`] if the generated value is not a valid
+    /// HTTP header value.
+    pub fn new(user: &str, pass: &str) -> Result<Self, ConfigError> {
+        let token = base64::engine::general_purpose::STANDARD.encode(format!("{user}:{pass}"));
+        let header =
+            HeaderValue::from_str(&format!("Basic {token}")).map_err(|_| ConfigError::BasicAuth)?;
+        Ok(Self { header })
+    }
+
+    /// The prevalidated `Authorization` header value.
     #[must_use]
-    pub fn header_value(&self) -> String {
-        let token = base64::engine::general_purpose::STANDARD
-            .encode(format!("{}:{}", self.user, self.pass));
-        format!("Basic {token}")
+    pub fn header_value(&self) -> &HeaderValue {
+        &self.header
     }
 
     fn parse(raw: &str) -> Result<Self, ConfigError> {
         let (user, pass) = raw.split_once(':').ok_or(ConfigError::BasicAuth)?;
-        Ok(Self {
-            user: user.to_string(),
-            pass: pass.to_string(),
-        })
+        Self::new(user, pass)
+    }
+}
+
+impl core::fmt::Debug for BasicAuth {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("BasicAuth([REDACTED])")
     }
 }
 
@@ -163,6 +178,7 @@ fn build_rules(args: &ProxyArgs) -> Result<RuleTable, ConfigError> {
             to,
             args.rewrite_host,
             args.upstream_plaintext,
+            args.insecure,
         )?);
     }
     if let (Some(from), Some(to)) = (&args.from, &args.to) {
@@ -171,6 +187,7 @@ fn build_rules(args: &ProxyArgs) -> Result<RuleTable, ConfigError> {
             to,
             args.rewrite_host,
             args.upstream_plaintext,
+            args.insecure,
         )?);
     }
     Ok(RuleTable(rules))
@@ -221,18 +238,22 @@ fn make_rule(
     to: &str,
     rewrite_host: bool,
     plaintext: bool,
+    insecure: bool,
 ) -> Result<Rule, ConfigError> {
     let from = from.to_ascii_lowercase();
     if !is_valid_host(&from) {
         return Err(ConfigError::InvalidFrom { value: from });
     }
     let to = Authority::parse(to, plaintext).map_err(|_| ConfigError::Rule)?;
-    Ok(Rule {
+    Rule::new(
         from,
         to,
         rewrite_host,
         plaintext,
-    })
+        insecure,
+        AddressPolicy::Dns,
+    )
+    .map_err(|_| ConfigError::Rule)
 }
 
 /// Resolves arguments into a [`ResolvedConfig`].
@@ -243,7 +264,7 @@ fn make_rule(
 /// invalid/forbidden listen address, malformed credentials, or an unknown
 /// browser.
 pub fn resolve(args: &ProxyArgs) -> Result<ResolvedConfig, Report<ConfigError>> {
-    let rules = build_rules(args).map_err(Report::from)?;
+    let mut rules = build_rules(args).map_err(Report::from)?;
     if rules.0.is_empty() {
         return Err(Report::new(ConfigError::NoRule));
     }
@@ -280,6 +301,12 @@ pub fn resolve(args: &ProxyArgs) -> Result<ResolvedConfig, Report<ConfigError>> 
     }
     let ca_dir = ca_dir(args);
     let resolve = build_resolve(args).map_err(Report::from)?;
+
+    for rule in &mut rules.0 {
+        if let Some(address) = resolve.get(rule.to.host()) {
+            rule.set_address_policy(AddressPolicy::Resolve(*address));
+        }
+    }
 
     // A `--resolve HOST:IP` whose HOST matches no rule's TO host is almost
     // certainly a typo: the pin would silently never apply. Warn rather than
@@ -322,7 +349,14 @@ fn resolve_basic_auth(args: &ProxyArgs) -> Result<Option<BasicAuth>, ConfigError
 
 #[cfg(test)]
 mod tests {
+    use hyper::header::HeaderValue;
+    use rustls::pki_types::ServerName;
+
     use super::*;
+    use crate::commands::dev::proxy::rewrite::rewrite_for;
+    use crate::commands::dev::proxy::upstream::key::{
+        AddressPolicy, ApplicationMode, OriginKey, ReferenceIdentity, Transport, VerifyMode,
+    };
 
     fn base_args() -> crate::commands::dev::proxy::ProxyArgs {
         // Construct via clap so defaults match the real surface.
@@ -367,7 +401,11 @@ mod tests {
             .rules
             .first_match("www.example-publisher.com")
             .expect("rule present");
-        assert!(!rule.rewrite_host, "default preserves FROM host");
+        assert_eq!(
+            rewrite_for(rule).host_header,
+            HeaderValue::from_static("www.example-publisher.com"),
+            "default preserves FROM host"
+        );
         assert_eq!(rule.to.host(), "to.edgecompute.app");
     }
 
@@ -377,11 +415,14 @@ mod tests {
         args.map = vec!["www.example-publisher.com=to.edgecompute.app".into()];
         args.rewrite_host = true;
         let cfg = resolve(&args).expect("should resolve");
-        assert!(
-            cfg.rules
-                .first_match("www.example-publisher.com")
-                .expect("rule")
-                .rewrite_host,
+        assert_eq!(
+            rewrite_for(
+                cfg.rules
+                    .first_match("www.example-publisher.com")
+                    .expect("rule")
+            )
+            .host_header,
+            HeaderValue::from_static("to.edgecompute.app"),
             "--rewrite-host sends Host: TO"
         );
     }
@@ -501,14 +542,97 @@ mod tests {
 
     #[test]
     fn basic_auth_header_is_base64() {
-        let auth = BasicAuth {
-            user: "dev".into(),
-            pass: "secret".into(),
-        };
+        let auth = BasicAuth::new("dev", "secret").expect("should build auth");
         assert_eq!(
             auth.header_value(),
-            "Basic ZGV2OnNlY3JldA==",
+            &HeaderValue::from_static("Basic ZGV2OnNlY3JldA=="),
             "Basic base64(user:pass)"
+        );
+        let debug = format!("{auth:?}");
+        assert_eq!(debug, "BasicAuth([REDACTED])", "Debug should be redacted");
+        assert!(!debug.contains("dev"), "Debug should not contain the user");
+        assert!(
+            !debug.contains("secret") && !debug.contains("ZGV2OnNlY3JldA=="),
+            "Debug should not contain raw or encoded credentials"
+        );
+    }
+
+    #[test]
+    fn resolve_precomputes_typed_rule_identity_and_headers() {
+        let mut args = base_args();
+        args.map = vec!["www.example.com=TO.Example.com:8443".into()];
+        args.rewrite_host = true;
+        args.insecure = true;
+        args.resolve = vec!["to.example.com:192.0.2.10".into()];
+
+        let cfg = resolve(&args).expect("should resolve");
+        let rule = cfg
+            .rules
+            .first_match("www.example.com")
+            .expect("should find rule");
+        let outcome = rewrite_for(rule);
+
+        assert_eq!(
+            outcome.host_header,
+            HeaderValue::from_static("to.example.com:8443"),
+            "should prevalidate upstream Host"
+        );
+        assert_eq!(
+            outcome.orig_host,
+            HeaderValue::from_static("www.example.com"),
+            "should prevalidate forwarding host"
+        );
+        assert_eq!(
+            outcome.sni,
+            Some(ServerName::try_from("to.example.com").expect("should parse server name")),
+            "should prevalidate normalized SNI"
+        );
+        assert_eq!(
+            rule.origin_key(),
+            &OriginKey::new(
+                Transport::Tls,
+                ReferenceIdentity::dns("to.example.com"),
+                8443,
+                VerifyMode::Insecure,
+                ApplicationMode::Http2Eligible,
+                AddressPolicy::Resolve("192.0.2.10".parse().expect("should parse pin")),
+            ),
+            "should precompute the complete transport identity"
+        );
+    }
+
+    #[test]
+    fn resolve_keeps_ip_reference_identities_http1_only() {
+        let mut args = base_args();
+        args.map = vec!["www.example.com=127.0.0.1".into()];
+        args.rewrite_host = true;
+
+        let cfg = resolve(&args).expect("should resolve");
+        let rule = cfg
+            .rules
+            .first_match("www.example.com")
+            .expect("should find rule");
+
+        assert_eq!(
+            rule.origin_key(),
+            &OriginKey::new(
+                Transport::Tls,
+                ReferenceIdentity::ip("127.0.0.1".parse().expect("should parse IP")),
+                443,
+                VerifyMode::Secure,
+                ApplicationMode::Http1Required,
+                AddressPolicy::Dns,
+            ),
+            "IP identities should validate as IP and remain HTTP/1-only"
+        );
+        assert_eq!(
+            rewrite_for(rule).sni,
+            Some(ServerName::from(
+                "127.0.0.1"
+                    .parse::<IpAddr>()
+                    .expect("should parse IP server name"),
+            )),
+            "TLS should use an IP server name rather than DNS SNI"
         );
     }
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/metrics.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/metrics.rs
@@ -1,0 +1,265 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+const DURATION_BUCKET_UPPER_BOUNDS_MICROS: [u64; 9] = [
+    100, 500, 1_000, 5_000, 10_000, 50_000, 100_000, 500_000, 1_000_000,
+];
+const DURATION_BUCKET_COUNT: usize = DURATION_BUCKET_UPPER_BOUNDS_MICROS.len() + 1;
+
+/// Low-overhead process-local metrics for `ts dev proxy`.
+#[derive(Default)]
+pub struct ProxyMetrics {
+    initial_heads_parsed: AtomicU64,
+    initial_heads_rejected: AtomicU64,
+    tcp_attempts: AtomicU64,
+    tcp_established: AtomicU64,
+    initial_head_parse_latency: DurationHistogram,
+    connect_latency: DurationHistogram,
+    pool_acquisition_latency: DurationHistogram,
+    queue_wait_latency: DurationHistogram,
+}
+
+impl ProxyMetrics {
+    pub fn record_initial_head_parsed(&self, duration: Duration) {
+        self.initial_heads_parsed.fetch_add(1, Ordering::Relaxed);
+        self.initial_head_parse_latency.record(duration);
+    }
+
+    pub fn record_initial_head_rejected(&self, duration: Duration) {
+        self.initial_heads_rejected.fetch_add(1, Ordering::Relaxed);
+        self.initial_head_parse_latency.record(duration);
+    }
+
+    pub fn record_tcp_attempt(&self) {
+        self.tcp_attempts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_tcp_established(&self, duration: Duration) {
+        self.tcp_established.fetch_add(1, Ordering::Relaxed);
+        self.connect_latency.record(duration);
+    }
+
+    pub fn record_pool_acquisition(&self, duration: Duration) {
+        self.pool_acquisition_latency.record(duration);
+    }
+
+    pub fn record_queue_wait(&self, duration: Duration) {
+        self.queue_wait_latency.record(duration);
+    }
+
+    #[must_use]
+    pub fn debug_summary(&self) -> String {
+        let snapshot = self.snapshot();
+        format!(
+            "dev proxy metrics: initial_heads_parsed={} initial_heads_rejected={} \
+             initial_head_parse_samples={} tcp_attempts={} tcp_established={} \
+             connect_samples={} pool_acquisition_samples={} queue_wait_samples={} \
+             duration_bounds_us={:?} initial_head_parse_us_buckets={:?} \
+             connect_us_buckets={:?} pool_acquisition_us_buckets={:?} \
+             queue_wait_us_buckets={:?}",
+            snapshot.initial_heads_parsed,
+            snapshot.initial_heads_rejected,
+            snapshot.initial_head_parse_latency.total(),
+            snapshot.tcp_attempts,
+            snapshot.tcp_established,
+            snapshot.connect_latency.total(),
+            snapshot.pool_acquisition_latency.total(),
+            snapshot.queue_wait_latency.total(),
+            DURATION_BUCKET_UPPER_BOUNDS_MICROS,
+            snapshot.initial_head_parse_latency.buckets(),
+            snapshot.connect_latency.buckets(),
+            snapshot.pool_acquisition_latency.buckets(),
+            snapshot.queue_wait_latency.buckets(),
+        )
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> ProxyMetricsSnapshot {
+        ProxyMetricsSnapshot {
+            initial_heads_parsed: self.initial_heads_parsed.load(Ordering::Relaxed),
+            initial_heads_rejected: self.initial_heads_rejected.load(Ordering::Relaxed),
+            tcp_attempts: self.tcp_attempts.load(Ordering::Relaxed),
+            tcp_established: self.tcp_established.load(Ordering::Relaxed),
+            initial_head_parse_latency: self.initial_head_parse_latency.snapshot(),
+            connect_latency: self.connect_latency.snapshot(),
+            pool_acquisition_latency: self.pool_acquisition_latency.snapshot(),
+            queue_wait_latency: self.queue_wait_latency.snapshot(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ProxyMetricsSnapshot {
+    pub initial_heads_parsed: u64,
+    pub initial_heads_rejected: u64,
+    pub tcp_attempts: u64,
+    pub tcp_established: u64,
+    pub initial_head_parse_latency: DurationHistogramSnapshot,
+    pub connect_latency: DurationHistogramSnapshot,
+    pub pool_acquisition_latency: DurationHistogramSnapshot,
+    pub queue_wait_latency: DurationHistogramSnapshot,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct DurationHistogramSnapshot {
+    buckets: [u64; DURATION_BUCKET_COUNT],
+}
+
+impl DurationHistogramSnapshot {
+    #[must_use]
+    pub fn buckets(&self) -> &[u64; DURATION_BUCKET_COUNT] {
+        &self.buckets
+    }
+
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.buckets.iter().sum()
+    }
+}
+
+struct DurationHistogram {
+    buckets: [AtomicU64; DURATION_BUCKET_COUNT],
+}
+
+impl Default for DurationHistogram {
+    fn default() -> Self {
+        Self {
+            buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+}
+
+impl DurationHistogram {
+    fn record(&self, duration: Duration) {
+        let micros = u64::try_from(duration.as_micros()).unwrap_or(u64::MAX);
+        let bucket = DURATION_BUCKET_UPPER_BOUNDS_MICROS
+            .iter()
+            .position(|upper_bound| micros <= *upper_bound)
+            .unwrap_or(DURATION_BUCKET_COUNT - 1);
+        self.buckets[bucket].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[must_use]
+    fn snapshot(&self) -> DurationHistogramSnapshot {
+        DurationHistogramSnapshot {
+            buckets: std::array::from_fn(|index| self.buckets[index].load(Ordering::Relaxed)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_separates_attempts_from_established() {
+        let metrics = ProxyMetrics::default();
+
+        metrics.record_tcp_attempt();
+        metrics.record_tcp_attempt();
+        metrics.record_tcp_established(Duration::from_millis(7));
+        let snapshot = metrics.snapshot();
+
+        assert_eq!(snapshot.tcp_attempts, 2, "should count every attempt");
+        assert_eq!(
+            snapshot.tcp_established, 1,
+            "should count only established connections"
+        );
+        assert_eq!(
+            snapshot.connect_latency.total(),
+            1,
+            "should record one successful connect duration"
+        );
+    }
+
+    #[test]
+    fn histogram_uses_fixed_bounded_buckets() {
+        let metrics = ProxyMetrics::default();
+
+        for duration in [
+            Duration::ZERO,
+            Duration::from_micros(100),
+            Duration::from_micros(101),
+            Duration::from_secs(1),
+            Duration::from_micros(1_000_001),
+        ] {
+            metrics.record_tcp_established(duration);
+        }
+        let snapshot = metrics.snapshot();
+
+        assert_eq!(
+            snapshot.connect_latency.buckets(),
+            &[2, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+            "should place timings into fixed buckets with a final overflow bucket"
+        );
+    }
+
+    #[test]
+    fn snapshot_records_initial_head_and_pool_phase_timings() {
+        let metrics = ProxyMetrics::default();
+
+        metrics.record_initial_head_parsed(Duration::from_micros(250));
+        metrics.record_initial_head_rejected(Duration::from_micros(500));
+        metrics.record_pool_acquisition(Duration::from_millis(2));
+        metrics.record_queue_wait(Duration::from_millis(3));
+        let snapshot = metrics.snapshot();
+
+        assert_eq!(
+            snapshot.initial_heads_parsed, 1,
+            "should count parsed heads"
+        );
+        assert_eq!(
+            snapshot.initial_heads_rejected, 1,
+            "should count rejected heads"
+        );
+        assert_eq!(
+            snapshot.initial_head_parse_latency.total(),
+            2,
+            "should time both accepted and rejected parsing"
+        );
+        assert_eq!(
+            snapshot.pool_acquisition_latency.total(),
+            1,
+            "should time pool acquisition"
+        );
+        assert_eq!(
+            snapshot.queue_wait_latency.total(),
+            1,
+            "should time queue waits"
+        );
+    }
+
+    #[test]
+    fn debug_summary_contains_only_aggregate_metrics() {
+        let metrics = ProxyMetrics::default();
+        metrics.record_tcp_attempt();
+        metrics.record_tcp_established(Duration::from_millis(7));
+        metrics.record_initial_head_parsed(Duration::from_micros(250));
+
+        let summary = metrics.debug_summary();
+
+        assert!(
+            summary.contains("tcp_attempts=1"),
+            "should report aggregate attempt count"
+        );
+        assert!(
+            summary.contains("connect_samples=1"),
+            "should report aggregate timing count"
+        );
+        assert!(
+            summary.contains("initial_heads_parsed=1"),
+            "should report aggregate parse count"
+        );
+        assert!(
+            summary.contains("duration_bounds_us=[100, 500")
+                && summary.contains("connect_us_buckets=[0, 0, 0, 0, 1"),
+            "should report interpretable aggregate timing buckets"
+        );
+        assert!(
+            !summary.contains("http://")
+                && !summary.contains("authorization")
+                && !summary.contains("certificate"),
+            "should not contain request or credential fields"
+        );
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/metrics.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/metrics.rs
@@ -38,92 +38,114 @@ pub struct ProxyMetrics {
 }
 
 impl ProxyMetrics {
+    /// Records an accepted browser-side connection.
     pub fn record_browser_connection(&self) {
         self.browser_connections.fetch_add(1, Ordering::Relaxed);
     }
+    /// Records a successfully parsed initial request head and its latency.
     pub fn record_initial_head_parsed(&self, duration: Duration) {
         self.initial_heads_parsed.fetch_add(1, Ordering::Relaxed);
         self.initial_head_parse_latency.record(duration);
     }
 
+    /// Records a rejected initial request head and its parse latency.
     pub fn record_initial_head_rejected(&self, duration: Duration) {
         self.initial_heads_rejected.fetch_add(1, Ordering::Relaxed);
         self.initial_head_parse_latency.record(duration);
     }
 
+    /// Records one TCP connection attempt.
     pub fn record_tcp_attempt(&self) {
         self.tcp_attempts.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records a successful TCP connection and its latency.
     pub fn record_tcp_established(&self, duration: Duration) {
         self.tcp_established.fetch_add(1, Ordering::Relaxed);
         self.connect_latency.record(duration);
     }
 
+    /// Records total manager acquisition latency, including failed acquisitions.
     pub fn record_pool_acquisition(&self, duration: Duration) {
         self.pool_acquisition_latency.record(duration);
     }
 
+    /// Records time spent queued behind upstream connection limits.
     pub fn record_queue_wait(&self, duration: Duration) {
         self.queue_wait_latency.record(duration);
     }
 
+    /// Records reuse of an idle upstream connection.
     pub fn record_pool_hit(&self) {
         self.pool_hits.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records a new upstream connection reservation.
     pub fn record_pool_miss(&self) {
         self.pool_misses.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records detection of a stale pooled sender.
     pub fn record_pool_stale(&self) {
         self.pool_stale.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records one safe stale-connection retry.
     pub fn record_pool_retry(&self) {
         self.pool_retries.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records a response that reached terminal end-of-stream successfully.
     pub fn record_request_completed(&self) {
         self.requests_completed.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records a request that terminated without a complete response.
     pub fn record_request_failed(&self) {
         self.requests_failed.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records latency from request dispatch to upstream response headers.
     pub fn record_request_to_headers(&self, duration: Duration) {
         self.request_to_headers_latency.record(duration);
     }
 
+    /// Records one underlying DNS lookup latency.
     pub fn record_dns_lookup(&self, duration: Duration) {
         self.dns_lookup_latency.record(duration);
     }
 
+    /// Records a ready or in-flight DNS cache hit.
     pub fn record_dns_cache_hit(&self) {
         self.dns_cache_hits.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records a DNS cache miss that starts resolver work.
     pub fn record_dns_cache_miss(&self) {
         self.dns_cache_misses.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records one completed TLS handshake latency.
     pub fn record_tls_handshake(&self, duration: Duration) {
         self.tls_handshake_latency.record(duration);
     }
 
+    /// Records one completed upstream HTTP handshake latency.
     pub fn record_http_handshake(&self, duration: Duration) {
         self.http_handshake_latency.record(duration);
     }
 
+    /// Records negotiation of an HTTP/1 upstream connection.
     pub fn record_negotiated_http1(&self) {
         self.negotiated_http1.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records reuse of a cached development leaf certificate.
     pub fn record_ca_hit(&self) {
         self.ca_hits.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records one development certificate mint and whether it was unexpected.
     pub fn record_ca_miss(&self, duration: Duration, unexpected: bool) {
         self.ca_misses.fetch_add(1, Ordering::Relaxed);
         self.ca_mint_latency.record(duration);
@@ -133,6 +155,7 @@ impl ProxyMetrics {
     }
 
     #[must_use]
+    /// Formats a redacted aggregate summary suitable for shutdown diagnostics.
     pub fn debug_summary(&self) -> String {
         let snapshot = self.snapshot();
         format!(
@@ -142,9 +165,16 @@ impl ProxyMetrics {
              requests_failed={} pool_acquisition_samples={} queue_wait_samples={} \
              request_to_headers_samples={} dns_lookup_samples={} dns_cache_hits={} dns_cache_misses={} tls_handshake_samples={} \
              http_handshake_samples={} negotiated_http1={} ca_hits={} ca_misses={} unexpected_ca_mints={} \
-             duration_bounds_us={:?} initial_head_parse_us_buckets={:?} \
-             connect_us_buckets={:?} pool_acquisition_us_buckets={:?} \
-             queue_wait_us_buckets={:?}",
+             ca_mint_samples={} duration_bounds_us={:?} \
+             initial_head_parse_us_total={} initial_head_parse_us_buckets={:?} \
+             connect_us_total={} connect_us_buckets={:?} \
+             pool_acquisition_us_total={} pool_acquisition_us_buckets={:?} \
+             queue_wait_us_total={} queue_wait_us_buckets={:?} \
+             request_to_headers_us_total={} request_to_headers_us_buckets={:?} \
+             dns_lookup_us_total={} dns_lookup_us_buckets={:?} \
+             tls_handshake_us_total={} tls_handshake_us_buckets={:?} \
+             http_handshake_us_total={} http_handshake_us_buckets={:?} \
+             ca_mint_us_total={} ca_mint_us_buckets={:?}",
             snapshot.browser_connections,
             snapshot.initial_heads_parsed,
             snapshot.initial_heads_rejected,
@@ -170,15 +200,31 @@ impl ProxyMetrics {
             snapshot.ca_hits,
             snapshot.ca_misses,
             snapshot.unexpected_ca_mints,
+            snapshot.ca_mint_latency.total(),
             DURATION_BUCKET_UPPER_BOUNDS_MICROS,
+            snapshot.initial_head_parse_latency.total_micros(),
             snapshot.initial_head_parse_latency.buckets(),
+            snapshot.connect_latency.total_micros(),
             snapshot.connect_latency.buckets(),
+            snapshot.pool_acquisition_latency.total_micros(),
             snapshot.pool_acquisition_latency.buckets(),
+            snapshot.queue_wait_latency.total_micros(),
             snapshot.queue_wait_latency.buckets(),
+            snapshot.request_to_headers_latency.total_micros(),
+            snapshot.request_to_headers_latency.buckets(),
+            snapshot.dns_lookup_latency.total_micros(),
+            snapshot.dns_lookup_latency.buckets(),
+            snapshot.tls_handshake_latency.total_micros(),
+            snapshot.tls_handshake_latency.buckets(),
+            snapshot.http_handshake_latency.total_micros(),
+            snapshot.http_handshake_latency.buckets(),
+            snapshot.ca_mint_latency.total_micros(),
+            snapshot.ca_mint_latency.buckets(),
         )
     }
 
     #[must_use]
+    /// Captures a point-in-time copy of every counter and duration histogram.
     pub fn snapshot(&self) -> ProxyMetricsSnapshot {
         ProxyMetricsSnapshot {
             browser_connections: self.browser_connections.load(Ordering::Relaxed),
@@ -212,36 +258,64 @@ impl ProxyMetrics {
 }
 
 #[derive(Debug, Eq, PartialEq)]
+/// Point-in-time aggregate metrics for tests and diagnostics.
 pub struct ProxyMetricsSnapshot {
+    /// Browser-side connections accepted.
     pub browser_connections: u64,
+    /// Initial request heads parsed successfully.
     pub initial_heads_parsed: u64,
+    /// Initial request heads rejected.
     pub initial_heads_rejected: u64,
+    /// TCP connection attempts.
     pub tcp_attempts: u64,
+    /// TCP connections established.
     pub tcp_established: u64,
+    /// Idle pool hits.
     pub pool_hits: u64,
+    /// New connection reservations.
     pub pool_misses: u64,
+    /// Stale pooled senders detected.
     pub pool_stale: u64,
+    /// Safe stale retries attempted.
     pub pool_retries: u64,
+    /// Responses completed successfully.
     pub requests_completed: u64,
+    /// Requests terminated unsuccessfully.
     pub requests_failed: u64,
+    /// Initial-head parsing latency.
     pub initial_head_parse_latency: DurationHistogramSnapshot,
+    /// Successful TCP connection latency.
     pub connect_latency: DurationHistogramSnapshot,
+    /// Manager acquisition latency.
     pub pool_acquisition_latency: DurationHistogramSnapshot,
+    /// Manager queue-wait latency.
     pub queue_wait_latency: DurationHistogramSnapshot,
+    /// Request-to-response-headers latency.
     pub request_to_headers_latency: DurationHistogramSnapshot,
+    /// Underlying DNS lookup latency.
     pub dns_lookup_latency: DurationHistogramSnapshot,
+    /// Ready or in-flight DNS cache hits.
     pub dns_cache_hits: u64,
+    /// DNS resolver work started after a cache miss.
     pub dns_cache_misses: u64,
+    /// TLS handshake latency.
     pub tls_handshake_latency: DurationHistogramSnapshot,
+    /// HTTP handshake latency.
     pub http_handshake_latency: DurationHistogramSnapshot,
+    /// HTTP/1 connections negotiated.
     pub negotiated_http1: u64,
+    /// Development certificate cache hits.
     pub ca_hits: u64,
+    /// Development certificate cache misses.
     pub ca_misses: u64,
+    /// Certificate mints after the expected startup set.
     pub unexpected_ca_mints: u64,
+    /// Development certificate mint latency.
     pub ca_mint_latency: DurationHistogramSnapshot,
 }
 
 #[derive(Debug, Eq, PartialEq)]
+/// Immutable fixed-bucket duration histogram snapshot.
 pub struct DurationHistogramSnapshot {
     buckets: [u64; DURATION_BUCKET_COUNT],
     total_micros: u64,
@@ -249,16 +323,19 @@ pub struct DurationHistogramSnapshot {
 
 impl DurationHistogramSnapshot {
     #[must_use]
+    /// Returns the fixed bucket counts in ascending-bound order plus overflow.
     pub fn buckets(&self) -> &[u64; DURATION_BUCKET_COUNT] {
         &self.buckets
     }
 
     #[must_use]
+    /// Returns the number of recorded duration samples.
     pub fn total(&self) -> u64 {
         self.buckets.iter().sum()
     }
 
     #[must_use]
+    /// Returns the saturating sum of recorded durations in microseconds.
     pub fn total_micros(&self) -> u64 {
         self.total_micros
     }
@@ -386,6 +463,11 @@ mod tests {
         metrics.record_tcp_attempt();
         metrics.record_tcp_established(Duration::from_millis(7));
         metrics.record_initial_head_parsed(Duration::from_micros(250));
+        metrics.record_request_to_headers(Duration::from_millis(5));
+        metrics.record_dns_lookup(Duration::from_millis(7));
+        metrics.record_tls_handshake(Duration::from_millis(11));
+        metrics.record_http_handshake(Duration::from_millis(13));
+        metrics.record_ca_miss(Duration::from_millis(17), false);
 
         let summary = metrics.debug_summary();
 
@@ -406,6 +488,23 @@ mod tests {
                 && summary.contains("connect_us_buckets=[0, 0, 0, 0, 1"),
             "should report interpretable aggregate timing buckets"
         );
+        for expected in [
+            "request_to_headers_us_total=5000",
+            "request_to_headers_us_buckets=",
+            "dns_lookup_us_total=7000",
+            "dns_lookup_us_buckets=",
+            "tls_handshake_us_total=11000",
+            "tls_handshake_us_buckets=",
+            "http_handshake_us_total=13000",
+            "http_handshake_us_buckets=",
+            "ca_mint_us_total=17000",
+            "ca_mint_us_buckets=",
+        ] {
+            assert!(
+                summary.contains(expected),
+                "summary should include {expected}: {summary}"
+            );
+        }
         assert!(
             !summary.contains("http://")
                 && !summary.contains("authorization")

--- a/crates/trusted-server-cli/src/commands/dev/proxy/metrics.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/metrics.rs
@@ -9,17 +9,38 @@ const DURATION_BUCKET_COUNT: usize = DURATION_BUCKET_UPPER_BOUNDS_MICROS.len() +
 /// Low-overhead process-local metrics for `ts dev proxy`.
 #[derive(Default)]
 pub struct ProxyMetrics {
+    browser_connections: AtomicU64,
     initial_heads_parsed: AtomicU64,
     initial_heads_rejected: AtomicU64,
     tcp_attempts: AtomicU64,
     tcp_established: AtomicU64,
+    pool_hits: AtomicU64,
+    pool_misses: AtomicU64,
+    pool_stale: AtomicU64,
+    pool_retries: AtomicU64,
+    requests_completed: AtomicU64,
+    requests_failed: AtomicU64,
     initial_head_parse_latency: DurationHistogram,
     connect_latency: DurationHistogram,
     pool_acquisition_latency: DurationHistogram,
     queue_wait_latency: DurationHistogram,
+    request_to_headers_latency: DurationHistogram,
+    dns_lookup_latency: DurationHistogram,
+    dns_cache_hits: AtomicU64,
+    dns_cache_misses: AtomicU64,
+    tls_handshake_latency: DurationHistogram,
+    http_handshake_latency: DurationHistogram,
+    negotiated_http1: AtomicU64,
+    ca_hits: AtomicU64,
+    ca_misses: AtomicU64,
+    unexpected_ca_mints: AtomicU64,
+    ca_mint_latency: DurationHistogram,
 }
 
 impl ProxyMetrics {
+    pub fn record_browser_connection(&self) {
+        self.browser_connections.fetch_add(1, Ordering::Relaxed);
+    }
     pub fn record_initial_head_parsed(&self, duration: Duration) {
         self.initial_heads_parsed.fetch_add(1, Ordering::Relaxed);
         self.initial_head_parse_latency.record(duration);
@@ -47,24 +68,108 @@ impl ProxyMetrics {
         self.queue_wait_latency.record(duration);
     }
 
+    pub fn record_pool_hit(&self) {
+        self.pool_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_pool_miss(&self) {
+        self.pool_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_pool_stale(&self) {
+        self.pool_stale.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_pool_retry(&self) {
+        self.pool_retries.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_request_completed(&self) {
+        self.requests_completed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_request_failed(&self) {
+        self.requests_failed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_request_to_headers(&self, duration: Duration) {
+        self.request_to_headers_latency.record(duration);
+    }
+
+    pub fn record_dns_lookup(&self, duration: Duration) {
+        self.dns_lookup_latency.record(duration);
+    }
+
+    pub fn record_dns_cache_hit(&self) {
+        self.dns_cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_dns_cache_miss(&self) {
+        self.dns_cache_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_tls_handshake(&self, duration: Duration) {
+        self.tls_handshake_latency.record(duration);
+    }
+
+    pub fn record_http_handshake(&self, duration: Duration) {
+        self.http_handshake_latency.record(duration);
+    }
+
+    pub fn record_negotiated_http1(&self) {
+        self.negotiated_http1.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_ca_hit(&self) {
+        self.ca_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_ca_miss(&self, duration: Duration, unexpected: bool) {
+        self.ca_misses.fetch_add(1, Ordering::Relaxed);
+        self.ca_mint_latency.record(duration);
+        if unexpected {
+            self.unexpected_ca_mints.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     #[must_use]
     pub fn debug_summary(&self) -> String {
         let snapshot = self.snapshot();
         format!(
-            "dev proxy metrics: initial_heads_parsed={} initial_heads_rejected={} \
+            "dev proxy metrics: browser_connections={} initial_heads_parsed={} initial_heads_rejected={} \
              initial_head_parse_samples={} tcp_attempts={} tcp_established={} \
-             connect_samples={} pool_acquisition_samples={} queue_wait_samples={} \
+             connect_samples={} pool_hits={} pool_misses={} pool_stale={} pool_retries={} requests_completed={} \
+             requests_failed={} pool_acquisition_samples={} queue_wait_samples={} \
+             request_to_headers_samples={} dns_lookup_samples={} dns_cache_hits={} dns_cache_misses={} tls_handshake_samples={} \
+             http_handshake_samples={} negotiated_http1={} ca_hits={} ca_misses={} unexpected_ca_mints={} \
              duration_bounds_us={:?} initial_head_parse_us_buckets={:?} \
              connect_us_buckets={:?} pool_acquisition_us_buckets={:?} \
              queue_wait_us_buckets={:?}",
+            snapshot.browser_connections,
             snapshot.initial_heads_parsed,
             snapshot.initial_heads_rejected,
             snapshot.initial_head_parse_latency.total(),
             snapshot.tcp_attempts,
             snapshot.tcp_established,
             snapshot.connect_latency.total(),
+            snapshot.pool_hits,
+            snapshot.pool_misses,
+            snapshot.pool_stale,
+            snapshot.pool_retries,
+            snapshot.requests_completed,
+            snapshot.requests_failed,
             snapshot.pool_acquisition_latency.total(),
             snapshot.queue_wait_latency.total(),
+            snapshot.request_to_headers_latency.total(),
+            snapshot.dns_lookup_latency.total(),
+            snapshot.dns_cache_hits,
+            snapshot.dns_cache_misses,
+            snapshot.tls_handshake_latency.total(),
+            snapshot.http_handshake_latency.total(),
+            snapshot.negotiated_http1,
+            snapshot.ca_hits,
+            snapshot.ca_misses,
+            snapshot.unexpected_ca_mints,
             DURATION_BUCKET_UPPER_BOUNDS_MICROS,
             snapshot.initial_head_parse_latency.buckets(),
             snapshot.connect_latency.buckets(),
@@ -76,33 +181,70 @@ impl ProxyMetrics {
     #[must_use]
     pub fn snapshot(&self) -> ProxyMetricsSnapshot {
         ProxyMetricsSnapshot {
+            browser_connections: self.browser_connections.load(Ordering::Relaxed),
             initial_heads_parsed: self.initial_heads_parsed.load(Ordering::Relaxed),
             initial_heads_rejected: self.initial_heads_rejected.load(Ordering::Relaxed),
             tcp_attempts: self.tcp_attempts.load(Ordering::Relaxed),
             tcp_established: self.tcp_established.load(Ordering::Relaxed),
+            pool_hits: self.pool_hits.load(Ordering::Relaxed),
+            pool_misses: self.pool_misses.load(Ordering::Relaxed),
+            pool_stale: self.pool_stale.load(Ordering::Relaxed),
+            pool_retries: self.pool_retries.load(Ordering::Relaxed),
+            requests_completed: self.requests_completed.load(Ordering::Relaxed),
+            requests_failed: self.requests_failed.load(Ordering::Relaxed),
             initial_head_parse_latency: self.initial_head_parse_latency.snapshot(),
             connect_latency: self.connect_latency.snapshot(),
             pool_acquisition_latency: self.pool_acquisition_latency.snapshot(),
             queue_wait_latency: self.queue_wait_latency.snapshot(),
+            request_to_headers_latency: self.request_to_headers_latency.snapshot(),
+            dns_lookup_latency: self.dns_lookup_latency.snapshot(),
+            dns_cache_hits: self.dns_cache_hits.load(Ordering::Relaxed),
+            dns_cache_misses: self.dns_cache_misses.load(Ordering::Relaxed),
+            tls_handshake_latency: self.tls_handshake_latency.snapshot(),
+            http_handshake_latency: self.http_handshake_latency.snapshot(),
+            negotiated_http1: self.negotiated_http1.load(Ordering::Relaxed),
+            ca_hits: self.ca_hits.load(Ordering::Relaxed),
+            ca_misses: self.ca_misses.load(Ordering::Relaxed),
+            unexpected_ca_mints: self.unexpected_ca_mints.load(Ordering::Relaxed),
+            ca_mint_latency: self.ca_mint_latency.snapshot(),
         }
     }
 }
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct ProxyMetricsSnapshot {
+    pub browser_connections: u64,
     pub initial_heads_parsed: u64,
     pub initial_heads_rejected: u64,
     pub tcp_attempts: u64,
     pub tcp_established: u64,
+    pub pool_hits: u64,
+    pub pool_misses: u64,
+    pub pool_stale: u64,
+    pub pool_retries: u64,
+    pub requests_completed: u64,
+    pub requests_failed: u64,
     pub initial_head_parse_latency: DurationHistogramSnapshot,
     pub connect_latency: DurationHistogramSnapshot,
     pub pool_acquisition_latency: DurationHistogramSnapshot,
     pub queue_wait_latency: DurationHistogramSnapshot,
+    pub request_to_headers_latency: DurationHistogramSnapshot,
+    pub dns_lookup_latency: DurationHistogramSnapshot,
+    pub dns_cache_hits: u64,
+    pub dns_cache_misses: u64,
+    pub tls_handshake_latency: DurationHistogramSnapshot,
+    pub http_handshake_latency: DurationHistogramSnapshot,
+    pub negotiated_http1: u64,
+    pub ca_hits: u64,
+    pub ca_misses: u64,
+    pub unexpected_ca_mints: u64,
+    pub ca_mint_latency: DurationHistogramSnapshot,
 }
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct DurationHistogramSnapshot {
     buckets: [u64; DURATION_BUCKET_COUNT],
+    total_micros: u64,
 }
 
 impl DurationHistogramSnapshot {
@@ -115,16 +257,23 @@ impl DurationHistogramSnapshot {
     pub fn total(&self) -> u64 {
         self.buckets.iter().sum()
     }
+
+    #[must_use]
+    pub fn total_micros(&self) -> u64 {
+        self.total_micros
+    }
 }
 
 struct DurationHistogram {
     buckets: [AtomicU64; DURATION_BUCKET_COUNT],
+    total_micros: AtomicU64,
 }
 
 impl Default for DurationHistogram {
     fn default() -> Self {
         Self {
             buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+            total_micros: AtomicU64::new(0),
         }
     }
 }
@@ -137,12 +286,14 @@ impl DurationHistogram {
             .position(|upper_bound| micros <= *upper_bound)
             .unwrap_or(DURATION_BUCKET_COUNT - 1);
         self.buckets[bucket].fetch_add(1, Ordering::Relaxed);
+        self.total_micros.fetch_add(micros, Ordering::Relaxed);
     }
 
     #[must_use]
     fn snapshot(&self) -> DurationHistogramSnapshot {
         DurationHistogramSnapshot {
             buckets: std::array::from_fn(|index| self.buckets[index].load(Ordering::Relaxed)),
+            total_micros: self.total_micros.load(Ordering::Relaxed),
         }
     }
 }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod metrics;
 pub mod rewrite;
 pub mod server;
+pub mod upstream;
 
 use std::sync::Arc;
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
@@ -62,6 +62,20 @@ pub enum ProxyError {
 
 impl core::error::Error for ProxyError {}
 
+async fn finish_interrupted_run<Restore, Stop, Drain>(
+    restore_system_proxy: Restore,
+    stop_accept_loop: Stop,
+    drain_manager: Drain,
+) where
+    Restore: FnOnce(),
+    Stop: FnOnce(),
+    Drain: std::future::Future<Output = ()>,
+{
+    restore_system_proxy();
+    stop_accept_loop();
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), drain_manager).await;
+}
+
 /// `ts dev proxy [OPTIONS]` — see the design spec §4.
 #[derive(Debug, clap::Args)]
 pub struct ProxyArgs {
@@ -296,16 +310,80 @@ pub fn run(args: &ProxyArgs) -> core::result::Result<(), error_stack::Report<Pro
             _ = tokio::signal::ctrl_c() => {
                 // Interactive: the cached sudo credential may have expired during
                 // a long run, so allow `sudo networksetup` to prompt for it.
-                browser::restore_system_proxy_if_pending(&cfg.ca_dir, true);
-                server.abort();
-                let _ = tokio::time::timeout(
-                    std::time::Duration::from_secs(2),
+                finish_interrupted_run(
+                    || browser::restore_system_proxy_if_pending(&cfg.ca_dir, true),
+                    || server.abort(),
                     state.upstream.shutdown(),
-                )
-                .await;
+                ).await;
                 log::debug!("{}", state.metrics.debug_summary());
                 Ok(())
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context, Poll};
+
+    use super::*;
+
+    struct DrainProbe {
+        events: Arc<Mutex<Vec<&'static str>>>,
+        recorded: bool,
+    }
+
+    impl std::future::Future for DrainProbe {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if !self.recorded {
+                self.events
+                    .lock()
+                    .expect("should lock shutdown events")
+                    .push("drain");
+                self.recorded = true;
+            }
+            Poll::Pending
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn interrupt_cleanup_restores_then_stops_then_bounds_drain() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let started = tokio::time::Instant::now();
+        finish_interrupted_run(
+            {
+                let events = Arc::clone(&events);
+                move || {
+                    events
+                        .lock()
+                        .expect("should lock shutdown events")
+                        .push("restore");
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || {
+                    events
+                        .lock()
+                        .expect("should lock shutdown events")
+                        .push("stop");
+                }
+            },
+            DrainProbe {
+                events: Arc::clone(&events),
+                recorded: false,
+            },
+        )
+        .await;
+
+        assert_eq!(
+            *events.lock().expect("should lock shutdown events"),
+            ["restore", "stop", "drain"]
+        );
+        assert_eq!(started.elapsed(), std::time::Duration::from_secs(2));
+    }
 }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
@@ -22,9 +22,21 @@ pub struct ProxyState {
 impl ProxyState {
     #[must_use]
     pub fn new(config: Arc<config::ResolvedConfig>) -> Arc<Self> {
+        Self::with_upstream_options(config, upstream::UpstreamOptions::default())
+    }
+
+    #[must_use]
+    pub fn with_upstream_options(
+        config: Arc<config::ResolvedConfig>,
+        options: upstream::UpstreamOptions,
+    ) -> Arc<Self> {
         let metrics = Arc::new(metrics::ProxyMetrics::default());
         Arc::new(Self {
-            upstream: upstream::UpstreamClient::new(Arc::clone(&metrics), config.connect_timeout),
+            upstream: upstream::UpstreamClient::with_options(
+                Arc::clone(&metrics),
+                config.connect_timeout,
+                options,
+            ),
             config,
             metrics,
         })

--- a/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
@@ -1,6 +1,7 @@
 pub mod browser;
 pub mod ca;
 pub mod config;
+pub mod metrics;
 pub mod rewrite;
 pub mod server;
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/mod.rs
@@ -2,6 +2,7 @@ pub mod browser;
 pub mod ca;
 pub mod config;
 pub mod metrics;
+pub mod prefixed_io;
 pub mod rewrite;
 pub mod server;
 pub mod upstream;
@@ -11,6 +12,24 @@ use std::sync::Arc;
 use error_stack::ResultExt as _;
 
 use crate::output;
+
+pub struct ProxyState {
+    pub config: Arc<config::ResolvedConfig>,
+    pub upstream: upstream::UpstreamClient,
+    pub metrics: Arc<metrics::ProxyMetrics>,
+}
+
+impl ProxyState {
+    #[must_use]
+    pub fn new(config: Arc<config::ResolvedConfig>) -> Arc<Self> {
+        let metrics = Arc::new(metrics::ProxyMetrics::default());
+        Arc::new(Self {
+            upstream: upstream::UpstreamClient::new(Arc::clone(&metrics), config.connect_timeout),
+            config,
+            metrics,
+        })
+    }
+}
 
 /// Errors surfaced by `ts dev proxy`.
 #[derive(Debug, derive_more::Display)]
@@ -231,11 +250,21 @@ pub fn run(args: &ProxyArgs) -> core::result::Result<(), error_stack::Report<Pro
             .change_context(ProxyError::Server)?;
         cfg.listen = listener.local_addr().change_context(ProxyError::Server)?;
         let cfg = Arc::new(cfg);
+        let state = ProxyState::new(Arc::clone(&cfg));
+        for rule in &cfg.rules.0 {
+            if ca.is_cached(&rule.from) {
+                continue;
+            }
+            let started = tokio::time::Instant::now();
+            ca.server_config(&rule.from)
+                .change_context(ProxyError::CertAuthority)?;
+            state.metrics.record_ca_miss(started.elapsed(), false);
+        }
         let pac: Arc<str> = Arc::from(browser::generate_pac(&cfg.rules, cfg.listen).as_str());
         output::info(&format!("ts dev proxy listening on {}", cfg.listen));
-        let server = tokio::spawn(server::serve_on(
+        let mut server = tokio::spawn(server::serve_on_with_state(
             listener,
-            Arc::clone(&cfg),
+            Arc::clone(&state),
             Arc::clone(&ca),
             Arc::clone(&pac),
         ));
@@ -251,11 +280,18 @@ pub fn run(args: &ProxyArgs) -> core::result::Result<(), error_stack::Report<Pro
         // Race the server against Ctrl-C.  On clean interrupt, restore any
         // system proxy state that was changed for Safari before exiting.
         tokio::select! {
-            result = server => result.change_context(ProxyError::Server)?,
+            result = &mut server => result.change_context(ProxyError::Server)?,
             _ = tokio::signal::ctrl_c() => {
                 // Interactive: the cached sudo credential may have expired during
                 // a long run, so allow `sudo networksetup` to prompt for it.
                 browser::restore_system_proxy_if_pending(&cfg.ca_dir, true);
+                server.abort();
+                let _ = tokio::time::timeout(
+                    std::time::Duration::from_secs(2),
+                    state.upstream.shutdown(),
+                )
+                .await;
+                log::debug!("{}", state.metrics.debug_summary());
                 Ok(())
             }
         }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/prefixed_io.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/prefixed_io.rs
@@ -1,0 +1,77 @@
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// An I/O stream that replays parser over-read bytes exactly once before the socket.
+pub struct PrefixedIo<T> {
+    inner: T,
+    prefix: Vec<u8>,
+    position: usize,
+}
+
+impl<T> PrefixedIo<T> {
+    #[must_use]
+    pub fn new(inner: T, prefix: Vec<u8>) -> Self {
+        Self {
+            inner,
+            prefix,
+            position: 0,
+        }
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for PrefixedIo<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.position < self.prefix.len() {
+            let count = (self.prefix.len() - self.position).min(buf.remaining());
+            let end = self.position + count;
+            buf.put_slice(&self.prefix[self.position..end]);
+            self.position = end;
+            return Poll::Ready(Ok(()));
+        }
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for PrefixedIo<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, duplex};
+
+    #[tokio::test]
+    async fn prefix_is_delivered_once_before_inner_bytes() {
+        let (mut writer, reader) = duplex(16);
+        tokio::spawn(async move {
+            writer.write_all(b"socket").await.expect("write inner");
+        });
+        let mut prefixed = PrefixedIo::new(reader, b"prefix-".to_vec());
+        let mut output = Vec::new();
+        prefixed.read_to_end(&mut output).await.expect("read all");
+        assert_eq!(output, b"prefix-socket");
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/rewrite.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/rewrite.rs
@@ -1,5 +1,14 @@
 //! Pure request-rewriting logic: rule matching and header outcomes (spec §8).
 
+use std::net::IpAddr;
+
+use hyper::header::HeaderValue;
+use rustls::pki_types::ServerName;
+
+use super::upstream::key::{
+    AddressPolicy, ApplicationMode, OriginKey, ReferenceIdentity, Transport, VerifyMode,
+};
+
 /// A rewrite-target authority: host plus a resolved port and its scheme default.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Authority {
@@ -23,6 +32,12 @@ pub enum RuleError {
     /// The authority host was empty.
     #[display("empty host in `{value}`")]
     EmptyHost { value: String },
+    /// A derived HTTP header was invalid.
+    #[display("invalid HTTP header derived from `{value}`")]
+    Header { value: String },
+    /// A TLS upstream identity was not a valid DNS name or IP address.
+    #[display("invalid TLS server identity `{value}`")]
+    ServerName { value: String },
 }
 
 impl core::error::Error for RuleError {}
@@ -35,19 +50,44 @@ impl Authority {
     /// Returns [`RuleError`] on an empty host or an unparseable port.
     pub fn parse(raw: &str, plaintext: bool) -> Result<Self, RuleError> {
         let default_port = if plaintext { 80 } else { 443 };
-        let (host, port) = match raw.rsplit_once(':') {
-            Some((h, p)) => {
-                if p.is_empty() {
-                    return Err(RuleError::Port {
+        let (host, port) = if let Ok(address) = raw.parse::<IpAddr>() {
+            (address.to_string(), default_port)
+        } else if let Some(bracketed) = raw.strip_prefix('[') {
+            let (host, remainder) =
+                bracketed
+                    .split_once(']')
+                    .ok_or_else(|| RuleError::EmptyHost {
                         value: raw.to_string(),
-                    });
-                }
-                let port = p.parse::<u16>().map_err(|_| RuleError::Port {
+                    })?;
+            let address = host.parse::<IpAddr>().map_err(|_| RuleError::EmptyHost {
+                value: raw.to_string(),
+            })?;
+            let port = if remainder.is_empty() {
+                default_port
+            } else {
+                let value = remainder.strip_prefix(':').ok_or_else(|| RuleError::Port {
                     value: raw.to_string(),
                 })?;
-                (h, port)
+                value.parse::<u16>().map_err(|_| RuleError::Port {
+                    value: raw.to_string(),
+                })?
+            };
+            (address.to_string(), port)
+        } else {
+            match raw.rsplit_once(':') {
+                Some((host, value)) => {
+                    if value.is_empty() {
+                        return Err(RuleError::Port {
+                            value: raw.to_string(),
+                        });
+                    }
+                    let port = value.parse::<u16>().map_err(|_| RuleError::Port {
+                        value: raw.to_string(),
+                    })?;
+                    (host.to_string(), port)
+                }
+                None => (raw.to_string(), default_port),
             }
-            None => (raw, default_port),
         };
         if host.is_empty() {
             return Err(RuleError::EmptyHost {
@@ -77,10 +117,15 @@ impl Authority {
     /// `host`, plus `:port` only when the port is non-default — for the `Host` header.
     #[must_use]
     pub fn host_with_port(&self) -> String {
-        if self.is_default_port() {
-            self.host.clone()
+        let host = if matches!(self.host.parse::<IpAddr>(), Ok(IpAddr::V6(_))) {
+            format!("[{}]", self.host)
         } else {
-            format!("{}:{}", self.host, self.port)
+            self.host.clone()
+        };
+        if self.is_default_port() {
+            host
+        } else {
+            format!("{host}:{}", self.port)
         }
     }
 }
@@ -93,11 +138,95 @@ pub struct Rule {
     /// Upstream target — kept a hostname so the SNI/certificate stay valid; the
     /// actual connection address may be pinned via `--resolve`.
     pub to: Authority,
-    /// `--rewrite-host`: when true, send `Host: TO`; otherwise (default) send
-    /// `Host: FROM`. The TLS SNI is always the `TO` host either way.
-    pub rewrite_host: bool,
-    /// Connect to the upstream over plaintext HTTP.
-    pub plaintext: bool,
+    outcome: RewriteOutcome,
+    origin_key: OriginKey,
+}
+
+impl Rule {
+    /// Builds a rule and validates all values used on the request path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuleError`] if a derived header or TLS server name is invalid.
+    pub fn new(
+        from: String,
+        to: Authority,
+        rewrite_host: bool,
+        plaintext: bool,
+        insecure: bool,
+        address_policy: AddressPolicy,
+    ) -> Result<Self, RuleError> {
+        let host_header_text = if rewrite_host {
+            to.host_with_port()
+        } else {
+            from.clone()
+        };
+        let host_header =
+            HeaderValue::from_str(&host_header_text).map_err(|_| RuleError::Header {
+                value: host_header_text.clone(),
+            })?;
+        let orig_host = HeaderValue::from_str(&from).map_err(|_| RuleError::Header {
+            value: from.clone(),
+        })?;
+        let reference = match to.host().parse::<IpAddr>() {
+            Ok(address) => ReferenceIdentity::ip(address),
+            Err(_) => ReferenceIdentity::dns(to.host()),
+        };
+        let sni = if plaintext {
+            None
+        } else {
+            Some(ServerName::try_from(to.host().to_string()).map_err(|_| {
+                RuleError::ServerName {
+                    value: to.host().to_string(),
+                }
+            })?)
+        };
+        let transport = if plaintext {
+            Transport::Plaintext
+        } else {
+            Transport::Tls
+        };
+        let application =
+            if !plaintext && rewrite_host && matches!(&reference, ReferenceIdentity::Dns(_)) {
+                ApplicationMode::Http2Eligible
+            } else {
+                ApplicationMode::Http1Required
+            };
+        let verify = if insecure {
+            VerifyMode::Insecure
+        } else {
+            VerifyMode::Secure
+        };
+        let origin_key = OriginKey::new(
+            transport,
+            reference,
+            to.port,
+            verify,
+            application,
+            address_policy,
+        );
+        let outcome = RewriteOutcome {
+            sni,
+            host_header,
+            orig_host,
+            scheme_is_tls: !plaintext,
+        };
+        Ok(Self {
+            from,
+            to,
+            outcome,
+            origin_key,
+        })
+    }
+
+    #[must_use]
+    pub fn origin_key(&self) -> &OriginKey {
+        &self.origin_key
+    }
+
+    pub(crate) fn set_address_policy(&mut self, address_policy: AddressPolicy) {
+        self.origin_key.set_address_policy(address_policy);
+    }
 }
 
 /// An ordered set of rules; first match wins.
@@ -120,32 +249,20 @@ impl RuleTable {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RewriteOutcome {
     /// SNI to present upstream — always the `TO` host; never carries a port.
-    pub sni: String,
+    pub sni: Option<ServerName<'static>>,
     /// Value for the upstream `Host` header.
-    pub host_header: String,
+    pub host_header: HeaderValue,
     /// The original first-party host (always FROM); sent upstream as
     /// `X-Forwarded-Host` (functional) and `X-Orig-Host` (informational).
-    pub orig_host: String,
+    pub orig_host: HeaderValue,
     /// Whether the upstream leg is TLS (`!plaintext`).
     pub scheme_is_tls: bool,
 }
 
 /// Computes the rewrite outcome for a matched rule (spec §8.3).
 #[must_use]
-pub fn rewrite_for(rule: &Rule) -> RewriteOutcome {
-    // SNI is always the TO host (the connection address may be pinned separately
-    // via `--resolve`); only the `Host` header depends on `rewrite_host`.
-    let host_header = if rule.rewrite_host {
-        rule.to.host_with_port()
-    } else {
-        rule.from.clone()
-    };
-    RewriteOutcome {
-        sni: rule.to.host().to_string(),
-        host_header,
-        orig_host: rule.from.clone(),
-        scheme_is_tls: !rule.plaintext,
-    }
+pub fn rewrite_for(rule: &Rule) -> &RewriteOutcome {
+    &rule.outcome
 }
 
 #[cfg(test)]
@@ -153,12 +270,15 @@ mod tests {
     use super::*;
 
     fn rule(from: &str, to: &str, rewrite_host: bool, plaintext: bool) -> Rule {
-        Rule {
-            from: from.to_string(),
-            to: Authority::parse(to, plaintext).expect("should parse authority"),
+        Rule::new(
+            from.to_string(),
+            Authority::parse(to, plaintext).expect("should parse authority"),
             rewrite_host,
             plaintext,
-        }
+            false,
+            AddressPolicy::Dns,
+        )
+        .expect("should build rule")
     }
 
     #[test]
@@ -191,6 +311,27 @@ mod tests {
             a.host_with_port(),
             "localhost:3000",
             "Host header includes non-default port"
+        );
+    }
+
+    #[test]
+    fn authority_normalizes_ipv6_identity_and_brackets_host_header() {
+        let explicit = Authority::parse("[::1]:8443", false).expect("should parse IPv6");
+        assert_eq!(explicit.host(), "::1", "identity should omit brackets");
+        assert_eq!(explicit.port, 8443, "should parse explicit port");
+        assert_eq!(
+            explicit.host_with_port(),
+            "[::1]:8443",
+            "Host should retain IPv6 brackets"
+        );
+
+        let default = Authority::parse("::1", false).expect("should parse bare IPv6");
+        assert_eq!(default.host(), "::1", "should preserve bare IP identity");
+        assert_eq!(default.port, 443, "should use the TLS default port");
+        assert_eq!(
+            default.host_with_port(),
+            "[::1]",
+            "Host should bracket IPv6 even when the port is omitted"
         );
     }
 
@@ -264,7 +405,8 @@ mod tests {
         );
         let out = rewrite_for(&r);
         assert_eq!(
-            out.sni, "to.edgecompute.app",
+            out.sni,
+            Some(ServerName::try_from("to.edgecompute.app").expect("should parse server name")),
             "SNI is TO host only, no port"
         );
         assert_eq!(
@@ -282,7 +424,7 @@ mod tests {
     fn rewrite_host_uses_to_authority_with_port() {
         let r = rule("www.example-publisher.com", "localhost:3000", true, true);
         let out = rewrite_for(&r);
-        assert_eq!(out.sni, "localhost", "SNI never carries a port");
+        assert_eq!(out.sni, None, "plaintext rules do not need TLS SNI");
         assert_eq!(
             out.host_header, "localhost:3000",
             "rewrite-host sends TO host:port"

--- a/crates/trusted-server-cli/src/commands/dev/proxy/rewrite.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/rewrite.rs
@@ -5,9 +5,7 @@ use std::net::IpAddr;
 use hyper::header::HeaderValue;
 use rustls::pki_types::ServerName;
 
-use super::upstream::key::{
-    AddressPolicy, ApplicationMode, OriginKey, ReferenceIdentity, Transport, VerifyMode,
-};
+use super::upstream::key::{AddressPolicy, OriginKey, ReferenceIdentity, Transport, VerifyMode};
 
 /// A rewrite-target authority: host plus a resolved port and its scheme default.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -186,25 +184,12 @@ impl Rule {
         } else {
             Transport::Tls
         };
-        let application =
-            if !plaintext && rewrite_host && matches!(&reference, ReferenceIdentity::Dns(_)) {
-                ApplicationMode::Http2Eligible
-            } else {
-                ApplicationMode::Http1Required
-            };
         let verify = if insecure {
             VerifyMode::Insecure
         } else {
             VerifyMode::Secure
         };
-        let origin_key = OriginKey::new(
-            transport,
-            reference,
-            to.port,
-            verify,
-            application,
-            address_policy,
-        );
+        let origin_key = OriginKey::new(transport, reference, to.port, verify, address_policy);
         let outcome = RewriteOutcome {
             sni,
             host_header,
@@ -392,6 +377,28 @@ mod tests {
                 .to
                 .host(),
             "first.edgecompute.app"
+        );
+    }
+
+    #[test]
+    fn request_local_host_rewrite_does_not_split_http1_pool() {
+        let preserved = rule(
+            "www.example-publisher.com",
+            "to.edgecompute.app",
+            false,
+            false,
+        );
+        let rewritten = rule(
+            "www.example-publisher.com",
+            "to.edgecompute.app",
+            true,
+            false,
+        );
+
+        assert_eq!(
+            preserved.origin_key(),
+            rewritten.origin_key(),
+            "request-local Host choice must not split retained HTTP/1 connections"
         );
     }
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
@@ -631,6 +631,71 @@ fn strip_hop_by_hop(headers: &mut hyper::HeaderMap) {
     }
 }
 
+struct UpstreamTrailerMetadata {
+    declarations: Vec<HeaderName>,
+    accepts_response_trailers: bool,
+}
+
+impl UpstreamTrailerMetadata {
+    fn capture(headers: &hyper::HeaderMap) -> Self {
+        let declarations = headers
+            .get_all(hyper::header::TRAILER)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .filter_map(|name| HeaderName::from_bytes(name.trim().as_bytes()).ok())
+            .filter(is_safe_trailer_field)
+            .collect();
+        let accepts_response_trailers = headers
+            .get_all(hyper::header::TE)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .any(|token| token.trim().eq_ignore_ascii_case("trailers"));
+        Self {
+            declarations,
+            accepts_response_trailers,
+        }
+    }
+
+    fn regenerate(self, headers: &mut hyper::HeaderMap) {
+        for declaration in self.declarations {
+            headers.append(
+                hyper::header::TRAILER,
+                HeaderValue::from_str(declaration.as_str())
+                    .expect("should serialize a validated trailer field name"),
+            );
+        }
+        if self.accepts_response_trailers {
+            headers.insert(hyper::header::TE, HeaderValue::from_static("trailers"));
+            headers.insert(hyper::header::CONNECTION, HeaderValue::from_static("TE"));
+        }
+    }
+}
+
+fn is_safe_trailer_field(name: &HeaderName) -> bool {
+    !matches!(
+        name.as_str(),
+        "authorization"
+            | "cache-control"
+            | "connection"
+            | "content-encoding"
+            | "content-length"
+            | "content-range"
+            | "content-type"
+            | "host"
+            | "keep-alive"
+            | "max-forwards"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "set-cookie"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
 /// Applies the rewrite outcome: strips inbound hop-by-hop headers, then sets
 /// upstream `Host`, `X-Forwarded-Host`/`X-Orig-Host` (both `FROM`, after
 /// stripping any higher-priority inbound `Forwarded`), an authoritative
@@ -642,6 +707,7 @@ fn rewrite_headers(
     outcome: &super::rewrite::RewriteOutcome,
     basic_auth: Option<&super::config::BasicAuth>,
 ) {
+    let trailer_metadata = UpstreamTrailerMetadata::capture(headers);
     // Strip hop-by-hop headers first, so a client cannot flag the authoritative
     // headers we stamp below as connection-specific and have them dropped.
     strip_hop_by_hop(headers);
@@ -680,6 +746,7 @@ fn rewrite_headers(
     {
         headers.insert(hyper::header::AUTHORIZATION, auth.header_value().clone());
     }
+    trailer_metadata.regenerate(headers);
 }
 
 fn status_response(status: StatusCode) -> Response<BoxBody<Bytes, hyper::Error>> {
@@ -864,6 +931,47 @@ mod tests {
         assert!(
             !metadata.replayable(),
             "chunked upload must never enter stale replay"
+        );
+    }
+
+    #[test]
+    fn rewrite_headers_regenerates_safe_request_trailer_metadata() {
+        let outcome = rewrite_outcome("to.edgecompute.app");
+        let mut headers = hyper::HeaderMap::new();
+        headers.append(
+            hyper::header::TRAILER,
+            HeaderValue::from_static("x-request-checksum, content-length"),
+        );
+        headers.append(
+            hyper::header::TRAILER,
+            HeaderValue::from_static("authorization, x-request-proof"),
+        );
+        headers.insert(
+            hyper::header::TE,
+            HeaderValue::from_static("gzip, trailers"),
+        );
+        headers.insert(
+            hyper::header::CONNECTION,
+            HeaderValue::from_static("keep-alive, TE"),
+        );
+
+        rewrite_headers(&mut headers, &outcome, None);
+
+        let declarations: Vec<_> = headers
+            .get_all(hyper::header::TRAILER)
+            .iter()
+            .map(|value| value.to_str().expect("should encode trailer name"))
+            .collect();
+        assert_eq!(declarations, ["x-request-checksum", "x-request-proof"]);
+        assert_eq!(
+            headers.get(hyper::header::TE).expect("should restore TE"),
+            "trailers"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::CONNECTION)
+                .expect("should declare TE hop-by-hop"),
+            "TE"
         );
     }
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
@@ -334,7 +334,11 @@ async fn blind_tunnel(
     let mut upstream = match connect_upstream(host, port, resolve, connect_timeout).await {
         Ok(stream) => stream,
         Err(err) => {
-            log::warn!("blind tunnel to {host}:{port} failed: {err}");
+            // Only unmatched hosts reach the blind tunnel, and real pages reference
+            // many third-party domains that are dead, blackholed, or DNS-blocked.
+            // Logging those at `warn` would drown out failures on mapped upstreams,
+            // so keep them at `debug`; the browser still sees the `502`.
+            log::debug!("blind tunnel to {host}:{port} failed: {err}");
             return respond_status_line(&mut client, StatusCode::BAD_GATEWAY).await;
         }
     };

--- a/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
@@ -22,12 +22,13 @@ use hyper::{Request, Response, StatusCode, Uri};
 use hyper_util::rt::TokioIo;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::{TcpListener, TcpStream};
-use tokio_rustls::{TlsAcceptor, TlsConnector};
+use tokio_rustls::TlsAcceptor;
 
-use super::ProxyError;
 use super::ca::CertAuthority;
 use super::config::ResolvedConfig;
+use super::prefixed_io::PrefixedIo;
 use super::rewrite::rewrite_for;
+use super::{ProxyError, ProxyState};
 
 const X_ORIG_HOST: &str = "x-orig-host";
 const X_FORWARDED_HOST: &str = "x-forwarded-host";
@@ -57,9 +58,23 @@ pub async fn serve_on(
     ca: Arc<CertAuthority>,
     pac: Arc<str>,
 ) -> Result<(), Report<ProxyError>> {
-    let is_loopback = is_loopback(cfg.listen.ip());
-    log::info!("listening on {}", cfg.listen);
-    for (host, ip) in &cfg.resolve {
+    serve_on_with_state(listener, ProxyState::new(cfg), ca, pac).await
+}
+
+/// Serves with process-shared upstream pooling and metrics state.
+///
+/// # Errors
+///
+/// Returns a server error if the accept loop cannot continue.
+pub async fn serve_on_with_state(
+    listener: TcpListener,
+    state: Arc<ProxyState>,
+    ca: Arc<CertAuthority>,
+    pac: Arc<str>,
+) -> Result<(), Report<ProxyError>> {
+    let is_loopback = is_loopback(state.config.listen.ip());
+    log::info!("listening on {}", state.config.listen);
+    for (host, ip) in &state.config.resolve {
         log::info!("--resolve pin: {host} -> {ip}");
     }
     loop {
@@ -70,11 +85,12 @@ pub async fn serve_on(
                 continue;
             }
         };
-        let cfg = Arc::clone(&cfg);
+        state.metrics.record_browser_connection();
+        let state = Arc::clone(&state);
         let ca = Arc::clone(&ca);
         let pac = Arc::clone(&pac);
         tokio::spawn(async move {
-            if let Err(err) = handle_connection(client, is_loopback, &cfg, &ca, &pac).await {
+            if let Err(err) = handle_connection(client, is_loopback, &state, &ca, &pac).await {
                 log::debug!("connection from {peer} ended: {err:?}");
             }
         });
@@ -100,6 +116,8 @@ struct RequestHead {
     /// cap. `false` means a truncated or oversized head that must be rejected
     /// with `400` rather than routed from a partially-read request.
     complete: bool,
+    /// Bytes read beyond the header terminator, replayed to the selected path.
+    prefix: Vec<u8>,
 }
 
 impl RequestHead {
@@ -125,21 +143,22 @@ impl RequestHead {
 /// absolute-form plain-HTTP request can be forwarded unchanged (spec §8.4) —
 /// `blind_forward_http` writes them to the upstream before piping the remainder.
 async fn read_request_head(client: &mut TcpStream) -> Result<RequestHead, Report<ProxyError>> {
-    let mut buf = Vec::with_capacity(256);
-    let mut byte = [0u8; 1];
-    // Read up to the end of the headers (\r\n\r\n) or a sane cap.
+    let mut buf = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
     let mut complete = false;
+    let mut head_end = 0;
     loop {
         let n = client
-            .read(&mut byte)
+            .read(&mut chunk)
             .await
             .change_context(ProxyError::Server)?;
         if n == 0 {
             break;
         }
-        buf.push(byte[0]);
-        if buf.ends_with(b"\r\n\r\n") {
-            complete = true;
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(position) = find_bytes(&buf, b"\r\n\r\n") {
+            head_end = position + 4;
+            complete = head_end <= 8192;
             break;
         }
         // Oversized head: stop reading, but mark it incomplete so the caller
@@ -148,6 +167,10 @@ async fn read_request_head(client: &mut TcpStream) -> Result<RequestHead, Report
             break;
         }
     }
+    if !complete {
+        head_end = buf.len();
+    }
+    let prefix = buf.split_off(head_end);
     let text = String::from_utf8_lossy(&buf);
     let first_line = text.lines().next().unwrap_or_default();
     let mut parts = first_line.split_whitespace();
@@ -158,32 +181,53 @@ async fn read_request_head(client: &mut TcpStream) -> Result<RequestHead, Report
         target,
         raw: buf,
         complete,
+        prefix,
     })
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }
 
 async fn handle_connection(
     mut client: TcpStream,
     is_loopback: bool,
-    cfg: &ResolvedConfig,
+    state: &ProxyState,
     ca: &CertAuthority,
     pac: &str,
 ) -> Result<(), Report<ProxyError>> {
+    let parse_started = tokio::time::Instant::now();
     let head = read_request_head(&mut client).await?;
+    let mut client = PrefixedIo::new(client, head.prefix.clone());
     // A truncated or oversized head (no `\r\n\r\n` within the cap) is malformed —
     // reject it cleanly instead of routing a partially-parsed request.
     if !head.complete {
+        state
+            .metrics
+            .record_initial_head_rejected(parse_started.elapsed());
         return respond_status_line(&mut client, StatusCode::BAD_REQUEST).await;
     }
+    state
+        .metrics
+        .record_initial_head_parsed(parse_started.elapsed());
     if let Some(authority) = head.connect_authority() {
         let authority = authority.to_string();
-        return handle_connect(client, &authority, is_loopback, cfg, ca).await;
+        return handle_connect(client, &authority, is_loopback, state, ca).await;
     }
     if head.is_local_pac_route() {
         return serve_pac(&mut client, pac).await;
     }
     // Stray absolute-form plain HTTP.
     if is_loopback {
-        blind_forward_http(client, &head, &cfg.resolve, cfg.connect_timeout).await
+        blind_forward_http(
+            client,
+            &head,
+            &state.config.resolve,
+            state.config.connect_timeout,
+        )
+        .await
     } else {
         respond_status_line(&mut client, StatusCode::FORBIDDEN).await
     }
@@ -201,10 +245,10 @@ fn split_authority(authority: &str) -> Option<(String, u16)> {
 }
 
 async fn handle_connect(
-    mut client: TcpStream,
+    mut client: PrefixedIo<TcpStream>,
     authority: &str,
     is_loopback: bool,
-    cfg: &ResolvedConfig,
+    state: &ProxyState,
     ca: &CertAuthority,
 ) -> Result<(), Report<ProxyError>> {
     let Some((host, port)) = split_authority(authority) else {
@@ -212,9 +256,9 @@ async fn handle_connect(
     };
 
     // Match BEFORE replying, so an unmatched non-loopback request is refused.
-    if cfg.rules.first_match(&host).is_some() {
+    if state.config.rules.first_match(&host).is_some() {
         write_connect_ok(&mut client).await?;
-        return mitm(client, &host, cfg, ca).await;
+        return mitm(client, &host, state, ca).await;
     }
 
     if !is_loopback {
@@ -223,7 +267,14 @@ async fn handle_connect(
     }
 
     // No match on loopback: connect upstream FIRST, then reply 200 (else 502).
-    blind_tunnel(client, &host, port, &cfg.resolve, cfg.connect_timeout).await
+    blind_tunnel(
+        client,
+        &host,
+        port,
+        &state.config.resolve,
+        state.config.connect_timeout,
+    )
+    .await
 }
 
 /// Opens an upstream TCP connection, honoring a `--resolve` pin for `host`.
@@ -260,7 +311,7 @@ async fn connect_upstream(
 /// Connects to the upstream first; on success replies `200` then pipes bytes
 /// in both directions without decrypting anything.
 async fn blind_tunnel(
-    mut client: TcpStream,
+    mut client: PrefixedIo<TcpStream>,
     host: &str,
     port: u16,
     resolve: &HashMap<String, IpAddr>,
@@ -283,7 +334,7 @@ async fn blind_tunnel(
     }
 }
 
-async fn write_connect_ok(client: &mut TcpStream) -> Result<(), Report<ProxyError>> {
+async fn write_connect_ok(client: &mut PrefixedIo<TcpStream>) -> Result<(), Report<ProxyError>> {
     client
         .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
         .await
@@ -292,7 +343,7 @@ async fn write_connect_ok(client: &mut TcpStream) -> Result<(), Report<ProxyErro
 }
 
 async fn respond_status_line(
-    client: &mut TcpStream,
+    client: &mut PrefixedIo<TcpStream>,
     status: StatusCode,
 ) -> Result<(), Report<ProxyError>> {
     let reason = status.canonical_reason().unwrap_or("");
@@ -307,7 +358,10 @@ async fn respond_status_line(
     client.flush().await.change_context(ProxyError::Server)
 }
 
-async fn serve_pac(client: &mut TcpStream, pac: &str) -> Result<(), Report<ProxyError>> {
+async fn serve_pac(
+    client: &mut PrefixedIo<TcpStream>,
+    pac: &str,
+) -> Result<(), Report<ProxyError>> {
     let response = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/x-ns-proxy-autoconfig\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{pac}",
         pac.len(),
@@ -325,7 +379,7 @@ async fn serve_pac(client: &mut TcpStream, pac: &str) -> Result<(), Report<Proxy
 /// verbatim, then pipes the remaining bytes bidirectionally (spec §8.4).
 /// Best-effort: failures are logged, never fatal.
 async fn blind_forward_http(
-    mut client: TcpStream,
+    mut client: PrefixedIo<TcpStream>,
     head: &RequestHead,
     resolve: &HashMap<String, IpAddr>,
     connect_timeout: Duration,
@@ -358,12 +412,22 @@ async fn blind_forward_http(
 /// run a hyper server connection whose service rewrites and forwards each
 /// request to the upstream over a fresh client connection (spec §5/§8).
 async fn mitm(
-    client: TcpStream,
+    client: PrefixedIo<TcpStream>,
     host: &str,
-    cfg: &ResolvedConfig,
+    state: &ProxyState,
     ca: &CertAuthority,
 ) -> Result<(), Report<ProxyError>> {
-    let server_config = ca.server_config(host).change_context(ProxyError::Server)?;
+    let normalized_host = host.to_ascii_lowercase();
+    let cached = ca.is_cached(&normalized_host);
+    let mint_started = tokio::time::Instant::now();
+    let server_config = ca
+        .server_config(&normalized_host)
+        .change_context(ProxyError::Server)?;
+    if cached {
+        state.metrics.record_ca_hit();
+    } else {
+        state.metrics.record_ca_miss(mint_started.elapsed(), true);
+    }
     let acceptor = TlsAcceptor::from(server_config);
     let tls = acceptor
         .accept(client)
@@ -375,23 +439,8 @@ async fn mitm(
     let service = service_fn(move |req: Request<Incoming>| {
         // Clone the per-request inputs into the future.
         let host = host.clone();
-        let rules = cfg.rules.clone();
-        let basic_auth = cfg.basic_auth.clone();
-        let insecure = cfg.insecure;
-        let resolve = cfg.resolve.clone();
-        let connect_timeout = cfg.connect_timeout;
-        async move {
-            forward_request(
-                req,
-                &host,
-                &rules,
-                basic_auth.as_ref(),
-                insecure,
-                &resolve,
-                connect_timeout,
-            )
-            .await
-        }
+        let state = state;
+        async move { forward_request(req, &host, state).await }
     });
 
     // serve_connection drives keep-alive: many sequential requests per tunnel.
@@ -419,11 +468,7 @@ async fn mitm(
 async fn forward_request(
     req: Request<Incoming>,
     connect_host: &str,
-    rules: &super::rewrite::RuleTable,
-    basic_auth: Option<&super::config::BasicAuth>,
-    insecure: bool,
-    resolve: &HashMap<String, IpAddr>,
-    connect_timeout: Duration,
+    state: &ProxyState,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Report<ProxyError>> {
     if req.headers().contains_key(hyper::header::UPGRADE) {
         log::info!("closing tunnel for {connect_host}: Upgrade (WebSocket) is out of scope");
@@ -434,11 +479,11 @@ async fn forward_request(
     // matches no rule is refused (421) rather than rerouted through the CONNECT
     // authority. Only a request with no Host falls back to the CONNECT authority.
     let rule = match request_host(&req) {
-        Some(host) => match rules.first_match(&host) {
+        Some(host) => match state.config.rules.first_match(&host) {
             Some(rule) => rule,
             None => return Ok(status_response(StatusCode::MISDIRECTED_REQUEST)),
         },
-        None => match rules.first_match(connect_host) {
+        None => match state.config.rules.first_match(connect_host) {
             Some(rule) => rule,
             // Should not happen: MITM is only entered on a CONNECT-authority match.
             None => return Ok(status_response(StatusCode::BAD_GATEWAY)),
@@ -451,11 +496,9 @@ async fn forward_request(
     match proxy_to_upstream(
         req,
         outcome,
-        basic_auth,
-        insecure,
-        (upstream_host, upstream_port),
-        resolve,
-        connect_timeout,
+        state.config.basic_auth.as_ref(),
+        rule,
+        &state.upstream,
     )
     .await
     {
@@ -488,12 +531,11 @@ async fn proxy_to_upstream(
     mut req: Request<Incoming>,
     outcome: &super::rewrite::RewriteOutcome,
     basic_auth: Option<&super::config::BasicAuth>,
-    insecure: bool,
-    upstream: (&str, u16),
-    resolve: &HashMap<String, IpAddr>,
-    connect_timeout: Duration,
+    rule: &super::rewrite::Rule,
+    upstream: &super::upstream::UpstreamClient,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Report<ProxyError>> {
-    let (upstream_host, upstream_port) = upstream;
+    let upstream_host = rule.to.host();
+    let upstream_port = rule.to.port;
     log::debug!(
         "{} {} -> {}:{} (Host={}, X-Orig-Host={})",
         req.method(),
@@ -512,54 +554,13 @@ async fn proxy_to_upstream(
 
     rewrite_headers(req.headers_mut(), outcome, basic_auth);
 
-    // Dial the `--resolve` pin when the upstream host has one; the SNI/`Host`
-    // (set above) stay the hostname, so the certificate still validates.
-    let tcp = connect_upstream(upstream_host, upstream_port, resolve, connect_timeout)
-        .await
-        .change_context(ProxyError::Server)?;
-
-    let mut response = if outcome.scheme_is_tls {
-        let connector = TlsConnector::from(client_config(insecure));
-        let server_name = outcome
-            .sni
-            .clone()
-            .expect("should precompute TLS server name");
-        let tls = connector
-            .connect(server_name, tcp)
-            .await
-            .change_context(ProxyError::Server)?;
-        send_over(TokioIo::new(tls), req).await?
-    } else {
-        send_over(TokioIo::new(tcp), req).await?
-    };
+    let mut response = upstream.send(req, rule, outcome).await?;
 
     // Strip hop-by-hop headers from the upstream response too. A `Connection: close`
     // (or a named connection token) is specific to the upstream leg and must not
     // leak onto the reusable browser↔proxy MITM tunnel and tear it down.
     strip_hop_by_hop(response.headers_mut());
-    Ok(response.map(http_body_util::BodyExt::boxed))
-}
-
-/// Drives one HTTP/1.1 request/response over an established (TLS or plain) IO.
-async fn send_over<I>(
-    io: I,
-    req: Request<Incoming>,
-) -> Result<Response<Incoming>, Report<ProxyError>>
-where
-    I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
-{
-    let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
-        .await
-        .change_context(ProxyError::Server)?;
-    tokio::spawn(async move {
-        if let Err(err) = conn.await {
-            log::debug!("upstream connection closed: {err}");
-        }
-    });
-    sender
-        .send_request(req)
-        .await
-        .change_context(ProxyError::Server)
+    Ok(response)
 }
 
 /// Removes RFC 7230 hop-by-hop request headers, plus every header named in an
@@ -647,33 +648,6 @@ fn rewrite_headers(
     }
 }
 
-/// Builds a rustls client config: a no-verification verifier when `insecure`,
-/// otherwise the bundled webpki roots.
-fn client_config(insecure: bool) -> Arc<rustls::ClientConfig> {
-    // The config is immutable across requests, so build it once per verification
-    // mode and share the `Arc` — rather than rebuilding (and re-parsing the whole
-    // webpki root store) on every upstream request.
-    static SECURE: std::sync::OnceLock<Arc<rustls::ClientConfig>> = std::sync::OnceLock::new();
-    static INSECURE: std::sync::OnceLock<Arc<rustls::ClientConfig>> = std::sync::OnceLock::new();
-    let cell = if insecure { &INSECURE } else { &SECURE };
-    Arc::clone(cell.get_or_init(|| {
-        let mut config = if insecure {
-            rustls::ClientConfig::builder()
-                .dangerous()
-                .with_custom_certificate_verifier(Arc::new(insecure::NoVerifier))
-                .with_no_client_auth()
-        } else {
-            let mut roots = rustls::RootCertStore::empty();
-            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-            rustls::ClientConfig::builder()
-                .with_root_certificates(roots)
-                .with_no_client_auth()
-        };
-        config.alpn_protocols = vec![b"http/1.1".to_vec()];
-        Arc::new(config)
-    }))
-}
-
 fn status_response(status: StatusCode) -> Response<BoxBody<Bytes, hyper::Error>> {
     let body = Full::new(Bytes::new())
         .map_err(|never| match never {})
@@ -686,54 +660,6 @@ fn status_response(status: StatusCode) -> Response<BoxBody<Bytes, hyper::Error>>
 /// Renders the request target without exposing credentials in query strings.
 fn redact_target(uri: &Uri) -> String {
     uri.path().to_string()
-}
-
-mod insecure {
-    use rustls::DigitallySignedStruct;
-    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-
-    /// A verifier that accepts any upstream certificate — only used under
-    /// `--insecure` for local development against self-signed origins.
-    #[derive(Debug)]
-    pub struct NoVerifier;
-
-    impl ServerCertVerifier for NoVerifier {
-        fn verify_server_cert(
-            &self,
-            _end_entity: &CertificateDer<'_>,
-            _intermediates: &[CertificateDer<'_>],
-            _server_name: &ServerName<'_>,
-            _ocsp_response: &[u8],
-            _now: UnixTime,
-        ) -> Result<ServerCertVerified, rustls::Error> {
-            Ok(ServerCertVerified::assertion())
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-
-        fn verify_tls13_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-
-        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-            rustls::crypto::aws_lc_rs::default_provider()
-                .signature_verification_algorithms
-                .supported_schemes()
-        }
-    }
 }
 
 #[cfg(test)]
@@ -759,6 +685,7 @@ mod tests {
             target: target.to_string(),
             raw: Vec::new(),
             complete: true,
+            prefix: Vec::new(),
         }
     }
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
@@ -574,7 +574,16 @@ async fn proxy_to_upstream(
     // Strip hop-by-hop headers from the upstream response too. A `Connection: close`
     // (or a named connection token) is specific to the upstream leg and must not
     // leak onto the reusable browser↔proxy MITM tunnel and tear it down.
+    let downstream_trailer = response.headers().get(hyper::header::TRAILER).cloned();
     strip_hop_by_hop(response.headers_mut());
+    if let Some(trailer) = downstream_trailer {
+        // Regenerate the trailer declaration for the downstream HTTP/1 leg so
+        // Hyper serializes forwarded trailer frames. This is new downstream
+        // framing metadata, not leaked upstream connection state.
+        response
+            .headers_mut()
+            .insert(hyper::header::TRAILER, trailer);
+    }
     Ok(response)
 }
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
@@ -20,7 +20,7 @@ use hyper::header::{HeaderName, HeaderValue};
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode, Uri};
 use hyper_util::rt::TokioIo;
-use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::TlsAcceptor;
 
@@ -142,7 +142,9 @@ impl RequestHead {
 /// The raw bytes are retained on the returned [`RequestHead`] so that a stray
 /// absolute-form plain-HTTP request can be forwarded unchanged (spec §8.4) —
 /// `blind_forward_http` writes them to the upstream before piping the remainder.
-async fn read_request_head(client: &mut TcpStream) -> Result<RequestHead, Report<ProxyError>> {
+async fn read_request_head<R: AsyncRead + Unpin>(
+    client: &mut R,
+) -> Result<RequestHead, Report<ProxyError>> {
     let mut buf = Vec::with_capacity(1024);
     let mut chunk = [0u8; 1024];
     let mut complete = false;
@@ -238,6 +240,18 @@ async fn handle_connection(
 /// Returns `None` when a port is present but not a valid `u16`, so the caller
 /// can reject the CONNECT with `400` instead of silently dialing `443`.
 fn split_authority(authority: &str) -> Option<(String, u16)> {
+    if let Some(bracketed) = authority.strip_prefix('[') {
+        let (host, suffix) = bracketed.split_once(']')?;
+        let port = if suffix.is_empty() {
+            443
+        } else {
+            suffix.strip_prefix(':')?.parse().ok()?
+        };
+        return Some((host.to_string(), port));
+    }
+    if authority.parse::<IpAddr>().is_ok() {
+        return Some((authority.to_string(), 443));
+    }
     match authority.rsplit_once(':') {
         Some((host, port)) => Some((host.to_string(), port.parse().ok()?)),
         None => Some((authority.to_string(), 443)),
@@ -552,9 +566,10 @@ async fn proxy_to_upstream(
             .expect("should prevalidate original host header"),
     );
 
+    let metadata = super::upstream::RequestMetadata::capture(&req);
     rewrite_headers(req.headers_mut(), outcome, basic_auth);
 
-    let mut response = upstream.send(req, rule, outcome).await?;
+    let mut response = upstream.send(req, metadata, rule, outcome).await?;
 
     // Strip hop-by-hop headers from the upstream response too. A `Connection: close`
     // (or a named connection token) is specific to the upstream leg and must not
@@ -667,6 +682,20 @@ mod tests {
     use super::*;
     use crate::commands::dev::proxy::rewrite::RewriteOutcome;
 
+    async fn parse_bytes(chunks: Vec<Vec<u8>>) -> RequestHead {
+        let capacity = chunks.iter().map(Vec::len).sum::<usize>().max(1);
+        let (mut writer, mut reader) = tokio::io::duplex(capacity);
+        tokio::spawn(async move {
+            for chunk in chunks {
+                writer.write_all(&chunk).await.expect("should write chunk");
+                tokio::task::yield_now().await;
+            }
+        });
+        read_request_head(&mut reader)
+            .await
+            .expect("should parse head")
+    }
+
     fn rewrite_outcome(host: &'static str) -> RewriteOutcome {
         RewriteOutcome {
             sni: Some(
@@ -710,6 +739,40 @@ mod tests {
     }
 
     #[test]
+    fn split_authority_normalizes_bracketed_ipv6() {
+        assert_eq!(
+            split_authority("[::1]:8443"),
+            Some(("::1".to_string(), 8443))
+        );
+        assert_eq!(split_authority("[::1]"), Some(("::1".to_string(), 443)));
+    }
+
+    #[tokio::test]
+    async fn buffered_head_parser_handles_delimiter_splits_and_exact_overread() {
+        let head = parse_bytes(vec![
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com\r\n\r".to_vec(),
+            b"\nclient-hello".to_vec(),
+        ])
+        .await;
+        assert!(head.complete);
+        assert_eq!(head.prefix, b"client-hello");
+        assert_eq!(head.connect_authority(), Some("example.com:443"));
+    }
+
+    #[tokio::test]
+    async fn buffered_head_parser_accepts_exactly_eight_kib_and_rejects_larger() {
+        let mut exact = b"GET / HTTP/1.1\r\nX-Fill: ".to_vec();
+        exact.resize(8192 - 4, b'a');
+        exact.extend_from_slice(b"\r\n\r\n");
+        assert!(parse_bytes(vec![exact]).await.complete);
+
+        let mut oversized = b"GET / HTTP/1.1\r\nX-Fill: ".to_vec();
+        oversized.resize(8192, b'a');
+        oversized.extend_from_slice(b"\r\n\r\n");
+        assert!(!parse_bytes(vec![oversized]).await.complete);
+    }
+
+    #[test]
     fn rewrite_headers_strips_proxy_connection() {
         let outcome = rewrite_outcome("www.example-publisher.com");
         let mut headers = hyper::HeaderMap::new();
@@ -728,6 +791,38 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("www.example-publisher.com"),
             "Host is still rewritten alongside the strip"
+        );
+    }
+
+    #[test]
+    fn request_metadata_captures_chunked_upload_before_sanitation() {
+        let mut request = Request::new(Full::new(Bytes::from_static(b"upload")));
+        *request.method_mut() = hyper::Method::POST;
+        request.headers_mut().insert(
+            hyper::header::TRANSFER_ENCODING,
+            HeaderValue::from_static("chunked"),
+        );
+
+        let metadata = super::super::upstream::RequestMetadata::capture(&request);
+        rewrite_headers(
+            request.headers_mut(),
+            &rewrite_outcome("to.edgecompute.app"),
+            None,
+        );
+
+        assert!(
+            !request
+                .headers()
+                .contains_key(hyper::header::TRANSFER_ENCODING),
+            "sanitation should still remove hop-by-hop framing"
+        );
+        assert!(
+            !metadata.upload_initially_complete(),
+            "chunked upload must remain streaming after sanitation"
+        );
+        assert!(
+            !metadata.replayable(),
+            "chunked upload must never enter stale replay"
         );
     }
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
@@ -574,17 +574,23 @@ async fn proxy_to_upstream(
     // Strip hop-by-hop headers from the upstream response too. A `Connection: close`
     // (or a named connection token) is specific to the upstream leg and must not
     // leak onto the reusable browser↔proxy MITM tunnel and tear it down.
-    let downstream_trailer = response.headers().get(hyper::header::TRAILER).cloned();
-    strip_hop_by_hop(response.headers_mut());
-    if let Some(trailer) = downstream_trailer {
+    sanitize_response_headers(response.headers_mut());
+    Ok(response)
+}
+
+fn sanitize_response_headers(headers: &mut hyper::HeaderMap) {
+    let downstream_trailers: Vec<_> = headers
+        .get_all(hyper::header::TRAILER)
+        .iter()
+        .cloned()
+        .collect();
+    strip_hop_by_hop(headers);
+    for trailer in downstream_trailers {
         // Regenerate the trailer declaration for the downstream HTTP/1 leg so
         // Hyper serializes forwarded trailer frames. This is new downstream
         // framing metadata, not leaked upstream connection state.
-        response
-            .headers_mut()
-            .insert(hyper::header::TRAILER, trailer);
+        headers.append(hyper::header::TRAILER, trailer);
     }
-    Ok(response)
 }
 
 /// Removes RFC 7230 hop-by-hop request headers, plus every header named in an
@@ -801,6 +807,28 @@ mod tests {
             Some("www.example-publisher.com"),
             "Host is still rewritten alongside the strip"
         );
+    }
+
+    #[test]
+    fn response_sanitation_preserves_every_trailer_declaration() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.append(
+            hyper::header::TRAILER,
+            HeaderValue::from_static("x-first-trailer"),
+        );
+        headers.append(
+            hyper::header::TRAILER,
+            HeaderValue::from_static("x-second-trailer"),
+        );
+
+        sanitize_response_headers(&mut headers);
+
+        let declarations: Vec<_> = headers
+            .get_all(hyper::header::TRAILER)
+            .iter()
+            .map(|value| value.to_str().expect("should encode trailer name"))
+            .collect();
+        assert_eq!(declarations, ["x-first-trailer", "x-second-trailer"]);
     }
 
     #[test]

--- a/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/server.rs
@@ -20,7 +20,6 @@ use hyper::header::{HeaderName, HeaderValue};
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode, Uri};
 use hyper_util::rt::TokioIo;
-use rustls::pki_types::ServerName;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{TlsAcceptor, TlsConnector};
@@ -446,15 +445,15 @@ async fn forward_request(
         },
     };
     let outcome = rewrite_for(rule);
-    let upstream_host = rule.to.host().to_string();
+    let upstream_host = rule.to.host();
     let upstream_port = rule.to.port;
 
     match proxy_to_upstream(
         req,
-        &outcome,
+        outcome,
         basic_auth,
         insecure,
-        (&upstream_host, upstream_port),
+        (upstream_host, upstream_port),
         resolve,
         connect_timeout,
     )
@@ -501,8 +500,14 @@ async fn proxy_to_upstream(
         redact_target(req.uri()),
         upstream_host,
         upstream_port,
-        outcome.host_header,
-        outcome.orig_host,
+        outcome
+            .host_header
+            .to_str()
+            .expect("should prevalidate Host header"),
+        outcome
+            .orig_host
+            .to_str()
+            .expect("should prevalidate original host header"),
     );
 
     rewrite_headers(req.headers_mut(), outcome, basic_auth);
@@ -515,8 +520,10 @@ async fn proxy_to_upstream(
 
     let mut response = if outcome.scheme_is_tls {
         let connector = TlsConnector::from(client_config(insecure));
-        let server_name =
-            ServerName::try_from(outcome.sni.clone()).change_context(ProxyError::Server)?;
+        let server_name = outcome
+            .sni
+            .clone()
+            .expect("should precompute TLS server name");
         let tls = connector
             .connect(server_name, tcp)
             .await
@@ -603,9 +610,7 @@ fn rewrite_headers(
     // Strip hop-by-hop headers first, so a client cannot flag the authoritative
     // headers we stamp below as connection-specific and have them dropped.
     strip_hop_by_hop(headers);
-    if let Ok(value) = HeaderValue::from_str(&outcome.host_header) {
-        headers.insert(hyper::header::HOST, value);
-    }
+    headers.insert(hyper::header::HOST, outcome.host_header.clone());
     // Tell the upstream the original first-party host (always `FROM`). Trusted
     // Server resolves the request host from `Forwarded` → `X-Forwarded-Host` →
     // `Host`, so a client-supplied `Forwarded` would outrank the value we inject.
@@ -617,10 +622,14 @@ fn rewrite_headers(
     // back to `Host` (`TO`). See the `--rewrite-host` caveat in the user guide.
     // The `insert`s below already overwrite any inbound `X-Forwarded-Host`/`X-Orig-Host`.
     headers.remove("forwarded");
-    if let Ok(value) = HeaderValue::from_str(&outcome.orig_host) {
-        headers.insert(HeaderName::from_static(X_FORWARDED_HOST), value.clone());
-        headers.insert(HeaderName::from_static(X_ORIG_HOST), value);
-    }
+    headers.insert(
+        HeaderName::from_static(X_FORWARDED_HOST),
+        outcome.orig_host.clone(),
+    );
+    headers.insert(
+        HeaderName::from_static(X_ORIG_HOST),
+        outcome.orig_host.clone(),
+    );
     // The browser→proxy leg is always TLS, so the original scheme is `https`.
     // Stamp it authoritatively (overwriting any inbound value) and drop the
     // spoofable `Fastly-SSL` signal, so a plaintext upstream (`--upstream-plaintext`)
@@ -633,9 +642,8 @@ fn rewrite_headers(
     headers.remove("fastly-ssl");
     if let Some(auth) = basic_auth
         && !headers.contains_key(hyper::header::AUTHORIZATION)
-        && let Ok(value) = HeaderValue::from_str(&auth.header_value())
     {
-        headers.insert(hyper::header::AUTHORIZATION, value);
+        headers.insert(hyper::header::AUTHORIZATION, auth.header_value().clone());
     }
 }
 
@@ -733,6 +741,18 @@ mod tests {
     use super::*;
     use crate::commands::dev::proxy::rewrite::RewriteOutcome;
 
+    fn rewrite_outcome(host: &'static str) -> RewriteOutcome {
+        RewriteOutcome {
+            sni: Some(
+                rustls::pki_types::ServerName::try_from("to.edgecompute.app")
+                    .expect("should parse server name"),
+            ),
+            host_header: HeaderValue::from_static(host),
+            orig_host: HeaderValue::from_static("www.example-publisher.com"),
+            scheme_is_tls: true,
+        }
+    }
+
     fn head(method: &str, target: &str) -> RequestHead {
         RequestHead {
             method: method.to_string(),
@@ -764,12 +784,7 @@ mod tests {
 
     #[test]
     fn rewrite_headers_strips_proxy_connection() {
-        let outcome = RewriteOutcome {
-            sni: "to.edgecompute.app".to_string(),
-            host_header: "www.example-publisher.com".to_string(),
-            orig_host: "www.example-publisher.com".to_string(),
-            scheme_is_tls: true,
-        };
+        let outcome = rewrite_outcome("www.example-publisher.com");
         let mut headers = hyper::HeaderMap::new();
         headers.insert(
             HeaderName::from_static("proxy-connection"),
@@ -794,12 +809,7 @@ mod tests {
         // Trusted Server resolves the request host from `Forwarded` BEFORE
         // `X-Forwarded-Host`. A client-supplied `Forwarded` must therefore be
         // dropped, or it would outrank the FROM host the proxy injects.
-        let outcome = RewriteOutcome {
-            sni: "to.edgecompute.app".to_string(),
-            host_header: "to.edgecompute.app".to_string(),
-            orig_host: "www.example-publisher.com".to_string(),
-            scheme_is_tls: true,
-        };
+        let outcome = rewrite_outcome("to.edgecompute.app");
         let mut headers = hyper::HeaderMap::new();
         headers.insert(
             HeaderName::from_static("forwarded"),
@@ -821,12 +831,7 @@ mod tests {
     fn rewrite_headers_stamps_https_scheme_and_drops_spoofed_signals() {
         // The browser leg is always TLS, so the scheme is authoritatively https;
         // a client-supplied X-Forwarded-Proto / Fastly-SSL must not downgrade it.
-        let outcome = RewriteOutcome {
-            sni: "to.edgecompute.app".to_string(),
-            host_header: "www.example-publisher.com".to_string(),
-            orig_host: "www.example-publisher.com".to_string(),
-            scheme_is_tls: true,
-        };
+        let outcome = rewrite_outcome("www.example-publisher.com");
         let mut headers = hyper::HeaderMap::new();
         headers.insert(
             HeaderName::from_static(X_FORWARDED_PROTO),
@@ -853,12 +858,7 @@ mod tests {
         // A client naming the proxy's own headers in `Connection` must not cause
         // them to be dropped downstream: we strip the client's copies + the
         // `Connection` header, then stamp our authoritative values.
-        let outcome = RewriteOutcome {
-            sni: "to.edgecompute.app".to_string(),
-            host_header: "to.edgecompute.app".to_string(),
-            orig_host: "www.example-publisher.com".to_string(),
-            scheme_is_tls: true,
-        };
+        let outcome = rewrite_outcome("to.edgecompute.app");
         let mut headers = hyper::HeaderMap::new();
         headers.insert(
             hyper::header::CONNECTION,

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::task::{Context, Poll};
 
 use bytes::Bytes;
+use http_body_util::{BodyExt as _, combinators::BoxBody};
 use hyper::body::{Body, Frame, Incoming, SizeHint};
 
 use super::connect::UpstreamSender;
@@ -14,14 +15,42 @@ const STREAMING: u8 = 0;
 const COMPLETE: u8 = 1;
 const FAILED: u8 = 2;
 
+#[derive(Debug, derive_more::Display)]
+pub enum ProxyBodyError {
+    #[display("upstream request body failed")]
+    Hyper(hyper::Error),
+}
+
+impl core::error::Error for ProxyBodyError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Hyper(error) => Some(error),
+        }
+    }
+}
+
+pub type ProxyRequestBody = BoxBody<Bytes, ProxyBodyError>;
+
 pub struct RequestUploadBody {
-    inner: Incoming,
+    inner: ProxyRequestBody,
     state: Arc<AtomicU8>,
 }
 
 impl RequestUploadBody {
     #[must_use]
     pub fn new(inner: Incoming, known_empty: bool) -> (Self, Arc<AtomicU8>) {
+        Self::from_boxed(inner.map_err(ProxyBodyError::Hyper).boxed(), known_empty)
+    }
+
+    #[must_use]
+    pub fn empty() -> Self {
+        let body = http_body_util::Empty::<Bytes>::new()
+            .map_err(|never| match never {})
+            .boxed();
+        Self::from_boxed(body, true).0
+    }
+
+    fn from_boxed(inner: ProxyRequestBody, known_empty: bool) -> (Self, Arc<AtomicU8>) {
         let state = Arc::new(AtomicU8::new(if known_empty || inner.is_end_stream() {
             COMPLETE
         } else {
@@ -39,7 +68,7 @@ impl RequestUploadBody {
 
 impl Body for RequestUploadBody {
     type Data = Bytes;
-    type Error = hyper::Error;
+    type Error = ProxyBodyError;
 
     fn poll_frame(
         mut self: Pin<&mut Self>,
@@ -54,18 +83,13 @@ impl Body for RequestUploadBody {
                 self.state.store(FAILED, Ordering::Release);
                 Poll::Ready(Some(Err(error)))
             }
-            Poll::Ready(Some(Ok(frame))) => {
-                if self.inner.is_end_stream() {
-                    self.state.store(COMPLETE, Ordering::Release);
-                }
-                Poll::Ready(Some(Ok(frame)))
-            }
+            Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
             Poll::Pending => Poll::Pending,
         }
     }
 
     fn is_end_stream(&self) -> bool {
-        self.inner.is_end_stream()
+        self.state.load(Ordering::Acquire) == COMPLETE
     }
 
     fn size_hint(&self) -> SizeHint {
@@ -119,10 +143,12 @@ impl PooledResponseBody {
         let Some(lease) = self.lease.take() else {
             return;
         };
-        let reusable = response_complete
-            && self.upload_state.load(Ordering::Acquire) == COMPLETE
-            && !self.close_intent
-            && !lease.connection.abort.is_finished();
+        let reusable = can_reuse(
+            response_complete,
+            self.upload_state.load(Ordering::Acquire),
+            self.close_intent,
+            lease.connection.abort.is_finished(),
+        );
         if reusable {
             self.metrics.record_request_completed();
             self.manager.return_idle(lease.connection);
@@ -131,6 +157,15 @@ impl PooledResponseBody {
             lease.connection.abort.abort();
         }
     }
+}
+
+fn can_reuse(
+    response_complete: bool,
+    upload_state: u8,
+    close_intent: bool,
+    driver_finished: bool,
+) -> bool {
+    response_complete && upload_state == COMPLETE && !close_intent && !driver_finished
 }
 
 impl Body for PooledResponseBody {
@@ -172,5 +207,103 @@ impl Body for PooledResponseBody {
 impl Drop for PooledResponseBody {
     fn drop(&mut self) {
         self.finalize(false);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    use hyper::HeaderMap;
+
+    use super::*;
+
+    struct ScriptedBody {
+        frames: VecDeque<Frame<Bytes>>,
+        polls: Arc<AtomicUsize>,
+    }
+
+    impl Body for ScriptedBody {
+        type Data = Bytes;
+        type Error = ProxyBodyError;
+
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            self.polls.fetch_add(1, AtomicOrdering::Relaxed);
+            Poll::Ready(self.frames.pop_front().map(Ok))
+        }
+
+        fn is_end_stream(&self) -> bool {
+            self.frames.is_empty()
+        }
+    }
+
+    #[tokio::test]
+    async fn upload_completes_only_after_terminal_eos_following_trailers() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let mut trailers = HeaderMap::new();
+        trailers.insert("x-trailer", hyper::header::HeaderValue::from_static("done"));
+        let scripted = ScriptedBody {
+            frames: VecDeque::from([
+                Frame::data(Bytes::from_static(b"data")),
+                Frame::trailers(trailers),
+            ]),
+            polls,
+        };
+        let (mut body, state) = RequestUploadBody::from_boxed(scripted.boxed(), false);
+
+        assert!(body.frame().await.is_some());
+        assert_eq!(state.load(Ordering::Acquire), STREAMING);
+        assert!(body.frame().await.is_some());
+        assert_eq!(
+            state.load(Ordering::Acquire),
+            STREAMING,
+            "trailers are not terminal until the following EOS poll"
+        );
+        assert!(body.frame().await.is_none());
+        assert_eq!(state.load(Ordering::Acquire), COMPLETE);
+    }
+
+    #[tokio::test]
+    async fn upload_adapter_does_not_prepoll_or_buffer_frames() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let scripted = ScriptedBody {
+            frames: VecDeque::from([
+                Frame::data(Bytes::from_static(b"one")),
+                Frame::data(Bytes::from_static(b"two")),
+            ]),
+            polls: Arc::clone(&polls),
+        };
+        let (mut body, _state) = RequestUploadBody::from_boxed(scripted.boxed(), false);
+
+        assert_eq!(polls.load(AtomicOrdering::Relaxed), 0);
+        assert!(body.frame().await.is_some());
+        assert_eq!(polls.load(AtomicOrdering::Relaxed), 1);
+        assert!(body.frame().await.is_some());
+        assert_eq!(polls.load(AtomicOrdering::Relaxed), 2);
+    }
+
+    #[test]
+    fn dropping_upload_before_eos_marks_it_failed() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let scripted = ScriptedBody {
+            frames: VecDeque::from([Frame::data(Bytes::from_static(b"pending"))]),
+            polls,
+        };
+        let (body, state) = RequestUploadBody::from_boxed(scripted.boxed(), false);
+        drop(body);
+        assert_eq!(state.load(Ordering::Acquire), FAILED);
+    }
+
+    #[test]
+    fn response_eos_while_upload_streams_is_never_reusable() {
+        assert!(!can_reuse(true, STREAMING, false, false));
+        assert!(!can_reuse(true, FAILED, false, false));
+        assert!(!can_reuse(true, COMPLETE, true, false));
+        assert!(!can_reuse(true, COMPLETE, false, true));
+        assert!(can_reuse(true, COMPLETE, false, false));
     }
 }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
@@ -125,6 +125,7 @@ impl PooledResponseBody {
         close_intent: bool,
         metrics: Arc<ProxyMetrics>,
     ) -> Self {
+        let response_complete = inner.is_end_stream();
         Self {
             inner,
             lease: Some(lease),
@@ -133,7 +134,7 @@ impl PooledResponseBody {
             close_intent,
             metrics,
             finalized: false,
-            response_complete: false,
+            response_complete,
         }
     }
 
@@ -228,7 +229,7 @@ mod tests {
     use std::convert::Infallible;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
-    use http_body_util::Full;
+    use http_body_util::{Empty, Full};
     use hyper::service::service_fn;
     use hyper::{HeaderMap, Request, Response};
     use hyper_util::rt::TokioIo;
@@ -377,6 +378,62 @@ mod tests {
         body.collect()
             .await
             .expect("should consume complete response");
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.requests_completed, 1);
+        assert_eq!(snapshot.requests_failed, 0);
+    }
+
+    #[tokio::test]
+    async fn empty_response_dropped_without_poll_is_completed() {
+        let (client_io, server_io) = tokio::io::duplex(1024);
+        tokio::spawn(async move {
+            let service =
+                service_fn(|_| async { Ok::<_, Infallible>(Response::new(Empty::<Bytes>::new())) });
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(TokioIo::new(server_io), service)
+                .await;
+        });
+        let (sender, connection) = hyper::client::conn::http1::handshake(TokioIo::new(client_io))
+            .await
+            .expect("should complete client handshake");
+        let manager = Manager::start(super::super::manager::PoolLimits::default());
+        let key = OriginKey::new(
+            Transport::Tls,
+            ReferenceIdentity::dns("empty.example"),
+            443,
+            VerifyMode::Secure,
+            AddressPolicy::Dns,
+        );
+        let Acquired::Open(reservation) = manager.acquire(key).await.expect("should reserve")
+        else {
+            panic!("should open connection");
+        };
+        let id = reservation.id();
+        let driver_manager = Arc::clone(&manager);
+        let driver = tokio::spawn(async move {
+            let _ = connection.await;
+            driver_manager.driver_closed(id);
+        });
+        let mut lease = reservation.register(&manager, sender, driver.abort_handle());
+        let response = lease
+            .connection
+            .value
+            .send_request(Request::new(RequestUploadBody::empty()))
+            .await
+            .expect("should receive response");
+        assert!(response.body().is_end_stream());
+        let metrics = Arc::new(ProxyMetrics::default());
+        let body = PooledResponseBody::new(
+            response.into_body(),
+            lease,
+            Arc::clone(&manager),
+            Arc::new(AtomicU8::new(COMPLETE)),
+            false,
+            Arc::clone(&metrics),
+        );
+
+        drop(body);
 
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.requests_completed, 1);

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
@@ -1,0 +1,176 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use hyper::body::{Body, Frame, Incoming, SizeHint};
+
+use super::connect::UpstreamSender;
+use super::manager::{Lease, Manager};
+use crate::commands::dev::proxy::metrics::ProxyMetrics;
+
+const STREAMING: u8 = 0;
+const COMPLETE: u8 = 1;
+const FAILED: u8 = 2;
+
+pub struct RequestUploadBody {
+    inner: Incoming,
+    state: Arc<AtomicU8>,
+}
+
+impl RequestUploadBody {
+    #[must_use]
+    pub fn new(inner: Incoming, known_empty: bool) -> (Self, Arc<AtomicU8>) {
+        let state = Arc::new(AtomicU8::new(if known_empty || inner.is_end_stream() {
+            COMPLETE
+        } else {
+            STREAMING
+        }));
+        (
+            Self {
+                inner,
+                state: Arc::clone(&state),
+            },
+            state,
+        )
+    }
+}
+
+impl Body for RequestUploadBody {
+    type Data = Bytes;
+    type Error = hyper::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match Pin::new(&mut self.inner).poll_frame(cx) {
+            Poll::Ready(None) => {
+                self.state.store(COMPLETE, Ordering::Release);
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Err(error))) => {
+                self.state.store(FAILED, Ordering::Release);
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(Some(Ok(frame))) => {
+                if self.inner.is_end_stream() {
+                    self.state.store(COMPLETE, Ordering::Release);
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl Drop for RequestUploadBody {
+    fn drop(&mut self) {
+        let _ = self
+            .state
+            .compare_exchange(STREAMING, FAILED, Ordering::AcqRel, Ordering::Acquire);
+    }
+}
+
+pub struct PooledResponseBody {
+    inner: Incoming,
+    lease: Option<Lease<UpstreamSender>>,
+    manager: Arc<Manager<UpstreamSender>>,
+    upload_state: Arc<AtomicU8>,
+    close_intent: bool,
+    metrics: Arc<ProxyMetrics>,
+    finalized: bool,
+}
+
+impl PooledResponseBody {
+    pub fn new(
+        inner: Incoming,
+        lease: Lease<UpstreamSender>,
+        manager: Arc<Manager<UpstreamSender>>,
+        upload_state: Arc<AtomicU8>,
+        close_intent: bool,
+        metrics: Arc<ProxyMetrics>,
+    ) -> Self {
+        Self {
+            inner,
+            lease: Some(lease),
+            manager,
+            upload_state,
+            close_intent,
+            metrics,
+            finalized: false,
+        }
+    }
+
+    fn finalize(&mut self, response_complete: bool) {
+        if self.finalized {
+            return;
+        }
+        self.finalized = true;
+        let Some(lease) = self.lease.take() else {
+            return;
+        };
+        let reusable = response_complete
+            && self.upload_state.load(Ordering::Acquire) == COMPLETE
+            && !self.close_intent
+            && !lease.connection.abort.is_finished();
+        if reusable {
+            self.metrics.record_request_completed();
+            self.manager.return_idle(lease.connection);
+        } else {
+            self.metrics.record_request_failed();
+            lease.connection.abort.abort();
+        }
+    }
+}
+
+impl Body for PooledResponseBody {
+    type Data = Bytes;
+    type Error = hyper::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match Pin::new(&mut self.inner).poll_frame(cx) {
+            Poll::Ready(None) => {
+                self.finalize(true);
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Err(error))) => {
+                self.finalize(false);
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(Some(Ok(frame))) => {
+                if self.inner.is_end_stream() {
+                    self.finalize(true);
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.finalized
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl Drop for PooledResponseBody {
+    fn drop(&mut self) {
+        self.finalize(false);
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
@@ -149,11 +149,14 @@ impl PooledResponseBody {
             self.close_intent,
             lease.connection.abort.is_finished(),
         );
-        if reusable {
+        if response_complete {
             self.metrics.record_request_completed();
-            self.manager.return_idle(lease.connection);
         } else {
             self.metrics.record_request_failed();
+        }
+        if reusable {
+            self.manager.return_idle(lease.connection);
+        } else {
             lease.connection.abort.abort();
         }
     }
@@ -213,10 +216,18 @@ impl Drop for PooledResponseBody {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::convert::Infallible;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
-    use hyper::HeaderMap;
+    use http_body_util::Full;
+    use hyper::service::service_fn;
+    use hyper::{HeaderMap, Request, Response};
+    use hyper_util::rt::TokioIo;
 
+    use super::super::key::{
+        AddressPolicy, ApplicationMode, OriginKey, ReferenceIdentity, Transport, VerifyMode,
+    };
+    use super::super::manager::Acquired;
     use super::*;
 
     struct ScriptedBody {
@@ -305,5 +316,64 @@ mod tests {
         assert!(!can_reuse(true, COMPLETE, true, false));
         assert!(!can_reuse(true, COMPLETE, false, true));
         assert!(can_reuse(true, COMPLETE, false, false));
+    }
+
+    #[tokio::test]
+    async fn complete_unpoolable_response_is_not_a_request_failure() {
+        let (client_io, server_io) = tokio::io::duplex(1024);
+        tokio::spawn(async move {
+            let service = service_fn(|_| async {
+                Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(b"done"))))
+            });
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(TokioIo::new(server_io), service)
+                .await;
+        });
+        let (sender, connection) = hyper::client::conn::http1::handshake(TokioIo::new(client_io))
+            .await
+            .expect("should complete client handshake");
+        let manager = Manager::start(super::super::manager::PoolLimits::default());
+        let key = OriginKey::new(
+            Transport::Tls,
+            ReferenceIdentity::dns("metrics.example"),
+            443,
+            VerifyMode::Secure,
+            ApplicationMode::Http1Required,
+            AddressPolicy::Dns,
+        );
+        let Acquired::Open(reservation) = manager.acquire(key).await.expect("should reserve")
+        else {
+            panic!("should open connection");
+        };
+        let id = reservation.id();
+        let driver_manager = Arc::clone(&manager);
+        let driver = tokio::spawn(async move {
+            let _ = connection.await;
+            driver_manager.driver_closed(id);
+        });
+        let mut lease = reservation.register(&manager, sender, driver.abort_handle());
+        let response = lease
+            .connection
+            .value
+            .send_request(Request::new(RequestUploadBody::empty()))
+            .await
+            .expect("should receive response");
+        let metrics = Arc::new(ProxyMetrics::default());
+        let body = PooledResponseBody::new(
+            response.into_body(),
+            lease,
+            Arc::clone(&manager),
+            Arc::new(AtomicU8::new(COMPLETE)),
+            true,
+            Arc::clone(&metrics),
+        );
+
+        body.collect()
+            .await
+            .expect("should consume complete response");
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.requests_completed, 1);
+        assert_eq!(snapshot.requests_failed, 0);
     }
 }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
@@ -16,7 +16,9 @@ const COMPLETE: u8 = 1;
 const FAILED: u8 = 2;
 
 #[derive(Debug, derive_more::Display)]
+/// Error emitted while streaming the browser request body upstream.
 pub enum ProxyBodyError {
+    /// Hyper rejected or failed an incoming body frame.
     #[display("upstream request body failed")]
     Hyper(hyper::Error),
 }
@@ -29,8 +31,10 @@ impl core::error::Error for ProxyBodyError {
     }
 }
 
+/// Type-erased streaming request body used by the upstream HTTP/1 sender.
 pub type ProxyRequestBody = BoxBody<Bytes, ProxyBodyError>;
 
+/// Request-body adapter that tracks terminal upload completion without buffering.
 pub struct RequestUploadBody {
     inner: ProxyRequestBody,
     state: Arc<AtomicU8>,
@@ -38,11 +42,13 @@ pub struct RequestUploadBody {
 
 impl RequestUploadBody {
     #[must_use]
+    /// Wraps a browser request body and returns its shared completion state.
     pub fn new(inner: Incoming, known_empty: bool) -> (Self, Arc<AtomicU8>) {
         Self::from_boxed(inner.map_err(ProxyBodyError::Hyper).boxed(), known_empty)
     }
 
     #[must_use]
+    /// Creates a replay-safe, already-complete empty request body.
     pub fn empty() -> Self {
         let body = http_body_util::Empty::<Bytes>::new()
             .map_err(|never| match never {})
@@ -105,6 +111,7 @@ impl Drop for RequestUploadBody {
     }
 }
 
+/// Response-body adapter that returns healthy connections only after terminal EOS.
 pub struct PooledResponseBody {
     inner: Incoming,
     lease: Option<Lease<UpstreamSender>>,
@@ -117,6 +124,8 @@ pub struct PooledResponseBody {
 }
 
 impl PooledResponseBody {
+    /// Wraps an upstream response and owns its lease until response and upload
+    /// lifecycle conditions decide whether reuse is safe.
     pub fn new(
         inner: Incoming,
         lease: Lease<UpstreamSender>,

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
@@ -224,9 +224,7 @@ mod tests {
     use hyper::{HeaderMap, Request, Response};
     use hyper_util::rt::TokioIo;
 
-    use super::super::key::{
-        AddressPolicy, ApplicationMode, OriginKey, ReferenceIdentity, Transport, VerifyMode,
-    };
+    use super::super::key::{AddressPolicy, OriginKey, ReferenceIdentity, Transport, VerifyMode};
     use super::super::manager::Acquired;
     use super::*;
 
@@ -338,7 +336,6 @@ mod tests {
             ReferenceIdentity::dns("metrics.example"),
             443,
             VerifyMode::Secure,
-            ApplicationMode::Http1Required,
             AddressPolicy::Dns,
         );
         let Acquired::Open(reservation) = manager.acquire(key).await.expect("should reserve")

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs
@@ -113,6 +113,7 @@ pub struct PooledResponseBody {
     close_intent: bool,
     metrics: Arc<ProxyMetrics>,
     finalized: bool,
+    response_complete: bool,
 }
 
 impl PooledResponseBody {
@@ -132,6 +133,7 @@ impl PooledResponseBody {
             close_intent,
             metrics,
             finalized: false,
+            response_complete: false,
         }
     }
 
@@ -181,6 +183,7 @@ impl Body for PooledResponseBody {
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         match Pin::new(&mut self.inner).poll_frame(cx) {
             Poll::Ready(None) => {
+                self.response_complete = true;
                 self.finalize(true);
                 Poll::Ready(None)
             }
@@ -189,7 +192,13 @@ impl Body for PooledResponseBody {
                 Poll::Ready(Some(Err(error)))
             }
             Poll::Ready(Some(Ok(frame))) => {
-                if self.inner.is_end_stream() {
+                if frame.is_trailers() {
+                    // A trailer frame from Hyper `Incoming` follows the terminal
+                    // chunk. Defer lease reconciliation until the downstream
+                    // driver releases this wrapper so it can serialize the frame.
+                    self.response_complete = true;
+                } else if self.inner.is_end_stream() {
+                    self.response_complete = true;
                     self.finalize(true);
                 }
                 Poll::Ready(Some(Ok(frame)))
@@ -209,7 +218,7 @@ impl Body for PooledResponseBody {
 
 impl Drop for PooledResponseBody {
     fn drop(&mut self) {
-        self.finalize(false);
+        self.finalize(self.response_complete);
     }
 }
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs
@@ -14,21 +14,64 @@ use tokio_rustls::TlsConnector;
 use super::body::RequestUploadBody;
 use super::dns::DnsCache;
 use super::key::{AddressPolicy, OriginKey, ReferenceIdentity, Transport, VerifyMode};
-use super::manager::{ConnectionId, Manager};
+use super::manager::{ConnectionId, Lease, Manager, Reservation};
 use crate::commands::dev::proxy::metrics::ProxyMetrics;
 
+/// HTTP/1 request sender whose upload body preserves streaming frames.
 pub type UpstreamSender = SendRequest<RequestUploadBody>;
 
+/// Successfully opened sender plus its driver controls and manager reservation.
 pub struct OpenedConnection {
-    pub sender: UpstreamSender,
-    pub abort: AbortHandle,
-    pub start: oneshot::Sender<()>,
+    sender: Option<UpstreamSender>,
+    abort: AbortHandle,
+    start: Option<oneshot::Sender<()>>,
+    reservation: Option<Reservation>,
+}
+
+impl OpenedConnection {
+    /// Acknowledges the successful connector result and registers its driver.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if internal code attempts to register the same opened
+    /// connection more than once.
+    pub fn register(
+        mut self,
+        manager: &Manager<UpstreamSender>,
+    ) -> (Lease<UpstreamSender>, oneshot::Sender<()>) {
+        let sender = self.sender.take().expect("should retain opened sender");
+        let start = self.start.take().expect("should retain driver start latch");
+        let reservation = self
+            .reservation
+            .take()
+            .expect("should retain connector reservation");
+        let lease = reservation.register(manager, sender, self.abort.clone());
+        (lease, start)
+    }
+}
+
+impl Drop for OpenedConnection {
+    fn drop(&mut self) {
+        if let Some(reservation) = self.reservation.take() {
+            reservation.abort_established(&self.abort);
+        }
+    }
+}
+
+struct EstablishedConnection {
+    sender: UpstreamSender,
+    abort: AbortHandle,
+    start: oneshot::Sender<()>,
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Timeouts and harness-only delays used while opening an upstream connection.
 pub struct ConnectPolicy {
+    /// Total deadline for DNS, TCP, TLS, and HTTP handshaking.
     pub timeout: Duration,
+    /// Harness-only delay before TCP connection attempts.
     pub connect_delay: Duration,
+    /// Harness-only delay before TLS handshaking.
     pub tls_delay: Duration,
 }
 
@@ -38,6 +81,9 @@ pub struct PendingConnection {
 }
 
 impl PendingConnection {
+    /// Spawns one connector while transferring manager-reservation ownership
+    /// into its task.
+    #[must_use]
     pub fn spawn(
         key: OriginKey,
         sni: Option<ServerName<'static>>,
@@ -45,11 +91,18 @@ impl PendingConnection {
         metrics: Arc<ProxyMetrics>,
         manager: Arc<Manager<UpstreamSender>>,
         dns: Arc<DnsCache>,
-        id: ConnectionId,
+        reservation: Reservation,
     ) -> Self {
         Self {
             task: Some(tokio::spawn(async move {
-                open(&key, sni, policy, metrics, manager, dns, id).await
+                let id = reservation.id();
+                let established = open(&key, sni, policy, metrics, manager, dns, id).await?;
+                Ok(OpenedConnection {
+                    sender: Some(established.sender),
+                    abort: established.abort,
+                    start: Some(established.start),
+                    reservation: Some(reservation),
+                })
             })),
         }
     }
@@ -100,7 +153,7 @@ impl Drop for PendingConnection {
 /// # Errors
 ///
 /// Returns the underlying DNS, connection, TLS, or HTTP handshake error.
-pub async fn open(
+async fn open(
     key: &OriginKey,
     sni: Option<ServerName<'static>>,
     policy: ConnectPolicy,
@@ -108,7 +161,7 @@ pub async fn open(
     manager: Arc<Manager<UpstreamSender>>,
     dns: Arc<DnsCache>,
     id: ConnectionId,
-) -> Result<OpenedConnection, Report<io::Error>> {
+) -> Result<EstablishedConnection, Report<io::Error>> {
     let deadline = tokio::time::Instant::now() + policy.timeout;
     let addresses: Vec<std::net::SocketAddr> = match key.address_policy() {
         AddressPolicy::Resolve(address) => vec![(address, key.port()).into()],
@@ -185,7 +238,7 @@ async fn handshake<I>(
     manager: Arc<Manager<UpstreamSender>>,
     id: ConnectionId,
     metrics: Arc<ProxyMetrics>,
-) -> Result<OpenedConnection, Report<io::Error>>
+) -> Result<EstablishedConnection, Report<io::Error>>
 where
     I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
 {
@@ -204,7 +257,7 @@ where
             log::debug!("upstream connection closed: {error}");
         }
     });
-    Ok(OpenedConnection {
+    Ok(EstablishedConnection {
         sender,
         abort: task.abort_handle(),
         start,
@@ -279,9 +332,15 @@ impl rustls::client::danger::ServerCertVerifier for NoVerifier {
         Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
     }
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        rustls::crypto::aws_lc_rs::default_provider()
-            .signature_verification_algorithms
-            .supported_schemes()
+        static SCHEMES: std::sync::OnceLock<Vec<rustls::SignatureScheme>> =
+            std::sync::OnceLock::new();
+        SCHEMES
+            .get_or_init(|| {
+                rustls::crypto::aws_lc_rs::default_provider()
+                    .signature_verification_algorithms
+                    .supported_schemes()
+            })
+            .clone()
     }
 }
 
@@ -345,20 +404,27 @@ mod tests {
             Arc::new(ProxyMetrics::default()),
             Arc::clone(&manager),
             Arc::new(DnsCache::default()),
-            id,
+            reservation,
         );
         let abort = pending.abort_handle();
         manager.register_connector(id, abort.clone());
 
         drop(pending);
-        drop(reservation);
-        tokio::task::yield_now().await;
-
-        assert!(
-            abort.is_finished(),
-            "connector task should be aborted on drop"
-        );
-        let Acquired::Open(replacement) = manager.acquire(key()).await.expect("should reconcile")
+        let replacement = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(key()).await }
+        });
+        while !abort.is_finished() {
+            assert!(
+                !replacement.is_finished(),
+                "replacement capacity must remain blocked until connector cancellation completes"
+            );
+            tokio::task::yield_now().await;
+        }
+        let Acquired::Open(replacement) = replacement
+            .await
+            .expect("should join replacement")
+            .expect("should reconcile")
         else {
             panic!("should admit one replacement");
         };
@@ -399,13 +465,12 @@ mod tests {
             Arc::new(ProxyMetrics::default()),
             Arc::clone(&manager),
             Arc::new(DnsCache::default()),
-            id,
+            reservation,
         );
         let abort = pending.abort_handle();
         manager.register_connector(id, abort.clone());
 
         let owner = tokio::spawn(async move {
-            let _reservation = reservation;
             let _pending = pending;
             panic!("exercise connector owner unwind");
         });
@@ -417,5 +482,48 @@ mod tests {
             manager.acquire(key()).await,
             Ok(Acquired::Open(_))
         ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_waits_for_connector_cancellation_completion() {
+        let manager = Manager::start(PoolLimits {
+            per_origin_live: 1,
+            global_live: 1,
+            ..PoolLimits::default()
+        });
+        let Acquired::Open(reservation) = manager.acquire(key()).await.expect("should reserve")
+        else {
+            panic!("should open connector reservation");
+        };
+        let id = reservation.id();
+        let pending = PendingConnection::spawn(
+            key(),
+            Some(ServerName::from(IpAddr::V4(Ipv4Addr::LOCALHOST))),
+            delayed_policy(),
+            Arc::new(ProxyMetrics::default()),
+            Arc::clone(&manager),
+            Arc::new(DnsCache::default()),
+            reservation,
+        );
+        let abort = pending.abort_handle();
+        manager.register_connector(id, abort.clone());
+
+        let shutdown = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.shutdown().await }
+        });
+        while !abort.is_finished() {
+            assert!(
+                !shutdown.is_finished(),
+                "shutdown must not acknowledge while the connector task is still live"
+            );
+            tokio::task::yield_now().await;
+        }
+        tokio::task::yield_now().await;
+        assert!(
+            shutdown.is_finished(),
+            "shutdown should acknowledge after connector cleanup reconciles capacity"
+        );
+        drop(pending);
     }
 }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs
@@ -25,6 +25,76 @@ pub struct OpenedConnection {
     pub start: oneshot::Sender<()>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ConnectPolicy {
+    pub timeout: Duration,
+    pub connect_delay: Duration,
+    pub tls_delay: Duration,
+}
+
+/// Abort-on-drop network connector owned by one manager reservation.
+pub struct PendingConnection {
+    task: Option<tokio::task::JoinHandle<Result<OpenedConnection, Report<io::Error>>>>,
+}
+
+impl PendingConnection {
+    pub fn spawn(
+        key: OriginKey,
+        sni: Option<ServerName<'static>>,
+        policy: ConnectPolicy,
+        metrics: Arc<ProxyMetrics>,
+        manager: Arc<Manager<UpstreamSender>>,
+        dns: Arc<DnsCache>,
+        id: ConnectionId,
+    ) -> Self {
+        Self {
+            task: Some(tokio::spawn(async move {
+                open(&key, sni, policy, metrics, manager, dns, id).await
+            })),
+        }
+    }
+
+    #[must_use]
+    /// Returns the task abort handle while the connector is pending.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if called after this value has already completed.
+    pub fn abort_handle(&self) -> AbortHandle {
+        self.task
+            .as_ref()
+            .expect("should retain connector task")
+            .abort_handle()
+    }
+
+    /// Waits for connector completion while retaining abort-on-caller-drop behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns the connection error or a task cancellation/panic as an I/O report.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if internal code removes the task before awaiting it.
+    pub async fn finish(mut self) -> Result<OpenedConnection, Report<io::Error>> {
+        let result = self
+            .task
+            .as_mut()
+            .expect("should retain connector task")
+            .await;
+        self.task.take();
+        result.map_err(|error| Report::new(io::Error::other(error.to_string())))?
+    }
+}
+
+impl Drop for PendingConnection {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
 /// Opens TCP/TLS and completes an HTTP/1 client handshake for one reservation.
 ///
 /// # Errors
@@ -33,19 +103,19 @@ pub struct OpenedConnection {
 pub async fn open(
     key: &OriginKey,
     sni: Option<ServerName<'static>>,
-    timeout: Duration,
+    policy: ConnectPolicy,
     metrics: Arc<ProxyMetrics>,
     manager: Arc<Manager<UpstreamSender>>,
     dns: Arc<DnsCache>,
     id: ConnectionId,
 ) -> Result<OpenedConnection, Report<io::Error>> {
-    let deadline = tokio::time::Instant::now() + timeout;
+    let deadline = tokio::time::Instant::now() + policy.timeout;
     let addresses: Vec<std::net::SocketAddr> = match key.address_policy() {
         AddressPolicy::Resolve(address) => vec![(address, key.port()).into()],
         AddressPolicy::Dns => match key.reference() {
             ReferenceIdentity::Ip(address) => vec![(*address, key.port()).into()],
             ReferenceIdentity::Dns(host) => dns
-                .lookup(host, key.port(), deadline, &metrics)
+                .lookup(host, key.port(), deadline, Arc::clone(&metrics))
                 .await?
                 .to_vec(),
         },
@@ -58,6 +128,9 @@ pub async fn open(
     }
     let mut last_error = None;
     let mut connected = None;
+    if !policy.connect_delay.is_zero() {
+        tokio::time::sleep(policy.connect_delay).await;
+    }
     for (index, address) in addresses.iter().enumerate() {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
@@ -93,6 +166,9 @@ pub async fn open(
             io::Error::new(io::ErrorKind::InvalidInput, "TLS origin has no server name")
         })?;
         let tls_started = tokio::time::Instant::now();
+        if !policy.tls_delay.is_zero() {
+            tokio::time::sleep(policy.tls_delay).await;
+        }
         let tls = connector
             .connect(server_name, tcp)
             .await

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs
@@ -284,3 +284,138 @@ impl rustls::client::danger::ServerCertVerifier for NoVerifier {
             .supported_schemes()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+    use crate::commands::dev::proxy::upstream::key::ReferenceIdentity;
+    use crate::commands::dev::proxy::upstream::manager::{Acquired, PoolLimits};
+
+    fn key() -> OriginKey {
+        let address = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        OriginKey::new(
+            Transport::Tls,
+            ReferenceIdentity::ip(address),
+            443,
+            VerifyMode::Insecure,
+            AddressPolicy::Dns,
+        )
+    }
+
+    fn delayed_policy() -> ConnectPolicy {
+        ConnectPolicy {
+            timeout: Duration::from_secs(30),
+            connect_delay: Duration::from_secs(10),
+            tls_delay: Duration::ZERO,
+        }
+    }
+
+    #[test]
+    fn client_configs_are_cached_by_verification_and_http1_only() {
+        let secure = client_config(VerifyMode::Secure);
+        let secure_again = client_config(VerifyMode::Secure);
+        let insecure = client_config(VerifyMode::Insecure);
+        let insecure_again = client_config(VerifyMode::Insecure);
+
+        assert!(Arc::ptr_eq(&secure, &secure_again));
+        assert!(Arc::ptr_eq(&insecure, &insecure_again));
+        assert!(!Arc::ptr_eq(&secure, &insecure));
+        assert_eq!(secure.alpn_protocols, [b"http/1.1".to_vec()]);
+        assert_eq!(insecure.alpn_protocols, [b"http/1.1".to_vec()]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropping_pending_connector_reconciles_reservation_once() {
+        let manager = Manager::start(PoolLimits {
+            per_origin_live: 1,
+            global_live: 1,
+            ..PoolLimits::default()
+        });
+        let Acquired::Open(reservation) = manager.acquire(key()).await.expect("should reserve")
+        else {
+            panic!("should open connector reservation");
+        };
+        let id = reservation.id();
+        let pending = PendingConnection::spawn(
+            key(),
+            Some(ServerName::from(IpAddr::V4(Ipv4Addr::LOCALHOST))),
+            delayed_policy(),
+            Arc::new(ProxyMetrics::default()),
+            Arc::clone(&manager),
+            Arc::new(DnsCache::default()),
+            id,
+        );
+        let abort = pending.abort_handle();
+        manager.register_connector(id, abort.clone());
+
+        drop(pending);
+        drop(reservation);
+        tokio::task::yield_now().await;
+
+        assert!(
+            abort.is_finished(),
+            "connector task should be aborted on drop"
+        );
+        let Acquired::Open(replacement) = manager.acquire(key()).await.expect("should reconcile")
+        else {
+            panic!("should admit one replacement");
+        };
+        manager.driver_closed(id);
+        let overflow = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(key()).await }
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !overflow.is_finished(),
+            "duplicate completion must not free replacement capacity"
+        );
+        drop(replacement);
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            overflow.await.expect("should join overflow"),
+            Ok(Acquired::Open(_))
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_owner_unwind_reconciles_reservation() {
+        let manager = Manager::start(PoolLimits {
+            per_origin_live: 1,
+            global_live: 1,
+            ..PoolLimits::default()
+        });
+        let Acquired::Open(reservation) = manager.acquire(key()).await.expect("should reserve")
+        else {
+            panic!("should open connector reservation");
+        };
+        let id = reservation.id();
+        let pending = PendingConnection::spawn(
+            key(),
+            Some(ServerName::from(IpAddr::V4(Ipv4Addr::LOCALHOST))),
+            delayed_policy(),
+            Arc::new(ProxyMetrics::default()),
+            Arc::clone(&manager),
+            Arc::new(DnsCache::default()),
+            id,
+        );
+        let abort = pending.abort_handle();
+        manager.register_connector(id, abort.clone());
+
+        let owner = tokio::spawn(async move {
+            let _reservation = reservation;
+            let _pending = pending;
+            panic!("exercise connector owner unwind");
+        });
+        assert!(owner.await.expect_err("owner should panic").is_panic());
+        tokio::task::yield_now().await;
+
+        assert!(abort.is_finished(), "unwind should abort connector task");
+        assert!(matches!(
+            manager.acquire(key()).await,
+            Ok(Acquired::Open(_))
+        ));
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs
@@ -1,0 +1,210 @@
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use error_stack::{Report, ResultExt as _};
+use hyper::client::conn::http1::SendRequest;
+use hyper_util::rt::TokioIo;
+use rustls::pki_types::ServerName;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tokio::task::AbortHandle;
+use tokio_rustls::TlsConnector;
+
+use super::body::RequestUploadBody;
+use super::dns::DnsCache;
+use super::key::{AddressPolicy, OriginKey, ReferenceIdentity, Transport, VerifyMode};
+use super::manager::{ConnectionId, Manager};
+use crate::commands::dev::proxy::metrics::ProxyMetrics;
+
+pub type UpstreamSender = SendRequest<RequestUploadBody>;
+
+pub struct OpenedConnection {
+    pub sender: UpstreamSender,
+    pub abort: AbortHandle,
+    pub start: oneshot::Sender<()>,
+}
+
+/// Opens TCP/TLS and completes an HTTP/1 client handshake for one reservation.
+///
+/// # Errors
+///
+/// Returns the underlying DNS, connection, TLS, or HTTP handshake error.
+pub async fn open(
+    key: &OriginKey,
+    sni: Option<ServerName<'static>>,
+    timeout: Duration,
+    metrics: Arc<ProxyMetrics>,
+    manager: Arc<Manager<UpstreamSender>>,
+    dns: Arc<DnsCache>,
+    id: ConnectionId,
+) -> Result<OpenedConnection, Report<io::Error>> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let addresses: Vec<std::net::SocketAddr> = match key.address_policy() {
+        AddressPolicy::Resolve(address) => vec![(address, key.port()).into()],
+        AddressPolicy::Dns => match key.reference() {
+            ReferenceIdentity::Ip(address) => vec![(*address, key.port()).into()],
+            ReferenceIdentity::Dns(host) => dns
+                .lookup(host, key.port(), deadline, &metrics)
+                .await?
+                .to_vec(),
+        },
+    };
+    if addresses.is_empty() {
+        return Err(Report::new(io::Error::new(
+            io::ErrorKind::NotFound,
+            "upstream DNS returned no addresses",
+        )));
+    }
+    let mut last_error = None;
+    let mut connected = None;
+    for (index, address) in addresses.iter().enumerate() {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let addresses_left = u32::try_from(addresses.len() - index).unwrap_or(u32::MAX);
+        let slice = remaining / addresses_left;
+        metrics.record_tcp_attempt();
+        let started = tokio::time::Instant::now();
+        match tokio::time::timeout(slice, TcpStream::connect(address)).await {
+            Ok(Ok(tcp)) => {
+                metrics.record_tcp_established(started.elapsed());
+                connected = Some(tcp);
+                break;
+            }
+            Ok(Err(error)) => last_error = Some(error),
+            Err(_) => {
+                last_error = Some(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("upstream connect to {address} timed out"),
+                ));
+            }
+        }
+    }
+    let tcp = connected.ok_or_else(|| {
+        Report::new(last_error.unwrap_or_else(|| {
+            io::Error::new(io::ErrorKind::TimedOut, "upstream connect deadline elapsed")
+        }))
+    })?;
+    if key.transport() == Transport::Tls {
+        let connector = TlsConnector::from(client_config(key.verify_mode()));
+        let server_name = sni.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "TLS origin has no server name")
+        })?;
+        let tls_started = tokio::time::Instant::now();
+        let tls = connector
+            .connect(server_name, tcp)
+            .await
+            .map_err(io::Error::other)?;
+        metrics.record_tls_handshake(tls_started.elapsed());
+        handshake(TokioIo::new(tls), manager, id, metrics).await
+    } else {
+        handshake(TokioIo::new(tcp), manager, id, metrics).await
+    }
+}
+
+async fn handshake<I>(
+    io: I,
+    manager: Arc<Manager<UpstreamSender>>,
+    id: ConnectionId,
+    metrics: Arc<ProxyMetrics>,
+) -> Result<OpenedConnection, Report<io::Error>>
+where
+    I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+{
+    let handshake_started = tokio::time::Instant::now();
+    let (sender, connection) = hyper::client::conn::http1::handshake(io)
+        .await
+        .map_err(io::Error::other)
+        .attach("HTTP/1 upstream handshake failed")?;
+    metrics.record_http_handshake(handshake_started.elapsed());
+    metrics.record_negotiated_http1();
+    let (start, started) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let _guard = DriverGuard { manager, id };
+        let _ = started.await;
+        if let Err(error) = connection.await {
+            log::debug!("upstream connection closed: {error}");
+        }
+    });
+    Ok(OpenedConnection {
+        sender,
+        abort: task.abort_handle(),
+        start,
+    })
+}
+
+struct DriverGuard {
+    manager: Arc<Manager<UpstreamSender>>,
+    id: ConnectionId,
+}
+
+impl Drop for DriverGuard {
+    fn drop(&mut self) {
+        self.manager.driver_closed(self.id);
+    }
+}
+
+fn client_config(mode: VerifyMode) -> Arc<rustls::ClientConfig> {
+    static SECURE: std::sync::OnceLock<Arc<rustls::ClientConfig>> = std::sync::OnceLock::new();
+    static INSECURE: std::sync::OnceLock<Arc<rustls::ClientConfig>> = std::sync::OnceLock::new();
+    let cell = if mode == VerifyMode::Insecure {
+        &INSECURE
+    } else {
+        &SECURE
+    };
+    Arc::clone(cell.get_or_init(|| {
+        let mut config = if mode == VerifyMode::Insecure {
+            rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(NoVerifier))
+                .with_no_client_auth()
+        } else {
+            let mut roots = rustls::RootCertStore::empty();
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth()
+        };
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+        Arc::new(config)
+    }))
+}
+
+#[derive(Debug)]
+struct NoVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _: &rustls::pki_types::CertificateDer<'_>,
+        _: &[rustls::pki_types::CertificateDer<'_>],
+        _: &ServerName<'_>,
+        _: &[u8],
+        _: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        _: &[u8],
+        _: &rustls::pki_types::CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _: &[u8],
+        _: &rustls::pki_types::CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/dns.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/dns.rs
@@ -1,0 +1,253 @@
+use std::collections::HashMap;
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{Mutex, watch};
+use tokio::time::Instant;
+
+use crate::commands::dev::proxy::metrics::ProxyMetrics;
+
+const TTL: Duration = Duration::from_secs(30);
+const MAX_ENTRIES: usize = 64;
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct CacheKey {
+    host: Arc<str>,
+    port: u16,
+}
+
+enum Entry {
+    Loading(watch::Sender<bool>),
+    Ready {
+        addresses: Arc<[SocketAddr]>,
+        expires: Instant,
+        used: u64,
+    },
+}
+
+#[derive(Default)]
+struct State {
+    entries: HashMap<CacheKey, Entry>,
+    sequence: u64,
+}
+
+/// Small process-local DNS cache used only while opening pooled connections.
+pub struct DnsCache {
+    state: Mutex<State>,
+    enabled: bool,
+}
+
+impl Default for DnsCache {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
+impl DnsCache {
+    #[must_use]
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            state: Mutex::new(State::default()),
+            enabled,
+        }
+    }
+
+    /// Resolves a logical DNS origin with TTL, LRU eviction, and miss coalescing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an owned resolver error; failures are never cached.
+    pub async fn lookup(
+        &self,
+        host: &str,
+        port: u16,
+        deadline: Instant,
+        metrics: &ProxyMetrics,
+    ) -> io::Result<Arc<[SocketAddr]>> {
+        let key = CacheKey {
+            host: Arc::from(host.to_ascii_lowercase()),
+            port,
+        };
+        if !self.enabled {
+            return resolve_uncached(&key, deadline, metrics).await;
+        }
+        loop {
+            enum Action {
+                Wait(watch::Receiver<bool>),
+                Resolve(watch::Sender<bool>),
+                Bypass,
+            }
+            let action = {
+                let mut state = self.state.lock().await;
+                state.sequence += 1;
+                let used = state.sequence;
+                match state.entries.get_mut(&key) {
+                    Some(Entry::Ready {
+                        addresses,
+                        expires,
+                        used: entry_used,
+                    }) if *expires > Instant::now() => {
+                        *entry_used = used;
+                        metrics.record_dns_cache_hit();
+                        return Ok(Arc::clone(addresses));
+                    }
+                    Some(Entry::Loading(notify)) => Action::Wait(notify.subscribe()),
+                    _ => {
+                        state.entries.remove(&key);
+                        state.entries.retain(|_, entry| {
+                            !matches!(entry, Entry::Ready { expires, .. } if *expires <= Instant::now())
+                        });
+                        if state.entries.len() >= MAX_ENTRIES
+                            && let Some(evict) = state
+                                .entries
+                                .iter()
+                                .filter_map(|(key, entry)| match entry {
+                                    Entry::Ready { used, .. } => Some((key.clone(), *used)),
+                                    Entry::Loading(_) => None,
+                                })
+                                .min_by_key(|(_, used)| *used)
+                                .map(|(key, _)| key)
+                        {
+                            state.entries.remove(&evict);
+                        }
+                        if state.entries.len() >= MAX_ENTRIES {
+                            Action::Bypass
+                        } else {
+                            let (notify, _) = watch::channel(false);
+                            state
+                                .entries
+                                .insert(key.clone(), Entry::Loading(notify.clone()));
+                            Action::Resolve(notify)
+                        }
+                    }
+                }
+            };
+            match action {
+                Action::Wait(mut notify) => {
+                    tokio::time::timeout_at(deadline, notify.changed())
+                        .await
+                        .map_err(|_| {
+                            io::Error::new(
+                                io::ErrorKind::TimedOut,
+                                "coalesced DNS lookup timed out",
+                            )
+                        })?
+                        .map_err(|_| {
+                            io::Error::new(io::ErrorKind::Interrupted, "DNS lookup owner exited")
+                        })?;
+                }
+                Action::Resolve(notify) => {
+                    return self
+                        .resolve_owner(key.clone(), deadline, metrics, notify)
+                        .await;
+                }
+                Action::Bypass => return resolve_uncached(&key, deadline, metrics).await,
+            }
+        }
+    }
+
+    async fn resolve_owner(
+        &self,
+        key: CacheKey,
+        deadline: Instant,
+        metrics: &ProxyMetrics,
+        notify: watch::Sender<bool>,
+    ) -> io::Result<Arc<[SocketAddr]>> {
+        let result = resolve_uncached(&key, deadline, metrics).await;
+        let mut state = self.state.lock().await;
+        state.sequence += 1;
+        let used = state.sequence;
+        state.entries.remove(&key);
+        if let Ok(addresses) = &result {
+            state.entries.insert(
+                key,
+                Entry::Ready {
+                    addresses: Arc::clone(addresses),
+                    expires: Instant::now() + TTL,
+                    used,
+                },
+            );
+        }
+        let _ = notify.send(true);
+        result
+    }
+}
+
+async fn resolve_uncached(
+    key: &CacheKey,
+    deadline: Instant,
+    metrics: &ProxyMetrics,
+) -> io::Result<Arc<[SocketAddr]>> {
+    metrics.record_dns_cache_miss();
+    let started = Instant::now();
+    let addresses: Arc<[SocketAddr]> = tokio::time::timeout_at(
+        deadline,
+        tokio::net::lookup_host((key.host.as_ref(), key.port)),
+    )
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "upstream DNS timed out"))??
+    .collect::<Vec<_>>()
+    .into();
+    metrics.record_dns_lookup(started.elapsed());
+    if addresses.is_empty() {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "upstream DNS returned no addresses",
+        ))
+    } else {
+        Ok(addresses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn caches_success_for_normalized_key() {
+        let cache = DnsCache::default();
+        let metrics = ProxyMetrics::default();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let first = cache
+            .lookup("localhost", 80, deadline, &metrics)
+            .await
+            .expect("resolve localhost");
+        let second = cache
+            .lookup("LOCALHOST", 80, deadline, &metrics)
+            .await
+            .expect("reuse normalized cache key");
+        assert_eq!(first, second);
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.dns_cache_misses, 1);
+        assert_eq!(snapshot.dns_cache_hits, 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_misses_are_coalesced() {
+        let cache = Arc::new(DnsCache::default());
+        let metrics = Arc::new(ProxyMetrics::default());
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            tasks.push(tokio::spawn(async move {
+                cache
+                    .lookup(
+                        "localhost",
+                        80,
+                        Instant::now() + Duration::from_secs(2),
+                        &metrics,
+                    )
+                    .await
+            }));
+        }
+        for task in tasks {
+            task.await.expect("join lookup").expect("resolve localhost");
+        }
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.dns_cache_misses, 1);
+        assert_eq!(snapshot.dns_cache_hits, 7);
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/dns.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/dns.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -12,14 +14,56 @@ use crate::commands::dev::proxy::metrics::ProxyMetrics;
 const TTL: Duration = Duration::from_secs(30);
 const MAX_ENTRIES: usize = 64;
 
+type ResolveFuture = Pin<Box<dyn Future<Output = io::Result<Vec<SocketAddr>>> + Send>>;
+
+trait Resolver: Send + Sync {
+    fn resolve(&self, host: Arc<str>, port: u16) -> ResolveFuture;
+}
+
+struct SystemResolver;
+
+impl Resolver for SystemResolver {
+    fn resolve(&self, host: Arc<str>, port: u16) -> ResolveFuture {
+        Box::pin(async move {
+            Ok(tokio::net::lookup_host((host.as_ref(), port))
+                .await?
+                .collect())
+        })
+    }
+}
+
 #[derive(Clone, Eq, Hash, PartialEq)]
 struct CacheKey {
     host: Arc<str>,
     port: u16,
 }
 
+#[derive(Clone)]
+struct OwnedError {
+    kind: io::ErrorKind,
+    message: Arc<str>,
+}
+
+impl OwnedError {
+    fn from_io(error: &io::Error) -> Self {
+        Self {
+            kind: error.kind(),
+            message: Arc::from(error.to_string()),
+        }
+    }
+
+    fn to_io(&self) -> io::Error {
+        io::Error::new(self.kind, self.message.to_string())
+    }
+}
+
+type SharedResult = Result<Arc<[SocketAddr]>, OwnedError>;
+
 enum Entry {
-    Loading(watch::Sender<bool>),
+    Loading {
+        generation: u64,
+        signal: watch::Sender<Option<SharedResult>>,
+    },
     Ready {
         addresses: Arc<[SocketAddr]>,
         expires: Instant,
@@ -35,8 +79,9 @@ struct State {
 
 /// Small process-local DNS cache used only while opening pooled connections.
 pub struct DnsCache {
-    state: Mutex<State>,
+    state: Arc<Mutex<State>>,
     enabled: bool,
+    resolver: Arc<dyn Resolver>,
 }
 
 impl Default for DnsCache {
@@ -48,9 +93,19 @@ impl Default for DnsCache {
 impl DnsCache {
     #[must_use]
     pub fn new(enabled: bool) -> Self {
+        Self::with_resolver_and_mode(Arc::new(SystemResolver), enabled)
+    }
+
+    #[cfg(test)]
+    fn with_resolver(resolver: Arc<dyn Resolver>) -> Self {
+        Self::with_resolver_and_mode(resolver, true)
+    }
+
+    fn with_resolver_and_mode(resolver: Arc<dyn Resolver>, enabled: bool) -> Self {
         Self {
-            state: Mutex::new(State::default()),
+            state: Arc::new(Mutex::new(State::default())),
             enabled,
+            resolver,
         }
     }
 
@@ -64,132 +119,189 @@ impl DnsCache {
         host: &str,
         port: u16,
         deadline: Instant,
-        metrics: &ProxyMetrics,
+        metrics: Arc<ProxyMetrics>,
     ) -> io::Result<Arc<[SocketAddr]>> {
         let key = CacheKey {
             host: Arc::from(host.to_ascii_lowercase()),
             port,
         };
         if !self.enabled {
-            return resolve_uncached(&key, deadline, metrics).await;
+            return resolve_uncached(Arc::clone(&self.resolver), &key, deadline, metrics).await;
         }
-        loop {
-            enum Action {
-                Wait(watch::Receiver<bool>),
-                Resolve(watch::Sender<bool>),
-                Bypass,
-            }
-            let action = {
-                let mut state = self.state.lock().await;
-                state.sequence += 1;
-                let used = state.sequence;
-                match state.entries.get_mut(&key) {
-                    Some(Entry::Ready {
-                        addresses,
-                        expires,
-                        used: entry_used,
-                    }) if *expires > Instant::now() => {
-                        *entry_used = used;
-                        metrics.record_dns_cache_hit();
-                        return Ok(Arc::clone(addresses));
-                    }
-                    Some(Entry::Loading(notify)) => Action::Wait(notify.subscribe()),
-                    _ => {
-                        state.entries.remove(&key);
-                        state.entries.retain(|_, entry| {
-                            !matches!(entry, Entry::Ready { expires, .. } if *expires <= Instant::now())
-                        });
-                        if state.entries.len() >= MAX_ENTRIES
-                            && let Some(evict) = state
-                                .entries
-                                .iter()
-                                .filter_map(|(key, entry)| match entry {
-                                    Entry::Ready { used, .. } => Some((key.clone(), *used)),
-                                    Entry::Loading(_) => None,
-                                })
-                                .min_by_key(|(_, used)| *used)
-                                .map(|(key, _)| key)
-                        {
-                            state.entries.remove(&evict);
-                        }
-                        if state.entries.len() >= MAX_ENTRIES {
-                            Action::Bypass
-                        } else {
-                            let (notify, _) = watch::channel(false);
-                            state
-                                .entries
-                                .insert(key.clone(), Entry::Loading(notify.clone()));
-                            Action::Resolve(notify)
-                        }
-                    }
-                }
-            };
-            match action {
-                Action::Wait(mut notify) => {
-                    tokio::time::timeout_at(deadline, notify.changed())
-                        .await
-                        .map_err(|_| {
-                            io::Error::new(
-                                io::ErrorKind::TimedOut,
-                                "coalesced DNS lookup timed out",
-                            )
-                        })?
-                        .map_err(|_| {
-                            io::Error::new(io::ErrorKind::Interrupted, "DNS lookup owner exited")
-                        })?;
-                }
-                Action::Resolve(notify) => {
-                    return self
-                        .resolve_owner(key.clone(), deadline, metrics, notify)
-                        .await;
-                }
-                Action::Bypass => return resolve_uncached(&key, deadline, metrics).await,
-            }
-        }
-    }
 
-    async fn resolve_owner(
-        &self,
-        key: CacheKey,
-        deadline: Instant,
-        metrics: &ProxyMetrics,
-        notify: watch::Sender<bool>,
-    ) -> io::Result<Arc<[SocketAddr]>> {
-        let result = resolve_uncached(&key, deadline, metrics).await;
-        let mut state = self.state.lock().await;
-        state.sequence += 1;
-        let used = state.sequence;
-        state.entries.remove(&key);
-        if let Ok(addresses) = &result {
-            state.entries.insert(
-                key,
-                Entry::Ready {
-                    addresses: Arc::clone(addresses),
-                    expires: Instant::now() + TTL,
-                    used,
-                },
-            );
+        enum Action {
+            Wait(watch::Receiver<Option<SharedResult>>),
+            Start {
+                generation: u64,
+                receiver: watch::Receiver<Option<SharedResult>>,
+                signal: watch::Sender<Option<SharedResult>>,
+            },
+            Bypass,
         }
-        let _ = notify.send(true);
-        result
+
+        let action = {
+            let mut state = self.state.lock().await;
+            state.sequence += 1;
+            let used = state.sequence;
+            match state.entries.get_mut(&key) {
+                Some(Entry::Ready {
+                    addresses,
+                    expires,
+                    used: entry_used,
+                }) if *expires > Instant::now() => {
+                    *entry_used = used;
+                    metrics.record_dns_cache_hit();
+                    return Ok(Arc::clone(addresses));
+                }
+                Some(Entry::Loading { signal, .. }) => {
+                    metrics.record_dns_cache_hit();
+                    Action::Wait(signal.subscribe())
+                }
+                _ => {
+                    state.entries.remove(&key);
+                    state.entries.retain(|_, entry| {
+                        !matches!(entry, Entry::Ready { expires, .. } if *expires <= Instant::now())
+                    });
+                    if state.entries.len() >= MAX_ENTRIES
+                        && let Some(evict) = state
+                            .entries
+                            .iter()
+                            .filter_map(|(key, entry)| match entry {
+                                Entry::Ready { used, .. } => Some((key.clone(), *used)),
+                                Entry::Loading { .. } => None,
+                            })
+                            .min_by_key(|(_, used)| *used)
+                            .map(|(key, _)| key)
+                    {
+                        state.entries.remove(&evict);
+                    }
+                    if state.entries.len() >= MAX_ENTRIES {
+                        Action::Bypass
+                    } else {
+                        state.sequence += 1;
+                        let generation = state.sequence;
+                        let (signal, receiver) = watch::channel(None);
+                        state.entries.insert(
+                            key.clone(),
+                            Entry::Loading {
+                                generation,
+                                signal: signal.clone(),
+                            },
+                        );
+                        Action::Start {
+                            generation,
+                            receiver,
+                            signal,
+                        }
+                    }
+                }
+            }
+        };
+
+        let receiver = match action {
+            Action::Wait(receiver) => receiver,
+            Action::Start {
+                generation,
+                receiver,
+                signal,
+            } => {
+                metrics.record_dns_cache_miss();
+                tokio::spawn(run_lookup(
+                    Arc::clone(&self.state),
+                    Arc::clone(&self.resolver),
+                    key,
+                    generation,
+                    deadline,
+                    Arc::clone(&metrics),
+                    signal,
+                ));
+                receiver
+            }
+            Action::Bypass => {
+                return resolve_uncached(Arc::clone(&self.resolver), &key, deadline, metrics).await;
+            }
+        };
+        wait_for_result(receiver, deadline).await
+    }
+}
+
+async fn wait_for_result(
+    mut receiver: watch::Receiver<Option<SharedResult>>,
+    deadline: Instant,
+) -> io::Result<Arc<[SocketAddr]>> {
+    let shared = tokio::time::timeout_at(deadline, async {
+        loop {
+            if let Some(result) = receiver.borrow().clone() {
+                return Ok::<SharedResult, io::Error>(result);
+            }
+            receiver.changed().await.map_err(|_| {
+                io::Error::new(io::ErrorKind::Interrupted, "DNS lookup owner exited")
+            })?;
+        }
+    })
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "coalesced DNS lookup timed out"))??;
+    shared.map_err(|error| error.to_io())
+}
+
+async fn run_lookup(
+    state: Arc<Mutex<State>>,
+    resolver: Arc<dyn Resolver>,
+    key: CacheKey,
+    generation: u64,
+    deadline: Instant,
+    metrics: Arc<ProxyMetrics>,
+    signal: watch::Sender<Option<SharedResult>>,
+) {
+    let result = resolve(resolver, &key, deadline, &metrics).await;
+    let shared = result.as_ref().map(Arc::clone).map_err(OwnedError::from_io);
+    let _ = signal.send(Some(shared.clone()));
+
+    let mut state = state.lock().await;
+    let still_owner = matches!(
+        state.entries.get(&key),
+        Some(Entry::Loading { generation: current, .. }) if *current == generation
+    );
+    if !still_owner {
+        return;
+    }
+    state.sequence += 1;
+    let used = state.sequence;
+    state.entries.remove(&key);
+    if let Ok(addresses) = result {
+        state.entries.insert(
+            key,
+            Entry::Ready {
+                addresses,
+                expires: Instant::now() + TTL,
+                used,
+            },
+        );
     }
 }
 
 async fn resolve_uncached(
+    resolver: Arc<dyn Resolver>,
+    key: &CacheKey,
+    deadline: Instant,
+    metrics: Arc<ProxyMetrics>,
+) -> io::Result<Arc<[SocketAddr]>> {
+    metrics.record_dns_cache_miss();
+    resolve(resolver, key, deadline, &metrics).await
+}
+
+async fn resolve(
+    resolver: Arc<dyn Resolver>,
     key: &CacheKey,
     deadline: Instant,
     metrics: &ProxyMetrics,
 ) -> io::Result<Arc<[SocketAddr]>> {
-    metrics.record_dns_cache_miss();
     let started = Instant::now();
-    let addresses: Arc<[SocketAddr]> = tokio::time::timeout_at(
-        deadline,
-        tokio::net::lookup_host((key.host.as_ref(), key.port)),
-    )
-    .await
-    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "upstream DNS timed out"))??
-    .collect::<Vec<_>>()
-    .into();
+    let addresses: Arc<[SocketAddr]> =
+        tokio::time::timeout_at(deadline, resolver.resolve(Arc::clone(&key.host), key.port))
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "upstream DNS timed out"))??
+            .into();
     metrics.record_dns_lookup(started.elapsed());
     if addresses.is_empty() {
         Err(io::Error::new(
@@ -205,17 +317,53 @@ async fn resolve_uncached(
 mod tests {
     use super::*;
 
+    struct ResolveRequest {
+        result: tokio::sync::oneshot::Sender<io::Result<Vec<SocketAddr>>>,
+    }
+
+    struct FakeResolver {
+        requests: tokio::sync::mpsc::UnboundedSender<ResolveRequest>,
+    }
+
+    impl Resolver for FakeResolver {
+        fn resolve(&self, _host: Arc<str>, _port: u16) -> ResolveFuture {
+            let (result, received) = tokio::sync::oneshot::channel();
+            self.requests
+                .send(ResolveRequest { result })
+                .expect("should observe lookup");
+            Box::pin(async move {
+                received.await.unwrap_or_else(|_| {
+                    Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "fake resolver dropped",
+                    ))
+                })
+            })
+        }
+    }
+
+    fn fake_cache() -> (
+        Arc<DnsCache>,
+        tokio::sync::mpsc::UnboundedReceiver<ResolveRequest>,
+    ) {
+        let (requests, received) = tokio::sync::mpsc::unbounded_channel();
+        (
+            Arc::new(DnsCache::with_resolver(Arc::new(FakeResolver { requests }))),
+            received,
+        )
+    }
+
     #[tokio::test]
     async fn caches_success_for_normalized_key() {
         let cache = DnsCache::default();
-        let metrics = ProxyMetrics::default();
+        let metrics = Arc::new(ProxyMetrics::default());
         let deadline = Instant::now() + Duration::from_secs(2);
         let first = cache
-            .lookup("localhost", 80, deadline, &metrics)
+            .lookup("localhost", 80, deadline, Arc::clone(&metrics))
             .await
             .expect("resolve localhost");
         let second = cache
-            .lookup("LOCALHOST", 80, deadline, &metrics)
+            .lookup("LOCALHOST", 80, deadline, Arc::clone(&metrics))
             .await
             .expect("reuse normalized cache key");
         assert_eq!(first, second);
@@ -238,7 +386,7 @@ mod tests {
                         "localhost",
                         80,
                         Instant::now() + Duration::from_secs(2),
-                        &metrics,
+                        metrics,
                     )
                     .await
             }));
@@ -249,5 +397,214 @@ mod tests {
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.dns_cache_misses, 1);
         assert_eq!(snapshot.dns_cache_hits, 7);
+    }
+
+    #[tokio::test]
+    async fn cancelling_lookup_owner_does_not_poison_in_flight_key() {
+        let (cache, mut requests) = fake_cache();
+        let metrics = Arc::new(ProxyMetrics::default());
+        let first = tokio::spawn({
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            async move {
+                cache
+                    .lookup(
+                        "example.test",
+                        443,
+                        Instant::now() + Duration::from_secs(5),
+                        metrics,
+                    )
+                    .await
+            }
+        });
+        let request = requests.recv().await.expect("should start one lookup");
+        first.abort();
+
+        let second = tokio::spawn({
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            async move {
+                cache
+                    .lookup(
+                        "example.test",
+                        443,
+                        Instant::now() + Duration::from_secs(5),
+                        metrics,
+                    )
+                    .await
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            requests.try_recv().is_err(),
+            "should coalesce after cancellation"
+        );
+        request
+            .result
+            .send(Ok(vec!["127.0.0.1:443".parse().expect("socket")]))
+            .expect("should deliver result");
+        assert_eq!(second.await.expect("join").expect("shared lookup").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_lookup_is_fanned_out_once_and_not_cached() {
+        let (cache, mut requests) = fake_cache();
+        let metrics = Arc::new(ProxyMetrics::default());
+        let mut waiters = Vec::new();
+        for _ in 0..2 {
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            waiters.push(tokio::spawn(async move {
+                cache
+                    .lookup(
+                        "failure.test",
+                        443,
+                        Instant::now() + Duration::from_secs(5),
+                        metrics,
+                    )
+                    .await
+                    .expect_err("should share failure")
+            }));
+        }
+        let request = requests.recv().await.expect("should start one lookup");
+        tokio::task::yield_now().await;
+        assert!(
+            requests.try_recv().is_err(),
+            "should have one resolver call"
+        );
+        request
+            .result
+            .send(Err(io::Error::other("shared failure")))
+            .expect("should deliver failure");
+        for waiter in waiters {
+            let error = waiter.await.expect("join");
+            assert_eq!(error.kind(), io::ErrorKind::Other);
+            assert_eq!(error.to_string(), "shared failure");
+        }
+        assert_eq!(metrics.snapshot().dns_cache_misses, 1);
+
+        let retry = tokio::spawn({
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            async move {
+                cache
+                    .lookup(
+                        "failure.test",
+                        443,
+                        Instant::now() + Duration::from_secs(5),
+                        metrics,
+                    )
+                    .await
+            }
+        });
+        let retry_request = requests.recv().await.expect("failure should not be cached");
+        retry_request
+            .result
+            .send(Ok(vec!["127.0.0.1:443".parse().expect("socket")]))
+            .expect("should deliver retry");
+        retry
+            .await
+            .expect("join retry")
+            .expect("retry should resolve");
+        assert_eq!(metrics.snapshot().dns_cache_misses, 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ready_entry_expires_at_thirty_seconds() {
+        let (cache, mut requests) = fake_cache();
+        let metrics = Arc::new(ProxyMetrics::default());
+        let first = tokio::spawn({
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            async move {
+                cache
+                    .lookup(
+                        "ttl.test",
+                        443,
+                        Instant::now() + Duration::from_secs(60),
+                        metrics,
+                    )
+                    .await
+            }
+        });
+        requests
+            .recv()
+            .await
+            .expect("first lookup")
+            .result
+            .send(Ok(vec!["127.0.0.1:443".parse().expect("socket")]))
+            .expect("first result");
+        first.await.expect("join").expect("first success");
+
+        tokio::time::advance(Duration::from_secs(29)).await;
+        cache
+            .lookup(
+                "ttl.test",
+                443,
+                Instant::now() + Duration::from_secs(5),
+                Arc::clone(&metrics),
+            )
+            .await
+            .expect("cache hit before expiry");
+        assert!(requests.try_recv().is_err());
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let expired = tokio::spawn({
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            async move {
+                cache
+                    .lookup(
+                        "ttl.test",
+                        443,
+                        Instant::now() + Duration::from_secs(5),
+                        metrics,
+                    )
+                    .await
+            }
+        });
+        requests
+            .recv()
+            .await
+            .expect("lookup after expiry")
+            .result
+            .send(Ok(vec!["127.0.0.1:443".parse().expect("socket")]))
+            .expect("expired result");
+        expired.await.expect("join").expect("expired success");
+        assert_eq!(metrics.snapshot().dns_cache_misses, 2);
+    }
+
+    #[tokio::test]
+    async fn all_in_flight_cache_stays_bounded_at_sixty_four() {
+        let (cache, mut requests) = fake_cache();
+        let metrics = Arc::new(ProxyMetrics::default());
+        let mut lookups = Vec::new();
+        let mut resolver_requests = Vec::new();
+        for index in 0..65 {
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            lookups.push(tokio::spawn(async move {
+                cache
+                    .lookup(
+                        &format!("bound-{index}.test"),
+                        443,
+                        Instant::now() + Duration::from_secs(5),
+                        metrics,
+                    )
+                    .await
+            }));
+            resolver_requests.push(requests.recv().await.expect("resolver request"));
+        }
+        assert_eq!(cache.state.lock().await.entries.len(), MAX_ENTRIES);
+
+        for request in resolver_requests {
+            request
+                .result
+                .send(Ok(vec!["127.0.0.1:443".parse().expect("socket")]))
+                .expect("deliver result");
+        }
+        for lookup in lookups {
+            lookup.await.expect("join lookup").expect("lookup success");
+        }
     }
 }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/dns.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/dns.rs
@@ -255,7 +255,7 @@ async fn run_lookup(
 ) {
     let result = resolve(resolver, &key, deadline, &metrics).await;
     let shared = result.as_ref().map(Arc::clone).map_err(OwnedError::from_io);
-    let _ = signal.send(Some(shared.clone()));
+    signal.send_replace(Some(shared.clone()));
 
     let mut state = state.lock().await;
     let still_owner = matches!(
@@ -444,6 +444,61 @@ mod tests {
             .send(Ok(vec!["127.0.0.1:443".parse().expect("socket")]))
             .expect("should deliver result");
         assert_eq!(second.await.expect("join").expect("shared lookup").len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn completed_lookup_is_retained_when_every_initial_waiter_cancels() {
+        let (cache, mut requests) = fake_cache();
+        let metrics = Arc::new(ProxyMetrics::default());
+        let first = tokio::spawn({
+            let cache = Arc::clone(&cache);
+            let metrics = Arc::clone(&metrics);
+            async move {
+                cache
+                    .lookup(
+                        "late.test",
+                        443,
+                        Instant::now() + Duration::from_secs(5),
+                        metrics,
+                    )
+                    .await
+            }
+        });
+        let request = requests.recv().await.expect("should start lookup");
+        first.abort();
+        let _ = first.await;
+
+        let key = CacheKey {
+            host: Arc::from("late.test"),
+            port: 443,
+        };
+        let state = cache.state.lock().await;
+        let signal = match state.entries.get(&key) {
+            Some(Entry::Loading { signal, .. }) => signal.clone(),
+            _ => panic!("lookup should remain loading while resolver is pending"),
+        };
+        request
+            .result
+            .send(Ok(vec!["127.0.0.1:443".parse().expect("socket")]))
+            .expect("should complete lookup");
+
+        tokio::time::timeout(Duration::from_millis(100), async {
+            while signal.borrow().is_none() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("completed value should be retained before cache-state replacement");
+        let late = signal.subscribe();
+        let retained = late
+            .borrow()
+            .clone()
+            .expect("late subscriber should immediately observe completion");
+        let Ok(addresses) = retained else {
+            panic!("lookup should succeed");
+        };
+        assert_eq!(addresses.len(), 1);
+        drop(state);
     }
 
     #[tokio::test]

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs
@@ -4,38 +4,48 @@ use std::sync::Arc;
 /// Upstream transport protocol.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum Transport {
+    /// Direct HTTP/1 over TCP.
     Plaintext,
+    /// HTTP/1 over authenticated TLS.
     Tls,
 }
 
 /// Certificate-verification policy for a TLS connection.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum VerifyMode {
+    /// Validate the upstream certificate against public roots.
     Secure,
+    /// Accept any upstream certificate after the CLI emits its warning.
     Insecure,
 }
 
 /// How the logical origin selects its connection address.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum AddressPolicy {
+    /// Resolve the reference identity through DNS.
     Dns,
+    /// Connect to an explicitly pinned address while preserving TLS identity.
     Resolve(IpAddr),
 }
 
 /// Exact DNS or IP identity authenticated by upstream TLS.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum ReferenceIdentity {
+    /// Normalized DNS identity.
     Dns(Arc<str>),
+    /// Literal IP identity.
     Ip(IpAddr),
 }
 
 impl ReferenceIdentity {
     #[must_use]
+    /// Creates a lowercased DNS reference identity.
     pub fn dns(host: &str) -> Self {
         Self::Dns(Arc::from(host.to_ascii_lowercase()))
     }
 
     #[must_use]
+    /// Creates a literal IP reference identity.
     pub fn ip(address: IpAddr) -> Self {
         Self::Ip(address)
     }
@@ -53,6 +63,7 @@ pub struct OriginKey {
 
 impl OriginKey {
     #[must_use]
+    /// Creates the complete identity that controls connection reuse.
     pub fn new(
         transport: Transport,
         reference: ReferenceIdentity,
@@ -70,26 +81,31 @@ impl OriginKey {
     }
 
     #[must_use]
+    /// Returns the upstream transport.
     pub fn transport(&self) -> Transport {
         self.transport
     }
 
     #[must_use]
+    /// Returns the logical DNS or IP identity.
     pub fn reference(&self) -> &ReferenceIdentity {
         &self.reference
     }
 
     #[must_use]
+    /// Returns the logical upstream port.
     pub fn port(&self) -> u16 {
         self.port
     }
 
     #[must_use]
+    /// Returns the TLS certificate-verification policy.
     pub fn verify_mode(&self) -> VerifyMode {
         self.verify
     }
 
     #[must_use]
+    /// Returns the DNS or pinned-address connection policy.
     pub fn address_policy(&self) -> AddressPolicy {
         self.address
     }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs
@@ -1,0 +1,231 @@
+use std::net::IpAddr;
+use std::sync::Arc;
+
+/// Upstream transport protocol.
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+pub enum Transport {
+    Plaintext,
+    Tls,
+}
+
+/// Certificate-verification policy for a TLS connection.
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+pub enum VerifyMode {
+    Secure,
+    Insecure,
+}
+
+/// HTTP application protocols a connection may negotiate.
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+pub enum ApplicationMode {
+    Http1Required,
+    Http2Eligible,
+}
+
+/// How the logical origin selects its connection address.
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+pub enum AddressPolicy {
+    Dns,
+    Resolve(IpAddr),
+}
+
+/// Exact DNS or IP identity authenticated by upstream TLS.
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub enum ReferenceIdentity {
+    Dns(Arc<str>),
+    Ip(IpAddr),
+}
+
+impl ReferenceIdentity {
+    #[must_use]
+    pub fn dns(host: &str) -> Self {
+        Self::Dns(Arc::from(host.to_ascii_lowercase()))
+    }
+
+    #[must_use]
+    pub fn ip(address: IpAddr) -> Self {
+        Self::Ip(address)
+    }
+}
+
+/// Complete identity for selecting a reusable upstream connection.
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub struct OriginKey {
+    transport: Transport,
+    reference: ReferenceIdentity,
+    port: u16,
+    verify: VerifyMode,
+    application: ApplicationMode,
+    address: AddressPolicy,
+}
+
+impl OriginKey {
+    #[must_use]
+    pub fn new(
+        transport: Transport,
+        reference: ReferenceIdentity,
+        port: u16,
+        verify: VerifyMode,
+        application: ApplicationMode,
+        address: AddressPolicy,
+    ) -> Self {
+        Self {
+            transport,
+            reference,
+            port,
+            verify,
+            application,
+            address,
+        }
+    }
+
+    #[must_use]
+    pub fn transport(&self) -> Transport {
+        self.transport
+    }
+
+    #[must_use]
+    pub fn reference(&self) -> &ReferenceIdentity {
+        &self.reference
+    }
+
+    #[must_use]
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    #[must_use]
+    pub fn verify_mode(&self) -> VerifyMode {
+        self.verify
+    }
+
+    #[must_use]
+    pub fn application_mode(&self) -> ApplicationMode {
+        self.application
+    }
+
+    #[must_use]
+    pub fn address_policy(&self) -> AddressPolicy {
+        self.address
+    }
+
+    pub(crate) fn set_address_policy(&mut self, address: AddressPolicy) {
+        self.address = address;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+
+    fn base_key() -> OriginKey {
+        OriginKey::new(
+            Transport::Tls,
+            ReferenceIdentity::dns("to.example.com"),
+            443,
+            VerifyMode::Secure,
+            ApplicationMode::Http1Required,
+            AddressPolicy::Dns,
+        )
+    }
+
+    #[test]
+    fn origin_key_separates_every_transport_and_security_field() {
+        let base = base_key();
+        let pinned = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let variants = [
+            OriginKey::new(
+                Transport::Plaintext,
+                base.reference().clone(),
+                base.port(),
+                base.verify_mode(),
+                base.application_mode(),
+                base.address_policy(),
+            ),
+            OriginKey::new(
+                base.transport(),
+                ReferenceIdentity::dns("other.example.com"),
+                base.port(),
+                base.verify_mode(),
+                base.application_mode(),
+                base.address_policy(),
+            ),
+            OriginKey::new(
+                base.transport(),
+                base.reference().clone(),
+                8443,
+                base.verify_mode(),
+                base.application_mode(),
+                base.address_policy(),
+            ),
+            OriginKey::new(
+                base.transport(),
+                base.reference().clone(),
+                base.port(),
+                VerifyMode::Insecure,
+                base.application_mode(),
+                base.address_policy(),
+            ),
+            OriginKey::new(
+                base.transport(),
+                base.reference().clone(),
+                base.port(),
+                base.verify_mode(),
+                ApplicationMode::Http2Eligible,
+                base.address_policy(),
+            ),
+            OriginKey::new(
+                base.transport(),
+                base.reference().clone(),
+                base.port(),
+                base.verify_mode(),
+                base.application_mode(),
+                AddressPolicy::Resolve(pinned),
+            ),
+        ];
+
+        for variant in variants {
+            assert_ne!(base, variant, "should separate every key field");
+        }
+    }
+
+    #[test]
+    fn dns_peer_selection_does_not_fragment_logical_origin() {
+        let first_peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let second_peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2));
+
+        let first = base_key();
+        let second = base_key();
+
+        assert_ne!(first_peer, second_peer, "test peers should differ");
+        assert_eq!(
+            first, second,
+            "selected peer address should not be part of a DNS origin key"
+        );
+    }
+
+    #[test]
+    fn shared_resolve_address_does_not_coalesce_reference_identities() {
+        let pin = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let first = OriginKey::new(
+            Transport::Tls,
+            ReferenceIdentity::dns("one.example.com"),
+            443,
+            VerifyMode::Secure,
+            ApplicationMode::Http1Required,
+            AddressPolicy::Resolve(pin),
+        );
+        let second = OriginKey::new(
+            Transport::Tls,
+            ReferenceIdentity::dns("two.example.com"),
+            443,
+            VerifyMode::Secure,
+            ApplicationMode::Http1Required,
+            AddressPolicy::Resolve(pin),
+        );
+
+        assert_ne!(first, second, "different TLS identities must not coalesce");
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs
@@ -15,13 +15,6 @@ pub enum VerifyMode {
     Insecure,
 }
 
-/// HTTP application protocols a connection may negotiate.
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
-pub enum ApplicationMode {
-    Http1Required,
-    Http2Eligible,
-}
-
 /// How the logical origin selects its connection address.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum AddressPolicy {
@@ -55,7 +48,6 @@ pub struct OriginKey {
     reference: ReferenceIdentity,
     port: u16,
     verify: VerifyMode,
-    application: ApplicationMode,
     address: AddressPolicy,
 }
 
@@ -66,7 +58,6 @@ impl OriginKey {
         reference: ReferenceIdentity,
         port: u16,
         verify: VerifyMode,
-        application: ApplicationMode,
         address: AddressPolicy,
     ) -> Self {
         Self {
@@ -74,7 +65,6 @@ impl OriginKey {
             reference,
             port,
             verify,
-            application,
             address,
         }
     }
@@ -100,11 +90,6 @@ impl OriginKey {
     }
 
     #[must_use]
-    pub fn application_mode(&self) -> ApplicationMode {
-        self.application
-    }
-
-    #[must_use]
     pub fn address_policy(&self) -> AddressPolicy {
         self.address
     }
@@ -126,7 +111,6 @@ mod tests {
             ReferenceIdentity::dns("to.example.com"),
             443,
             VerifyMode::Secure,
-            ApplicationMode::Http1Required,
             AddressPolicy::Dns,
         )
     }
@@ -141,7 +125,6 @@ mod tests {
                 base.reference().clone(),
                 base.port(),
                 base.verify_mode(),
-                base.application_mode(),
                 base.address_policy(),
             ),
             OriginKey::new(
@@ -149,7 +132,6 @@ mod tests {
                 ReferenceIdentity::dns("other.example.com"),
                 base.port(),
                 base.verify_mode(),
-                base.application_mode(),
                 base.address_policy(),
             ),
             OriginKey::new(
@@ -157,7 +139,6 @@ mod tests {
                 base.reference().clone(),
                 8443,
                 base.verify_mode(),
-                base.application_mode(),
                 base.address_policy(),
             ),
             OriginKey::new(
@@ -165,7 +146,6 @@ mod tests {
                 base.reference().clone(),
                 base.port(),
                 VerifyMode::Insecure,
-                base.application_mode(),
                 base.address_policy(),
             ),
             OriginKey::new(
@@ -173,15 +153,6 @@ mod tests {
                 base.reference().clone(),
                 base.port(),
                 base.verify_mode(),
-                ApplicationMode::Http2Eligible,
-                base.address_policy(),
-            ),
-            OriginKey::new(
-                base.transport(),
-                base.reference().clone(),
-                base.port(),
-                base.verify_mode(),
-                base.application_mode(),
                 AddressPolicy::Resolve(pinned),
             ),
         ];
@@ -214,7 +185,6 @@ mod tests {
             ReferenceIdentity::dns("one.example.com"),
             443,
             VerifyMode::Secure,
-            ApplicationMode::Http1Required,
             AddressPolicy::Resolve(pin),
         );
         let second = OriginKey::new(
@@ -222,7 +192,6 @@ mod tests {
             ReferenceIdentity::dns("two.example.com"),
             443,
             VerifyMode::Secure,
-            ApplicationMode::Http1Required,
             AddressPolicy::Resolve(pin),
         );
 

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs
@@ -1,0 +1,663 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::AbortHandle;
+use tokio::time::Instant;
+
+use super::key::OriginKey;
+
+const ORDINARY_CHANNEL_CAPACITY: usize = 64;
+
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+pub struct ConnectionId(u64);
+
+#[derive(Debug, Clone, Copy)]
+pub struct PoolLimits {
+    pub per_origin_live: usize,
+    pub global_live: usize,
+    pub per_origin_idle: usize,
+    pub global_idle: usize,
+    pub per_origin_waiters: usize,
+    pub global_waiters: usize,
+    pub acquire_timeout: Duration,
+    pub idle_timeout: Duration,
+}
+
+impl Default for PoolLimits {
+    fn default() -> Self {
+        Self {
+            per_origin_live: 6,
+            global_live: 64,
+            per_origin_idle: 2,
+            global_idle: 32,
+            per_origin_waiters: 32,
+            global_waiters: 128,
+            acquire_timeout: Duration::from_secs(30),
+            idle_timeout: Duration::from_secs(60),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AcquireError {
+    Overloaded,
+    TimedOut,
+    ShuttingDown,
+}
+
+pub struct IdleConnection<T> {
+    pub id: ConnectionId,
+    pub key: OriginKey,
+    pub value: T,
+    pub abort: AbortHandle,
+}
+
+pub struct Lease<T> {
+    pub connection: IdleConnection<T>,
+    pub reused: bool,
+}
+
+pub struct Reservation {
+    id: ConnectionId,
+    key: OriginKey,
+    control: mpsc::UnboundedSender<Control>,
+    completed: bool,
+}
+
+impl Reservation {
+    #[must_use]
+    pub fn id(&self) -> ConnectionId {
+        self.id
+    }
+
+    #[must_use]
+    pub fn key(&self) -> &OriginKey {
+        &self.key
+    }
+
+    pub fn register<T: Send + 'static>(
+        mut self,
+        manager: &Manager<T>,
+        value: T,
+        abort: AbortHandle,
+    ) -> Lease<T> {
+        manager.register_driver(self.id, abort.clone());
+        self.completed = true;
+        Lease {
+            connection: IdleConnection {
+                id: self.id,
+                key: self.key.clone(),
+                value,
+                abort,
+            },
+            reused: false,
+        }
+    }
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        if !self.completed {
+            let _ = self.control.send(Control::ConnectFailed(self.id));
+        }
+    }
+}
+
+pub enum Acquired<T> {
+    Reused(Lease<T>),
+    Open(Reservation),
+}
+
+struct AcquireTicket {
+    cancelled: AtomicBool,
+}
+
+struct AcquireRequest<T> {
+    sequence: u64,
+    key: OriginKey,
+    deadline: Instant,
+    ticket: Arc<AcquireTicket>,
+    reply: oneshot::Sender<Result<Acquired<T>, AcquireError>>,
+}
+
+enum Command<T> {
+    Acquire(AcquireRequest<T>),
+    Return(IdleConnection<T>),
+}
+
+enum Control {
+    Cancel(u64),
+    ConnectFailed(ConnectionId),
+    DriverRegistered(ConnectionId, AbortHandle),
+    DriverClosed(ConnectionId),
+    Shutdown(oneshot::Sender<()>),
+}
+
+pub struct Manager<T> {
+    ordinary: mpsc::Sender<Command<T>>,
+    control: mpsc::UnboundedSender<Control>,
+    next_sequence: AtomicU64,
+    acquire_timeout: Duration,
+}
+
+impl<T: Send + 'static> Manager<T> {
+    #[must_use]
+    pub fn start(limits: PoolLimits) -> Arc<Self> {
+        let (ordinary, ordinary_rx) = mpsc::channel(ORDINARY_CHANNEL_CAPACITY);
+        // This lane is API-unbounded so synchronous Drop paths cannot lose lifecycle
+        // events. It is logically bounded: each accepted acquire emits at most one
+        // cancellation, each of at most 64 connection IDs has one close event, and
+        // the owner emits one shutdown.
+        let (control, control_rx) = mpsc::unbounded_channel();
+        let manager = Arc::new(Self {
+            ordinary,
+            control,
+            next_sequence: AtomicU64::new(1),
+            acquire_timeout: limits.acquire_timeout,
+        });
+        tokio::spawn(Actor::new(limits, ordinary_rx, control_rx, manager.control.clone()).run());
+        manager
+    }
+
+    /// Acquires an idle connection or an exclusive reservation to open one.
+    ///
+    /// # Errors
+    ///
+    /// Returns overload, timeout, or shutdown when no lease can be granted.
+    pub async fn acquire(&self, key: OriginKey) -> Result<Acquired<T>, AcquireError> {
+        let sequence = self.next_sequence.fetch_add(1, Ordering::Relaxed);
+        let ticket = Arc::new(AcquireTicket {
+            cancelled: AtomicBool::new(false),
+        });
+        let (reply, received) = oneshot::channel();
+        self.ordinary
+            .send(Command::Acquire(AcquireRequest {
+                sequence,
+                key,
+                deadline: Instant::now() + self.acquire_timeout,
+                ticket: Arc::clone(&ticket),
+                reply,
+            }))
+            .await
+            .map_err(|_| AcquireError::ShuttingDown)?;
+        let mut guard = AcquireGuard {
+            sequence,
+            ticket,
+            control: self.control.clone(),
+            armed: true,
+        };
+        let result = received.await.unwrap_or(Err(AcquireError::ShuttingDown));
+        guard.armed = false;
+        result
+    }
+
+    pub fn return_idle(&self, connection: IdleConnection<T>) {
+        if let Err(error) = self.ordinary.try_send(Command::Return(connection))
+            && let Command::Return(connection) = error.into_inner()
+        {
+            connection.abort.abort();
+        }
+    }
+
+    pub fn driver_closed(&self, id: ConnectionId) {
+        let _ = self.control.send(Control::DriverClosed(id));
+    }
+
+    fn register_driver(&self, id: ConnectionId, abort: AbortHandle) {
+        let _ = self.control.send(Control::DriverRegistered(id, abort));
+    }
+
+    pub async fn shutdown(&self) {
+        let (reply, received) = oneshot::channel();
+        if self.control.send(Control::Shutdown(reply)).is_ok() {
+            let _ = received.await;
+        }
+    }
+}
+
+struct AcquireGuard {
+    sequence: u64,
+    ticket: Arc<AcquireTicket>,
+    control: mpsc::UnboundedSender<Control>,
+    armed: bool,
+}
+
+impl Drop for AcquireGuard {
+    fn drop(&mut self) {
+        if self.armed && !self.ticket.cancelled.swap(true, Ordering::AcqRel) {
+            let _ = self.control.send(Control::Cancel(self.sequence));
+        }
+    }
+}
+
+struct LiveConnection {
+    key: OriginKey,
+    abort: Option<AbortHandle>,
+}
+
+struct Actor<T> {
+    limits: PoolLimits,
+    ordinary: mpsc::Receiver<Command<T>>,
+    control: mpsc::UnboundedReceiver<Control>,
+    control_tx: mpsc::UnboundedSender<Control>,
+    live: HashMap<ConnectionId, LiveConnection>,
+    idle: HashMap<OriginKey, VecDeque<(Instant, IdleConnection<T>)>>,
+    waiters: VecDeque<AcquireRequest<T>>,
+    next_connection: u64,
+    closing: bool,
+    shutdown_reply: Option<oneshot::Sender<()>>,
+}
+
+impl<T: Send + 'static> Actor<T> {
+    fn new(
+        limits: PoolLimits,
+        ordinary: mpsc::Receiver<Command<T>>,
+        control: mpsc::UnboundedReceiver<Control>,
+        control_tx: mpsc::UnboundedSender<Control>,
+    ) -> Self {
+        Self {
+            limits,
+            ordinary,
+            control,
+            control_tx,
+            live: HashMap::new(),
+            idle: HashMap::new(),
+            waiters: VecDeque::new(),
+            next_connection: 1,
+            closing: false,
+            shutdown_reply: None,
+        }
+    }
+
+    async fn run(mut self) {
+        loop {
+            self.expire();
+            self.maybe_finish_shutdown();
+            let deadline = self.next_deadline();
+            tokio::select! {
+                biased;
+                event = self.control.recv() => match event {
+                    Some(event) => self.control(event),
+                    None => break,
+                },
+                command = self.ordinary.recv() => match command {
+                    Some(command) => self.command(command),
+                    None => break,
+                },
+                () = sleep_until_optional(deadline) => {}
+            }
+        }
+    }
+
+    fn command(&mut self, command: Command<T>) {
+        match command {
+            Command::Acquire(request) => self.acquire(request),
+            Command::Return(connection) => self.return_connection(connection),
+        }
+    }
+
+    fn acquire(&mut self, request: AcquireRequest<T>) {
+        if self.closing || request.ticket.cancelled.load(Ordering::Acquire) {
+            let _ = request.reply.send(Err(AcquireError::ShuttingDown));
+            return;
+        }
+        if request.deadline <= Instant::now() {
+            let _ = request.reply.send(Err(AcquireError::TimedOut));
+            return;
+        }
+        if let Some(connection) = self.take_idle(&request.key) {
+            let _ = request.reply.send(Ok(Acquired::Reused(Lease {
+                connection,
+                reused: true,
+            })));
+        } else if self.can_open(&request.key) {
+            self.open_for(request);
+        } else {
+            let origin_waiters = self
+                .waiters
+                .iter()
+                .filter(|item| item.key == request.key)
+                .count();
+            if origin_waiters >= self.limits.per_origin_waiters
+                || self.waiters.len() >= self.limits.global_waiters
+            {
+                let _ = request.reply.send(Err(AcquireError::Overloaded));
+            } else {
+                self.waiters.push_back(request);
+            }
+        }
+    }
+
+    fn can_open(&self, key: &OriginKey) -> bool {
+        self.live.len() < self.limits.global_live
+            && self.live.values().filter(|item| &item.key == key).count()
+                < self.limits.per_origin_live
+    }
+
+    fn open_for(&mut self, request: AcquireRequest<T>) {
+        let id = ConnectionId(self.next_connection);
+        self.next_connection += 1;
+        self.live.insert(
+            id,
+            LiveConnection {
+                key: request.key.clone(),
+                abort: None,
+            },
+        );
+        let reservation = Reservation {
+            id,
+            key: request.key,
+            control: self.control_tx.clone(),
+            completed: false,
+        };
+        if request.reply.send(Ok(Acquired::Open(reservation))).is_err() {
+            self.release(id);
+        }
+    }
+
+    fn take_idle(&mut self, key: &OriginKey) -> Option<IdleConnection<T>> {
+        let entries = self.idle.get_mut(key)?;
+        let result = entries.pop_front().map(|(_, connection)| connection);
+        if entries.is_empty() {
+            self.idle.remove(key);
+        }
+        result
+    }
+
+    fn return_connection(&mut self, connection: IdleConnection<T>) {
+        if self.closing || !self.live.contains_key(&connection.id) {
+            connection.abort.abort();
+            return;
+        }
+        if let Some(index) = self.waiters.iter().position(|waiter| {
+            waiter.key == connection.key && !waiter.ticket.cancelled.load(Ordering::Acquire)
+        }) {
+            let waiter = self.waiters.remove(index).expect("should find waiter");
+            let _ = waiter.reply.send(Ok(Acquired::Reused(Lease {
+                connection,
+                reused: true,
+            })));
+            return;
+        }
+        let origin_idle = self.idle.get(&connection.key).map_or(0, VecDeque::len);
+        let global_idle: usize = self.idle.values().map(VecDeque::len).sum();
+        if origin_idle >= self.limits.per_origin_idle || global_idle >= self.limits.global_idle {
+            // Dropping the last HTTP sender lets Hyper close a healthy idle socket
+            // cleanly. Capacity remains live until the driver guard reports exit.
+            drop(connection);
+            return;
+        }
+        self.idle
+            .entry(connection.key.clone())
+            .or_default()
+            .push_back((Instant::now() + self.limits.idle_timeout, connection));
+    }
+
+    fn control(&mut self, event: Control) {
+        match event {
+            Control::Cancel(sequence) => {
+                if let Some(index) = self
+                    .waiters
+                    .iter()
+                    .position(|item| item.sequence == sequence)
+                {
+                    self.waiters.remove(index);
+                }
+            }
+            Control::ConnectFailed(id) | Control::DriverClosed(id) => self.release(id),
+            Control::DriverRegistered(id, abort) => {
+                if let Some(live) = self.live.get_mut(&id) {
+                    live.abort = Some(abort);
+                } else {
+                    abort.abort();
+                }
+            }
+            Control::Shutdown(reply) => {
+                self.closing = true;
+                self.shutdown_reply = Some(reply);
+                for waiter in self.waiters.drain(..) {
+                    let _ = waiter.reply.send(Err(AcquireError::ShuttingDown));
+                }
+                for entries in self.idle.values_mut() {
+                    for (_, connection) in entries.drain(..) {
+                        connection.abort.abort();
+                    }
+                }
+                self.idle.clear();
+                for live in self.live.values() {
+                    if let Some(abort) = &live.abort {
+                        abort.abort();
+                    }
+                }
+            }
+        }
+    }
+
+    fn release(&mut self, id: ConnectionId) {
+        if self.live.remove(&id).is_some() {
+            for entries in self.idle.values_mut() {
+                if let Some(index) = entries.iter().position(|(_, item)| item.id == id) {
+                    entries.remove(index);
+                    break;
+                }
+            }
+            self.admit_waiters();
+        }
+    }
+
+    fn admit_waiters(&mut self) {
+        while let Some(index) = self.waiters.iter().position(|waiter| {
+            !waiter.ticket.cancelled.load(Ordering::Acquire) && self.can_open(&waiter.key)
+        }) {
+            let request = self
+                .waiters
+                .remove(index)
+                .expect("should find admissible waiter");
+            self.open_for(request);
+        }
+    }
+
+    fn expire(&mut self) {
+        let now = Instant::now();
+        let mut index = 0;
+        while index < self.waiters.len() {
+            if self.waiters[index].ticket.cancelled.load(Ordering::Acquire) {
+                self.waiters.remove(index);
+            } else if self.waiters[index].deadline <= now {
+                let waiter = self
+                    .waiters
+                    .remove(index)
+                    .expect("should find expired waiter");
+                let _ = waiter.reply.send(Err(AcquireError::TimedOut));
+            } else {
+                index += 1;
+            }
+        }
+        for entries in self.idle.values_mut() {
+            while entries
+                .front()
+                .is_some_and(|(deadline, _)| *deadline <= now)
+            {
+                let (_, connection) = entries.pop_front().expect("should have expired idle");
+                connection.abort.abort();
+            }
+        }
+        self.idle.retain(|_, entries| !entries.is_empty());
+    }
+
+    fn next_deadline(&self) -> Option<Instant> {
+        self.waiters
+            .iter()
+            .map(|item| item.deadline)
+            .chain(self.idle.values().flatten().map(|(deadline, _)| *deadline))
+            .min()
+    }
+
+    fn maybe_finish_shutdown(&mut self) {
+        if self.closing
+            && self.live.is_empty()
+            && let Some(reply) = self.shutdown_reply.take()
+        {
+            let _ = reply.send(());
+        }
+    }
+}
+
+async fn sleep_until_optional(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use super::*;
+    use crate::commands::dev::proxy::upstream::key::{
+        AddressPolicy, ApplicationMode, ReferenceIdentity, Transport, VerifyMode,
+    };
+
+    fn key(host: &str) -> OriginKey {
+        OriginKey::new(
+            Transport::Tls,
+            ReferenceIdentity::dns(host),
+            443,
+            VerifyMode::Secure,
+            ApplicationMode::Http1Required,
+            AddressPolicy::Dns,
+        )
+    }
+
+    fn abort_handle() -> AbortHandle {
+        tokio::spawn(std::future::pending::<()>()).abort_handle()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn limits_live_connections_and_times_out_waiters() {
+        let manager = Manager::<()>::start(PoolLimits {
+            per_origin_live: 1,
+            global_live: 1,
+            ..PoolLimits::default()
+        });
+        let first = manager.acquire(key("one.example")).await.expect("first");
+        assert!(matches!(first, Acquired::Open(_)));
+
+        let waiting = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(key("one.example")).await }
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(29)).await;
+        assert!(!waiting.is_finished());
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(matches!(
+            waiting.await.expect("join"),
+            Err(AcquireError::TimedOut)
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reuses_returned_connection_and_expires_it_at_sixty_seconds() {
+        let manager = Manager::start(PoolLimits::default());
+        let Acquired::Open(reservation) = manager.acquire(key("one.example")).await.expect("open")
+        else {
+            panic!("should open");
+        };
+        let id = reservation.id();
+        let lease = reservation.register(&manager, 7_u8, abort_handle());
+        manager.return_idle(lease.connection);
+        tokio::task::yield_now().await;
+        let Acquired::Reused(lease) = manager.acquire(key("one.example")).await.expect("reuse")
+        else {
+            panic!("should reuse");
+        };
+        assert_eq!(lease.connection.value, 7);
+        manager.return_idle(lease.connection);
+        tokio::time::advance(Duration::from_secs(60)).await;
+        tokio::task::yield_now().await;
+        manager.driver_closed(id);
+        let next = manager.acquire(key("one.example")).await.expect("next");
+        assert!(matches!(next, Acquired::Open(_)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn oldest_admissible_origin_bypasses_blocked_origin() {
+        let manager = Manager::<()>::start(PoolLimits {
+            per_origin_live: 1,
+            global_live: 2,
+            ..PoolLimits::default()
+        });
+        let first = manager.acquire(key("one.example")).await.expect("first");
+        let second = manager.acquire(key("two.example")).await.expect("second");
+        let Acquired::Open(first) = first else {
+            panic!("open")
+        };
+        let Acquired::Open(second) = second else {
+            panic!("open")
+        };
+        let blocked_one = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(key("one.example")).await }
+        });
+        let admissible_three = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(key("three.example")).await }
+        });
+        tokio::task::yield_now().await;
+        drop(second);
+        tokio::task::yield_now().await;
+        assert!(admissible_three.is_finished());
+        assert!(!blocked_one.is_finished());
+        drop(first);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn enforces_six_live_and_bounded_waiters_per_origin() {
+        let manager = Manager::<()>::start(PoolLimits {
+            per_origin_waiters: 2,
+            global_waiters: 2,
+            ..PoolLimits::default()
+        });
+        let mut reservations = Vec::new();
+        for _ in 0..6 {
+            let Acquired::Open(reservation) = manager
+                .acquire(key("one.example"))
+                .await
+                .expect("reserve within cap")
+            else {
+                panic!("should reserve a new connection");
+            };
+            reservations.push(reservation);
+        }
+        let first_waiter = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(key("one.example")).await }
+        });
+        let second_waiter = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(key("one.example")).await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!first_waiter.is_finished() && !second_waiter.is_finished());
+        assert!(matches!(
+            manager.acquire(key("one.example")).await,
+            Err(AcquireError::Overloaded)
+        ));
+
+        first_waiter.abort();
+        tokio::task::yield_now().await;
+        drop(reservations.pop());
+        tokio::task::yield_now().await;
+        assert!(second_waiter.is_finished());
+    }
+
+    #[test]
+    fn origin_key_fixture_accepts_ip_policy() {
+        let _ = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs
@@ -12,17 +12,27 @@ use super::key::OriginKey;
 const ORDINARY_CHANNEL_CAPACITY: usize = 64;
 
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+/// Actor-owned identity for one connecting or live upstream connection.
 pub struct ConnectionId(u64);
 
 #[derive(Debug, Clone, Copy)]
+/// Hard connection, idle, waiter, and timeout bounds for the pool actor.
 pub struct PoolLimits {
+    /// Maximum connecting plus live connections per origin.
     pub per_origin_live: usize,
+    /// Maximum connecting plus live connections across all origins.
     pub global_live: usize,
+    /// Maximum reusable idle connections retained per origin.
     pub per_origin_idle: usize,
+    /// Maximum reusable idle connections retained globally.
     pub global_idle: usize,
+    /// Maximum queued acquisition waiters per origin.
     pub per_origin_waiters: usize,
+    /// Maximum queued acquisition waiters globally.
     pub global_waiters: usize,
+    /// Maximum duration for one acquisition request.
     pub acquire_timeout: Duration,
+    /// Maximum duration for retaining an idle connection.
     pub idle_timeout: Duration,
 }
 
@@ -42,25 +52,38 @@ impl Default for PoolLimits {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// Terminal manager acquisition failure.
 pub enum AcquireError {
+    /// A bounded waiter limit was already full.
     Overloaded,
+    /// No connection became available before the acquisition deadline.
     TimedOut,
+    /// The manager is shutting down or has stopped.
     ShuttingDown,
 }
 
+/// Sender plus lifecycle controls retained while a connection is idle or leased.
 pub struct IdleConnection<T> {
+    /// Actor-owned connection identity.
     pub id: ConnectionId,
+    /// Complete reusable origin identity.
     pub key: OriginKey,
+    /// Protocol sender or test value carried by the connection.
     pub value: T,
+    /// Abort handle for its independently running driver.
     pub abort: AbortHandle,
 }
 
+/// Exclusive connection lease returned to one requester.
 pub struct Lease<T> {
+    /// Leased connection payload and lifecycle controls.
     pub connection: IdleConnection<T>,
+    /// Whether this lease came from the idle pool.
     pub reused: bool,
     queue_wait: Option<Duration>,
 }
 
+/// Exclusive capacity reservation retained while a connector is in flight.
 pub struct Reservation {
     id: ConnectionId,
     key: OriginKey,
@@ -71,15 +94,18 @@ pub struct Reservation {
 
 impl Reservation {
     #[must_use]
+    /// Returns the actor-owned identity allocated for this reservation.
     pub fn id(&self) -> ConnectionId {
         self.id
     }
 
     #[must_use]
+    /// Returns the complete origin identity reserved by this connector.
     pub fn key(&self) -> &OriginKey {
         &self.key
     }
 
+    /// Transitions a successful connector reservation to a live driver lease.
     pub fn register<T: Send + 'static>(
         mut self,
         manager: &Manager<T>,
@@ -99,6 +125,16 @@ impl Reservation {
             queue_wait: self.queue_wait,
         }
     }
+
+    /// Transitions an established but unclaimed connection to a live driver,
+    /// then aborts it without releasing capacity before [`Manager::driver_closed`].
+    pub(crate) fn abort_established(mut self, abort: &AbortHandle) {
+        let _ = self
+            .control
+            .send(Control::DriverRegistered(self.id, abort.clone()));
+        self.completed = true;
+        abort.abort();
+    }
 }
 
 impl Drop for Reservation {
@@ -109,13 +145,17 @@ impl Drop for Reservation {
     }
 }
 
+/// Result of acquiring either an idle sender or capacity for a new connector.
 pub enum Acquired<T> {
+    /// Existing idle connection leased for reuse.
     Reused(Lease<T>),
+    /// Reservation that must be transferred into a connector task.
     Open(Reservation),
 }
 
 impl<T> Acquired<T> {
     #[must_use]
+    /// Returns time spent queued behind capacity, when queuing occurred.
     pub fn queue_wait(&self) -> Option<Duration> {
         match self {
             Self::Reused(lease) => lease.queue_wait,
@@ -190,6 +230,7 @@ enum Control {
     Shutdown(oneshot::Sender<()>),
 }
 
+/// Handle for the bounded single-owner connection-pool actor.
 pub struct Manager<T> {
     ordinary: mpsc::Sender<Command<T>>,
     control: mpsc::UnboundedSender<Control>,
@@ -199,6 +240,7 @@ pub struct Manager<T> {
 
 impl<T: Send + 'static> Manager<T> {
     #[must_use]
+    /// Starts the manager actor with explicit hard bounds.
     pub fn start(limits: PoolLimits) -> Arc<Self> {
         let (ordinary, ordinary_rx) = mpsc::channel(ORDINARY_CHANNEL_CAPACITY);
         // This lane is API-unbounded so synchronous Drop paths cannot lose lifecycle
@@ -265,6 +307,7 @@ impl<T: Send + 'static> Manager<T> {
         result
     }
 
+    /// Returns an idle connection to the actor without awaiting a bounded lane.
     pub fn return_idle(&self, connection: IdleConnection<T>) {
         if let Err(error) = self.ordinary.try_send(Command::Return(connection))
             && let Command::Return(connection) = error.into_inner()
@@ -273,6 +316,7 @@ impl<T: Send + 'static> Manager<T> {
         }
     }
 
+    /// Reports confirmed termination of one registered connection driver.
     pub fn driver_closed(&self, id: ConnectionId) {
         let _ = self.control.send(Control::DriverClosed(id));
     }
@@ -285,6 +329,7 @@ impl<T: Send + 'static> Manager<T> {
         let _ = self.control.send(Control::DriverRegistered(id, abort));
     }
 
+    /// Aborts all connectors and drivers and waits for capacity reconciliation.
     pub async fn shutdown(&self) {
         let (reply, received) = oneshot::channel();
         if self.control.send(Control::Shutdown(reply)).is_ok() {
@@ -459,22 +504,31 @@ impl<T: Send + 'static> Actor<T> {
         result
     }
 
-    fn return_connection(&mut self, connection: IdleConnection<T>) {
+    fn return_connection(&mut self, mut connection: IdleConnection<T>) {
         if self.closing || !self.live.contains_key(&connection.id) {
             connection.abort.abort();
             return;
         }
-        if let Some(index) = self.waiters.iter().position(|waiter| {
-            waiter.allow_reuse && waiter.key == connection.key && !waiter.ticket.is_cancelled()
-        }) {
+        while let Some(index) = self
+            .waiters
+            .iter()
+            .position(|waiter| waiter.allow_reuse && waiter.key == connection.key)
+        {
             let waiter = self.waiters.remove(index).expect("should find waiter");
-            if waiter.ticket.resolve() {
-                let _ = waiter.reply.send(Ok(Acquired::Reused(Lease {
-                    connection,
-                    reused: true,
-                    queue_wait: waiter.queue_started.map(|started| started.elapsed()),
-                })));
-                return;
+            if !waiter.ticket.resolve() {
+                continue;
+            }
+            let result = Ok(Acquired::Reused(Lease {
+                connection,
+                reused: true,
+                queue_wait: waiter.queue_started.map(|started| started.elapsed()),
+            }));
+            match waiter.reply.send(result) {
+                Ok(()) => return,
+                Err(Ok(Acquired::Reused(lease))) => connection = lease.connection,
+                Err(Ok(Acquired::Open(_)) | Err(_)) => {
+                    unreachable!("return handoff constructs only a reused lease")
+                }
             }
         }
         let origin_idle = self.idle.get(&connection.key).map_or(0, VecDeque::len);
@@ -623,6 +677,7 @@ async fn sleep_until_optional(deadline: Option<Instant>) {
 #[cfg(test)]
 mod tests {
     use std::net::IpAddr;
+    use std::sync::Barrier;
 
     use super::*;
     use crate::commands::dev::proxy::upstream::key::{
@@ -641,6 +696,21 @@ mod tests {
 
     fn abort_handle() -> AbortHandle {
         tokio::spawn(std::future::pending::<()>()).abort_handle()
+    }
+
+    struct DelayedDriverClosed {
+        manager: Arc<Manager<()>>,
+        id: ConnectionId,
+        entered: std::sync::mpsc::SyncSender<()>,
+        release: Arc<Barrier>,
+    }
+
+    impl Drop for DelayedDriverClosed {
+        fn drop(&mut self) {
+            let _ = self.entered.send(());
+            self.release.wait();
+            self.manager.driver_closed(self.id);
+        }
     }
 
     #[test]
@@ -810,6 +880,65 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn abandoned_established_connection_retains_capacity_until_driver_exit() {
+        let manager = Manager::start(PoolLimits {
+            per_origin_live: 1,
+            global_live: 1,
+            ..PoolLimits::default()
+        });
+        let origin = key("established.example");
+        let Acquired::Open(reservation) = manager.acquire(origin.clone()).await.expect("reserve")
+        else {
+            panic!("should reserve connector capacity");
+        };
+        let id = reservation.id();
+        let (entered, observed) = std::sync::mpsc::sync_channel(1);
+        let release = Arc::new(Barrier::new(2));
+        let driver = tokio::spawn({
+            let guard = DelayedDriverClosed {
+                manager: Arc::clone(&manager),
+                id,
+                entered,
+                release: Arc::clone(&release),
+            };
+            async move {
+                let _guard = guard;
+                std::future::pending::<()>().await;
+            }
+        });
+        manager.register_connector(id, driver.abort_handle());
+        reservation.abort_established(&driver.abort_handle());
+        tokio::task::spawn_blocking(move || observed.recv())
+            .await
+            .expect("should join driver-drop observer")
+            .expect("driver drop should begin");
+
+        let replacement = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(origin).await }
+        });
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !replacement.is_finished(),
+            "replacement must remain blocked before confirmed DriverClosed"
+        );
+
+        release.wait();
+        assert!(
+            driver
+                .await
+                .expect_err("driver should be aborted")
+                .is_cancelled()
+        );
+        assert!(matches!(
+            replacement.await.expect("replacement should join"),
+            Ok(Acquired::Open(_))
+        ));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn priority_shutdown_overtakes_a_saturated_ordinary_lane() {
         let limits = PoolLimits::default();
@@ -882,6 +1011,62 @@ mod tests {
         manager.driver_closed(id);
         tokio::task::yield_now().await;
         assert!(matches!(fresh.await.expect("join"), Ok(Acquired::Open(_))));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn failed_waiter_delivery_hands_connection_to_next_waiter() {
+        let limits = PoolLimits::default();
+        let (_ordinary, ordinary_rx) = mpsc::channel(ORDINARY_CHANNEL_CAPACITY);
+        let (control, control_rx) = mpsc::unbounded_channel();
+        let mut actor = Actor::new(limits, ordinary_rx, control_rx, control);
+        let origin = key("handoff.example");
+        let id = ConnectionId(1);
+        actor.live.insert(
+            id,
+            LiveConnection {
+                key: origin.clone(),
+                abort: None,
+            },
+        );
+
+        let (first_reply, first_received) = oneshot::channel();
+        drop(first_received);
+        actor.waiters.push_back(AcquireRequest {
+            sequence: 1,
+            key: origin.clone(),
+            deadline: Instant::now() + limits.acquire_timeout,
+            ticket: Arc::new(AcquireTicket::new()),
+            allow_reuse: true,
+            queue_started: Some(Instant::now()),
+            reply: first_reply,
+        });
+        let (second_reply, mut second_received) = oneshot::channel();
+        actor.waiters.push_back(AcquireRequest {
+            sequence: 2,
+            key: origin.clone(),
+            deadline: Instant::now() + limits.acquire_timeout,
+            ticket: Arc::new(AcquireTicket::new()),
+            allow_reuse: true,
+            queue_started: Some(Instant::now()),
+            reply: second_reply,
+        });
+
+        actor.return_connection(IdleConnection {
+            id,
+            key: origin,
+            value: 7_u8,
+            abort: abort_handle(),
+        });
+
+        let Acquired::Reused(lease) = second_received
+            .try_recv()
+            .expect("second waiter should receive the recovered connection")
+            .expect("handoff should succeed")
+        else {
+            panic!("handoff should reuse the returned connection");
+        };
+        assert_eq!(lease.connection.value, 7);
+        assert!(actor.waiters.is_empty(), "both waiters should be removed");
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs
@@ -626,7 +626,7 @@ mod tests {
 
     use super::*;
     use crate::commands::dev::proxy::upstream::key::{
-        AddressPolicy, ApplicationMode, ReferenceIdentity, Transport, VerifyMode,
+        AddressPolicy, ReferenceIdentity, Transport, VerifyMode,
     };
 
     fn key(host: &str) -> OriginKey {
@@ -635,7 +635,6 @@ mod tests {
             ReferenceIdentity::dns(host),
             443,
             VerifyMode::Secure,
-            ApplicationMode::Http1Required,
             AddressPolicy::Dns,
         )
     }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
@@ -58,6 +58,7 @@ pub struct IdleConnection<T> {
 pub struct Lease<T> {
     pub connection: IdleConnection<T>,
     pub reused: bool,
+    queue_wait: Option<Duration>,
 }
 
 pub struct Reservation {
@@ -65,6 +66,7 @@ pub struct Reservation {
     key: OriginKey,
     control: mpsc::UnboundedSender<Control>,
     completed: bool,
+    queue_wait: Option<Duration>,
 }
 
 impl Reservation {
@@ -94,6 +96,7 @@ impl Reservation {
                 abort,
             },
             reused: false,
+            queue_wait: self.queue_wait,
         }
     }
 }
@@ -111,8 +114,56 @@ pub enum Acquired<T> {
     Open(Reservation),
 }
 
+impl<T> Acquired<T> {
+    #[must_use]
+    pub fn queue_wait(&self) -> Option<Duration> {
+        match self {
+            Self::Reused(lease) => lease.queue_wait,
+            Self::Open(reservation) => reservation.queue_wait,
+        }
+    }
+}
+
 struct AcquireTicket {
-    cancelled: AtomicBool,
+    state: AtomicU8,
+}
+
+impl AcquireTicket {
+    const PENDING: u8 = 0;
+    const CANCELLED: u8 = 1;
+    const RESOLVED: u8 = 2;
+
+    fn new() -> Self {
+        Self {
+            state: AtomicU8::new(Self::PENDING),
+        }
+    }
+
+    fn cancel(&self) -> bool {
+        self.state
+            .compare_exchange(
+                Self::PENDING,
+                Self::CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn resolve(&self) -> bool {
+        self.state
+            .compare_exchange(
+                Self::PENDING,
+                Self::RESOLVED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.state.load(Ordering::Acquire) == Self::CANCELLED
+    }
 }
 
 struct AcquireRequest<T> {
@@ -120,6 +171,8 @@ struct AcquireRequest<T> {
     key: OriginKey,
     deadline: Instant,
     ticket: Arc<AcquireTicket>,
+    allow_reuse: bool,
+    queue_started: Option<Instant>,
     reply: oneshot::Sender<Result<Acquired<T>, AcquireError>>,
 }
 
@@ -131,6 +184,7 @@ enum Command<T> {
 enum Control {
     Cancel(u64),
     ConnectFailed(ConnectionId),
+    ConnectorRegistered(ConnectionId, AbortHandle),
     DriverRegistered(ConnectionId, AbortHandle),
     DriverClosed(ConnectionId),
     Shutdown(oneshot::Sender<()>),
@@ -168,10 +222,25 @@ impl<T: Send + 'static> Manager<T> {
     ///
     /// Returns overload, timeout, or shutdown when no lease can be granted.
     pub async fn acquire(&self, key: OriginKey) -> Result<Acquired<T>, AcquireError> {
+        self.acquire_with_reuse(key, true).await
+    }
+
+    /// Acquires a newly opened connection, never an idle pooled sender.
+    ///
+    /// # Errors
+    ///
+    /// Returns overload, timeout, or shutdown when no reservation can be granted.
+    pub async fn acquire_fresh(&self, key: OriginKey) -> Result<Acquired<T>, AcquireError> {
+        self.acquire_with_reuse(key, false).await
+    }
+
+    async fn acquire_with_reuse(
+        &self,
+        key: OriginKey,
+        allow_reuse: bool,
+    ) -> Result<Acquired<T>, AcquireError> {
         let sequence = self.next_sequence.fetch_add(1, Ordering::Relaxed);
-        let ticket = Arc::new(AcquireTicket {
-            cancelled: AtomicBool::new(false),
-        });
+        let ticket = Arc::new(AcquireTicket::new());
         let (reply, received) = oneshot::channel();
         self.ordinary
             .send(Command::Acquire(AcquireRequest {
@@ -179,6 +248,8 @@ impl<T: Send + 'static> Manager<T> {
                 key,
                 deadline: Instant::now() + self.acquire_timeout,
                 ticket: Arc::clone(&ticket),
+                allow_reuse,
+                queue_started: None,
                 reply,
             }))
             .await
@@ -206,6 +277,10 @@ impl<T: Send + 'static> Manager<T> {
         let _ = self.control.send(Control::DriverClosed(id));
     }
 
+    pub(crate) fn register_connector(&self, id: ConnectionId, abort: AbortHandle) {
+        let _ = self.control.send(Control::ConnectorRegistered(id, abort));
+    }
+
     fn register_driver(&self, id: ConnectionId, abort: AbortHandle) {
         let _ = self.control.send(Control::DriverRegistered(id, abort));
     }
@@ -227,7 +302,7 @@ struct AcquireGuard {
 
 impl Drop for AcquireGuard {
     fn drop(&mut self) {
-        if self.armed && !self.ticket.cancelled.swap(true, Ordering::AcqRel) {
+        if self.armed && self.ticket.cancel() {
             let _ = self.control.send(Control::Cancel(self.sequence));
         }
     }
@@ -299,23 +374,35 @@ impl<T: Send + 'static> Actor<T> {
         }
     }
 
-    fn acquire(&mut self, request: AcquireRequest<T>) {
-        if self.closing || request.ticket.cancelled.load(Ordering::Acquire) {
-            let _ = request.reply.send(Err(AcquireError::ShuttingDown));
+    fn acquire(&mut self, mut request: AcquireRequest<T>) {
+        if self.closing || request.ticket.is_cancelled() {
+            Self::resolve_error(request, AcquireError::ShuttingDown);
             return;
         }
         if request.deadline <= Instant::now() {
-            let _ = request.reply.send(Err(AcquireError::TimedOut));
+            Self::resolve_error(request, AcquireError::TimedOut);
             return;
         }
-        if let Some(connection) = self.take_idle(&request.key) {
-            let _ = request.reply.send(Ok(Acquired::Reused(Lease {
-                connection,
-                reused: true,
-            })));
+        if request.allow_reuse
+            && let Some(connection) = self.take_idle(&request.key)
+        {
+            if request.ticket.resolve() {
+                let _ = request.reply.send(Ok(Acquired::Reused(Lease {
+                    connection,
+                    reused: true,
+                    queue_wait: request.queue_started.map(|started| started.elapsed()),
+                })));
+            } else {
+                self.return_connection(connection);
+            }
         } else if self.can_open(&request.key) {
             self.open_for(request);
         } else {
+            if !request.allow_reuse
+                && let Some(connection) = self.take_idle(&request.key)
+            {
+                connection.abort.abort();
+            }
             let origin_waiters = self
                 .waiters
                 .iter()
@@ -324,8 +411,9 @@ impl<T: Send + 'static> Actor<T> {
             if origin_waiters >= self.limits.per_origin_waiters
                 || self.waiters.len() >= self.limits.global_waiters
             {
-                let _ = request.reply.send(Err(AcquireError::Overloaded));
+                Self::resolve_error(request, AcquireError::Overloaded);
             } else {
+                request.queue_started = Some(Instant::now());
                 self.waiters.push_back(request);
             }
         }
@@ -338,6 +426,9 @@ impl<T: Send + 'static> Actor<T> {
     }
 
     fn open_for(&mut self, request: AcquireRequest<T>) {
+        if !request.ticket.resolve() {
+            return;
+        }
         let id = ConnectionId(self.next_connection);
         self.next_connection += 1;
         self.live.insert(
@@ -352,6 +443,7 @@ impl<T: Send + 'static> Actor<T> {
             key: request.key,
             control: self.control_tx.clone(),
             completed: false,
+            queue_wait: request.queue_started.map(|started| started.elapsed()),
         };
         if request.reply.send(Ok(Acquired::Open(reservation))).is_err() {
             self.release(id);
@@ -373,14 +465,17 @@ impl<T: Send + 'static> Actor<T> {
             return;
         }
         if let Some(index) = self.waiters.iter().position(|waiter| {
-            waiter.key == connection.key && !waiter.ticket.cancelled.load(Ordering::Acquire)
+            waiter.allow_reuse && waiter.key == connection.key && !waiter.ticket.is_cancelled()
         }) {
             let waiter = self.waiters.remove(index).expect("should find waiter");
-            let _ = waiter.reply.send(Ok(Acquired::Reused(Lease {
-                connection,
-                reused: true,
-            })));
-            return;
+            if waiter.ticket.resolve() {
+                let _ = waiter.reply.send(Ok(Acquired::Reused(Lease {
+                    connection,
+                    reused: true,
+                    queue_wait: waiter.queue_started.map(|started| started.elapsed()),
+                })));
+                return;
+            }
         }
         let origin_idle = self.idle.get(&connection.key).map_or(0, VecDeque::len);
         let global_idle: usize = self.idle.values().map(VecDeque::len).sum();
@@ -408,9 +503,13 @@ impl<T: Send + 'static> Actor<T> {
                 }
             }
             Control::ConnectFailed(id) | Control::DriverClosed(id) => self.release(id),
-            Control::DriverRegistered(id, abort) => {
+            Control::ConnectorRegistered(id, abort) | Control::DriverRegistered(id, abort) => {
                 if let Some(live) = self.live.get_mut(&id) {
-                    live.abort = Some(abort);
+                    if self.closing {
+                        abort.abort();
+                    } else {
+                        live.abort = Some(abort);
+                    }
                 } else {
                     abort.abort();
                 }
@@ -419,7 +518,7 @@ impl<T: Send + 'static> Actor<T> {
                 self.closing = true;
                 self.shutdown_reply = Some(reply);
                 for waiter in self.waiters.drain(..) {
-                    let _ = waiter.reply.send(Err(AcquireError::ShuttingDown));
+                    Self::resolve_error(waiter, AcquireError::ShuttingDown);
                 }
                 for entries in self.idle.values_mut() {
                     for (_, connection) in entries.drain(..) {
@@ -449,9 +548,11 @@ impl<T: Send + 'static> Actor<T> {
     }
 
     fn admit_waiters(&mut self) {
-        while let Some(index) = self.waiters.iter().position(|waiter| {
-            !waiter.ticket.cancelled.load(Ordering::Acquire) && self.can_open(&waiter.key)
-        }) {
+        while let Some(index) = self
+            .waiters
+            .iter()
+            .position(|waiter| !waiter.ticket.is_cancelled() && self.can_open(&waiter.key))
+        {
             let request = self
                 .waiters
                 .remove(index)
@@ -464,14 +565,14 @@ impl<T: Send + 'static> Actor<T> {
         let now = Instant::now();
         let mut index = 0;
         while index < self.waiters.len() {
-            if self.waiters[index].ticket.cancelled.load(Ordering::Acquire) {
+            if self.waiters[index].ticket.is_cancelled() {
                 self.waiters.remove(index);
             } else if self.waiters[index].deadline <= now {
                 let waiter = self
                     .waiters
                     .remove(index)
                     .expect("should find expired waiter");
-                let _ = waiter.reply.send(Err(AcquireError::TimedOut));
+                Self::resolve_error(waiter, AcquireError::TimedOut);
             } else {
                 index += 1;
             }
@@ -502,6 +603,12 @@ impl<T: Send + 'static> Actor<T> {
             && let Some(reply) = self.shutdown_reply.take()
         {
             let _ = reply.send(());
+        }
+    }
+
+    fn resolve_error(request: AcquireRequest<T>, error: AcquireError) {
+        if request.ticket.resolve() {
+            let _ = request.reply.send(Err(error));
         }
     }
 }
@@ -535,6 +642,19 @@ mod tests {
 
     fn abort_handle() -> AbortHandle {
         tokio::spawn(std::future::pending::<()>()).abort_handle()
+    }
+
+    #[test]
+    fn acquire_ticket_has_exactly_one_terminal_transition() {
+        let cancelled = AcquireTicket::new();
+        assert!(cancelled.cancel());
+        assert!(!cancelled.cancel());
+        assert!(!cancelled.resolve());
+
+        let resolved = AcquireTicket::new();
+        assert!(resolved.resolve());
+        assert!(!resolved.resolve());
+        assert!(!resolved.cancel());
     }
 
     #[tokio::test(start_paused = true)]
@@ -654,6 +774,143 @@ mod tests {
         drop(reservations.pop());
         tokio::task::yield_now().await;
         assert!(second_waiter.is_finished());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_aborts_registered_connector_before_it_finishes() {
+        let manager = Manager::<()>::start(PoolLimits::default());
+        let Acquired::Open(reservation) = manager
+            .acquire(key("connector.example"))
+            .await
+            .expect("reserve connector")
+        else {
+            panic!("should open connector");
+        };
+        let connector = tokio::spawn(std::future::pending::<()>());
+        manager.register_connector(reservation.id(), connector.abort_handle());
+
+        let shutdown = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.shutdown().await }
+        });
+        tokio::task::yield_now().await;
+
+        assert!(
+            connector.is_finished(),
+            "shutdown should abort connector task"
+        );
+        assert!(
+            !shutdown.is_finished(),
+            "capacity remains until completion event"
+        );
+        drop(reservation);
+        tokio::task::yield_now().await;
+        assert!(
+            shutdown.is_finished(),
+            "connector completion should reconcile capacity"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn priority_shutdown_overtakes_a_saturated_ordinary_lane() {
+        let limits = PoolLimits::default();
+        let (ordinary, ordinary_rx) = mpsc::channel::<Command<()>>(ORDINARY_CHANNEL_CAPACITY);
+        let (control, control_rx) = mpsc::unbounded_channel();
+        let mut replies = Vec::new();
+        for sequence in 0..ORDINARY_CHANNEL_CAPACITY as u64 {
+            let (reply, received) = oneshot::channel();
+            ordinary
+                .try_send(Command::Acquire(AcquireRequest {
+                    sequence,
+                    key: key("saturated.example"),
+                    deadline: Instant::now() + limits.acquire_timeout,
+                    ticket: Arc::new(AcquireTicket::new()),
+                    allow_reuse: true,
+                    queue_started: None,
+                    reply,
+                }))
+                .expect("should fill ordinary lane");
+            replies.push(received);
+        }
+        assert!(
+            ordinary.try_reserve().is_err(),
+            "ordinary lane should be full"
+        );
+        let (shutdown_reply, shutdown_received) = oneshot::channel();
+        control
+            .send(Control::Shutdown(shutdown_reply))
+            .expect("should enqueue priority shutdown");
+
+        tokio::spawn(Actor::new(limits, ordinary_rx, control_rx, control.clone()).run());
+
+        shutdown_received
+            .await
+            .expect("shutdown should bypass ordinary lane capacity");
+        for received in replies {
+            assert!(matches!(
+                received.await.expect("actor should answer acquire"),
+                Err(AcquireError::ShuttingDown)
+            ));
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fresh_acquire_never_returns_an_idle_sender() {
+        let manager = Manager::start(PoolLimits {
+            per_origin_live: 1,
+            global_live: 1,
+            ..PoolLimits::default()
+        });
+        let Acquired::Open(reservation) =
+            manager.acquire(key("stale.example")).await.expect("open")
+        else {
+            panic!("should open");
+        };
+        let id = reservation.id();
+        let lease = reservation.register(&manager, 1_u8, abort_handle());
+        manager.return_idle(lease.connection);
+        tokio::task::yield_now().await;
+
+        let fresh = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire_fresh(key("stale.example")).await }
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !fresh.is_finished(),
+            "fresh acquire should close rather than reuse idle"
+        );
+        manager.driver_closed(id);
+        tokio::task::yield_now().await;
+        assert!(matches!(fresh.await.expect("join"), Ok(Acquired::Open(_))));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn global_live_limit_is_atomic_across_origins() {
+        let manager = Manager::<()>::start(PoolLimits::default());
+        let mut reservations = Vec::new();
+        for index in 0..64 {
+            let Acquired::Open(reservation) = manager
+                .acquire(key(&format!("origin-{index}.example")))
+                .await
+                .expect("reserve within global cap")
+            else {
+                panic!("should reserve connection");
+            };
+            reservations.push(reservation);
+        }
+        let blocked = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.acquire(key("overflow.example")).await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!blocked.is_finished());
+        drop(reservations.pop());
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            blocked.await.expect("join"),
+            Ok(Acquired::Open(_))
+        ));
     }
 
     #[test]

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
@@ -1,0 +1,1 @@
+pub mod key;

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
@@ -15,7 +15,7 @@ use hyper::{Request, Response};
 
 use self::body::{PooledResponseBody, RequestUploadBody};
 use self::connect::UpstreamSender;
-use self::manager::{Acquired, Manager};
+use self::manager::{AcquireError, Acquired, Manager};
 use super::ProxyError;
 use super::metrics::ProxyMetrics;
 use super::rewrite::{RewriteOutcome, Rule};
@@ -98,6 +98,23 @@ pub struct UpstreamClient {
 }
 
 #[derive(Debug, Clone, Copy)]
+enum AcquisitionMode {
+    Normal,
+    FreshAfterReadinessFailure,
+}
+
+async fn acquire_for_mode<T: Send + 'static>(
+    manager: &Manager<T>,
+    key: key::OriginKey,
+    mode: AcquisitionMode,
+) -> Result<Acquired<T>, AcquireError> {
+    match mode {
+        AcquisitionMode::Normal => manager.acquire(key).await,
+        AcquisitionMode::FreshAfterReadinessFailure => manager.acquire_fresh(key).await,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct UpstreamOptions {
     pub limits: manager::PoolLimits,
     pub dns_cache: bool,
@@ -155,16 +172,16 @@ impl UpstreamClient {
         let request_started = tokio::time::Instant::now();
         let replay_template = ReplayTemplate::capture(&request, metadata);
         let mut stale_retry = false;
+        let mut acquisition_mode = AcquisitionMode::Normal;
         let mut lease = loop {
             let acquisition_started = tokio::time::Instant::now();
-            let acquired = self
-                .manager
-                .acquire(rule.origin_key().clone())
-                .await
-                .map_err(|error| {
-                    Report::new(ProxyError::Server)
-                        .attach(format!("pool acquire failed: {error:?}"))
-                })?;
+            let acquired =
+                acquire_for_mode(&self.manager, rule.origin_key().clone(), acquisition_mode)
+                    .await
+                    .map_err(|error| {
+                        Report::new(ProxyError::Server)
+                            .attach(format!("pool acquire failed: {error:?}"))
+                    })?;
             self.metrics
                 .record_pool_acquisition(acquisition_started.elapsed());
             if let Some(queue_wait) = acquired.queue_wait() {
@@ -205,6 +222,7 @@ impl UpstreamClient {
                 Ok(_) => break candidate,
                 Err(_error) if candidate.reused && !stale_retry => {
                     stale_retry = true;
+                    acquisition_mode = AcquisitionMode::FreshAfterReadinessFailure;
                     self.metrics.record_pool_stale();
                     self.metrics.record_pool_retry();
                     candidate.connection.abort.abort();
@@ -331,7 +349,26 @@ impl UpstreamClient {
 mod tests {
     use http_body_util::Empty;
 
+    use super::key::{
+        AddressPolicy, ApplicationMode, OriginKey, ReferenceIdentity, Transport, VerifyMode,
+    };
+    use super::manager::PoolLimits;
     use super::*;
+
+    fn key() -> OriginKey {
+        OriginKey::new(
+            Transport::Tls,
+            ReferenceIdentity::dns("readiness.example"),
+            443,
+            VerifyMode::Secure,
+            ApplicationMode::Http1Required,
+            AddressPolicy::Dns,
+        )
+    }
+
+    fn abort_handle() -> tokio::task::AbortHandle {
+        tokio::spawn(std::future::pending::<()>()).abort_handle()
+    }
 
     #[test]
     fn replay_template_reconstructs_only_provably_empty_idempotent_request() {
@@ -365,5 +402,48 @@ mod tests {
         request.extensions_mut().clear();
         *request.method_mut() = hyper::Method::POST;
         assert!(ReplayTemplate::capture(&request, RequestMetadata::capture(&request)).is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn readiness_retry_waits_for_a_fresh_reservation() {
+        let manager = Manager::start(PoolLimits {
+            per_origin_live: 2,
+            global_live: 2,
+            ..PoolLimits::default()
+        });
+        let mut reservations = Vec::new();
+        for _ in 0..2 {
+            let Acquired::Open(reservation) = manager.acquire(key()).await.expect("should reserve")
+            else {
+                panic!("should open connection");
+            };
+            reservations.push(reservation);
+        }
+        let mut ids = Vec::new();
+        for (reservation, value) in reservations.into_iter().zip([1_u8, 2_u8]) {
+            ids.push(reservation.id());
+            let lease = reservation.register(&manager, value, abort_handle());
+            manager.return_idle(lease.connection);
+        }
+        tokio::task::yield_now().await;
+
+        let retry = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move {
+                acquire_for_mode(&manager, key(), AcquisitionMode::FreshAfterReadinessFailure).await
+            }
+        });
+        tokio::task::yield_now().await;
+
+        assert!(
+            !retry.is_finished(),
+            "readiness retry must discard idle senders and wait for fresh capacity"
+        );
+        manager.driver_closed(ids[0]);
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            retry.await.expect("should join retry"),
+            Ok(Acquired::Open(_))
+        ));
     }
 }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
@@ -1,1 +1,169 @@
+pub mod body;
+pub mod connect;
+pub mod dns;
 pub mod key;
+pub mod manager;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use error_stack::{Report, ResultExt as _};
+use http_body_util::{BodyExt as _, combinators::BoxBody};
+use hyper::body::Incoming;
+use hyper::{Request, Response};
+
+use self::body::{PooledResponseBody, RequestUploadBody};
+use self::connect::UpstreamSender;
+use self::manager::{Acquired, Manager};
+use super::ProxyError;
+use super::metrics::ProxyMetrics;
+use super::rewrite::{RewriteOutcome, Rule};
+
+pub struct UpstreamClient {
+    manager: Arc<Manager<UpstreamSender>>,
+    metrics: Arc<ProxyMetrics>,
+    connect_timeout: Duration,
+    dns: Arc<dns::DnsCache>,
+}
+
+impl UpstreamClient {
+    #[must_use]
+    pub fn new(metrics: Arc<ProxyMetrics>, connect_timeout: Duration) -> Self {
+        let perf_variant = std::env::var("TS_PERF_VARIANT").unwrap_or_default();
+        let pool_disabled = matches!(
+            perf_variant.as_str(),
+            "baseline" | "dns_no_cache" | "dns_cache"
+        );
+        let limits = if pool_disabled {
+            manager::PoolLimits {
+                per_origin_live: 64,
+                per_origin_idle: 0,
+                ..manager::PoolLimits::default()
+            }
+        } else if perf_variant == "cap20" {
+            manager::PoolLimits {
+                per_origin_live: 20,
+                ..manager::PoolLimits::default()
+            }
+        } else {
+            manager::PoolLimits::default()
+        };
+        Self {
+            manager: Manager::start(limits),
+            metrics,
+            connect_timeout,
+            dns: Arc::new(dns::DnsCache::new(perf_variant != "dns_no_cache")),
+        }
+    }
+
+    /// Sends one mapped request over a bounded reusable HTTP/1 connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an acquisition, connection, handshake, or request-dispatch error.
+    pub async fn send(
+        &self,
+        request: Request<Incoming>,
+        rule: &Rule,
+        outcome: &RewriteOutcome,
+    ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Report<ProxyError>> {
+        let request_started = tokio::time::Instant::now();
+        let mut stale_retry = false;
+        let mut lease = loop {
+            let acquisition_started = tokio::time::Instant::now();
+            let acquired = self
+                .manager
+                .acquire(rule.origin_key().clone())
+                .await
+                .map_err(|error| {
+                    Report::new(ProxyError::Server)
+                        .attach(format!("pool acquire failed: {error:?}"))
+                })?;
+            self.metrics
+                .record_pool_acquisition(acquisition_started.elapsed());
+
+            let (mut candidate, start) = match acquired {
+                Acquired::Reused(lease) => {
+                    self.metrics.record_pool_hit();
+                    (lease, None)
+                }
+                Acquired::Open(reservation) => {
+                    self.metrics.record_pool_miss();
+                    let opened = connect::open(
+                        rule.origin_key(),
+                        outcome.sni.clone(),
+                        self.connect_timeout,
+                        Arc::clone(&self.metrics),
+                        Arc::clone(&self.manager),
+                        Arc::clone(&self.dns),
+                        reservation.id(),
+                    )
+                    .await
+                    .change_context(ProxyError::Server)?;
+                    let start = opened.start;
+                    let lease = reservation.register(&self.manager, opened.sender, opened.abort);
+                    (lease, Some(start))
+                }
+            };
+            if let Some(start) = start {
+                let _ = start.send(());
+            }
+            match candidate.connection.value.ready().await {
+                Ok(_) => break candidate,
+                Err(_error) if candidate.reused && !stale_retry => {
+                    stale_retry = true;
+                    self.metrics.record_pool_stale();
+                    self.metrics.record_pool_retry();
+                    candidate.connection.abort.abort();
+                }
+                Err(error) => {
+                    candidate.connection.abort.abort();
+                    self.metrics.record_request_failed();
+                    return Err(Report::new(ProxyError::Server).attach(error.to_string()));
+                }
+            }
+        };
+
+        let known_empty = !request
+            .headers()
+            .contains_key(hyper::header::CONTENT_LENGTH)
+            && !request
+                .headers()
+                .contains_key(hyper::header::TRANSFER_ENCODING);
+        let (parts, body) = request.into_parts();
+        let (body, upload_state) = RequestUploadBody::new(body, known_empty);
+        let request = Request::from_parts(parts, body);
+        let response = match lease.connection.value.send_request(request).await {
+            Ok(response) => response,
+            Err(error) => {
+                lease.connection.abort.abort();
+                self.metrics.record_request_failed();
+                return Err(Report::new(ProxyError::Server).attach(error.to_string()));
+            }
+        };
+        self.metrics
+            .record_request_to_headers(request_started.elapsed());
+        let close_intent = response
+            .headers()
+            .get_all(hyper::header::CONNECTION)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .any(|token| token.trim().eq_ignore_ascii_case("close"));
+        let (parts, body) = response.into_parts();
+        let pooled = PooledResponseBody::new(
+            body,
+            lease,
+            Arc::clone(&self.manager),
+            upload_state,
+            close_intent,
+            Arc::clone(&self.metrics),
+        );
+        Ok(Response::from_parts(parts, pooled.boxed()))
+    }
+
+    pub async fn shutdown(&self) {
+        self.manager.shutdown().await;
+    }
+}

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
@@ -349,9 +349,7 @@ impl UpstreamClient {
 mod tests {
     use http_body_util::Empty;
 
-    use super::key::{
-        AddressPolicy, ApplicationMode, OriginKey, ReferenceIdentity, Transport, VerifyMode,
-    };
+    use super::key::{AddressPolicy, OriginKey, ReferenceIdentity, Transport, VerifyMode};
     use super::manager::PoolLimits;
     use super::*;
 
@@ -361,7 +359,6 @@ mod tests {
             ReferenceIdentity::dns("readiness.example"),
             443,
             VerifyMode::Secure,
-            ApplicationMode::Http1Required,
             AddressPolicy::Dns,
         )
     }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use error_stack::{Report, ResultExt as _};
 use http_body_util::{BodyExt as _, combinators::BoxBody};
-use hyper::body::Incoming;
+use hyper::body::{Body, Incoming};
 use hyper::{Request, Response};
 
 use self::body::{PooledResponseBody, RequestUploadBody};
@@ -20,40 +20,123 @@ use super::ProxyError;
 use super::metrics::ProxyMetrics;
 use super::rewrite::{RewriteOutcome, Rule};
 
+/// Immutable body/framing facts captured before hop-by-hop sanitation.
+#[derive(Debug, Clone, Copy)]
+pub struct RequestMetadata {
+    upload_initially_complete: bool,
+    replayable: bool,
+}
+
+impl RequestMetadata {
+    #[must_use]
+    pub fn capture<B: Body>(request: &Request<B>) -> Self {
+        let unframed = !request
+            .headers()
+            .contains_key(hyper::header::CONTENT_LENGTH)
+            && !request
+                .headers()
+                .contains_key(hyper::header::TRANSFER_ENCODING);
+        let replayable_method = matches!(
+            *request.method(),
+            hyper::Method::GET | hyper::Method::HEAD | hyper::Method::OPTIONS
+        );
+        Self {
+            // The browser leg is HTTP/1.1. An unframed request has no message body.
+            upload_initially_complete: unframed,
+            replayable: replayable_method
+                && unframed
+                && request.body().size_hint().exact() == Some(0)
+                && request.body().is_end_stream()
+                && request.extensions().is_empty(),
+        }
+    }
+
+    #[must_use]
+    pub fn upload_initially_complete(self) -> bool {
+        self.upload_initially_complete
+    }
+
+    #[must_use]
+    pub fn replayable(self) -> bool {
+        self.replayable
+    }
+}
+
+#[derive(Clone)]
+struct ReplayTemplate {
+    method: hyper::Method,
+    uri: hyper::Uri,
+    version: hyper::Version,
+    headers: hyper::HeaderMap,
+}
+
+impl ReplayTemplate {
+    fn capture<B>(request: &Request<B>, metadata: RequestMetadata) -> Option<Self> {
+        metadata.replayable().then(|| Self {
+            method: request.method().clone(),
+            uri: request.uri().clone(),
+            version: request.version(),
+            headers: request.headers().clone(),
+        })
+    }
+
+    fn build(&self) -> Request<RequestUploadBody> {
+        let mut request = Request::new(RequestUploadBody::empty());
+        *request.method_mut() = self.method.clone();
+        *request.uri_mut() = self.uri.clone();
+        *request.version_mut() = self.version;
+        *request.headers_mut() = self.headers.clone();
+        request
+    }
+}
+
 pub struct UpstreamClient {
     manager: Arc<Manager<UpstreamSender>>,
     metrics: Arc<ProxyMetrics>,
-    connect_timeout: Duration,
+    connect_policy: connect::ConnectPolicy,
     dns: Arc<dns::DnsCache>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UpstreamOptions {
+    pub limits: manager::PoolLimits,
+    pub dns_cache: bool,
+    pub connect_delay: Duration,
+    pub tls_delay: Duration,
+}
+
+impl Default for UpstreamOptions {
+    fn default() -> Self {
+        Self {
+            limits: manager::PoolLimits::default(),
+            dns_cache: true,
+            connect_delay: Duration::ZERO,
+            tls_delay: Duration::ZERO,
+        }
+    }
 }
 
 impl UpstreamClient {
     #[must_use]
     pub fn new(metrics: Arc<ProxyMetrics>, connect_timeout: Duration) -> Self {
-        let perf_variant = std::env::var("TS_PERF_VARIANT").unwrap_or_default();
-        let pool_disabled = matches!(
-            perf_variant.as_str(),
-            "baseline" | "dns_no_cache" | "dns_cache"
-        );
-        let limits = if pool_disabled {
-            manager::PoolLimits {
-                per_origin_live: 64,
-                per_origin_idle: 0,
-                ..manager::PoolLimits::default()
-            }
-        } else if perf_variant == "cap20" {
-            manager::PoolLimits {
-                per_origin_live: 20,
-                ..manager::PoolLimits::default()
-            }
-        } else {
-            manager::PoolLimits::default()
-        };
+        Self::with_options(metrics, connect_timeout, UpstreamOptions::default())
+    }
+
+    #[must_use]
+    pub fn with_options(
+        metrics: Arc<ProxyMetrics>,
+        connect_timeout: Duration,
+        options: UpstreamOptions,
+    ) -> Self {
         Self {
-            manager: Manager::start(limits),
+            manager: Manager::start(options.limits),
             metrics,
-            connect_timeout,
-            dns: Arc::new(dns::DnsCache::new(perf_variant != "dns_no_cache")),
+            connect_policy: connect::ConnectPolicy {
+                timeout: connect_timeout,
+                connect_delay: options.connect_delay,
+                tls_delay: options.tls_delay,
+            },
+            dns: Arc::new(dns::DnsCache::new(options.dns_cache)),
         }
     }
 
@@ -65,10 +148,12 @@ impl UpstreamClient {
     pub async fn send(
         &self,
         request: Request<Incoming>,
+        metadata: RequestMetadata,
         rule: &Rule,
         outcome: &RewriteOutcome,
     ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Report<ProxyError>> {
         let request_started = tokio::time::Instant::now();
+        let replay_template = ReplayTemplate::capture(&request, metadata);
         let mut stale_retry = false;
         let mut lease = loop {
             let acquisition_started = tokio::time::Instant::now();
@@ -82,6 +167,9 @@ impl UpstreamClient {
                 })?;
             self.metrics
                 .record_pool_acquisition(acquisition_started.elapsed());
+            if let Some(queue_wait) = acquired.queue_wait() {
+                self.metrics.record_queue_wait(queue_wait);
+            }
 
             let (mut candidate, start) = match acquired {
                 Acquired::Reused(lease) => {
@@ -90,17 +178,21 @@ impl UpstreamClient {
                 }
                 Acquired::Open(reservation) => {
                     self.metrics.record_pool_miss();
-                    let opened = connect::open(
-                        rule.origin_key(),
+                    let connector = connect::PendingConnection::spawn(
+                        rule.origin_key().clone(),
                         outcome.sni.clone(),
-                        self.connect_timeout,
+                        self.connect_policy,
                         Arc::clone(&self.metrics),
                         Arc::clone(&self.manager),
                         Arc::clone(&self.dns),
                         reservation.id(),
-                    )
-                    .await
-                    .change_context(ProxyError::Server)?;
+                    );
+                    self.manager
+                        .register_connector(reservation.id(), connector.abort_handle());
+                    let opened = connector
+                        .finish()
+                        .await
+                        .change_context(ProxyError::Server)?;
                     let start = opened.start;
                     let lease = reservation.register(&self.manager, opened.sender, opened.abort);
                     (lease, Some(start))
@@ -125,21 +217,35 @@ impl UpstreamClient {
             }
         };
 
-        let known_empty = !request
-            .headers()
-            .contains_key(hyper::header::CONTENT_LENGTH)
-            && !request
-                .headers()
-                .contains_key(hyper::header::TRANSFER_ENCODING);
         let (parts, body) = request.into_parts();
-        let (body, upload_state) = RequestUploadBody::new(body, known_empty);
+        let (body, upload_state) =
+            RequestUploadBody::new(body, metadata.upload_initially_complete());
         let request = Request::from_parts(parts, body);
-        let response = match lease.connection.value.send_request(request).await {
-            Ok(response) => response,
-            Err(error) => {
-                lease.connection.abort.abort();
-                self.metrics.record_request_failed();
-                return Err(Report::new(ProxyError::Server).attach(error.to_string()));
+        let mut request = request;
+        let response = loop {
+            match lease.connection.value.send_request(request).await {
+                Ok(response) => break response,
+                Err(_error) if lease.reused && !stale_retry && replay_template.is_some() => {
+                    stale_retry = true;
+                    self.metrics.record_pool_stale();
+                    self.metrics.record_pool_retry();
+                    lease.connection.abort.abort();
+                    let (replacement, start) = self.acquire_connection(rule, outcome).await?;
+                    lease = replacement;
+                    if let Some(start) = start {
+                        let _ = start.send(());
+                    }
+                    let Some(template) = replay_template.as_ref() else {
+                        return Err(Report::new(ProxyError::Server)
+                            .attach("replay eligibility lost before retry"));
+                    };
+                    request = template.build();
+                }
+                Err(error) => {
+                    lease.connection.abort.abort();
+                    self.metrics.record_request_failed();
+                    return Err(Report::new(ProxyError::Server).attach(error.to_string()));
+                }
             }
         };
         self.metrics
@@ -165,5 +271,99 @@ impl UpstreamClient {
 
     pub async fn shutdown(&self) {
         self.manager.shutdown().await;
+    }
+
+    async fn acquire_connection(
+        &self,
+        rule: &Rule,
+        outcome: &RewriteOutcome,
+    ) -> Result<
+        (
+            manager::Lease<UpstreamSender>,
+            Option<tokio::sync::oneshot::Sender<()>>,
+        ),
+        Report<ProxyError>,
+    > {
+        let acquisition_started = tokio::time::Instant::now();
+        let acquired = self
+            .manager
+            .acquire_fresh(rule.origin_key().clone())
+            .await
+            .map_err(|error| {
+                Report::new(ProxyError::Server).attach(format!("pool acquire failed: {error:?}"))
+            })?;
+        self.metrics
+            .record_pool_acquisition(acquisition_started.elapsed());
+        if let Some(queue_wait) = acquired.queue_wait() {
+            self.metrics.record_queue_wait(queue_wait);
+        }
+        match acquired {
+            Acquired::Reused(lease) => {
+                self.metrics.record_pool_hit();
+                Ok((lease, None))
+            }
+            Acquired::Open(reservation) => {
+                self.metrics.record_pool_miss();
+                let connector = connect::PendingConnection::spawn(
+                    rule.origin_key().clone(),
+                    outcome.sni.clone(),
+                    self.connect_policy,
+                    Arc::clone(&self.metrics),
+                    Arc::clone(&self.manager),
+                    Arc::clone(&self.dns),
+                    reservation.id(),
+                );
+                self.manager
+                    .register_connector(reservation.id(), connector.abort_handle());
+                let opened = connector
+                    .finish()
+                    .await
+                    .change_context(ProxyError::Server)?;
+                let start = opened.start;
+                let lease = reservation.register(&self.manager, opened.sender, opened.abort);
+                Ok((lease, Some(start)))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_body_util::Empty;
+
+    use super::*;
+
+    #[test]
+    fn replay_template_reconstructs_only_provably_empty_idempotent_request() {
+        let mut request = Request::new(Empty::<Bytes>::new());
+        *request.method_mut() = hyper::Method::GET;
+        *request.uri_mut() = "/asset?version=1".parse().expect("should parse URI");
+        request
+            .headers_mut()
+            .insert("x-test", hyper::header::HeaderValue::from_static("value"));
+        let metadata = RequestMetadata::capture(&request);
+
+        let template =
+            ReplayTemplate::capture(&request, metadata).expect("empty GET should be replayable");
+        let rebuilt = template.build();
+
+        assert_eq!(rebuilt.method(), hyper::Method::GET);
+        assert_eq!(
+            rebuilt.uri().path_and_query().expect("path").as_str(),
+            "/asset?version=1"
+        );
+        assert_eq!(rebuilt.headers()["x-test"], "value");
+        assert!(rebuilt.body().is_end_stream());
+    }
+
+    #[test]
+    fn replay_template_rejects_extensions_and_non_idempotent_methods() {
+        let mut request = Request::new(Empty::<Bytes>::new());
+        request.extensions_mut().insert(7_u8);
+        assert!(ReplayTemplate::capture(&request, RequestMetadata::capture(&request)).is_none());
+
+        request.extensions_mut().clear();
+        *request.method_mut() = hyper::Method::POST;
+        assert!(ReplayTemplate::capture(&request, RequestMetadata::capture(&request)).is_none());
     }
 }

--- a/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
+++ b/crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs
@@ -1,7 +1,12 @@
+/// Streaming upload and pooled response-body adapters.
 pub mod body;
+/// DNS/TCP/TLS/HTTP connection establishment.
 pub mod connect;
+/// Bounded TTL DNS cache with concurrent-miss coalescing.
 pub mod dns;
+/// Strong upstream origin identity types.
 pub mod key;
+/// Bounded connection-pool actor and lifecycle types.
 pub mod manager;
 
 use std::sync::Arc;
@@ -29,6 +34,7 @@ pub struct RequestMetadata {
 
 impl RequestMetadata {
     #[must_use]
+    /// Captures framing and replay facts before hop-by-hop sanitation.
     pub fn capture<B: Body>(request: &Request<B>) -> Self {
         let unframed = !request
             .headers()
@@ -52,11 +58,13 @@ impl RequestMetadata {
     }
 
     #[must_use]
+    /// Returns whether the browser upload is already known to be complete.
     pub fn upload_initially_complete(self) -> bool {
         self.upload_initially_complete
     }
 
     #[must_use]
+    /// Returns whether the request can be reconstructed for one safe stale retry.
     pub fn replayable(self) -> bool {
         self.replayable
     }
@@ -90,11 +98,38 @@ impl ReplayTemplate {
     }
 }
 
+/// Process-shared bounded upstream HTTP/1 client and DNS cache.
 pub struct UpstreamClient {
     manager: Arc<Manager<UpstreamSender>>,
     metrics: Arc<ProxyMetrics>,
     connect_policy: connect::ConnectPolicy,
     dns: Arc<dns::DnsCache>,
+}
+
+struct SendOutcomeGuard<'a> {
+    metrics: &'a ProxyMetrics,
+    handed_to_response_body: bool,
+}
+
+impl<'a> SendOutcomeGuard<'a> {
+    fn new(metrics: &'a ProxyMetrics) -> Self {
+        Self {
+            metrics,
+            handed_to_response_body: false,
+        }
+    }
+
+    fn hand_to_response_body(&mut self) {
+        self.handed_to_response_body = true;
+    }
+}
+
+impl Drop for SendOutcomeGuard<'_> {
+    fn drop(&mut self) {
+        if !self.handed_to_response_body {
+            self.metrics.record_request_failed();
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -115,10 +150,15 @@ async fn acquire_for_mode<T: Send + 'static>(
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Production pool defaults plus harness-only upstream timing controls.
 pub struct UpstreamOptions {
+    /// Manager connection, idle, waiter, and timeout bounds.
     pub limits: manager::PoolLimits,
+    /// Whether successful DNS results are cached for the bounded TTL.
     pub dns_cache: bool,
+    /// Harness-only delay before each new TCP connection.
     pub connect_delay: Duration,
+    /// Harness-only delay before each new TLS handshake.
     pub tls_delay: Duration,
 }
 
@@ -135,11 +175,13 @@ impl Default for UpstreamOptions {
 
 impl UpstreamClient {
     #[must_use]
+    /// Creates a client with production pool and DNS defaults.
     pub fn new(metrics: Arc<ProxyMetrics>, connect_timeout: Duration) -> Self {
         Self::with_options(metrics, connect_timeout, UpstreamOptions::default())
     }
 
     #[must_use]
+    /// Creates a client with explicit harness or boundary-test options.
     pub fn with_options(
         metrics: Arc<ProxyMetrics>,
         connect_timeout: Duration,
@@ -169,6 +211,7 @@ impl UpstreamClient {
         rule: &Rule,
         outcome: &RewriteOutcome,
     ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Report<ProxyError>> {
+        let mut outcome_guard = SendOutcomeGuard::new(&self.metrics);
         let request_started = tokio::time::Instant::now();
         let replay_template = ReplayTemplate::capture(&request, metadata);
         let mut stale_retry = false;
@@ -176,14 +219,12 @@ impl UpstreamClient {
         let mut lease = loop {
             let acquisition_started = tokio::time::Instant::now();
             let acquired =
-                acquire_for_mode(&self.manager, rule.origin_key().clone(), acquisition_mode)
-                    .await
-                    .map_err(|error| {
-                        Report::new(ProxyError::Server)
-                            .attach(format!("pool acquire failed: {error:?}"))
-                    })?;
+                acquire_for_mode(&self.manager, rule.origin_key().clone(), acquisition_mode).await;
             self.metrics
                 .record_pool_acquisition(acquisition_started.elapsed());
+            let acquired = acquired.map_err(|error| {
+                Report::new(ProxyError::Server).attach(format!("pool acquire failed: {error:?}"))
+            })?;
             if let Some(queue_wait) = acquired.queue_wait() {
                 self.metrics.record_queue_wait(queue_wait);
             }
@@ -195,6 +236,7 @@ impl UpstreamClient {
                 }
                 Acquired::Open(reservation) => {
                     self.metrics.record_pool_miss();
+                    let connector_id = reservation.id();
                     let connector = connect::PendingConnection::spawn(
                         rule.origin_key().clone(),
                         outcome.sni.clone(),
@@ -202,16 +244,15 @@ impl UpstreamClient {
                         Arc::clone(&self.metrics),
                         Arc::clone(&self.manager),
                         Arc::clone(&self.dns),
-                        reservation.id(),
+                        reservation,
                     );
                     self.manager
-                        .register_connector(reservation.id(), connector.abort_handle());
+                        .register_connector(connector_id, connector.abort_handle());
                     let opened = connector
                         .finish()
                         .await
                         .change_context(ProxyError::Server)?;
-                    let start = opened.start;
-                    let lease = reservation.register(&self.manager, opened.sender, opened.abort);
+                    let (lease, start) = opened.register(&self.manager);
                     (lease, Some(start))
                 }
             };
@@ -229,7 +270,6 @@ impl UpstreamClient {
                 }
                 Err(error) => {
                     candidate.connection.abort.abort();
-                    self.metrics.record_request_failed();
                     return Err(Report::new(ProxyError::Server).attach(error.to_string()));
                 }
             }
@@ -243,6 +283,10 @@ impl UpstreamClient {
         let response = loop {
             match lease.connection.value.send_request(request).await {
                 Ok(response) => break response,
+                // Replaying a non-idempotent or streaming request could submit it
+                // twice after an origin processed the first attempt. Return 502
+                // instead unless pre-sanitization metadata proved an empty
+                // GET/HEAD/OPTIONS request can be reconstructed exactly.
                 Err(_error) if lease.reused && !stale_retry && replay_template.is_some() => {
                     stale_retry = true;
                     self.metrics.record_pool_stale();
@@ -261,7 +305,6 @@ impl UpstreamClient {
                 }
                 Err(error) => {
                     lease.connection.abort.abort();
-                    self.metrics.record_request_failed();
                     return Err(Report::new(ProxyError::Server).attach(error.to_string()));
                 }
             }
@@ -284,9 +327,11 @@ impl UpstreamClient {
             close_intent,
             Arc::clone(&self.metrics),
         );
+        outcome_guard.hand_to_response_body();
         Ok(Response::from_parts(parts, pooled.boxed()))
     }
 
+    /// Aborts connectors and drivers, then waits for lifecycle reconciliation.
     pub async fn shutdown(&self) {
         self.manager.shutdown().await;
     }
@@ -303,15 +348,12 @@ impl UpstreamClient {
         Report<ProxyError>,
     > {
         let acquisition_started = tokio::time::Instant::now();
-        let acquired = self
-            .manager
-            .acquire_fresh(rule.origin_key().clone())
-            .await
-            .map_err(|error| {
-                Report::new(ProxyError::Server).attach(format!("pool acquire failed: {error:?}"))
-            })?;
+        let acquired = self.manager.acquire_fresh(rule.origin_key().clone()).await;
         self.metrics
             .record_pool_acquisition(acquisition_started.elapsed());
+        let acquired = acquired.map_err(|error| {
+            Report::new(ProxyError::Server).attach(format!("pool acquire failed: {error:?}"))
+        })?;
         if let Some(queue_wait) = acquired.queue_wait() {
             self.metrics.record_queue_wait(queue_wait);
         }
@@ -322,6 +364,7 @@ impl UpstreamClient {
             }
             Acquired::Open(reservation) => {
                 self.metrics.record_pool_miss();
+                let connector_id = reservation.id();
                 let connector = connect::PendingConnection::spawn(
                     rule.origin_key().clone(),
                     outcome.sni.clone(),
@@ -329,16 +372,15 @@ impl UpstreamClient {
                     Arc::clone(&self.metrics),
                     Arc::clone(&self.manager),
                     Arc::clone(&self.dns),
-                    reservation.id(),
+                    reservation,
                 );
                 self.manager
-                    .register_connector(reservation.id(), connector.abort_handle());
+                    .register_connector(connector_id, connector.abort_handle());
                 let opened = connector
                     .finish()
                     .await
                     .change_context(ProxyError::Server)?;
-                let start = opened.start;
-                let lease = reservation.register(&self.manager, opened.sender, opened.abort);
+                let (lease, start) = opened.register(&self.manager);
                 Ok((lease, Some(start)))
             }
         }

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -140,6 +140,29 @@ async fn keep_alive_serves_multiple_sequential_requests() {
         responses[1].path, "/two",
         "second request reused the tunnel"
     );
+    let snapshot = upstream.snapshot();
+    assert_eq!(
+        snapshot.accepted_connections, 1,
+        "sequential mapped requests should reuse one upstream TCP connection"
+    );
+    assert_eq!(
+        snapshot.tls_handshakes, 1,
+        "sequential mapped requests should reuse one upstream TLS session"
+    );
+}
+
+#[tokio::test]
+async fn upstream_connection_close_is_not_reused() {
+    let upstream = support::start_closing_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+
+    let responses = support::drive_sequential_requests(cfg, ca, &["/one", "/two"]).await;
+
+    assert!(responses.iter().all(|response| response.status == 200));
+    let snapshot = upstream.snapshot();
+    assert_eq!(snapshot.accepted_connections, 2);
+    assert_eq!(snapshot.tls_handshakes, 2);
 }
 
 #[tokio::test]

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -17,6 +17,28 @@ use trusted_server_cli::commands::dev::proxy::{ca, config};
 
 mod support;
 
+async fn wait_for_request_metrics(
+    state: &trusted_server_cli::commands::dev::proxy::ProxyState,
+    completed: u64,
+    failed: u64,
+) {
+    let settled = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let snapshot = state.metrics.snapshot();
+            if snapshot.requests_completed >= completed && snapshot.requests_failed >= failed {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(
+        settled.is_ok(),
+        "request metrics should settle: {:?}",
+        state.metrics.snapshot()
+    );
+}
+
 #[tokio::test]
 async fn matched_host_is_rewritten_and_forwarded() {
     let upstream = support::start_echo_upstream().await;
@@ -297,6 +319,85 @@ async fn large_chunked_upload_and_response_are_byte_identical() {
         },
         "one streamed exchange should use one healthy upstream connection"
     );
+}
+
+#[tokio::test]
+async fn early_response_completes_without_pooling_streaming_upload() {
+    let upstream = support::start_early_response_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+
+    let status = support::drive_early_response(proxy).await;
+    assert_eq!(status, 200, "browser should receive early response");
+    wait_for_request_metrics(&state, 1, 0).await;
+    let next = support::drive_sequential_requests_through_proxy(proxy, &["/next"]).await;
+
+    assert_eq!(next[0].status, 200);
+    assert_eq!(
+        upstream.snapshot().accepted_connections,
+        2,
+        "streaming upload connection must close instead of pooling"
+    );
+    let metrics = state.metrics.snapshot();
+    assert_eq!(metrics.requests_completed, 2);
+    assert_eq!(metrics.requests_failed, 0);
+}
+
+#[tokio::test]
+async fn browser_cancellation_closes_slow_response_and_counts_failure() {
+    let upstream = support::start_slow_response_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+
+    support::cancel_slow_response(proxy).await;
+    wait_for_request_metrics(&state, 0, 1).await;
+
+    tokio::time::timeout(Duration::from_secs(1), state.upstream.shutdown())
+        .await
+        .expect("cancelled response driver should reconcile");
+    assert_eq!(state.metrics.snapshot().requests_completed, 0);
+}
+
+#[tokio::test]
+async fn truncated_upstream_response_counts_failure() {
+    let upstream = support::start_truncated_response_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+
+    let (declared, received) = support::drive_truncated_response(proxy).await;
+    wait_for_request_metrics(&state, 0, 1).await;
+
+    assert_eq!(declared, 10);
+    assert_eq!(received, 3);
+    assert_eq!(state.metrics.snapshot().requests_completed, 0);
+}
+
+#[tokio::test]
+async fn response_trailers_finish_before_connection_reuse() {
+    let upstream = support::start_trailer_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+
+    let responses = support::drive_trailer_requests(proxy).await;
+    wait_for_request_metrics(&state, 2, 0).await;
+
+    assert_eq!(responses.len(), 2);
+    for (body, trailers) in responses {
+        assert_eq!(body, b"data");
+        assert!(
+            trailers
+                .to_ascii_lowercase()
+                .contains("x-test-trailer: done"),
+            "response trailer should be forwarded: {trailers:?}"
+        );
+    }
+    let snapshot = upstream.snapshot();
+    assert_eq!(snapshot.accepted_connections, 1);
+    assert_eq!(snapshot.requests, 2);
 }
 
 #[tokio::test]

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -243,6 +243,42 @@ async fn keep_alive_serves_multiple_sequential_requests() {
 }
 
 #[tokio::test]
+async fn distinct_from_hosts_reuse_the_same_logical_to_pool() {
+    let upstream = support::start_echo_upstream().await;
+    let cfg = support::test_config_shared_to(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let proxy = support::spawn_proxy(cfg, ca).await;
+
+    let first = support::drive_host_through_proxy(proxy, support::FROM_HOST, "/first").await;
+    let second = support::drive_host_through_proxy(proxy, support::ALT_FROM_HOST, "/second").await;
+
+    assert_eq!(first.seen_host, support::FROM_HOST);
+    assert_eq!(first.seen_forwarded_host, support::FROM_HOST);
+    assert_eq!(second.seen_host, support::ALT_FROM_HOST);
+    assert_eq!(second.seen_forwarded_host, support::ALT_FROM_HOST);
+    let snapshot = upstream.snapshot();
+    assert_eq!(snapshot.accepted_connections, 1);
+    assert_eq!(snapshot.requests, 2);
+}
+
+#[tokio::test]
+async fn distinct_to_ports_never_share_upstream_connections() {
+    let first_upstream = support::start_echo_upstream().await;
+    let second_upstream = support::start_echo_upstream().await;
+    let cfg = support::test_config_distinct_to(&first_upstream.addr, &second_upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let proxy = support::spawn_proxy(cfg, ca).await;
+
+    let first = support::drive_host_through_proxy(proxy, support::FROM_HOST, "/first").await;
+    let second = support::drive_host_through_proxy(proxy, support::ALT_FROM_HOST, "/second").await;
+
+    assert_eq!(first.path, "/first");
+    assert_eq!(second.path, "/second");
+    assert_eq!(first_upstream.snapshot().accepted_connections, 1);
+    assert_eq!(second_upstream.snapshot().accepted_connections, 1);
+}
+
+#[tokio::test]
 async fn upstream_connection_close_is_not_reused() {
     let upstream = support::start_closing_upstream().await;
     let cfg = support::test_config(&upstream.addr);

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -114,10 +114,7 @@ async fn unmatched_host_is_blind_tunneled_on_loopback() {
 async fn basic_auth_injected_when_absent_clears_401() {
     let upstream = support::start_gated_upstream().await;
     let mut cfg = support::test_config(&upstream.addr);
-    cfg.basic_auth = Some(config::BasicAuth {
-        user: "dev".into(),
-        pass: "secret".into(),
-    });
+    cfg.basic_auth = Some(config::BasicAuth::new("dev", "secret").expect("should build auth"));
     let ca = Arc::new(support::dev_ca());
 
     let response = support::drive_request_through_proxy(cfg, ca).await;

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -291,6 +291,51 @@ async fn manager_shutdown_aborts_idle_driver_and_acknowledges() {
 }
 
 #[tokio::test]
+async fn shutdown_waits_for_delayed_driver_reconciliation() {
+    let manager = trusted_server_cli::commands::dev::proxy::upstream::manager::Manager::start(
+        trusted_server_cli::commands::dev::proxy::upstream::manager::PoolLimits::default(),
+    );
+    let key = trusted_server_cli::commands::dev::proxy::upstream::key::OriginKey::new(
+        trusted_server_cli::commands::dev::proxy::upstream::key::Transport::Tls,
+        trusted_server_cli::commands::dev::proxy::upstream::key::ReferenceIdentity::dns(
+            "shutdown.example",
+        ),
+        443,
+        trusted_server_cli::commands::dev::proxy::upstream::key::VerifyMode::Secure,
+        trusted_server_cli::commands::dev::proxy::upstream::key::AddressPolicy::Dns,
+    );
+    let trusted_server_cli::commands::dev::proxy::upstream::manager::Acquired::Open(reservation) =
+        manager.acquire(key).await.expect("should reserve driver")
+    else {
+        panic!("should open driver reservation");
+    };
+    let id = reservation.id();
+    let driver = tokio::spawn(std::future::pending::<()>());
+    let lease = reservation.register(&manager, (), driver.abort_handle());
+    manager.return_idle(lease.connection);
+    tokio::task::yield_now().await;
+    let shutdown = tokio::spawn({
+        let manager = Arc::clone(&manager);
+        async move { manager.shutdown().await }
+    });
+    tokio::task::yield_now().await;
+
+    assert!(
+        driver.is_finished(),
+        "shutdown should abort registered driver"
+    );
+    assert!(
+        !shutdown.is_finished(),
+        "shutdown must await delayed lifecycle reconciliation"
+    );
+    manager.driver_closed(id);
+    tokio::time::timeout(Duration::from_secs(1), shutdown)
+        .await
+        .expect("reconciled shutdown should remain externally bounded")
+        .expect("shutdown task should join");
+}
+
+#[tokio::test]
 async fn post_dispatch_failure_does_not_retry_post() {
     let upstream = support::start_post_dispatch_stale_upstream().await;
     let cfg = support::test_config(&upstream.addr);

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -10,6 +10,7 @@
 #![cfg(target_os = "macos")]
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use trusted_server_cli::commands::dev::proxy::{ca, config};
 
@@ -163,6 +164,82 @@ async fn upstream_connection_close_is_not_reused() {
     let snapshot = upstream.snapshot();
     assert_eq!(snapshot.accepted_connections, 2);
     assert_eq!(snapshot.tls_handshakes, 2);
+}
+
+#[tokio::test]
+async fn reused_empty_get_retries_once_after_post_dispatch_close() {
+    let upstream = support::start_post_dispatch_stale_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+
+    let responses = support::drive_sequential_requests(cfg, ca, &["/one", "/two"]).await;
+
+    assert!(responses.iter().all(|response| response.status == 200));
+    let snapshot = upstream.snapshot();
+    assert_eq!(
+        snapshot.accepted_connections, 2,
+        "retry should open one replacement"
+    );
+    assert_eq!(
+        snapshot.requests, 3,
+        "second GET should be attempted exactly twice"
+    );
+}
+
+#[tokio::test]
+async fn manager_shutdown_aborts_idle_driver_and_acknowledges() {
+    let upstream = support::start_echo_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+    let responses = support::drive_sequential_requests_through_proxy(proxy, &["/idle"]).await;
+    assert_eq!(responses[0].status, 200);
+
+    tokio::time::timeout(Duration::from_secs(1), state.upstream.shutdown())
+        .await
+        .expect("manager should acknowledge after driver guard closes");
+}
+
+#[tokio::test]
+async fn post_dispatch_failure_does_not_retry_post() {
+    let upstream = support::start_post_dispatch_stale_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+
+    let responses = support::drive_get_then_post(cfg, ca).await;
+
+    assert_eq!(responses[0].status, 200);
+    assert_eq!(responses[1].status, 502);
+    let snapshot = upstream.snapshot();
+    assert_eq!(
+        snapshot.accepted_connections, 1,
+        "POST must not open retry connection"
+    );
+    assert_eq!(snapshot.requests, 2, "POST must be attempted exactly once");
+}
+
+#[tokio::test]
+async fn large_chunked_upload_and_response_are_byte_identical() {
+    let upstream = support::start_chunked_body_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let body: Vec<u8> = (0..2 * 1024 * 1024)
+        .map(|index| ((index * 31 + 17) % 251) as u8)
+        .collect();
+
+    let response = support::drive_chunked_body(cfg, ca, &body).await;
+
+    assert_eq!(response, body, "chunked body should remain byte-identical");
+    assert_eq!(
+        upstream.snapshot(),
+        support::UpstreamSnapshot {
+            accepted_connections: 1,
+            tls_handshakes: 1,
+            requests: 1,
+            failures: 0,
+        },
+        "one streamed exchange should use one healthy upstream connection"
+    );
 }
 
 #[tokio::test]

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -493,6 +493,75 @@ async fn response_trailers_finish_before_connection_reuse() {
 }
 
 #[tokio::test]
+async fn request_and_response_trailers_cross_the_upstream_leg() {
+    let upstream = support::start_request_trailer_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let proxy = support::spawn_proxy(cfg, ca).await;
+
+    let (body, trailers) = support::drive_request_trailer(proxy).await;
+
+    assert_eq!(body, b"accepted");
+    assert!(
+        trailers
+            .to_ascii_lowercase()
+            .contains("x-response-accepted: yes"),
+        "conditional response trailer should reach the browser: {trailers:?}"
+    );
+    assert_eq!(upstream.snapshot().requests, 1);
+    assert_eq!(upstream.snapshot().failures, 0);
+}
+
+#[tokio::test]
+async fn unreachable_origin_counts_one_terminal_request_failure() {
+    let unused =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("should reserve an unused loopback port");
+    let unreachable = unused.local_addr().expect("should read unused port");
+    drop(unused);
+    let cfg = support::test_config(&unreachable);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+
+    let responses =
+        support::drive_sequential_requests_through_proxy(proxy, &["/unreachable"]).await;
+    assert_eq!(responses[0].status, 502);
+    wait_for_request_metrics(&state, 0, 1).await;
+
+    let snapshot = state.metrics.snapshot();
+    assert_eq!(snapshot.requests_completed, 0);
+    assert_eq!(snapshot.requests_failed, 1);
+}
+
+#[tokio::test]
+async fn failed_acquisition_records_latency_and_one_failure() {
+    let unused =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("should reserve an unused loopback port");
+    let unreachable = unused.local_addr().expect("should read unused port");
+    drop(unused);
+    let cfg = support::test_config(&unreachable);
+    let ca = Arc::new(support::dev_ca());
+    let options = trusted_server_cli::commands::dev::proxy::upstream::UpstreamOptions {
+        limits: trusted_server_cli::commands::dev::proxy::upstream::manager::PoolLimits {
+            per_origin_live: 0,
+            global_live: 0,
+            acquire_timeout: Duration::ZERO,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let (proxy, state) = support::spawn_proxy_with_upstream_options(cfg, ca, options).await;
+
+    let responses = support::drive_sequential_requests_through_proxy(proxy, &["/overloaded"]).await;
+    assert_eq!(responses[0].status, 502);
+    wait_for_request_metrics(&state, 0, 1).await;
+
+    let snapshot = state.metrics.snapshot();
+    assert_eq!(snapshot.requests_completed, 0);
+    assert_eq!(snapshot.requests_failed, 1);
+    assert_eq!(snapshot.pool_acquisition_latency.total(), 1);
+}
+
+#[tokio::test]
 async fn mismatched_host_over_mitm_tunnel_is_refused_with_421() {
     // CONNECT a mapped host (so the tunnel is MITM'd), then send a request whose
     // Host header matches NO rule. It must be refused with 421 (Misdirected

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -13,6 +13,7 @@ use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
+use tokio::io::AsyncReadExt as _;
 use trusted_server_cli::commands::dev::proxy::{ca, config};
 
 mod support;
@@ -37,6 +38,16 @@ async fn wait_for_request_metrics(
         "request metrics should settle: {:?}",
         state.metrics.snapshot()
     );
+}
+
+async fn wait_for_raw_connections(upstream: &support::RawUpstream, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while upstream.accepted_connections() < expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("raw upstream connections should settle");
 }
 
 #[tokio::test]
@@ -434,4 +445,92 @@ async fn unmatched_connect_off_loopback_is_refused_with_403() {
         status.contains(" 403 "),
         "off-loopback unmatched CONNECT must be refused with 403, got: {status}"
     );
+}
+
+#[tokio::test]
+async fn blind_and_plain_forwarding_bypass_mapped_pool_capacity() {
+    let mapped = support::start_echo_upstream().await;
+    let raw = support::start_raw_echo_upstream().await;
+    let cfg = support::test_config(&mapped.addr);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+    let authority = raw.addr.to_string();
+
+    let mut blind = Vec::new();
+    for _ in 0..65 {
+        blind.push(support::open_blind_tunnel(proxy, &authority, &[]).await);
+    }
+    wait_for_raw_connections(&raw, 65).await;
+    let first = support::drive_sequential_requests_through_proxy(proxy, &["/after-blind"]).await;
+    assert_eq!(first[0].status, 200);
+    drop(blind);
+
+    let mut plain = Vec::new();
+    for _ in 0..65 {
+        plain.push(support::open_plain_forward(proxy, raw.addr, b"").await.0);
+    }
+    wait_for_raw_connections(&raw, 130).await;
+    let second = support::drive_sequential_requests_through_proxy(proxy, &["/after-plain"]).await;
+    assert_eq!(second[0].status, 200);
+    drop(plain);
+
+    tokio::time::timeout(Duration::from_secs(1), state.upstream.shutdown())
+        .await
+        .expect("forwarding sockets should not block mapped manager shutdown");
+}
+
+#[tokio::test]
+async fn blind_tunnel_overread_reaches_upstream_exactly_once() {
+    let mapped = support::start_echo_upstream().await;
+    let raw = support::start_raw_echo_upstream().await;
+    let cfg = support::test_config(&mapped.addr);
+    let ca = Arc::new(support::dev_ca());
+    let proxy = support::spawn_proxy(cfg, ca).await;
+    let payload = b"blind-overread-prefix";
+
+    let mut tunnel = support::open_blind_tunnel(proxy, &raw.addr.to_string(), payload).await;
+    let mut echoed = vec![0_u8; payload.len()];
+    tokio::time::timeout(Duration::from_secs(1), tunnel.read_exact(&mut echoed))
+        .await
+        .expect("blind overread should be echoed")
+        .expect("should read blind overread");
+
+    assert_eq!(echoed, payload);
+    wait_for_raw_connections(&raw, 1).await;
+    assert_eq!(raw.captured()[0], payload);
+}
+
+#[tokio::test]
+async fn plain_forward_overread_reaches_upstream_exactly_once() {
+    let mapped = support::start_echo_upstream().await;
+    let raw = support::start_raw_echo_upstream().await;
+    let cfg = support::test_config(&mapped.addr);
+    let ca = Arc::new(support::dev_ca());
+    let proxy = support::spawn_proxy(cfg, ca).await;
+
+    let (_client, expected) =
+        support::open_plain_forward(proxy, raw.addr, b"plain-overread-body").await;
+    wait_for_raw_connections(&raw, 1).await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while raw.captured()[0].len() < expected.len() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("plain overread should reach raw upstream");
+
+    assert_eq!(raw.captured()[0], expected);
+}
+
+#[tokio::test]
+async fn mitm_connect_overread_preserves_tls_client_hello() {
+    let upstream = support::start_echo_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let proxy = support::spawn_proxy(cfg, ca).await;
+
+    let response = support::drive_mitm_connect_overread(proxy).await;
+
+    assert_eq!(response.status, 200);
+    assert_eq!(response.path, "/mitm-overread");
 }

--- a/crates/trusted-server-cli/tests/proxy_e2e.rs
+++ b/crates/trusted-server-cli/tests/proxy_e2e.rs
@@ -9,6 +9,7 @@
 // on other targets so it does not reference the macOS-scoped dev-dependencies.
 #![cfg(target_os = "macos")]
 
+use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -121,6 +122,62 @@ async fn basic_auth_injected_when_absent_clears_401() {
     let response = support::drive_request_through_proxy(cfg, ca).await;
 
     assert_eq!(response.status, 200, "injected Basic auth clears the 401");
+}
+
+#[tokio::test]
+async fn authorization_does_not_persist_on_reused_connection() {
+    let upstream = support::start_gated_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+
+    let responses = support::drive_authorized_then_absent(cfg, ca).await;
+
+    assert_eq!(
+        responses[0].status, 200,
+        "first request carries authorization"
+    );
+    assert_eq!(
+        responses[1].status, 401,
+        "second request must not inherit it"
+    );
+    let snapshot = upstream.snapshot();
+    assert_eq!(snapshot.accepted_connections, 1);
+    assert_eq!(snapshot.requests, 2);
+}
+
+#[test]
+fn insecure_mode_warns_before_startup_failure() {
+    let occupied =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("should reserve loopback port");
+    let listen = occupied
+        .local_addr()
+        .expect("should read occupied address")
+        .to_string();
+    let ca_dir = tempfile::tempdir().expect("should create temporary CA directory");
+    let output = Command::new(env!("CARGO_BIN_EXE_ts"))
+        .args([
+            "dev",
+            "proxy",
+            "--map",
+            "www.example.com=127.0.0.1:443",
+            "--listen",
+            &listen,
+            "--ca-dir",
+            ca_dir.path().to_str().expect("should encode CA path"),
+            "--insecure",
+        ])
+        .output()
+        .expect("should run ts process");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "occupied port should fail startup"
+    );
+    assert!(
+        stderr.contains("--insecure: upstream TLS verification is DISABLED"),
+        "stderr should warn loudly before bind failure: {stderr}"
+    );
 }
 
 #[tokio::test]

--- a/crates/trusted-server-cli/tests/proxy_perf.rs
+++ b/crates/trusted-server-cli/tests/proxy_perf.rs
@@ -1,0 +1,137 @@
+//! Explicitly selected local performance workloads for `ts dev proxy`.
+//!
+//! These tests assert deterministic connection and handshake counts. Their
+//! wall-clock output is evidence for manual comparison, never a CI threshold.
+
+#![cfg(target_os = "macos")]
+#![allow(clippy::print_stdout)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures::{StreamExt as _, stream};
+
+mod support;
+
+const REQUEST_COUNT: usize = 100;
+
+#[tokio::test]
+#[ignore = "manual performance workload"]
+async fn perf_baseline_sequential_tls() {
+    let upstream = support::start_echo_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let proxy = support::spawn_proxy(cfg, ca).await;
+    let paths = numbered_paths();
+    let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+
+    let started = Instant::now();
+    let responses = support::drive_sequential_requests_through_proxy(proxy, &path_refs).await;
+    let duration = started.elapsed();
+    let snapshot = upstream.snapshot();
+
+    println!(
+        "PERF_RUN workload=sequential_tls variant=baseline run=1 duration_us={} \
+         tcp_attempts={} tcp_established={} tls_handshakes={} failures={}",
+        duration.as_micros(),
+        snapshot.accepted_connections,
+        snapshot.accepted_connections,
+        snapshot.tls_handshakes,
+        snapshot.failures,
+    );
+    assert_eq!(
+        responses.len(),
+        REQUEST_COUNT,
+        "should answer every request"
+    );
+    assert!(
+        responses.iter().all(|response| response.status == 200),
+        "should return success for every request"
+    );
+    assert_eq!(
+        snapshot.accepted_connections, REQUEST_COUNT as u64,
+        "baseline should open one upstream connection per request"
+    );
+    assert_eq!(
+        snapshot.tls_handshakes, REQUEST_COUNT as u64,
+        "baseline should negotiate TLS once per request"
+    );
+    assert_eq!(
+        snapshot.requests, REQUEST_COUNT as u64,
+        "upstream should receive every request"
+    );
+    assert_eq!(snapshot.failures, 0, "baseline should have no failures");
+}
+
+#[tokio::test]
+#[ignore = "manual performance workload"]
+async fn perf_baseline_matched_concurrency_six() {
+    run_concurrent_baseline("matched_concurrency_6", 6).await;
+}
+
+#[tokio::test]
+#[ignore = "manual performance workload"]
+async fn perf_baseline_saturation_concurrency_twenty() {
+    run_concurrent_baseline("saturation_concurrency_20", 20).await;
+}
+
+async fn run_concurrent_baseline(workload: &str, concurrency: usize) {
+    let upstream = support::start_delayed_echo_upstream(Duration::from_millis(25)).await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let proxy = support::spawn_proxy(cfg, ca).await;
+
+    let started = Instant::now();
+    let responses: Vec<support::ProxiedResponse> = stream::iter(0..REQUEST_COUNT)
+        .map(|index| async move {
+            let path = format!("/asset-{index}");
+            support::drive_sequential_requests_through_proxy(proxy, &[path.as_str()])
+                .await
+                .into_iter()
+                .next()
+                .expect("should receive one response")
+        })
+        .buffer_unordered(concurrency)
+        .collect()
+        .await;
+    let duration = started.elapsed();
+    let snapshot = upstream.snapshot();
+
+    println!(
+        "PERF_RUN workload={workload} variant=baseline run=1 duration_us={} \
+         tcp_attempts={} tcp_established={} tls_handshakes={} failures={}",
+        duration.as_micros(),
+        snapshot.accepted_connections,
+        snapshot.accepted_connections,
+        snapshot.tls_handshakes,
+        snapshot.failures,
+    );
+    assert_eq!(
+        responses.len(),
+        REQUEST_COUNT,
+        "should answer every request"
+    );
+    assert!(
+        responses.iter().all(|response| response.status == 200),
+        "should return success for every request"
+    );
+    assert_eq!(
+        snapshot.accepted_connections, REQUEST_COUNT as u64,
+        "baseline should open one upstream connection per request"
+    );
+    assert_eq!(
+        snapshot.tls_handshakes, REQUEST_COUNT as u64,
+        "baseline should negotiate TLS once per request"
+    );
+    assert_eq!(
+        snapshot.requests, REQUEST_COUNT as u64,
+        "upstream should receive every request"
+    );
+    assert_eq!(snapshot.failures, 0, "baseline should have no failures");
+}
+
+fn numbered_paths() -> Vec<String> {
+    (0..REQUEST_COUNT)
+        .map(|index| format!("/asset-{index}"))
+        .collect()
+}

--- a/crates/trusted-server-cli/tests/proxy_perf.rs
+++ b/crates/trusted-server-cli/tests/proxy_perf.rs
@@ -76,6 +76,9 @@ async fn perf_pooled_saturation_concurrency_twenty() {
 #[tokio::test]
 #[ignore = "manual performance workload"]
 async fn perf_http1_remote_model() {
+    let variant = perf_variant();
+    validate_remote_variant(&variant)
+        .expect("remote workload requires TS_PERF_VARIANT=remote_baseline or remote_pooled");
     run_concurrent_pooled("http1_remote_model_30_30_25", 20).await;
 }
 
@@ -147,6 +150,22 @@ async fn run_concurrent_pooled(workload: &str, concurrency: usize) {
 
 fn perf_variant() -> String {
     std::env::var("TS_PERF_VARIANT").unwrap_or_else(|_| "pooled".to_string())
+}
+
+fn validate_remote_variant(variant: &str) -> Result<(), &'static str> {
+    match variant {
+        "remote_baseline" | "remote_pooled" => Ok(()),
+        _ => Err("remote workload requires a remote_* performance variant"),
+    }
+}
+
+#[test]
+fn remote_workload_accepts_only_remote_variants() {
+    assert!(validate_remote_variant("remote_baseline").is_ok());
+    assert!(validate_remote_variant("remote_pooled").is_ok());
+    assert!(validate_remote_variant("baseline").is_err());
+    assert!(validate_remote_variant("pooled").is_err());
+    assert!(validate_remote_variant("cap20").is_err());
 }
 
 fn numbered_paths() -> Vec<String> {

--- a/crates/trusted-server-cli/tests/proxy_perf.rs
+++ b/crates/trusted-server-cli/tests/proxy_perf.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::{StreamExt as _, stream};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::TcpStream;
 
 mod support;
 
@@ -17,7 +19,8 @@ const REQUEST_COUNT: usize = 100;
 
 #[tokio::test]
 #[ignore = "manual performance workload"]
-async fn perf_baseline_sequential_tls() {
+async fn perf_pooled_sequential_tls() {
+    let variant = perf_variant();
     let upstream = support::start_echo_upstream().await;
     let cfg = support::test_config(&upstream.addr);
     let ca = Arc::new(support::dev_ca());
@@ -31,7 +34,7 @@ async fn perf_baseline_sequential_tls() {
     let snapshot = upstream.snapshot();
 
     println!(
-        "PERF_RUN workload=sequential_tls variant=baseline run=1 duration_us={} \
+        "PERF_RUN workload=sequential_tls variant={variant} run=1 duration_us={} \
          tcp_attempts={} tcp_established={} tls_handshakes={} failures={}",
         duration.as_micros(),
         snapshot.accepted_connections,
@@ -48,14 +51,9 @@ async fn perf_baseline_sequential_tls() {
         responses.iter().all(|response| response.status == 200),
         "should return success for every request"
     );
-    assert_eq!(
-        snapshot.accepted_connections, REQUEST_COUNT as u64,
-        "baseline should open one upstream connection per request"
-    );
-    assert_eq!(
-        snapshot.tls_handshakes, REQUEST_COUNT as u64,
-        "baseline should negotiate TLS once per request"
-    );
+    let expected_connections = if variant == "baseline" { 100 } else { 1 };
+    assert_eq!(snapshot.accepted_connections, expected_connections);
+    assert_eq!(snapshot.tls_handshakes, expected_connections);
     assert_eq!(
         snapshot.requests, REQUEST_COUNT as u64,
         "upstream should receive every request"
@@ -65,17 +63,18 @@ async fn perf_baseline_sequential_tls() {
 
 #[tokio::test]
 #[ignore = "manual performance workload"]
-async fn perf_baseline_matched_concurrency_six() {
-    run_concurrent_baseline("matched_concurrency_6", 6).await;
+async fn perf_pooled_matched_concurrency_six() {
+    run_concurrent_pooled("matched_concurrency_6", 6).await;
 }
 
 #[tokio::test]
 #[ignore = "manual performance workload"]
-async fn perf_baseline_saturation_concurrency_twenty() {
-    run_concurrent_baseline("saturation_concurrency_20", 20).await;
+async fn perf_pooled_saturation_concurrency_twenty() {
+    run_concurrent_pooled("saturation_concurrency_20", 20).await;
 }
 
-async fn run_concurrent_baseline(workload: &str, concurrency: usize) {
+async fn run_concurrent_pooled(workload: &str, concurrency: usize) {
+    let variant = perf_variant();
     let upstream = support::start_delayed_echo_upstream(Duration::from_millis(25)).await;
     let cfg = support::test_config(&upstream.addr);
     let ca = Arc::new(support::dev_ca());
@@ -98,7 +97,7 @@ async fn run_concurrent_baseline(workload: &str, concurrency: usize) {
     let snapshot = upstream.snapshot();
 
     println!(
-        "PERF_RUN workload={workload} variant=baseline run=1 duration_us={} \
+        "PERF_RUN workload={workload} variant={variant} run=1 duration_us={} \
          tcp_attempts={} tcp_established={} tls_handshakes={} failures={}",
         duration.as_micros(),
         snapshot.accepted_connections,
@@ -115,14 +114,24 @@ async fn run_concurrent_baseline(workload: &str, concurrency: usize) {
         responses.iter().all(|response| response.status == 200),
         "should return success for every request"
     );
-    assert_eq!(
-        snapshot.accepted_connections, REQUEST_COUNT as u64,
-        "baseline should open one upstream connection per request"
-    );
-    assert_eq!(
-        snapshot.tls_handshakes, REQUEST_COUNT as u64,
-        "baseline should negotiate TLS once per request"
-    );
+    if variant == "baseline" {
+        assert_eq!(snapshot.accepted_connections, REQUEST_COUNT as u64);
+    } else if variant == "cap20" {
+        assert!(snapshot.accepted_connections < REQUEST_COUNT as u64);
+    } else if concurrency > 6 {
+        assert!(
+            (2..=6).contains(&snapshot.accepted_connections),
+            "queued saturation should keep total connections within the six-live cap, observed {}",
+            snapshot.accepted_connections
+        );
+    } else {
+        assert!(
+            snapshot.accepted_connections < REQUEST_COUNT as u64,
+            "matched concurrency should still reduce connection churn, observed {}",
+            snapshot.accepted_connections
+        );
+    }
+    assert_eq!(snapshot.tls_handshakes, snapshot.accepted_connections);
     assert_eq!(
         snapshot.requests, REQUEST_COUNT as u64,
         "upstream should receive every request"
@@ -130,8 +139,71 @@ async fn run_concurrent_baseline(workload: &str, concurrency: usize) {
     assert_eq!(snapshot.failures, 0, "baseline should have no failures");
 }
 
+fn perf_variant() -> String {
+    std::env::var("TS_PERF_VARIANT").unwrap_or_else(|_| "pooled".to_string())
+}
+
 fn numbered_paths() -> Vec<String> {
     (0..REQUEST_COUNT)
         .map(|index| format!("/asset-{index}"))
         .collect()
+}
+
+#[tokio::test]
+#[ignore = "manual performance workload"]
+async fn perf_parser_local() {
+    const CONNECTIONS: usize = 1_000;
+    let upstream = support::start_echo_upstream().await;
+    let cfg = support::test_config(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+    let started = Instant::now();
+    for _ in 0..CONNECTIONS {
+        let mut stream = TcpStream::connect(proxy).await.expect("connect proxy");
+        stream
+            .write_all(b"GET /proxy.pac HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .expect("write PAC request");
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.expect("read PAC");
+        assert!(response.starts_with(b"HTTP/1.1 200"));
+    }
+    let duration = started.elapsed();
+    let snapshot = state.metrics.snapshot();
+    let parse_us = snapshot.initial_head_parse_latency.total_micros();
+    let ratio = parse_us as f64 / duration.as_micros() as f64;
+    println!(
+        "PERF_RUN workload=parser_local variant=byte_reader run=1 duration_us={} parse_us={} parse_ratio={ratio:.6}",
+        duration.as_micros(),
+        parse_us,
+    );
+    assert_eq!(snapshot.initial_heads_parsed, CONNECTIONS as u64);
+}
+
+#[tokio::test]
+#[ignore = "manual performance workload"]
+async fn perf_dns_lookup_contribution() {
+    let variant = perf_variant();
+    let upstream = support::start_echo_upstream().await;
+    let cfg = support::test_config_dns(&upstream.addr);
+    let ca = Arc::new(support::dev_ca());
+    let (proxy, state) = support::spawn_proxy_with_state(cfg, ca).await;
+    let paths = numbered_paths();
+    let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+    let started = Instant::now();
+    let responses = support::drive_sequential_requests_through_proxy(proxy, &path_refs).await;
+    let duration = started.elapsed();
+    assert!(responses.iter().all(|response| response.status == 200));
+    let snapshot = state.metrics.snapshot();
+    let dns_us = snapshot.dns_lookup_latency.total_micros();
+    let headers_us = snapshot.request_to_headers_latency.total_micros();
+    let ratio = dns_us as f64 / headers_us.max(1) as f64;
+    println!(
+        "PERF_RUN workload=dns_lookup_contribution variant={variant} run=1 duration_us={} dns_us={} request_to_headers_us={} dns_ratio={ratio:.6} dns_hits={} dns_misses={}",
+        duration.as_micros(),
+        dns_us,
+        headers_us,
+        snapshot.dns_cache_hits,
+        snapshot.dns_cache_misses,
+    );
 }

--- a/crates/trusted-server-cli/tests/proxy_perf.rs
+++ b/crates/trusted-server-cli/tests/proxy_perf.rs
@@ -73,6 +73,12 @@ async fn perf_pooled_saturation_concurrency_twenty() {
     run_concurrent_pooled("saturation_concurrency_20", 20).await;
 }
 
+#[tokio::test]
+#[ignore = "manual performance workload"]
+async fn perf_http1_remote_model() {
+    run_concurrent_pooled("http1_remote_model_30_30_25", 20).await;
+}
+
 async fn run_concurrent_pooled(workload: &str, concurrency: usize) {
     let variant = perf_variant();
     let upstream = support::start_delayed_echo_upstream(Duration::from_millis(25)).await;
@@ -114,7 +120,7 @@ async fn run_concurrent_pooled(workload: &str, concurrency: usize) {
         responses.iter().all(|response| response.status == 200),
         "should return success for every request"
     );
-    if variant == "baseline" {
+    if matches!(variant.as_str(), "baseline" | "remote_baseline") {
         assert_eq!(snapshot.accepted_connections, REQUEST_COUNT as u64);
     } else if variant == "cap20" {
         assert!(snapshot.accepted_connections < REQUEST_COUNT as u64);

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -1035,7 +1035,7 @@ impl AsyncRead for ConnectPrefixedIo {
     }
 }
 
-/// Forces CONNECT head plus rustls ClientHello into one buffered first flight.
+/// Forces CONNECT head plus rustls `ClientHello` into one buffered first flight.
 pub async fn drive_mitm_connect_overread(proxy: SocketAddr) -> ProxiedResponse {
     let tcp = TcpStream::connect(proxy)
         .await

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -387,6 +387,84 @@ pub async fn start_trailer_upstream() -> Upstream {
     start_scripted_upstream(ScriptedResponse::Trailers).await
 }
 
+/// Starts an origin that accepts a declared request trailer and returns a
+/// response trailer only when the proxy also forwards `TE: trailers`.
+pub async fn start_request_trailer_upstream() -> Upstream {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("should bind request-trailer upstream");
+    let addr = listener.local_addr().expect("should read scripted address");
+    let acceptor = upstream_tls_acceptor();
+    let counters = Arc::new(UpstreamCounters::default());
+    let task_counters = Arc::clone(&counters);
+    tokio::spawn(async move {
+        let Ok((tcp, _)) = listener.accept().await else {
+            return;
+        };
+        task_counters
+            .accepted_connections
+            .fetch_add(1, Ordering::Relaxed);
+        let Ok(mut tls) = acceptor.accept(tcp).await else {
+            task_counters.failures.fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        task_counters.tls_handshakes.fetch_add(1, Ordering::Relaxed);
+
+        let mut encoded = Vec::new();
+        let mut scratch = [0_u8; 1024];
+        let head_end = loop {
+            if let Some(position) = find_subslice(&encoded, b"\r\n\r\n") {
+                break position + 4;
+            }
+            let Ok(count) = tls.read(&mut scratch).await else {
+                return;
+            };
+            if count == 0 {
+                return;
+            }
+            encoded.extend_from_slice(&scratch[..count]);
+        };
+        let head = String::from_utf8_lossy(&encoded[..head_end]).to_string();
+        let body_prefix = encoded.split_off(head_end);
+        let Some((body, trailers)) = decode_chunked_body(&mut tls, body_prefix).await else {
+            task_counters.failures.fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        task_counters.requests.fetch_add(1, Ordering::Relaxed);
+        let trailer_declared = header_value(&head, "trailer")
+            .is_some_and(|value| value.eq_ignore_ascii_case("x-request-checksum"));
+        let accepts_trailers = header_value(&head, "te").is_some_and(|value| {
+            value
+                .split(',')
+                .any(|token| token.trim().eq_ignore_ascii_case("trailers"))
+        });
+        let connection_declares_te = header_value(&head, "connection").is_some_and(|value| {
+            value
+                .split(',')
+                .any(|token| token.trim().eq_ignore_ascii_case("te"))
+        });
+        let request_trailer_arrived = trailers
+            .to_ascii_lowercase()
+            .contains("x-request-checksum: verified");
+        let accepted = body == b"data"
+            && trailer_declared
+            && accepts_trailers
+            && connection_declares_te
+            && request_trailer_arrived;
+        let response = if accepted {
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nTrailer: x-response-accepted\r\nConnection: keep-alive\r\n\r\n8\r\naccepted\r\n0\r\nx-response-accepted: yes\r\n\r\n"
+                .as_slice()
+        } else {
+            b"HTTP/1.1 400 Bad Request\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n0\r\n\r\n"
+                .as_slice()
+        };
+        if tls.write_all(response).await.is_err() || tls.flush().await.is_err() {
+            task_counters.failures.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    Upstream { addr, counters }
+}
+
 #[derive(Clone, Copy)]
 enum ScriptedResponse {
     Early,
@@ -754,6 +832,31 @@ pub async fn spawn_proxy_with_state(
     };
     let state =
         trusted_server_cli::commands::dev::proxy::ProxyState::with_upstream_options(cfg, options);
+    let pac: Arc<str> = Arc::from("function FindProxyForURL(u, h) { return \"DIRECT\"; }");
+    let task_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        let _ = server::serve_on_with_state(listener, task_state, ca, pac).await;
+    });
+    (addr, state)
+}
+
+/// Spawns the proxy with explicit upstream options for boundary-condition tests.
+pub async fn spawn_proxy_with_upstream_options(
+    cfg: config::ResolvedConfig,
+    ca: Arc<ca::CertAuthority>,
+    options: trusted_server_cli::commands::dev::proxy::upstream::UpstreamOptions,
+) -> (
+    SocketAddr,
+    Arc<trusted_server_cli::commands::dev::proxy::ProxyState>,
+) {
+    let listener = server::bind(cfg.listen)
+        .await
+        .expect("should bind proxy listener");
+    let addr = listener.local_addr().expect("should read proxy addr");
+    let state = trusted_server_cli::commands::dev::proxy::ProxyState::with_upstream_options(
+        Arc::new(cfg),
+        options,
+    );
     let pac: Arc<str> = Arc::from("function FindProxyForURL(u, h) { return \"DIRECT\"; }");
     let task_state = Arc::clone(&state);
     tokio::spawn(async move {
@@ -1321,6 +1424,21 @@ pub async fn drive_trailer_requests(proxy: SocketAddr) -> Vec<(Vec<u8>, String)>
         );
     }
     responses
+}
+
+/// Sends a chunked request with a declared trailer and asks the origin to
+/// return response trailers.
+pub async fn drive_request_trailer(proxy: SocketAddr) -> (Vec<u8>, String) {
+    let mut tls = open_mitm_client(proxy).await;
+    let request = format!(
+        "POST /request-trailer HTTP/1.1\r\nHost: {FROM_HOST}\r\nTransfer-Encoding: chunked\r\nTrailer: x-request-checksum\r\nTE: trailers\r\nConnection: TE\r\n\r\n4\r\ndata\r\n0\r\nx-request-checksum: verified\r\n\r\n"
+    );
+    tls.write_all(request.as_bytes())
+        .await
+        .expect("should send request trailers");
+    read_chunked_response(&mut tls)
+        .await
+        .expect("origin should return a chunked response with trailers")
 }
 
 /// Streams `body` through the proxy with chunked request framing and returns

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -189,26 +189,90 @@ fn upstream_tls_acceptor() -> TlsAcceptor {
 /// Starts an HTTPS upstream that echoes the `Host`/`X-Orig-Host`/path it saw and
 /// always returns `200`. Serves keep-alive (many requests per connection).
 pub async fn start_echo_upstream() -> Upstream {
-    start_upstream(false, Duration::ZERO, false).await
+    start_upstream(false, Duration::ZERO, false, false).await
 }
 
 /// Starts the echo upstream with a fixed delay before every response.
 pub async fn start_delayed_echo_upstream(response_delay: Duration) -> Upstream {
-    start_upstream(false, response_delay, false).await
+    start_upstream(false, response_delay, false, false).await
 }
 
 /// Starts an upstream that requests connection closure after every response.
 pub async fn start_closing_upstream() -> Upstream {
-    start_upstream(false, Duration::ZERO, true).await
+    start_upstream(false, Duration::ZERO, true, false).await
+}
+
+/// First connection closes after consuming its second request but before headers.
+pub async fn start_post_dispatch_stale_upstream() -> Upstream {
+    start_upstream(false, Duration::ZERO, false, true).await
+}
+
+/// Starts an HTTPS upstream that echoes one chunked request body as a chunked
+/// response body.
+pub async fn start_chunked_body_upstream() -> Upstream {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("should bind chunked upstream");
+    let addr = listener
+        .local_addr()
+        .expect("should read chunked upstream addr");
+    let acceptor = upstream_tls_acceptor();
+    let counters = Arc::new(UpstreamCounters::default());
+    let task_counters = Arc::clone(&counters);
+    tokio::spawn(async move {
+        let Ok((tcp, _)) = listener.accept().await else {
+            return;
+        };
+        task_counters
+            .accepted_connections
+            .fetch_add(1, Ordering::Relaxed);
+        let Ok(mut tls) = acceptor.accept(tcp).await else {
+            task_counters.failures.fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        task_counters.tls_handshakes.fetch_add(1, Ordering::Relaxed);
+        let Some(body) = read_chunked_message(&mut tls).await else {
+            task_counters.failures.fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        task_counters.requests.fetch_add(1, Ordering::Relaxed);
+        if tls
+            .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+            .await
+            .is_err()
+        {
+            task_counters.failures.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        for chunk in body.chunks(8 * 1024) {
+            let head = format!("{:x}\r\n", chunk.len());
+            if tls.write_all(head.as_bytes()).await.is_err()
+                || tls.write_all(chunk).await.is_err()
+                || tls.write_all(b"\r\n").await.is_err()
+            {
+                task_counters.failures.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        }
+        if tls.write_all(b"0\r\n\r\n").await.is_err() || tls.flush().await.is_err() {
+            task_counters.failures.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    Upstream { addr, counters }
 }
 
 /// Starts an HTTPS upstream that returns `401` unless an `Authorization` header
 /// is present, otherwise `200`.
 pub async fn start_gated_upstream() -> Upstream {
-    start_upstream(true, Duration::ZERO, false).await
+    start_upstream(true, Duration::ZERO, false, false).await
 }
 
-async fn start_upstream(gated: bool, response_delay: Duration, close: bool) -> Upstream {
+async fn start_upstream(
+    gated: bool,
+    response_delay: Duration,
+    close: bool,
+    fail_second_on_first: bool,
+) -> Upstream {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("should bind upstream");
@@ -221,9 +285,10 @@ async fn start_upstream(gated: bool, response_delay: Duration, close: bool) -> U
             let Ok((tcp, _)) = listener.accept().await else {
                 break;
             };
-            task_counters
+            let connection_index = task_counters
                 .accepted_connections
-                .fetch_add(1, Ordering::Relaxed);
+                .fetch_add(1, Ordering::Relaxed)
+                + 1;
             let acceptor = acceptor.clone();
             let counters = Arc::clone(&task_counters);
             tokio::spawn(async move {
@@ -237,7 +302,15 @@ async fn start_upstream(gated: bool, response_delay: Duration, close: bool) -> U
                         return;
                     }
                 };
-                serve_upstream_connection(&mut tls, gated, response_delay, close, &counters).await;
+                serve_upstream_connection(
+                    &mut tls,
+                    gated,
+                    response_delay,
+                    close,
+                    fail_second_on_first && connection_index == 1,
+                    &counters,
+                )
+                .await;
             });
         }
     });
@@ -251,12 +324,14 @@ async fn serve_upstream_connection<S>(
     gated: bool,
     response_delay: Duration,
     close: bool,
+    fail_second_request: bool,
     counters: &UpstreamCounters,
 ) where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
 {
     let mut buf = Vec::new();
     let mut chunk = [0u8; 1024];
+    let mut request_index = 0;
     loop {
         // Read until we have a full header block.
         let head_end = loop {
@@ -274,6 +349,7 @@ async fn serve_upstream_connection<S>(
             buf.extend_from_slice(&chunk[..n]);
         };
         counters.requests.fetch_add(1, Ordering::Relaxed);
+        request_index += 1;
         let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
         buf.drain(..head_end);
 
@@ -287,6 +363,10 @@ async fn serve_upstream_connection<S>(
         let orig_host = header_value(&head, "x-orig-host").unwrap_or_default();
         let fwd_host = header_value(&head, "x-forwarded-host").unwrap_or_default();
         let has_auth = header_value(&head, "authorization").is_some();
+
+        if fail_second_request && request_index == 2 {
+            return;
+        }
 
         let (status_line, body) = if gated && !has_auth {
             ("HTTP/1.1 401 Unauthorized", String::new())
@@ -329,6 +409,71 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len()).position(|w| w == needle)
 }
 
+async fn read_chunked_message<S>(stream: &mut S) -> Option<Vec<u8>>
+where
+    S: AsyncReadExt + Unpin,
+{
+    let mut encoded = Vec::new();
+    let mut scratch = [0_u8; 1024];
+    let head_end = loop {
+        if let Some(position) = find_subslice(&encoded, b"\r\n\r\n") {
+            break position + 4;
+        }
+        let count = stream.read(&mut scratch).await.ok()?;
+        if count == 0 {
+            return None;
+        }
+        encoded.extend_from_slice(&scratch[..count]);
+    };
+    encoded.drain(..head_end);
+    decode_chunked_body(stream, encoded).await
+}
+
+async fn decode_chunked_body<S>(stream: &mut S, mut encoded: Vec<u8>) -> Option<Vec<u8>>
+where
+    S: AsyncReadExt + Unpin,
+{
+    let mut body = Vec::new();
+    let mut scratch = [0_u8; 1024];
+    loop {
+        let line_end = loop {
+            if let Some(position) = find_subslice(&encoded, b"\r\n") {
+                break position;
+            }
+            let count = stream.read(&mut scratch).await.ok()?;
+            if count == 0 {
+                return None;
+            }
+            encoded.extend_from_slice(&scratch[..count]);
+        };
+        let size =
+            usize::from_str_radix(std::str::from_utf8(&encoded[..line_end]).ok()?, 16).ok()?;
+        encoded.drain(..line_end + 2);
+        if size == 0 {
+            while encoded.len() < 2 {
+                let count = stream.read(&mut scratch).await.ok()?;
+                if count == 0 {
+                    return None;
+                }
+                encoded.extend_from_slice(&scratch[..count]);
+            }
+            return encoded.starts_with(b"\r\n").then_some(body);
+        }
+        while encoded.len() < size + 2 {
+            let count = stream.read(&mut scratch).await.ok()?;
+            if count == 0 {
+                return None;
+            }
+            encoded.extend_from_slice(&scratch[..count]);
+        }
+        body.extend_from_slice(&encoded[..size]);
+        if &encoded[size..size + 2] != b"\r\n" {
+            return None;
+        }
+        encoded.drain(..size + 2);
+    }
+}
+
 // ---- proxy lifecycle ----
 
 /// Spawns the proxy in the background and returns the loopback address it bound.
@@ -349,7 +494,35 @@ pub async fn spawn_proxy_with_state(
         .expect("should bind proxy listener");
     let addr = listener.local_addr().expect("should read proxy addr");
     let cfg = Arc::new(cfg);
-    let state = trusted_server_cli::commands::dev::proxy::ProxyState::new(cfg);
+    let variant = std::env::var("TS_PERF_VARIANT").unwrap_or_default();
+    let pool_disabled = matches!(
+        variant.as_str(),
+        "baseline" | "dns_no_cache" | "dns_cache" | "remote_baseline"
+    );
+    let mut limits =
+        trusted_server_cli::commands::dev::proxy::upstream::manager::PoolLimits::default();
+    if pool_disabled {
+        limits.per_origin_live = 64;
+        limits.per_origin_idle = 0;
+    } else if variant == "cap20" {
+        limits.per_origin_live = 20;
+    }
+    let options = trusted_server_cli::commands::dev::proxy::upstream::UpstreamOptions {
+        limits,
+        dns_cache: variant != "dns_no_cache",
+        connect_delay: if variant.starts_with("remote_") {
+            Duration::from_millis(30)
+        } else {
+            Duration::ZERO
+        },
+        tls_delay: if variant.starts_with("remote_") {
+            Duration::from_millis(30)
+        } else {
+            Duration::ZERO
+        },
+    };
+    let state =
+        trusted_server_cli::commands::dev::proxy::ProxyState::with_upstream_options(cfg, options);
     let pac: Arc<str> = Arc::from("function FindProxyForURL(u, h) { return \"DIRECT\"; }");
     let task_state = Arc::clone(&state);
     tokio::spawn(async move {
@@ -548,6 +721,75 @@ pub async fn drive_sequential_requests_through_proxy(
         results.push(read_http_response(&mut tls).await);
     }
     results
+}
+
+/// Sends a GET followed by a non-replayable POST on one browser tunnel.
+pub async fn drive_get_then_post(
+    cfg: config::ResolvedConfig,
+    ca: Arc<ca::CertAuthority>,
+) -> Vec<ProxiedResponse> {
+    let proxy = spawn_proxy(cfg, ca).await;
+    let authority = format!("{FROM_HOST}:443");
+    let tcp = proxy_connect(proxy, &authority).await;
+    let connector = accept_any_connector();
+    let server_name = ServerName::try_from(FROM_HOST.to_string()).expect("valid server name");
+    let mut tls = connector
+        .connect(server_name, tcp)
+        .await
+        .expect("client TLS handshake with proxy leaf");
+
+    let get = format!("GET /one HTTP/1.1\r\nHost: {FROM_HOST}\r\n\r\n");
+    tls.write_all(get.as_bytes()).await.expect("write GET");
+    let first = read_http_response(&mut tls).await;
+    let post = format!("POST /two HTTP/1.1\r\nHost: {FROM_HOST}\r\nContent-Length: 0\r\n\r\n");
+    tls.write_all(post.as_bytes()).await.expect("write POST");
+    let second = read_http_response(&mut tls).await;
+    vec![first, second]
+}
+
+/// Streams `body` through the proxy with chunked request framing and returns
+/// the decoded chunked response body.
+pub async fn drive_chunked_body(
+    cfg: config::ResolvedConfig,
+    ca: Arc<ca::CertAuthority>,
+    body: &[u8],
+) -> Vec<u8> {
+    let proxy = spawn_proxy(cfg, ca).await;
+    let authority = format!("{FROM_HOST}:443");
+    let tcp = proxy_connect(proxy, &authority).await;
+    let connector = accept_any_connector();
+    let server_name = ServerName::try_from(FROM_HOST.to_string()).expect("valid server name");
+    let mut tls = connector
+        .connect(server_name, tcp)
+        .await
+        .expect("client TLS handshake with proxy leaf");
+
+    let request = format!(
+        "POST /chunked HTTP/1.1\r\nHost: {FROM_HOST}\r\nTransfer-Encoding: chunked\r\n\r\n"
+    );
+    tls.write_all(request.as_bytes())
+        .await
+        .expect("should write chunked request head");
+    for chunk in body.chunks(16 * 1024) {
+        let head = format!("{:x}\r\n", chunk.len());
+        tls.write_all(head.as_bytes())
+            .await
+            .expect("should write request chunk head");
+        tls.write_all(chunk)
+            .await
+            .expect("should write request chunk");
+        tls.write_all(b"\r\n")
+            .await
+            .expect("should finish request chunk");
+    }
+    tls.write_all(b"0\r\n\r\n")
+        .await
+        .expect("should finish chunked request");
+    tls.flush().await.expect("should flush chunked request");
+
+    read_chunked_message(&mut tls)
+        .await
+        .expect("should decode chunked response")
 }
 
 /// CONNECTs to the mapped [`FROM_HOST`] (so the tunnel is MITM'd), then sends a

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -20,6 +20,7 @@ use trusted_server_cli::commands::dev::proxy::{ca, config, server};
 
 /// The production hostname the matched rule rewrites from (and preserves).
 pub const FROM_HOST: &str = "www.example-publisher.com";
+pub const ALT_FROM_HOST: &str = "shop.example-publisher.com";
 
 /// What the echo upstream reports back to the test.
 pub struct ProxiedResponse {
@@ -125,6 +126,41 @@ pub fn test_config_rewrite_host(addr: &SocketAddr) -> config::ResolvedConfig {
         "--map",
         &map,
         "--rewrite-host",
+        "--listen",
+        "127.0.0.1:0",
+        "--insecure",
+    ])
+}
+
+/// Maps two browser hosts to the same logical upstream origin.
+pub fn test_config_shared_to(addr: &SocketAddr) -> config::ResolvedConfig {
+    let first = format!("{FROM_HOST}={addr}");
+    let second = format!("{ALT_FROM_HOST}={addr}");
+    resolve(&[
+        "ts",
+        "--map",
+        &first,
+        "--map",
+        &second,
+        "--listen",
+        "127.0.0.1:0",
+        "--insecure",
+    ])
+}
+
+/// Maps two browser hosts to distinct upstream ports.
+pub fn test_config_distinct_to(
+    first_addr: &SocketAddr,
+    second_addr: &SocketAddr,
+) -> config::ResolvedConfig {
+    let first = format!("{FROM_HOST}={first_addr}");
+    let second = format!("{ALT_FROM_HOST}={second_addr}");
+    resolve(&[
+        "ts",
+        "--map",
+        &first,
+        "--map",
+        &second,
         "--listen",
         "127.0.0.1:0",
         "--insecure",
@@ -1086,6 +1122,27 @@ pub async fn drive_request_through_proxy(
         .into_iter()
         .next()
         .expect("should get one response")
+}
+
+/// Sends one mapped request for an arbitrary configured browser host.
+pub async fn drive_host_through_proxy(
+    proxy: SocketAddr,
+    host: &str,
+    path: &str,
+) -> ProxiedResponse {
+    let authority = format!("{host}:443");
+    let tcp = proxy_connect(proxy, &authority).await;
+    let connector = accept_any_connector();
+    let server_name = ServerName::try_from(host.to_string()).expect("valid server name");
+    let mut tls = connector
+        .connect(server_name, tcp)
+        .await
+        .expect("client TLS handshake with proxy leaf");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: {host}\r\n\r\n");
+    tls.write_all(request.as_bytes())
+        .await
+        .expect("should send host-specific request");
+    read_http_response(&mut tls).await
 }
 
 /// Issues several GETs over ONE keep-alive MITM tunnel and returns them in order.

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -86,6 +86,12 @@ pub fn test_config(addr: &SocketAddr) -> config::ResolvedConfig {
     resolve(&["ts", "--map", &map, "--listen", "127.0.0.1:0", "--insecure"])
 }
 
+/// Uses a real DNS identity (`localhost`) rather than an IP-literal TO.
+pub fn test_config_dns(addr: &SocketAddr) -> config::ResolvedConfig {
+    let map = format!("{FROM_HOST}=localhost:{}", addr.port());
+    resolve(&["ts", "--map", &map, "--listen", "127.0.0.1:0", "--insecure"])
+}
+
 /// Like [`test_config`] but with `--rewrite-host`, so the upstream sees
 /// `Host: <TO>` while `X-Forwarded-Host` stays `FROM`.
 pub fn test_config_rewrite_host(addr: &SocketAddr) -> config::ResolvedConfig {
@@ -183,21 +189,26 @@ fn upstream_tls_acceptor() -> TlsAcceptor {
 /// Starts an HTTPS upstream that echoes the `Host`/`X-Orig-Host`/path it saw and
 /// always returns `200`. Serves keep-alive (many requests per connection).
 pub async fn start_echo_upstream() -> Upstream {
-    start_upstream(false, Duration::ZERO).await
+    start_upstream(false, Duration::ZERO, false).await
 }
 
 /// Starts the echo upstream with a fixed delay before every response.
 pub async fn start_delayed_echo_upstream(response_delay: Duration) -> Upstream {
-    start_upstream(false, response_delay).await
+    start_upstream(false, response_delay, false).await
+}
+
+/// Starts an upstream that requests connection closure after every response.
+pub async fn start_closing_upstream() -> Upstream {
+    start_upstream(false, Duration::ZERO, true).await
 }
 
 /// Starts an HTTPS upstream that returns `401` unless an `Authorization` header
 /// is present, otherwise `200`.
 pub async fn start_gated_upstream() -> Upstream {
-    start_upstream(true, Duration::ZERO).await
+    start_upstream(true, Duration::ZERO, false).await
 }
 
-async fn start_upstream(gated: bool, response_delay: Duration) -> Upstream {
+async fn start_upstream(gated: bool, response_delay: Duration, close: bool) -> Upstream {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("should bind upstream");
@@ -226,7 +237,7 @@ async fn start_upstream(gated: bool, response_delay: Duration) -> Upstream {
                         return;
                     }
                 };
-                serve_upstream_connection(&mut tls, gated, response_delay, &counters).await;
+                serve_upstream_connection(&mut tls, gated, response_delay, close, &counters).await;
             });
         }
     });
@@ -239,6 +250,7 @@ async fn serve_upstream_connection<S>(
     stream: &mut S,
     gated: bool,
     response_delay: Duration,
+    close: bool,
     counters: &UpstreamCounters,
 ) where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
@@ -285,8 +297,9 @@ async fn serve_upstream_connection<S>(
         if !response_delay.is_zero() {
             tokio::time::sleep(response_delay).await;
         }
+        let connection = if close { "close" } else { "keep-alive" };
         let response = format!(
-            "{status_line}\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n{body}",
+            "{status_line}\r\nContent-Length: {}\r\nConnection: {connection}\r\n\r\n{body}",
             body.len()
         );
         if stream.write_all(response.as_bytes()).await.is_err() {
@@ -295,6 +308,9 @@ async fn serve_upstream_connection<S>(
         }
         if stream.flush().await.is_err() {
             counters.failures.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        if close {
             return;
         }
     }
@@ -317,16 +333,29 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 
 /// Spawns the proxy in the background and returns the loopback address it bound.
 pub async fn spawn_proxy(cfg: config::ResolvedConfig, ca: Arc<ca::CertAuthority>) -> SocketAddr {
+    spawn_proxy_with_state(cfg, ca).await.0
+}
+
+/// Spawns the proxy and returns its shared state for deterministic metric gates.
+pub async fn spawn_proxy_with_state(
+    cfg: config::ResolvedConfig,
+    ca: Arc<ca::CertAuthority>,
+) -> (
+    SocketAddr,
+    Arc<trusted_server_cli::commands::dev::proxy::ProxyState>,
+) {
     let listener = server::bind(cfg.listen)
         .await
         .expect("should bind proxy listener");
     let addr = listener.local_addr().expect("should read proxy addr");
     let cfg = Arc::new(cfg);
+    let state = trusted_server_cli::commands::dev::proxy::ProxyState::new(cfg);
     let pac: Arc<str> = Arc::from("function FindProxyForURL(u, h) { return \"DIRECT\"; }");
+    let task_state = Arc::clone(&state);
     tokio::spawn(async move {
-        let _ = server::serve_on(listener, cfg, ca, pac).await;
+        let _ = server::serve_on_with_state(listener, task_state, ca, pac).await;
     });
-    addr
+    (addr, state)
 }
 
 /// Spawns a proxy that behaves as if it were bound on a non-loopback address,

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -747,6 +747,36 @@ pub async fn drive_get_then_post(
     vec![first, second]
 }
 
+/// Sends browser Authorization only on the first of two pooled requests.
+pub async fn drive_authorized_then_absent(
+    cfg: config::ResolvedConfig,
+    ca: Arc<ca::CertAuthority>,
+) -> Vec<ProxiedResponse> {
+    let proxy = spawn_proxy(cfg, ca).await;
+    let authority = format!("{FROM_HOST}:443");
+    let tcp = proxy_connect(proxy, &authority).await;
+    let connector = accept_any_connector();
+    let server_name = ServerName::try_from(FROM_HOST.to_string()).expect("valid server name");
+    let mut tls = connector
+        .connect(server_name, tcp)
+        .await
+        .expect("client TLS handshake with proxy leaf");
+
+    let authorized = format!(
+        "GET /authorized HTTP/1.1\r\nHost: {FROM_HOST}\r\nAuthorization: Basic ZGV2OnNlY3JldA==\r\n\r\n"
+    );
+    tls.write_all(authorized.as_bytes())
+        .await
+        .expect("should write authorized GET");
+    let first = read_http_response(&mut tls).await;
+    let absent = format!("GET /absent HTTP/1.1\r\nHost: {FROM_HOST}\r\n\r\n");
+    tls.write_all(absent.as_bytes())
+        .await
+        .expect("should write GET without authorization");
+    let second = read_http_response(&mut tls).await;
+    vec![first, second]
+}
+
 /// Streams `body` through the proxy with chunked request framing and returns
 /// the decoded chunked response body.
 pub async fn drive_chunked_body(

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -5,6 +5,8 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use rustls::DigitallySignedStruct;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
@@ -29,6 +31,35 @@ pub struct ProxiedResponse {
 /// A running upstream and the loopback address it bound.
 pub struct Upstream {
     pub addr: SocketAddr,
+    counters: Arc<UpstreamCounters>,
+}
+
+impl Upstream {
+    #[must_use]
+    pub fn snapshot(&self) -> UpstreamSnapshot {
+        UpstreamSnapshot {
+            accepted_connections: self.counters.accepted_connections.load(Ordering::Relaxed),
+            tls_handshakes: self.counters.tls_handshakes.load(Ordering::Relaxed),
+            requests: self.counters.requests.load(Ordering::Relaxed),
+            failures: self.counters.failures.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct UpstreamSnapshot {
+    pub accepted_connections: u64,
+    pub tls_handshakes: u64,
+    pub requests: u64,
+    pub failures: u64,
+}
+
+#[derive(Default)]
+struct UpstreamCounters {
+    accepted_connections: AtomicU64,
+    tls_handshakes: AtomicU64,
+    requests: AtomicU64,
+    failures: AtomicU64,
 }
 
 /// The leaf certificate the client observed at the end of a tunnel.
@@ -152,42 +183,64 @@ fn upstream_tls_acceptor() -> TlsAcceptor {
 /// Starts an HTTPS upstream that echoes the `Host`/`X-Orig-Host`/path it saw and
 /// always returns `200`. Serves keep-alive (many requests per connection).
 pub async fn start_echo_upstream() -> Upstream {
-    start_upstream(false).await
+    start_upstream(false, Duration::ZERO).await
+}
+
+/// Starts the echo upstream with a fixed delay before every response.
+pub async fn start_delayed_echo_upstream(response_delay: Duration) -> Upstream {
+    start_upstream(false, response_delay).await
 }
 
 /// Starts an HTTPS upstream that returns `401` unless an `Authorization` header
 /// is present, otherwise `200`.
 pub async fn start_gated_upstream() -> Upstream {
-    start_upstream(true).await
+    start_upstream(true, Duration::ZERO).await
 }
 
-async fn start_upstream(gated: bool) -> Upstream {
+async fn start_upstream(gated: bool, response_delay: Duration) -> Upstream {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("should bind upstream");
     let addr = listener.local_addr().expect("should read upstream addr");
     let acceptor = upstream_tls_acceptor();
+    let counters = Arc::new(UpstreamCounters::default());
+    let task_counters = Arc::clone(&counters);
     tokio::spawn(async move {
         loop {
             let Ok((tcp, _)) = listener.accept().await else {
                 break;
             };
+            task_counters
+                .accepted_connections
+                .fetch_add(1, Ordering::Relaxed);
             let acceptor = acceptor.clone();
+            let counters = Arc::clone(&task_counters);
             tokio::spawn(async move {
-                let Ok(mut tls) = acceptor.accept(tcp).await else {
-                    return;
+                let mut tls = match acceptor.accept(tcp).await {
+                    Ok(tls) => {
+                        counters.tls_handshakes.fetch_add(1, Ordering::Relaxed);
+                        tls
+                    }
+                    Err(_) => {
+                        counters.failures.fetch_add(1, Ordering::Relaxed);
+                        return;
+                    }
                 };
-                serve_upstream_connection(&mut tls, gated).await;
+                serve_upstream_connection(&mut tls, gated, response_delay, &counters).await;
             });
         }
     });
-    Upstream { addr }
+    Upstream { addr, counters }
 }
 
 /// Minimal HTTP/1.1 keep-alive loop: parse each request head, echo the headers
 /// the test cares about, respond, repeat until the peer closes.
-async fn serve_upstream_connection<S>(stream: &mut S, gated: bool)
-where
+async fn serve_upstream_connection<S>(
+    stream: &mut S,
+    gated: bool,
+    response_delay: Duration,
+    counters: &UpstreamCounters,
+) where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
 {
     let mut buf = Vec::new();
@@ -199,11 +252,16 @@ where
                 break pos + 4;
             }
             let n = match stream.read(&mut chunk).await {
-                Ok(0) | Err(_) => return,
+                Ok(0) => return,
                 Ok(n) => n,
+                Err(_) => {
+                    counters.failures.fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
             };
             buf.extend_from_slice(&chunk[..n]);
         };
+        counters.requests.fetch_add(1, Ordering::Relaxed);
         let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
         buf.drain(..head_end);
 
@@ -224,14 +282,21 @@ where
             let body = format!("host={host};orig={orig_host};fwd={fwd_host};path={path}");
             ("HTTP/1.1 200 OK", body)
         };
+        if !response_delay.is_zero() {
+            tokio::time::sleep(response_delay).await;
+        }
         let response = format!(
             "{status_line}\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n{body}",
             body.len()
         );
         if stream.write_all(response.as_bytes()).await.is_err() {
+            counters.failures.fetch_add(1, Ordering::Relaxed);
             return;
         }
-        let _ = stream.flush().await;
+        if stream.flush().await.is_err() {
+            counters.failures.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
     }
 }
 
@@ -251,7 +316,7 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 // ---- proxy lifecycle ----
 
 /// Spawns the proxy in the background and returns the loopback address it bound.
-async fn spawn_proxy(cfg: config::ResolvedConfig, ca: Arc<ca::CertAuthority>) -> SocketAddr {
+pub async fn spawn_proxy(cfg: config::ResolvedConfig, ca: Arc<ca::CertAuthority>) -> SocketAddr {
     let listener = server::bind(cfg.listen)
         .await
         .expect("should bind proxy listener");
@@ -425,6 +490,14 @@ pub async fn drive_sequential_requests(
     paths: &[&str],
 ) -> Vec<ProxiedResponse> {
     let proxy = spawn_proxy(cfg, ca).await;
+    drive_sequential_requests_through_proxy(proxy, paths).await
+}
+
+/// Issues several GETs over one keep-alive MITM tunnel to an existing proxy.
+pub async fn drive_sequential_requests_through_proxy(
+    proxy: SocketAddr,
+    paths: &[&str],
+) -> Vec<ProxiedResponse> {
     let authority = format!("{FROM_HOST}:443");
     let tcp = proxy_connect(proxy, &authority).await;
 

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -267,6 +267,124 @@ pub async fn start_gated_upstream() -> Upstream {
     start_upstream(true, Duration::ZERO, false, false).await
 }
 
+/// Starts an upstream that responds before consuming a streaming upload.
+pub async fn start_early_response_upstream() -> Upstream {
+    start_scripted_upstream(ScriptedResponse::Early).await
+}
+
+/// Starts an upstream that sends one response chunk and then stalls.
+pub async fn start_slow_response_upstream() -> Upstream {
+    start_scripted_upstream(ScriptedResponse::Slow).await
+}
+
+/// Starts an upstream that truncates a declared fixed-length response.
+pub async fn start_truncated_response_upstream() -> Upstream {
+    start_scripted_upstream(ScriptedResponse::Truncated).await
+}
+
+/// Starts an upstream that sends response trailers on every request.
+pub async fn start_trailer_upstream() -> Upstream {
+    start_scripted_upstream(ScriptedResponse::Trailers).await
+}
+
+#[derive(Clone, Copy)]
+enum ScriptedResponse {
+    Early,
+    Slow,
+    Truncated,
+    Trailers,
+}
+
+async fn start_scripted_upstream(script: ScriptedResponse) -> Upstream {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("should bind scripted upstream");
+    let addr = listener.local_addr().expect("should read scripted address");
+    let acceptor = upstream_tls_acceptor();
+    let counters = Arc::new(UpstreamCounters::default());
+    let task_counters = Arc::clone(&counters);
+    tokio::spawn(async move {
+        loop {
+            let Ok((tcp, _)) = listener.accept().await else {
+                break;
+            };
+            task_counters
+                .accepted_connections
+                .fetch_add(1, Ordering::Relaxed);
+            let acceptor = acceptor.clone();
+            let counters = Arc::clone(&task_counters);
+            tokio::spawn(async move {
+                let Ok(mut tls) = acceptor.accept(tcp).await else {
+                    counters.failures.fetch_add(1, Ordering::Relaxed);
+                    return;
+                };
+                counters.tls_handshakes.fetch_add(1, Ordering::Relaxed);
+                let mut buffered = Vec::new();
+                loop {
+                    if !read_one_head(&mut tls, &mut buffered).await {
+                        return;
+                    }
+                    counters.requests.fetch_add(1, Ordering::Relaxed);
+                    let response = match script {
+                        ScriptedResponse::Early => {
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nearly"
+                                .as_slice()
+                        }
+                        ScriptedResponse::Slow => {
+                            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n5\r\nfirst\r\n"
+                                .as_slice()
+                        }
+                        ScriptedResponse::Truncated => {
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: keep-alive\r\n\r\nabc"
+                                .as_slice()
+                        }
+                        ScriptedResponse::Trailers => {
+                            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nTrailer: x-test-trailer\r\nConnection: keep-alive\r\n\r\n4\r\ndata\r\n0\r\nx-test-trailer: done\r\n\r\n"
+                                .as_slice()
+                        }
+                    };
+                    if tls.write_all(response).await.is_err() || tls.flush().await.is_err() {
+                        return;
+                    }
+                    match script {
+                        ScriptedResponse::Early => {
+                            let mut byte = [0_u8; 1];
+                            while tls.read(&mut byte).await.is_ok_and(|count| count > 0) {}
+                            return;
+                        }
+                        ScriptedResponse::Slow => {
+                            std::future::pending::<()>().await;
+                        }
+                        ScriptedResponse::Truncated => return,
+                        ScriptedResponse::Trailers => {}
+                    }
+                }
+            });
+        }
+    });
+    Upstream { addr, counters }
+}
+
+async fn read_one_head<S>(stream: &mut S, buffered: &mut Vec<u8>) -> bool
+where
+    S: AsyncReadExt + Unpin,
+{
+    let mut chunk = [0_u8; 1024];
+    loop {
+        if let Some(position) = find_subslice(buffered, b"\r\n\r\n") {
+            buffered.drain(..position + 4);
+            return true;
+        }
+        let Ok(count) = stream.read(&mut chunk).await else {
+            return false;
+        };
+        if count == 0 {
+            return false;
+        }
+        buffered.extend_from_slice(&chunk[..count]);
+    }
+}
+
 async fn start_upstream(
     gated: bool,
     response_delay: Duration,
@@ -413,6 +531,13 @@ async fn read_chunked_message<S>(stream: &mut S) -> Option<Vec<u8>>
 where
     S: AsyncReadExt + Unpin,
 {
+    read_chunked_response(stream).await.map(|(body, _)| body)
+}
+
+async fn read_chunked_response<S>(stream: &mut S) -> Option<(Vec<u8>, String)>
+where
+    S: AsyncReadExt + Unpin,
+{
     let mut encoded = Vec::new();
     let mut scratch = [0_u8; 1024];
     let head_end = loop {
@@ -429,7 +554,7 @@ where
     decode_chunked_body(stream, encoded).await
 }
 
-async fn decode_chunked_body<S>(stream: &mut S, mut encoded: Vec<u8>) -> Option<Vec<u8>>
+async fn decode_chunked_body<S>(stream: &mut S, mut encoded: Vec<u8>) -> Option<(Vec<u8>, String)>
 where
     S: AsyncReadExt + Unpin,
 {
@@ -450,14 +575,20 @@ where
             usize::from_str_radix(std::str::from_utf8(&encoded[..line_end]).ok()?, 16).ok()?;
         encoded.drain(..line_end + 2);
         if size == 0 {
-            while encoded.len() < 2 {
+            loop {
+                if encoded.starts_with(b"\r\n") {
+                    return Some((body, String::new()));
+                }
+                if let Some(end) = find_subslice(&encoded, b"\r\n\r\n") {
+                    let trailers = String::from_utf8_lossy(&encoded[..end + 4]).to_string();
+                    return Some((body, trailers));
+                }
                 let count = stream.read(&mut scratch).await.ok()?;
                 if count == 0 {
                     return None;
                 }
                 encoded.extend_from_slice(&scratch[..count]);
             }
-            return encoded.starts_with(b"\r\n").then_some(body);
         }
         while encoded.len() < size + 2 {
             let count = stream.read(&mut scratch).await.ok()?;
@@ -651,6 +782,18 @@ async fn proxy_connect(proxy: SocketAddr, authority: &str) -> TcpStream {
     stream
 }
 
+/// Opens one browser-side TLS session through a mapped CONNECT tunnel.
+pub async fn open_mitm_client(proxy: SocketAddr) -> tokio_rustls::client::TlsStream<TcpStream> {
+    let authority = format!("{FROM_HOST}:443");
+    let tcp = proxy_connect(proxy, &authority).await;
+    let connector = accept_any_connector();
+    let server_name = ServerName::try_from(FROM_HOST.to_string()).expect("valid server name");
+    connector
+        .connect(server_name, tcp)
+        .await
+        .expect("client TLS handshake with proxy leaf")
+}
+
 /// Reads bytes until the end of the response head and returns its first line.
 async fn read_status_line(stream: &mut TcpStream) -> String {
     let mut buf = Vec::new();
@@ -775,6 +918,92 @@ pub async fn drive_authorized_then_absent(
         .expect("should write GET without authorization");
     let second = read_http_response(&mut tls).await;
     vec![first, second]
+}
+
+/// Starts a chunked upload, reads the upstream early response, then cancels it.
+pub async fn drive_early_response(proxy: SocketAddr) -> u16 {
+    let tls = open_mitm_client(proxy).await;
+    let (mut reader, mut writer) = tokio::io::split(tls);
+    let request = format!(
+        "POST /early HTTP/1.1\r\nHost: {FROM_HOST}\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nfirst\r\n"
+    );
+    writer
+        .write_all(request.as_bytes())
+        .await
+        .expect("should start streaming upload");
+    writer.flush().await.expect("should flush upload prefix");
+    let response = read_http_response(&mut reader).await;
+    drop(writer);
+    drop(reader);
+    response.status
+}
+
+/// Reads one chunk from a slow response and drops the browser tunnel.
+pub async fn cancel_slow_response(proxy: SocketAddr) {
+    let mut tls = open_mitm_client(proxy).await;
+    let request = format!("GET /slow HTTP/1.1\r\nHost: {FROM_HOST}\r\n\r\n");
+    tls.write_all(request.as_bytes())
+        .await
+        .expect("should request slow response");
+    let mut received = Vec::new();
+    let mut chunk = [0_u8; 256];
+    while !received
+        .windows(b"first".len())
+        .any(|item| item == b"first")
+    {
+        let count = tls
+            .read(&mut chunk)
+            .await
+            .expect("should read slow response");
+        assert!(count > 0, "slow response should send first chunk");
+        received.extend_from_slice(&chunk[..count]);
+    }
+}
+
+/// Returns declared and received body lengths for a truncated response.
+pub async fn drive_truncated_response(proxy: SocketAddr) -> (usize, usize) {
+    let mut tls = open_mitm_client(proxy).await;
+    let request = format!("GET /truncated HTTP/1.1\r\nHost: {FROM_HOST}\r\n\r\n");
+    tls.write_all(request.as_bytes())
+        .await
+        .expect("should request truncated response");
+    let mut received = Vec::new();
+    let read = tokio::time::timeout(Duration::from_secs(1), tls.read_to_end(&mut received))
+        .await
+        .expect("truncated browser response should terminate");
+    if let Err(error) = read {
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::UnexpectedEof,
+            "only truncated TLS EOF is expected"
+        );
+    }
+    let head_end = find_subslice(&received, b"\r\n\r\n")
+        .map(|position| position + 4)
+        .expect("should receive response head");
+    let head = String::from_utf8_lossy(&received[..head_end]);
+    let declared = header_value(&head, "content-length")
+        .and_then(|value| value.parse().ok())
+        .expect("should declare content length");
+    (declared, received.len() - head_end)
+}
+
+/// Sends two GETs and returns decoded bodies plus forwarded trailer blocks.
+pub async fn drive_trailer_requests(proxy: SocketAddr) -> Vec<(Vec<u8>, String)> {
+    let mut tls = open_mitm_client(proxy).await;
+    let mut responses = Vec::new();
+    for path in ["/trailers-one", "/trailers-two"] {
+        let request = format!("GET {path} HTTP/1.1\r\nHost: {FROM_HOST}\r\nTE: trailers\r\n\r\n");
+        tls.write_all(request.as_bytes())
+            .await
+            .expect("should request trailer response");
+        responses.push(
+            read_chunked_response(&mut tls)
+                .await
+                .expect("should decode trailer response"),
+        );
+    }
+    responses
 }
 
 /// Streams `body` through the proxy with chunked request framing and returns

--- a/crates/trusted-server-cli/tests/support/mod.rs
+++ b/crates/trusted-server-cli/tests/support/mod.rs
@@ -4,14 +4,16 @@
 #![allow(dead_code)]
 
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use rustls::DigitallySignedStruct;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 use trusted_server_cli::commands::dev::proxy::{ca, config, server};
@@ -32,6 +34,28 @@ pub struct ProxiedResponse {
 pub struct Upstream {
     pub addr: SocketAddr,
     counters: Arc<UpstreamCounters>,
+}
+
+/// A raw loopback echo upstream used for tunnel/accounting tests.
+pub struct RawUpstream {
+    pub addr: SocketAddr,
+    received: Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
+}
+
+impl RawUpstream {
+    pub fn accepted_connections(&self) -> usize {
+        self.received
+            .lock()
+            .expect("should lock raw captures")
+            .len()
+    }
+
+    pub fn captured(&self) -> Vec<Vec<u8>> {
+        self.received
+            .lock()
+            .expect("should lock raw captures")
+            .clone()
+    }
 }
 
 impl Upstream {
@@ -184,6 +208,46 @@ fn upstream_tls_acceptor() -> TlsAcceptor {
         .expect("should build upstream server config");
     config.alpn_protocols = vec![b"http/1.1".to_vec()];
     TlsAcceptor::from(Arc::new(config))
+}
+
+/// Starts a raw TCP upstream that captures and echoes every byte per connection.
+pub async fn start_raw_echo_upstream() -> RawUpstream {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("should bind raw echo upstream");
+    let addr = listener.local_addr().expect("should read raw echo address");
+    let received = Arc::new(std::sync::Mutex::new(Vec::<Vec<u8>>::new()));
+    let task_received = Arc::clone(&received);
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let index = {
+                let mut captures = task_received.lock().expect("should lock raw captures");
+                captures.push(Vec::new());
+                captures.len() - 1
+            };
+            let received = Arc::clone(&task_received);
+            tokio::spawn(async move {
+                let mut chunk = [0_u8; 2048];
+                loop {
+                    let Ok(count) = stream.read(&mut chunk).await else {
+                        return;
+                    };
+                    if count == 0 {
+                        return;
+                    }
+                    received.lock().expect("should lock raw capture")[index]
+                        .extend_from_slice(&chunk[..count]);
+                    if stream.write_all(&chunk[..count]).await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+    RawUpstream { addr, received }
 }
 
 /// Starts an HTTPS upstream that echoes the `Host`/`X-Orig-Host`/path it saw and
@@ -712,6 +776,51 @@ pub async fn connect_and_read_status(proxy: SocketAddr, authority: &str) -> Stri
     read_status_line(&mut stream).await
 }
 
+/// Opens an unmatched CONNECT tunnel and optionally pipelines payload bytes
+/// with the CONNECT head in one write.
+pub async fn open_blind_tunnel(proxy: SocketAddr, authority: &str, pipelined: &[u8]) -> TcpStream {
+    let mut stream = TcpStream::connect(proxy)
+        .await
+        .expect("should connect to proxy");
+    let mut request =
+        format!("CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\n\r\n").into_bytes();
+    request.extend_from_slice(pipelined);
+    stream
+        .write_all(&request)
+        .await
+        .expect("should write CONNECT and prefix");
+    stream.flush().await.expect("should flush CONNECT prefix");
+    let status = read_status_line(&mut stream).await;
+    assert!(
+        status.contains(" 200 "),
+        "blind CONNECT should succeed: {status}"
+    );
+    stream
+}
+
+/// Opens a stray absolute-form HTTP forward and keeps the client socket alive.
+pub async fn open_plain_forward(
+    proxy: SocketAddr,
+    upstream: SocketAddr,
+    pipelined: &[u8],
+) -> (TcpStream, Vec<u8>) {
+    let mut stream = TcpStream::connect(proxy)
+        .await
+        .expect("should connect plain client to proxy");
+    let mut request = format!(
+        "POST http://{upstream}/overread HTTP/1.1\r\nHost: {upstream}\r\nContent-Length: {}\r\n\r\n",
+        pipelined.len()
+    )
+    .into_bytes();
+    request.extend_from_slice(pipelined);
+    stream
+        .write_all(&request)
+        .await
+        .expect("should write absolute request and prefix");
+    stream.flush().await.expect("should flush plain request");
+    (stream, request)
+}
+
 // ---- client legs: a no-verify verifier so the test can trust either CA ----
 
 #[derive(Debug)]
@@ -761,6 +870,157 @@ fn accept_any_connector() -> TlsConnector {
         .with_no_client_auth();
     config.alpn_protocols = vec![b"http/1.1".to_vec()];
     TlsConnector::from(Arc::new(config))
+}
+
+struct ConnectPrefixedIo {
+    inner: TcpStream,
+    connect_head: Option<Vec<u8>>,
+    pending_write: Vec<u8>,
+    write_offset: usize,
+    response_buffer: Vec<u8>,
+    response_done: bool,
+}
+
+impl ConnectPrefixedIo {
+    fn new(inner: TcpStream, connect_head: Vec<u8>) -> Self {
+        Self {
+            inner,
+            connect_head: Some(connect_head),
+            pending_write: Vec::new(),
+            write_offset: 0,
+            response_buffer: Vec::new(),
+            response_done: false,
+        }
+    }
+
+    fn poll_flush_pending(&mut self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        while self.write_offset < self.pending_write.len() {
+            let count = match Pin::new(&mut self.inner)
+                .poll_write(cx, &self.pending_write[self.write_offset..])
+            {
+                Poll::Ready(Ok(count)) => count,
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Pending => return Poll::Pending,
+            };
+            if count == 0 {
+                return Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "proxy tunnel write returned zero",
+                )));
+            }
+            self.write_offset += count;
+        }
+        self.pending_write.clear();
+        self.write_offset = 0;
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncWrite for ConnectPrefixedIo {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        if let Some(head) = self.connect_head.take() {
+            self.pending_write.extend_from_slice(&head);
+        }
+        self.pending_write.extend_from_slice(buffer);
+        Poll::Ready(Ok(buffer.len()))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.poll_flush_pending(cx) {
+            Poll::Ready(Ok(())) => Pin::new(&mut self.inner).poll_flush(cx),
+            result => result,
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.poll_flush_pending(cx) {
+            Poll::Ready(Ok(())) => Pin::new(&mut self.inner).poll_shutdown(cx),
+            result => result,
+        }
+    }
+}
+
+impl AsyncRead for ConnectPrefixedIo {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if self.response_done {
+            if !self.response_buffer.is_empty() {
+                let count = output.remaining().min(self.response_buffer.len());
+                output.put_slice(&self.response_buffer[..count]);
+                self.response_buffer.drain(..count);
+                return Poll::Ready(Ok(()));
+            }
+            return Pin::new(&mut self.inner).poll_read(cx, output);
+        }
+
+        let mut scratch = [0_u8; 4096];
+        let mut buffered = ReadBuf::new(&mut scratch);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut buffered) {
+            Poll::Ready(Ok(())) if buffered.filled().is_empty() => Poll::Ready(Ok(())),
+            Poll::Ready(Ok(())) => {
+                self.response_buffer.extend_from_slice(buffered.filled());
+                if let Some(end) = find_subslice(&self.response_buffer, b"\r\n\r\n") {
+                    let head = String::from_utf8_lossy(&self.response_buffer[..end + 4]);
+                    if !head
+                        .lines()
+                        .next()
+                        .is_some_and(|line| line.contains(" 200 "))
+                    {
+                        return Poll::Ready(Err(std::io::Error::other(format!(
+                            "proxy CONNECT failed: {head}"
+                        ))));
+                    }
+                    self.response_buffer.drain(..end + 4);
+                    self.response_done = true;
+                    let count = output.remaining().min(self.response_buffer.len());
+                    if count == 0 {
+                        cx.waker().wake_by_ref();
+                        Poll::Pending
+                    } else {
+                        output.put_slice(&self.response_buffer[..count]);
+                        self.response_buffer.drain(..count);
+                        Poll::Ready(Ok(()))
+                    }
+                } else {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Forces CONNECT head plus rustls ClientHello into one buffered first flight.
+pub async fn drive_mitm_connect_overread(proxy: SocketAddr) -> ProxiedResponse {
+    let tcp = TcpStream::connect(proxy)
+        .await
+        .expect("should connect overread client");
+    let authority = format!("{FROM_HOST}:443");
+    let connect = format!("CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\n\r\n").into_bytes();
+    let io = ConnectPrefixedIo::new(tcp, connect);
+    let connector = accept_any_connector();
+    let server_name = ServerName::try_from(FROM_HOST.to_string()).expect("valid server name");
+    let mut tls = tokio::time::timeout(Duration::from_secs(2), connector.connect(server_name, io))
+        .await
+        .expect("prefixed TLS handshake should not stall")
+        .expect("prefixed TLS handshake should succeed");
+    let request = format!("GET /mitm-overread HTTP/1.1\r\nHost: {FROM_HOST}\r\n\r\n");
+    tls.write_all(request.as_bytes())
+        .await
+        .expect("should write mapped request");
+    tls.flush().await.expect("should flush mapped request");
+    tokio::time::timeout(Duration::from_secs(2), read_http_response(&mut tls))
+        .await
+        .expect("mapped response should not stall")
 }
 
 /// Sends `CONNECT host:port` to the proxy and reads its status line.

--- a/docs/guide/ts-dev-proxy.md
+++ b/docs/guide/ts-dev-proxy.md
@@ -33,17 +33,37 @@ logic, CMP/consent flows, first-party context — before any DNS cutover.
 **Non-goals.** Not a production proxy or load-testing tool. Does not modify any
 Fastly service. Local only, developer-facing.
 
-## Build and run
+## Install and run
 
-`ts dev proxy` is part of `crates/trusted-server-cli`, a workspace member that
-builds for the host. Because the workspace default target is `wasm32-wasip1`
-(where the CLI is an empty shell), build and run it with an explicit native
-target:
+`ts dev proxy` is a subcommand of the `ts` CLI, and is **macOS-only** — its
+dependencies are scoped to macOS, so the command is not present in the CLI on
+other platforms. On macOS, install (or update) the `ts` binary from the
+repository root (see [the CLI guide](./cli.md#install-from-source) for details):
 
 ```bash
-cargo run --manifest-path crates/trusted-server-cli/Cargo.toml \
-  --target "$(rustc -vV | sed -n 's/host: //p')" -- dev proxy --help
+cargo install-cli
 ```
+
+Rerun `cargo install-cli` after pulling CLI changes to refresh the installed
+binary. Then trust the dev CA once (see
+[the development CA](#the-development-ca)), map the production hostname to your
+upstream, and launch a browser:
+
+```bash
+ts dev proxy ca install
+ts dev proxy \
+  --map www.example-publisher.com=trusted-server-example.edgecompute.app \
+  --rewrite-host \
+  --launch chrome
+```
+
+`--rewrite-host` sends the upstream `Host: <TO>`, which most dev and staging
+upstreams require — they don't have the production hostname configured and would
+reject the default `Host: <FROM>`. See
+[Host header behavior](#host-header-behavior) for the one case where you can drop
+it.
+
+Run `ts dev proxy --help` to list every flag.
 
 ### Passing the rewrite rule
 
@@ -52,9 +72,7 @@ The upstream is always passed explicitly — there is no inference from
 shorthand, or one or more `--map FROM=TO` rules:
 
 ```bash
-cargo run --manifest-path crates/trusted-server-cli/Cargo.toml \
-  --target "$(rustc -vV | sed -n 's/host: //p')" -- dev proxy \
-  -f www.example-publisher.com -t trusted-server-example.edgecompute.app
+ts dev proxy -f www.example-publisher.com -t trusted-server-example.edgecompute.app
 ```
 
 With no `--map`/`-f`/`-t`, the proxy exits with
@@ -63,8 +81,7 @@ With no `--map`/`-f`/`-t`, the proxy exits with
 ### Explicit rule and browser launch
 
 ```bash
-cargo run --manifest-path crates/trusted-server-cli/Cargo.toml \
-  --target "$(rustc -vV | sed -n 's/host: //p')" -- dev proxy \
+ts dev proxy \
   --map www.example-publisher.com=trusted-server-example.edgecompute.app \
   --launch chrome,firefox,safari
 ```
@@ -79,7 +96,8 @@ omitted the proxy runs without opening any browser.
 ts dev proxy \
   -f www.example-publisher.com \
   -t staging.example.net \
-  --basic-auth dev:secret \
+  --rewrite-host \
+  --basic-auth-file ./staging-creds.txt \
   --launch firefox
 
 # Local instance over plain HTTP, no browser:
@@ -89,23 +107,25 @@ ts dev proxy \
   --upstream-plaintext
 ```
 
-## First run: CA setup
+## The development CA
 
-On first run the proxy generates a per-machine Certificate Authority and prints:
+The proxy relies on a per-machine Certificate Authority that your browser must
+trust. `ts dev proxy ca install` (in the quick start above) generates it if
+needed and trusts it in one step, so you don't have to run the proxy first.
+Running the proxy also generates the CA on first use, printing:
 
 ```
 generated dev CA at ~/Library/Application Support/trusted-server/dev-proxy/ca-cert.pem
 — run `ts dev proxy ca install` to trust it
 ```
 
-The CA key is stored with mode `0600` outside the repository and is never
-committed.
+The CA key is written with mode `0600` and, by default, is stored outside the
+repository; it is never committed.
 
 ### Trust the CA on macOS (Chrome and Safari)
 
 ```bash
-cargo run --manifest-path crates/trusted-server-cli/Cargo.toml \
-  --target "$(rustc -vV | sed -n 's/host: //p')" -- dev proxy ca install
+ts dev proxy ca install
 ```
 
 This adds the CA to the macOS login keychain (no `sudo` required; prompts for
@@ -120,18 +140,16 @@ Firefox profile's NSS database using `certutil`. If you are pointing an existing
 Firefox profile at the proxy manually, run:
 
 ```bash
-certutil -A -n "Trusted Server DEV-ONLY Proxy CA" \
+certutil -A -n "Trusted Server DEV-ONLY Proxy CA — DO NOT TRUST IN PRODUCTION" \
   -t "CT,," \
-  -i "$(cargo run --manifest-path crates/trusted-server-cli/Cargo.toml \
-    --target "$(rustc -vV | sed -n 's/host: //p')" -- dev proxy ca path)" \
-  -d "$HOME/Library/Application Support/Firefox/Profiles/<profile>"
+  -i "$(ts dev proxy ca path)" \
+  -d "sql:$HOME/Library/Application Support/Firefox/Profiles/<profile>"
 ```
 
 ### Revoking trust when done
 
 ```bash
-cargo run --manifest-path crates/trusted-server-cli/Cargo.toml \
-  --target "$(rustc -vV | sed -n 's/host: //p')" -- dev proxy ca uninstall
+ts dev proxy ca uninstall
 ```
 
 This removes the CA from the macOS keychain. Run it when you are finished —
@@ -175,8 +193,9 @@ all HTML/URL rewriting to it (it prefers `X-Forwarded-Host`, then `Host`), so
 **first-party URLs always stay on the production domain regardless of the `Host`
 header**. That decouples routing (`Host`) from the first-party host.
 
-By default `Host: <FROM>` too, which works against a Trusted Server Compute
-upstream because Fastly routes by SNI (`= TO`) and passes `Host` through unchanged.
+By default `Host: <FROM>` too. Fastly routes by SNI (`= TO`) and passes `Host`
+through unchanged, so `Host: <FROM>` reaches the upstream — but the upstream still
+has to be configured to accept it, which a dev or staging service usually isn't.
 
 **Targeting a specific server by IP.** To point at a particular server or load
 balancer — for example when the `TO` hostname isn't in DNS yet — keep `--to` a
@@ -208,9 +227,12 @@ hostname (e.g. a Fastly Deliver service that rejects an unconfigured `Host`), pa
 > **Caveat with real Trusted Server adapters.** The Fastly and Spin adapter
 > request paths strip inbound `X-Forwarded-Host` before routing, so with
 > `--rewrite-host` a real Trusted Server upstream falls back to `Host` (`TO`) and
-> emits first-party URLs on `TO`, not `FROM`. Prefer the default (no
-> `--rewrite-host`) with Trusted Server upstreams; reach for `--rewrite-host`
-> only when the upstream rejects an unconfigured `Host`.
+> emits first-party URLs on `TO`, not `FROM`. Even so, `--rewrite-host` is the
+> right choice for most upstreams — dev and staging services rarely have the
+> production hostname configured and would reject the plain `Host: <FROM>`. Drop
+> it only when the upstream is configured to accept `Host: <FROM>` and you
+> specifically need first-party URLs anchored to `FROM` — the `--resolve` example
+> above is exactly that case.
 
 The TLS SNI is always the `TO` host either way:
 
@@ -257,11 +279,14 @@ Options:
       --basic-auth-file <PATH>  Read USER:PASS from a file
       --insecure                Skip upstream TLS certificate verification
       --upstream-plaintext      Connect to upstream over plain HTTP
+      --connect-timeout <SECONDS>  Upstream connect timeout in seconds [default: 10]
       --ca-dir <PATH>           CA cert/key directory [default: ~/Library/Application Support/
                                 trusted-server/dev-proxy on macOS]
 ```
 
-The tool is flags-only; there are no environment variable overrides.
+The tool is flags-only; there are no environment variable overrides. The
+`[COMMAND]` slot is the `ca` subcommand — see
+[CA companion commands](#ca-companion-commands).
 
 ## Browser details
 

--- a/docs/guide/ts-dev-proxy.md
+++ b/docs/guide/ts-dev-proxy.md
@@ -57,11 +57,13 @@ ts dev proxy \
   --launch chrome
 ```
 
-`--rewrite-host` sends the upstream `Host: <TO>`, which most dev and staging
-upstreams require — they don't have the production hostname configured and would
-reject the default `Host: <FROM>`. See
-[Host header behavior](#host-header-behavior) for the one case where you can drop
-it.
+`--rewrite-host` sends the upstream `Host: <TO>` so upstreams that reject the
+default `Host: <FROM>` — most dev and staging services, which aren't configured
+for the production hostname — still serve a page. Trade-off: against a real
+Trusted Server adapter, first-party URLs then render on the upstream host, not the
+production domain. To keep them on the production domain, point at an upstream that
+accepts `Host: <FROM>` and omit `--rewrite-host` — see
+[Host header behavior](#host-header-behavior).
 
 Run `ts dev proxy --help` to list every flag.
 
@@ -78,6 +80,9 @@ ts dev proxy -f www.example-publisher.com -t trusted-server-example.edgecompute.
 With no `--map`/`-f`/`-t`, the proxy exits with
 `no rewrite rule: pass --map FROM=TO (or -f/--from with -t/--to)`.
 
+Connection options — `--rewrite-host`, `--basic-auth`/`--basic-auth-file`,
+`--insecure`, and `--upstream-plaintext` — apply to every mapping, not per-rule.
+
 ### Explicit rule and browser launch
 
 ```bash
@@ -87,7 +92,9 @@ ts dev proxy \
 ```
 
 `--launch` takes a comma list (`chrome`, `firefox`, `safari`) or `all`. When
-omitted the proxy runs without opening any browser.
+omitted the proxy runs without opening any browser. With multiple `--map` rules,
+every mapping is proxied, but `--launch` opens only the first rule's `FROM`
+hostname — navigate to the others manually.
 
 ### Other examples
 
@@ -135,9 +142,11 @@ will trust the proxy's certificates immediately.
 ### Trust the CA in Firefox
 
 Firefox does not reliably consult the macOS login keychain. When you use
-`--launch firefox`, the proxy automatically imports the CA into the temporary
-Firefox profile's NSS database using `certutil`. If you are pointing an existing
-Firefox profile at the proxy manually, run:
+`--launch firefox`, the proxy imports the CA into the temporary Firefox profile's
+NSS database using `certutil`. `certutil` is not built into macOS — install it
+with `brew install nss`; without it the proxy prints a warning and Firefox opens
+with certificate errors. If you are pointing an existing Firefox profile at the
+proxy manually, run:
 
 ```bash
 certutil -A -n "Trusted Server DEV-ONLY Proxy CA — DO NOT TRUST IN PRODUCTION" \
@@ -190,8 +199,10 @@ trust the new CA.
 The proxy always sends `X-Forwarded-Host: <FROM>` (the production hostname) — the
 standard "original host" header for a forward proxy. Trusted Server core anchors
 all HTML/URL rewriting to it (it prefers `X-Forwarded-Host`, then `Host`), so
-**first-party URLs always stay on the production domain regardless of the `Host`
-header**. That decouples routing (`Host`) from the first-party host.
+**first-party URLs stay on the production domain regardless of the `Host` header —
+as long as the upstream preserves `X-Forwarded-Host`**. That decouples routing
+(`Host`) from the first-party host. (Real Trusted Server adapters strip inbound
+`X-Forwarded-Host`; the caveat below covers what that means with `--rewrite-host`.)
 
 By default `Host: <FROM>` too. Fastly routes by SNI (`= TO`) and passes `Host`
 through unchanged, so `Host: <FROM>` reaches the upstream — but the upstream still
@@ -306,7 +317,7 @@ the terminal (only that command is elevated; the proxy keeps running as you). If
 `sudo` is declined or there is no terminal (e.g. the proxy is backgrounded), it
 prints the exact `networksetup` command and the System Settings path so you can
 set the PAC manually. The change is system-wide (all apps) but PAC-scoped to the
-`FROM` hosts, and only while the proxy runs. The prior setting — including
+`FROM` hosts, and — on a clean exit — only while the proxy runs. The prior setting — including
 whether auto-proxy was enabled or disabled — is saved and restored. On a clean
 exit (Ctrl-C) the restore uses `sudo` and may prompt once more if a long run
 outlived the cached credential. After a hard kill (`SIGKILL`) the next
@@ -316,11 +327,11 @@ command.
 
 ## Troubleshooting
 
-| Symptom                                        | Cause                                                                                                                                                                                       | Fix                                                                                                                                                                                                |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "unknown domain" or `404` from upstream        | The upstream service does not accept `Host: <FROM>` (the default). A domain can be active on only one Fastly service at a time, so you cannot add the production hostname to a dev service. | Use a Trusted Server Compute upstream (routes by SNI, not `Host`), or pass `--rewrite-host` to send `Host: <TO>`.                                                                                  |
-| Upstream returns `401`                         | Upstream is behind Basic auth.                                                                                                                                                              | Pass `--basic-auth user:pass` or `--basic-auth-file ./creds.txt`.                                                                                                                                  |
-| Upstream unreachable (`502` / `503`)           | Upstream service is down or the domain is not provisioned.                                                                                                                                  | Verify the upstream URL and its Fastly service health.                                                                                                                                             |
-| Browser shows an untrusted-certificate warning | The dev CA is not trusted in the browser.                                                                                                                                                   | Run `ts dev proxy ca install` for Chrome and Safari. For Firefox, use `--launch firefox` (auto-imports) or run `certutil` manually (see above). After `ca regenerate`, re-trust with `ca install`. |
-| Listen address already in use                  | Another process holds port 18080.                                                                                                                                                           | Pass `--listen 127.0.0.1:18081` (or another free port).                                                                                                                                            |
-| `--listen` rejected as non-loopback            | A non-loopback address was given without the required flag.                                                                                                                                 | Add `--allow-non-loopback`.                                                                                                                                                                        |
+| Symptom                                        | Cause                                                                                                                                                                                       | Fix                                                                                                                                                                                                                                                  |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "unknown domain" or `404` from upstream        | The upstream service does not accept `Host: <FROM>` (the default). A domain can be active on only one Fastly service at a time, so you cannot add the production hostname to a dev service. | Use a Trusted Server Compute upstream (routes by SNI, not `Host`), or pass `--rewrite-host` to send `Host: <TO>`.                                                                                                                                    |
+| Upstream returns `401`                         | Upstream is behind Basic auth.                                                                                                                                                              | Pass `--basic-auth user:pass` or `--basic-auth-file ./creds.txt`.                                                                                                                                                                                    |
+| Upstream unreachable (`502` / `503`)           | Upstream service is down or the domain is not provisioned.                                                                                                                                  | Verify the upstream URL and its Fastly service health.                                                                                                                                                                                               |
+| Browser shows an untrusted-certificate warning | The dev CA is not trusted in the browser.                                                                                                                                                   | Run `ts dev proxy ca install` for Chrome and Safari. For Firefox, use `--launch firefox` (auto-imports when `certutil` is installed — `brew install nss`) or run `certutil` manually (see above). After `ca regenerate`, re-trust with `ca install`. |
+| Listen address already in use                  | Another process holds port 18080.                                                                                                                                                           | Pass `--listen 127.0.0.1:18081` (or another free port).                                                                                                                                                                                              |
+| `--listen` rejected as non-loopback            | A non-loopback address was given without the required flag.                                                                                                                                 | Add `--allow-non-loopback`.                                                                                                                                                                                                                          |

--- a/docs/guide/ts-dev-proxy.md
+++ b/docs/guide/ts-dev-proxy.md
@@ -327,6 +327,11 @@ command.
 
 ## Troubleshooting
 
+Mapped HTTP/1.1 upstream connections are reused automatically. With debug
+logging enabled, a clean shutdown prints an aggregate, redacted proxy metrics
+summary that can help distinguish DNS, connection, TLS, and pool wait latency;
+it never includes request URLs, headers, credentials, or certificate contents.
+
 | Symptom                                        | Cause                                                                                                                                                                                       | Fix                                                                                                                                                                                                                                                  |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | "unknown domain" or `404` from upstream        | The upstream service does not accept `Host: <FROM>` (the default). A domain can be active on only one Fastly service at a time, so you cannot add the production hostname to a dev service. | Use a Trusted Server Compute upstream (routes by SNI, not `Host`), or pass `--rewrite-host` to send `Host: <TO>`.                                                                                                                                    |

--- a/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
@@ -141,7 +141,20 @@ A fresh adversarial review found and corrected seven lifecycle gaps before merge
 
 The exact remote model requested by the plan uses 100 empty GETs at concurrency
 20, 30 ms injected connection delay, 30 ms injected TLS delay, and a 25 ms
-upstream response delay. After two warmups and ten alternating runs:
+upstream response delay. The recorded run used the following exact alternating
+commands. Runs 1–2 were discarded as warmups; runs 3–12 produced the ten samples
+per variant:
+
+```bash
+for run in $(seq 1 12); do
+  echo "remote pair ${run}"
+  TS_PERF_VARIANT=remote_baseline cargo test --package trusted-server-cli --target aarch64-apple-darwin --test proxy_perf perf_http1_remote_model -- --ignored --nocapture --test-threads=1
+  TS_PERF_VARIANT=remote_pooled cargo test --package trusted-server-cli --target aarch64-apple-darwin --test proxy_perf perf_http1_remote_model -- --ignored --nocapture --test-threads=1
+done
+```
+
+The workload now rejects any variant other than `remote_baseline` or
+`remote_pooled`, so a default local-delay run cannot be labeled as remote.
 
 | Variant       | Median (µs) | p95 (µs) | MAD (µs) | Connections / handshakes | Failures |
 | ------------- | ----------: | -------: | -------: | -----------------------: | -------: |

--- a/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
@@ -113,3 +113,43 @@ socket-option code was removed.
 - Waiters: 32 per origin, 128 global, 30-second acquisition timeout
 - DNS: 30-second TTL, 64 entries
 - Shutdown manager drain: 2 seconds after Safari/system proxy restoration
+
+## Post-implementation self-review corrections
+
+A fresh adversarial review found and corrected seven lifecycle gaps before merge:
+
+- request framing and replay eligibility are now captured before hop-by-hop
+  sanitation, so removing `Transfer-Encoding` cannot misclassify a chunked
+  upload as empty;
+- upload completion requires terminal EOS after trailers, and response reuse
+  rejects streaming/failed uploads, close intent, and terminated drivers;
+- DNS lookup work is independent of any individual waiter, so caller
+  cancellation cannot poison an in-flight key. One owned success or failure is
+  fanned out, failures are not cached, and TTL behavior is tested under paused
+  time;
+- connector abort handles are registered with the manager before DNS/TCP/TLS
+  awaits. Shutdown and caller cancellation therefore abort pending connector
+  tasks and reconcile the exact reservation;
+- stale post-dispatch retry now reconstructs only a pre-sanitization-proven empty
+  GET/HEAD/OPTIONS request, uses a fresh connection, and runs at most once;
+- performance variants are injected by integration-test support. Production
+  startup no longer reads `TS_PERF_VARIANT`, and queue-wait metrics are now wired
+  from actor admission;
+- a 2 MiB chunked upload/response round trip proves byte identity through both
+  streaming adapters, while priority shutdown is tested with all 64 ordinary
+  command slots occupied.
+
+The exact remote model requested by the plan uses 100 empty GETs at concurrency
+20, 30 ms injected connection delay, 30 ms injected TLS delay, and a 25 ms
+upstream response delay. After two warmups and ten alternating runs:
+
+| Variant       | Median (µs) | p95 (µs) | MAD (µs) | Connections / handshakes | Failures |
+| ------------- | ----------: | -------: | -------: | -----------------------: | -------: |
+| pool disabled |     534,816 |  557,768 |    7,220 |                100 / 100 |        0 |
+| pooled, cap 6 |   583,207.5 |  585,816 |  1,925.5 |                    6 / 6 |        0 |
+
+The concurrency-20 result is intentionally a saturation/HTTP/2-entry diagnostic:
+the production six-connection bound trades 9.0% duration for bounded upstream
+load while reducing connections and handshakes by 94%. Retention regression
+gates remain the sequential and matched-concurrency-six comparisons documented
+above; this diagnostic is not presented as an HTTP/1 latency win.

--- a/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
@@ -31,10 +31,85 @@ and ten alternating baseline/pooled runs before drawing timing conclusions.
 
 ## Experiment Decisions
 
-| Stage                       | Decision | Evidence |
-| --------------------------- | -------- | -------- |
-| HTTP/1 pooling              | Pending  | Task 10  |
-| Buffered initial-head parse | Pending  | Task 10  |
-| DNS cache                   | Pending  | Task 10  |
-| Upstream HTTP/2             | Pending  | Task 10  |
-| `TCP_NODELAY`               | Pending  | Task 14  |
+| Stage                       | Decision | Evidence                                               |
+| --------------------------- | -------- | ------------------------------------------------------ |
+| HTTP/1 pooling              | RETAIN   | 100→1 sequential connections; 59.7% median improvement |
+| Buffered initial-head parse | RETAIN   | Entry 28.5%; retained parser contribution 8.6%         |
+| DNS cache                   | RETAIN   | 13.6% median churn-workload improvement                |
+| Upstream HTTP/2             | REJECT   | Entry passed; bounded-capacity feasibility failed      |
+| `TCP_NODELAY`               | REJECT   | Both one-sided median gains were below 3%              |
+
+## HTTP/1 Pooling Results
+
+Commands used the ignored `proxy_perf` workloads with two discarded warmup
+rounds, then ten alternating runs per variant. `TS_PERF_VARIANT=baseline` is a
+harness-only pool-disabled mode; it is not a CLI option.
+
+| Workload / variant       | Median (µs) |  p95 (µs) | MAD (µs) | Connections / handshakes | Failures |
+| ------------------------ | ----------: | --------: | -------: | -----------------------: | -------: |
+| sequential / baseline    |    83,962.5 |   108,705 |    883.5 |                100 / 100 |        0 |
+| sequential / pooled      |    33,828.5 |    41,289 |    335.5 |                    1 / 1 |        0 |
+| concurrency 6 / baseline |   601,727.5 | 1,296,127 |    4,225 |                100 / 100 |        0 |
+| concurrency 6 / pooled   |   566,188.5 |   574,799 |    3,627 |            53–68 / 53–68 |        0 |
+
+Sequential localhost duration improved 59.7%, with the structural result of
+100-to-1 TCP connections and TLS handshakes. Matched concurrency improved 5.9%.
+At exactly six synchronized clients, the two-idle-per-origin bound deliberately
+retires burst-surplus connections between waves; under concurrency-20
+saturation, queued work retains exactly six live connections.
+
+## Buffered Initial Parsing
+
+The 1,000-connection PAC workload measured the original byte reader at
+77,933 µs total and 22,239 µs aggregate parse time (28.5%), clearing the 5%
+entry gate. The retained 1 KiB chunk reader plus exact-once prefixed I/O measured
+48,667 µs total and 4,205 µs parse time (8.6%). The 8 KiB limit applies only
+through the header terminator; over-read bytes are replayed on MITM, blind
+tunnel, and plain-forward paths.
+
+## DNS Cache
+
+The post-pooling DNS workload measured 1,936 µs of lookup time against 8,590 µs
+of upstream-header time (22.5%), clearing entry. The retained cache uses a
+30-second TTL, 64-entry LRU bound, concurrent-miss coalescing, no failure
+caching, and strict `--resolve` bypass.
+
+| Variant        | Median (µs) | p95 (µs) | MAD (µs) | Lookups per 100 opens |
+| -------------- | ----------: | -------: | -------: | --------------------: |
+| cache disabled |   111,461.5 |  120,372 |    1,514 |                   100 |
+| cache enabled  |    96,273.5 |   97,998 |    1,135 |      1 miss + 99 hits |
+
+The cache improved median duration by 13.6% with no added failures, so it was
+retained.
+
+## HTTP/2 Feasibility
+
+The cap-6 versus harness-only cap-20 entry comparison measured medians of
+521,830.5 µs and 200,660.5 µs respectively (61.5% contribution), so feasibility
+was evaluated. It was rejected because Hyper's maintained public client API
+does not expose the peer's current and dynamically lowered
+`SETTINGS_MAX_CONCURRENT_STREAMS` in a way that can prove the combined manager
+and Hyper waiter bounds. `SendRequest::ready()` is not sufficient. No `http2`
+feature, proof scaffolding, or dormant production code remains.
+
+## TCP_NODELAY
+
+Ten retained samples after two warmups produced:
+
+| Variant       | Median (µs) | p95 (µs) | MAD (µs) | Gain vs off |
+| ------------- | ----------: | -------: | -------: | ----------: |
+| off/off       |    40,794.5 |   42,649 |    1,368 |           — |
+| browser only  |    40,329.5 |   42,199 |    1,844 |        1.1% |
+| upstream only |    40,166.5 |   42,561 |  2,032.5 |        1.5% |
+| both          |    40,568.5 |   41,928 |    827.5 |        0.6% |
+
+Neither one-sided variant reached the 3% retention threshold. All experimental
+socket-option code was removed.
+
+## Retained Constants
+
+- HTTP/1 live connections: 6 per origin, 64 global
+- Idle HTTP/1 connections: 2 per origin, 32 global, 60-second expiry
+- Waiters: 32 per origin, 128 global, 30-second acquisition timeout
+- DNS: 30-second TTL, 64 entries
+- Shutdown manager drain: 2 seconds after Safari/system proxy restoration

--- a/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
@@ -1,0 +1,40 @@
+# Dev Proxy Performance Implementation Notes
+
+## Environment
+
+- Date: 2026-07-11
+- Machine architecture: Apple arm64
+- Operating system: macOS 26.5.1 (25F80)
+- Rust: 1.95.0 (`aarch64-apple-darwin`, LLVM 22.1.2)
+- Branch: `perf/dev-proxy-optimization`
+
+## Task 1: Baseline
+
+Command:
+
+```bash
+cargo test --package trusted-server-cli --target aarch64-apple-darwin --test proxy_perf -- --ignored --nocapture --test-threads=1
+```
+
+Raw output:
+
+```text
+PERF_RUN workload=matched_concurrency_6 variant=baseline run=1 duration_us=608415 tcp_attempts=100 tcp_established=100 tls_handshakes=100 failures=0
+PERF_RUN workload=saturation_concurrency_20 variant=baseline run=1 duration_us=206839 tcp_attempts=100 tcp_established=100 tls_handshakes=100 failures=0
+PERF_RUN workload=sequential_tls variant=baseline run=1 duration_us=70804 tcp_attempts=100 tcp_established=100 tls_handshakes=100 failures=0
+```
+
+The baseline confirms the structural problem: every request establishes a new
+upstream TCP connection and performs a new TLS handshake. These are single-run
+foundation measurements, not retention evidence. Task 10 performs two warmups
+and ten alternating baseline/pooled runs before drawing timing conclusions.
+
+## Experiment Decisions
+
+| Stage                       | Decision | Evidence |
+| --------------------------- | -------- | -------- |
+| HTTP/1 pooling              | Pending  | Task 10  |
+| Buffered initial-head parse | Pending  | Task 10  |
+| DNS cache                   | Pending  | Task 10  |
+| Upstream HTTP/2             | Pending  | Task 10  |
+| `TCP_NODELAY`               | Pending  | Task 14  |

--- a/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md
@@ -153,3 +153,34 @@ the production six-connection bound trades 9.0% duration for bounded upstream
 load while reducing connections and handshakes by 94%. Retention regression
 gates remain the sequential and matched-concurrency-six comparisons documented
 above; this diagnostic is not presented as an HTTP/1 latency win.
+
+## Final review backfill
+
+The final PR review produced three code corrections and a broader lifecycle test
+matrix:
+
+- terminal response EOS now determines completed versus failed request metrics
+  independently from whether the upstream connection is reusable, including
+  already-empty responses that Hyper does not need to poll;
+- a reused sender that fails readiness retries through `acquire_fresh`, so it
+  cannot consume a second idle sender;
+- the rejected HTTP/2 `ApplicationMode` key discriminant was removed. Retained
+  origin identity is transport, normalized TO reference identity, port,
+  verification mode, and address policy; both TLS configurations advertise only
+  HTTP/1.1;
+- response trailer frames are serialized before lease reconciliation, with every
+  downstream trailer declaration regenerated after hop-by-hop sanitation. DATA,
+  trailers, and terminal completion now precede reuse;
+- connector cancellation and owner unwind abort before DNS/TCP and reconcile
+  capacity exactly once;
+- integration coverage now includes early responses, browser cancellation,
+  truncated bodies, response trailers, per-request Authorization isolation,
+  the `--insecure` warning, 65 blind plus 65 plain-forward connections bypassing
+  mapped pool limits, and exact-once over-read delivery to blind, plain, and MITM
+  consumers;
+- Ctrl-C cleanup is tested in the exact restore-system-proxy → stop accept loop →
+  bounded manager-drain order, with delayed driver reconciliation covered
+  separately;
+- feasible cross-rule cases prove shared logical TO reuse and distinct TO-port
+  isolation. Process-global TLS/plaintext and secure/insecure combinations remain
+  independently covered at the origin-key and TLS-config boundary.

--- a/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
@@ -78,7 +78,7 @@ fn snapshot_separates_attempts_from_established() {
 - [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" metrics::tests`. Expected: RED because metrics do not exist.
 - [ ] Implement `ProxyMetrics` with `AtomicU64` fields and fixed atomic duration buckets, including methods for initial-head parse, pool acquisition, and queue wait. Expose `snapshot`, phase-recording methods, and a redacted debug summary; retain no per-request labels or samples. Task 1 uses fixture counters for the baseline; runtime phase wiring occurs when `ProxyState` reaches `server.rs` in Task 6.
 - [ ] Extend the TLS upstream fixture with shared accepted-connection, request, handshake, and failure counters.
-- [ ] Add two baseline `#[ignore = "manual performance workload"]` tests: 100 sequential TLS GETs and 100 delayed GETs at concurrency 20. Add the injectable remote-latency model in Task 10 after the connection factory exists.
+- [ ] Add baseline `#[ignore = "manual performance workload"]` tests for 100 sequential TLS GETs, 100 delayed GETs at matched concurrency six, and a separate concurrency-20 saturation workload. Add the injectable remote-latency model in Task 10 after the connection factory exists.
 - [ ] Run the ignored harness with `--ignored --nocapture --test-threads=1`. Expected baseline: approximately 100 established upstream connections and handshakes for 100 sequential requests.
 - [ ] Record raw output, machine, OS, Rust version, and command in implementation notes.
 - [ ] Run `./scripts/test-cli.sh` and commit as `Establish dev proxy performance baseline`.
@@ -125,35 +125,38 @@ pub enum ReferenceIdentity { Dns(Arc<str>), Ip(IpAddr) }
 
 - [ ] Add Tokio `test-util` only to the macOS dev-dependency feature set.
 - [ ] Note in the code/implementation notes that Cargo feature unification makes `test-util` available in the macOS test build, while pause/advance behavior remains inert unless tests explicitly use it.
-- [ ] With paused time and a test harness that observes `ConnectRequested` commands and manually replies `Connected`, write failing tests for: six live HTTP/1 connections per origin, 64 globally, two idle per origin, 32 idle globally, 32 queued per origin, 128 queued globally, FIFO wakeup, dropped-waiter removal, and 30-second timeout.
+- [ ] With paused time and a test harness that observes `ConnectRequested` commands and manually replies `Connected`, write failing tests for: six live HTTP/1 connections per origin, 64 globally, two idle per origin, 32 idle globally, 32 queued per origin, 128 queued globally, FIFO wakeup within an origin, oldest-admissible wakeup across origins without head-of-line blocking, dropped-waiter removal, and 30-second timeout.
 - [ ] Add a test proving origin/global admission is atomic and never reserves one capacity while waiting for the other.
 - [ ] Run manager tests. Expected: RED because the actor is absent.
 - [ ] Implement one bounded command actor:
 
 ```rust
 enum Command {
-    Acquire { key: OriginKey, reply: oneshot::Sender<Result<Lease, AcquireError>> },
+    Acquire { key: OriginKey, ticket: Arc<AcquireTicket>, reply: oneshot::Sender<Result<Lease, AcquireError>> },
     Return(IdleConnection),
-    Cancel(WaiterId),
-    Expire(Instant),
-    Shutdown { reply: oneshot::Sender<()> },
 }
 
-enum LifecycleEvent {
+enum ControlEvent {
+    Cancel(WaiterId),
+    Shutdown { reply: oneshot::Sender<()> },
     ConnectFinished { id: ConnectionId, key: OriginKey, result: Result<IdleConnection, ConnectError> },
     DriverClosed(ConnectionId),
 }
 ```
 
 - [ ] Keep all counts and FIFO queues actor-owned. Spawn connection work and report completion; never await network work inside the actor.
-- [ ] Use two lanes: a bounded ordinary `mpsc::channel` for Acquire/Return/Cancel/Shutdown and an unbounded lifecycle channel for `ConnectFinished` and `DriverClosed`. The actor selects both lanes; spawned network completion and synchronous drop never use `try_send` on the bounded lane.
+- [ ] Use two lanes: a bounded ordinary `mpsc::channel` for Acquire/Return and an unbounded control/lifecycle channel for exactly-once waiter `Cancel`, the single owner-issued `Shutdown`, `ConnectFinished`, and `DriverClosed`. Use `tokio::select! { biased; ... }` to service control first; cancellation, shutdown delivery, spawned network completion, and synchronous drop never wait on or use `try_send` against the bounded lane.
+- [ ] Give every acquire a unique waiter ID and shared `AcquireTicket` with atomic `Pending`, `Cancelled`, and `Resolved` states. Arm its drop guard only after the bounded ordinary send succeeds. Dropping races `Pending -> Cancelled` and emits one priority `Cancel` only on success; every terminal manager result races `Pending -> Resolved` before sending a lease or acquisition error. Check ticket state when dequeuing Acquire and before later admission/timeout, so Cancel may overtake Acquire without a tombstone.
+- [ ] Prove the unbounded API lane is logically bounded: only successfully enqueued ordinary acquires and at most 128 admitted waiter IDs can emit one cancellation before resolution; no more than 64 manager-owned connection IDs exist; the driver start latch prevents one connection ID from having `ConnectFinished` and `DriverClosed` outstanding together; and only one `Shutdown` producer exists. Document this invariant beside the channel construction.
+- [ ] Test cancellation overtaking its Acquire, cancellation while queued with the ordinary lane full, and simultaneous races against admission and timeout. Every case resolves the ticket and manager accounting once; a resolved ticket cannot emit a later stale cancellation.
 - [ ] Store production defaults in injectable `PoolLimits`; permit harness-only cap variants and pool-disabled baseline mode without adding CLI flags.
 - [ ] Make capacity driver-owned: in actor tests, closing a lease emits an abort request but only a synthetic `DriverClosed(ConnectionId)` decrements live counts. Defer the real socket/upload assertion to Task 7 after the connector and body wrapper exist.
-- [ ] Use one next-deadline timer rather than a task per idle connection. Add paused-time assertions at 59 seconds (still idle) and 60 seconds (expiry requests abort). Expiry removes the entry but does not decrement/admit until `DriverClosed`.
-- [ ] Add actor-shutdown tests proving all waiters are failed, every live driver is aborted, queues/idle maps are cleared, and counts reach zero only through synthetic `DriverClosed` events.
-- [ ] Implement a Closing state: `Shutdown` rejects new Acquire commands, fails queued waiters, aborts every driver, and continues processing both unbounded lifecycle events. Reconcile every `ConnectFinished` by its reserved `ConnectionId`, never by key; failure releases that exact connecting count, while success publishes nothing, aborts the new driver, and waits for matching `DriverClosed`. Acknowledge only when connecting and driver counts are both zero.
+- [ ] Use one actor-owned next-deadline timer branch for waiter acquisition deadlines and idle expiry rather than channel messages or a task per entry. Add paused-time assertions at 29/30 seconds for waiters and 59/60 seconds for idle connections. Idle expiry removes the entry and requests abort but does not decrement/admit until `DriverClosed`.
+- [ ] Add actor-shutdown tests proving priority `Shutdown` is observed with the ordinary lane full, all waiters are failed, every pending connector and live driver is aborted, queues/idle maps are cleared, and counts reach zero only through synthetic `ConnectFinished`/`DriverClosed` events.
+- [ ] Implement a Closing state: `Shutdown` rejects new Acquire commands, fails queued waiters, aborts every connector and driver, and continues processing unbounded lifecycle events. Reconcile every `ConnectFinished` by its reserved `ConnectionId`, never by key; failure/cancellation releases that exact connecting count, while success publishes nothing, aborts the new driver, and waits for matching `DriverClosed`. Acknowledge only when connecting and driver counts are both zero.
 - [ ] Add shutdown-race tests for both successful and failed `ConnectFinished` after Closing begins; prove no connection reaches a waiter and capacity is reconciled exactly once.
-- [ ] Saturate the bounded ordinary channel in a paused-time actor test, mass-abort drivers, and prove every unbounded lifecycle event is received and zero-live acknowledgment succeeds.
+- [ ] Add both message-order tests: `Return` then `DriverClosed` removes an idle connection once; priority `DriverClosed` then stale `Return` discards the sender without another decrement or invariant failure.
+- [ ] Saturate the bounded ordinary channel in a paused-time actor test, enqueue priority `Shutdown`, mass-abort drivers, and prove shutdown is observed promptly, every lifecycle event is received, and zero-live acknowledgment succeeds.
 - [ ] Run manager tests. Expected: GREEN without wall-clock sleeps.
 - [ ] Commit as `Add bounded dev proxy upstream manager`.
 
@@ -167,7 +170,7 @@ enum LifecycleEvent {
 - [ ] Fake DNS must consume part of the deadline; prove each remaining address receives at most `remaining / addresses_left` and no attempt extends the original deadline.
 - [ ] Run focused tests. Expected: RED because `ConnectionFactory` is absent.
 - [ ] Define `ProxyRequestBody = BoxBody<Bytes, ProxyBodyError>` in `upstream/mod.rs`, where `ProxyBodyError` wraps `hyper::Error` and represents local cancellation. Then implement a narrow injectable factory returning an opened HTTP/1 sender, driver health, explicit abort handle, driver drop guard, connection ID, and actual peer.
-- [ ] Allocate `ConnectionId` and register a Connecting reservation in the actor before spawning network work. Include that ID in `ConnectFinished`. Start every successful Hyper driver behind a one-shot latch: enqueue completion, let the actor transition the exact reservation to Live/Closing, then release the latch. With simultaneous connects for one key, prove success/failure affects only its ID; also prove `DriverClosed` cannot arrive first and unknown IDs are never published/reconciled twice.
+- [ ] Allocate `ConnectionId`, register a Connecting reservation, and retain a connector abort handle in the actor before spawning network work. Give every connector an exactly-once completion guard: normal completion sends its `ConnectFinished` result and disarms it; cancellation, actor-requested abort, or unwind synchronously sends cancelled completion on drop. Start every successful Hyper driver behind a one-shot latch: enqueue completion, let the actor transition the exact reservation to Live/Closing, then release the latch. With simultaneous connects for one key, prove success/failure affects only its ID; abort and unwind tests must reconcile Connecting once, and `DriverClosed` must never arrive before registration.
 - [ ] Preserve IP-literal compatibility: DNS identities send SNI and validate DNS SAN; IP identities send no DNS SNI and validate IP SAN. Mark IP rules HTTP/1-required.
 - [ ] Compute one deadline before resolution. Record DNS lookup duration, TCP attempt before `connect`, established/connect duration after success, TLS handshake duration after TLS success, and HTTP handshake duration after Hyper success.
 - [ ] Spawn one Hyper driver per opened connection and report termination to the actor.
@@ -219,7 +222,7 @@ pub struct ProxyState {
 - [ ] Wire initial-head parse duration and manager acquisition/queue timing into the shared metrics at their actual boundaries.
 - [ ] Wire every core metric at its boundary: accepted browser connections; parsed and rejected initial heads plus parse duration; CA hit/miss; DNS lookup duration; TCP attempt/established/connect duration; TLS and Hyper handshake durations; negotiated HTTP/1 count; pool hit/miss/stale/retry; pool acquisition/queue wait; request-to-header; request completion/failure. Add a snapshot integration test that drives one success, one rejected head, and one failure and checks every core category's expected delta. Task 9 adds mint metrics; Tasks 12/13 add retained-experiment metrics.
 - [ ] On every clean shutdown path, emit the redacted debug summary after Safari restoration. Add a formatting test proving it contains counts/timings but no URL query, auth value, certificate data, or sensitive headers.
-- [ ] Implement Ctrl-C ordering explicitly: restore Safari/system PAC first while the proxy is alive; abort/stop the accept-loop task; send manager `Shutdown`; wait with a fixed two-second Tokio timeout; emit current metrics on success or timeout; then return so runtime teardown reaps leftovers. Never await manager drain before Safari restoration.
+- [ ] Implement Ctrl-C ordering explicitly: restore Safari/system PAC first while the proxy is alive; abort/stop the accept-loop task; enqueue manager `Shutdown` without waiting on the priority control/lifecycle lane; place the entire acknowledgment wait under a fixed two-second Tokio timeout; emit current metrics on success or timeout; then return so runtime teardown reaps leftovers. Never await manager drain before Safari restoration.
 - [ ] Delegate mapped traffic to `UpstreamClient`. Keep blind tunnels, stray plain-HTTP forwarding, local PAC, Host-based per-request routing, and `421` behavior unchanged.
 - [ ] Capture upstream close intent before response hop-by-hop sanitation, then wrap the response body with its lease.
 - [ ] Make the two-request smoke GREEN, then add the 100-request acceptance case and run all existing proxy E2E tests. Expected: one established connection/handshake and unchanged routing/security behavior.
@@ -238,7 +241,7 @@ pub struct ProxyState {
 - [ ] Prove unmatched blind tunnels and stray plain-HTTP forwarding bypass the manager and do not consume/decrement its 64 mapped-connection count.
 - [ ] For every non-reusable case, require the next request to open a fresh connection.
 - [ ] In the early-response case, require immediate browser response, driver abort, upload polling to stop, socket closure, and no live-capacity release until the driver drop guard reports termination.
-- [ ] Add an adversarial shutdown orchestration test with injected hooks: saturate ordinary manager commands and delay one lifecycle close beyond two seconds. Assert Safari restoration is invoked first, new accepts stop next, shutdown returns at the deadline, and current metrics are emitted.
+- [ ] Add an adversarial shutdown orchestration test with injected hooks: saturate ordinary manager commands and delay one lifecycle close beyond two seconds. Assert Safari restoration is invoked first, new accepts stop next, priority shutdown is observed despite saturation, shutdown returns at the deadline, and current metrics are emitted.
 - [ ] Add bidirectional large streaming E2E cases (for example 2 MiB in small deterministic chunks): a successful chunked upload captured byte-for-byte at the upstream, and a chunked response read byte-for-byte at the browser. Assert incremental polling/backpressure on both paths rather than whole-body buffering.
 - [ ] Add a real proxy-shutdown test proving active/idle mapped drivers are aborted, sockets close, bounded queues are discarded, and the manager task exits without retained state.
 - [ ] Run `proxy_pool_e2e`. Task 5 unit tests may make lifecycle cases GREEN immediately; treat that as acceptance evidence. If an integration case fails, verify the failure is the intended missing behavior before changing production code.
@@ -282,12 +285,12 @@ pub struct ProxyState {
 **Files:** Modify `proxy_perf.rs` and implementation notes.
 
 - [ ] Run deterministic pool tests. Expected: exactly one established connection/handshake for sequential work and all bounds/lifecycle tests pass.
-- [ ] Run two warmups and ten alternating baseline/pooled measurements; record raw runs, median, p95, and median absolute deviation.
+- [ ] Run two warmups and ten alternating baseline/pooled measurements for the sequential and matched-concurrency-six workloads; record raw runs, median, p95, and median absolute deviation. Run concurrency 20 as a bounds/queueing diagnostic only, because comparison with the unbounded baseline would measure the intentional six-connection cap rather than manager overhead.
 - [ ] Add and run the injectable exact remote model: 100 zero-body GETs with no `Content-Length` or `Transfer-Encoding`, immediate request EOS, concurrency 20, 30 ms connect delay, 30 ms TLS delay, and 25 ms response delay. Upstream responses use keep-alive plus explicit `Content-Length`; never use close-delimited framing. Use harness-only `PoolMode` and `PoolLimits`; expose no CLI flags.
 - [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_http1_comparison -- --ignored --nocapture --test-threads=1`.
 - [ ] Record entry evidence for parser, DNS, and HTTP/2; label those stages `ENTER` or `SKIP`. `TCP_NODELAY` is always measured in Task 14 and is labeled only `RETAIN` or `REJECT`. For HTTP/2, calculate the spec's cold/preconnected and cap-6/cap-20 ratios from median durations.
 - [ ] Run `perf_allocation_comparison` with harness-only `PoolMode::Disabled` for both baseline-compatible and precomputed variants so pooling gains cannot mask allocation effects. Record process CPU and total duration, or a written simplification justification if timing is neutral.
-- [ ] Confirm HTTP/1 pooling does not regress median or p95 more than 5% and adds no failures.
+- [ ] Confirm HTTP/1 pooling does not regress median or p95 more than 5% in the sequential and matched-concurrency-six comparisons and adds no failures in any workload.
 - [ ] State explicitly in the notes: localhost success is primarily 100-to-1 connection/handshake reduction; material wall-clock gains are expected and judged on the remote/staging latency model.
 - [ ] Commit notes as `Record dev proxy HTTP/1 performance results`.
 
@@ -360,8 +363,8 @@ pub struct ProxyState {
 - [ ] Run this task unconditionally; there is no entry-gate `SKIP` outcome.
 - [ ] Write failing injected-option tests proving application immediately after accept/connect and before TLS/HTTP, success/failure counters, one warning per socket class, and nonfatal failure.
 - [ ] Implement independently selectable `off_off`, `browser_on`, `upstream_on`, and `both_on` variants through `TS_PERF_VARIANT`, used only by the harness; add no CLI flag.
-- [ ] After two warmups, run each setting as a separate process ten times in round-robin order. Example command: `/usr/bin/time -p env TS_PERF_VARIANT=browser_on cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_tcp_nodelay -- --ignored --nocapture --test-threads=1`. Repeat with each variant value so CPU evidence is per variant.
-- [ ] Retain browser/upstream settings independently only with at least 3% median improvement, p95 regression no worse than 5%, and per-process CPU regression no worse than 5%.
+- [ ] Use the named sequential TLS workload. After two complete warmup rounds, run each setting as a separate process ten times in round-robin order. Example command: `/usr/bin/time -p env TS_PERF_VARIANT=browser_on cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_tcp_nodelay -- --ignored --nocapture --test-threads=1`. Repeat with each variant value so CPU evidence is per variant.
+- [ ] Compare `browser_on` and `upstream_on` independently with `off_off`; each retained setting requires at least 3% median improvement, p95 regression no worse than 5%, and per-process CPU regression no worse than 5%. If both pass, require `both_on` to preserve at least 3% median improvement and both regression limits; otherwise retain only the passing one-sided variant with the larger median benefit.
 - [ ] Remove option abstractions for rejected variants. Commit retained code or notes-only rejection.
 - [ ] Use `Tune dev proxy TCP latency` for retained settings or `Reject dev proxy TCP_NODELAY experiment` for notes-only rejection.
 

--- a/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
@@ -89,10 +89,10 @@ fn snapshot_separates_attempts_from_established() {
 
 **Files:** Create `upstream/{mod.rs,key.rs}`; modify `config.rs`, `rewrite.rs`, and proxy `mod.rs`.
 
-- [ ] Write failing key tests varying transport, normalized TO/SNI host, port, verify mode, application mode, DNS policy, and `--resolve` pin independently.
-- [ ] Add a test proving two peer IPs selected for one DNS origin do not fragment the logical key, and two TO names sharing one IP never compare equal.
-- [ ] Run focused tests. Expected: RED because `OriginKey` does not exist.
-- [ ] Implement closed key types:
+- [x] Write failing key tests varying transport, normalized TO/SNI host, port, verify mode, application mode, DNS policy, and `--resolve` pin independently.
+- [x] Add a test proving two peer IPs selected for one DNS origin do not fragment the logical key, and two TO names sharing one IP never compare equal.
+- [x] Run focused tests. Expected: RED because `OriginKey` does not exist.
+- [x] Implement closed key types:
 
 ```rust
 pub enum Transport { Plaintext, Tls }
@@ -111,11 +111,11 @@ pub struct OriginKey {
 pub enum ReferenceIdentity { Dns(Arc<str>), Ip(IpAddr) }
 ```
 
-- [ ] Write failing tests requiring prevalidated `HeaderValue`s, `ServerName<'static>`, and a Basic-auth Debug output containing neither username, password, nor encoded token.
-- [ ] Replace `BasicAuth { user, pass }` with a private reusable header and custom `Debug` rendering `BasicAuth([REDACTED])`. Update fixtures to construct it through a checked constructor.
-- [ ] Precompute rule host/forwarding headers, SNI, transport, and stable origin-key fields during `config::resolve`; eliminate per-request Base64 and host-header formatting.
-- [ ] Run config/rewrite/key tests and existing E2E tests. Expected: GREEN with unchanged behavior.
-- [ ] Commit as `Precompute dev proxy upstream identity`.
+- [x] Write failing tests requiring prevalidated `HeaderValue`s, `ServerName<'static>`, and a Basic-auth Debug output containing neither username, password, nor encoded token.
+- [x] Replace `BasicAuth { user, pass }` with a private reusable header and custom `Debug` rendering `BasicAuth([REDACTED])`. Update fixtures to construct it through a checked constructor.
+- [x] Precompute rule host/forwarding headers, SNI, transport, and stable origin-key fields during `config::resolve`; eliminate per-request Base64 and host-header formatting.
+- [x] Run config/rewrite/key tests and existing E2E tests. Expected: GREEN with unchanged behavior.
+- [x] Commit as `Precompute dev proxy upstream identity`.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
@@ -1,0 +1,360 @@
+# Dev Proxy Performance Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ts dev proxy` materially faster by reusing upstream HTTP/1.1 connections, then retain optional parser, DNS, HTTP/2, and socket optimizations only when measurements clear the approved gates.
+
+**Architecture:** Create a shared `ProxyState` and bounded upstream-manager actor. The actor owns exact origin-key isolation, FIFO admission, connection opening, sender leases, and idle return; body adapters preserve streaming and return a lease only when request upload and response download both completed successfully. Deterministic counters prove correctness before manual timing comparisons.
+
+**Tech Stack:** Rust 2024, Tokio, Hyper 1, hyper-util, Rustls 0.23, tokio-rustls, error-stack, macOS CLI integration tests.
+
+**Design:** `docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+
+- `crates/trusted-server-cli/src/commands/dev/proxy/metrics.rs` — atomic counters, fixed timing buckets, snapshots.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs` — `UpstreamClient` facade.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs` — transport/SNI/port/verification/application/address-policy identity.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs` — bounded actor, FIFO waiters, idle expiry and return.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs` — address selection, total deadline, TCP/TLS/Hyper handshakes.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs` — request completion and pooled response body state machines.
+- `crates/trusted-server-cli/tests/proxy_pool_e2e.rs` — pooling lifecycle tests.
+- `crates/trusted-server-cli/tests/proxy_perf.rs` — ignored performance harness.
+- `docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md` — evidence and gate decisions.
+
+**Create only if the gate passes:**
+
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/dns.rs`
+- `crates/trusted-server-cli/src/commands/dev/proxy/prefixed_io.rs`
+
+**Modify:** `proxy/{mod.rs,config.rs,rewrite.rs,server.rs,ca.rs}`, `trusted-server-cli/Cargo.toml`, `tests/support/mod.rs`, `tests/proxy_e2e.rs`, and user docs only for observable changes.
+
+## Global Rules
+
+- Follow red-green-refactor for every behavior: write one test, observe the expected failure, implement minimally, rerun the focused test, then rerun the affected test binary.
+- Use `./scripts/test-cli.sh`; never use a bare workspace test.
+- Keep optional experiments out of v1 commits. If a gate fails, record `SKIP` or `REJECT` and remove experimental production code.
+- Commit after each task only when its focused tests and the affected test binary pass.
+
+Every performance run prints one raw record, and each ten-run comparison prints
+separate across-run summaries:
+
+```text
+PERF_RUN workload=<name> variant=<name> run=<n> duration_us=<n> tcp_attempts=<n> tcp_established=<n> tls_handshakes=<n> failures=<n>
+PERF_SUMMARY workload=<name> variant=<name> runs=10 median_duration_us=<n> p95_duration_us=<n> mad_duration_us=<n> failures=<n>
+```
+
+Each comparison test alternates variants internally after two warmups and prints median, p95, and MAD summary records. Harness-only preconnection opens the configured HTTP/1 connections and waits for manager idle state before starting the timer.
+
+---
+
+### Task 1: Baseline Metrics and Harness
+
+**Files:** Create `metrics.rs`, `proxy_perf.rs`, and implementation notes; modify `mod.rs` and `tests/support/mod.rs`.
+
+- [ ] Run `./scripts/test-cli.sh`. Expected: baseline PASS; stop if it does not.
+- [ ] Write failing `metrics.rs` tests requiring separate TCP-attempt/established counters and a fixed-size timing histogram.
+
+```rust
+#[test]
+fn snapshot_separates_attempts_from_established() {
+    let metrics = ProxyMetrics::default();
+    metrics.record_tcp_attempt();
+    metrics.record_tcp_attempt();
+    metrics.record_tcp_established(Duration::from_millis(7));
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.tcp_attempts, 2);
+    assert_eq!(snapshot.tcp_established, 1);
+    assert_eq!(snapshot.connect_latency.total(), 1);
+}
+```
+
+- [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" metrics::tests`. Expected: RED because metrics do not exist.
+- [ ] Implement `ProxyMetrics` with `AtomicU64` fields and fixed atomic duration buckets, including methods for initial-head parse, pool acquisition, and queue wait. Expose `snapshot`, phase-recording methods, and a redacted debug summary; retain no per-request labels or samples. Task 1 uses fixture counters for the baseline; runtime phase wiring occurs when `ProxyState` reaches `server.rs` in Task 6.
+- [ ] Extend the TLS upstream fixture with shared accepted-connection, request, handshake, and failure counters.
+- [ ] Add two baseline `#[ignore = "manual performance workload"]` tests: 100 sequential TLS GETs and 100 delayed GETs at concurrency 20. Add the injectable remote-latency model in Task 10 after the connection factory exists.
+- [ ] Run the ignored harness with `--ignored --nocapture --test-threads=1`. Expected baseline: approximately 100 established upstream connections and handshakes for 100 sequential requests.
+- [ ] Record raw output, machine, OS, Rust version, and command in implementation notes.
+- [ ] Run `./scripts/test-cli.sh` and commit as `test(cli): establish dev proxy performance baseline`.
+
+---
+
+### Task 2: Safe Precomputed Origin Identity
+
+**Files:** Create `upstream/{mod.rs,key.rs}`; modify `config.rs`, `rewrite.rs`, and proxy `mod.rs`.
+
+- [ ] Write failing key tests varying transport, normalized TO/SNI host, port, verify mode, application mode, DNS policy, and `--resolve` pin independently.
+- [ ] Add a test proving two peer IPs selected for one DNS origin do not fragment the logical key, and two TO names sharing one IP never compare equal.
+- [ ] Run focused tests. Expected: RED because `OriginKey` does not exist.
+- [ ] Implement closed key types:
+
+```rust
+pub enum Transport { Plaintext, Tls }
+pub enum VerifyMode { Secure, Insecure }
+pub enum ApplicationMode { Http1Required, Http2Eligible }
+pub enum AddressPolicy { Dns, Resolve(IpAddr) }
+pub struct OriginKey {
+    transport: Transport,
+    reference: ReferenceIdentity,
+    port: u16,
+    verify: VerifyMode,
+    application: ApplicationMode,
+    address: AddressPolicy,
+}
+
+pub enum ReferenceIdentity { Dns(Arc<str>), Ip(IpAddr) }
+```
+
+- [ ] Write failing tests requiring prevalidated `HeaderValue`s, `ServerName<'static>`, and a Basic-auth Debug output containing neither username, password, nor encoded token.
+- [ ] Replace `BasicAuth { user, pass }` with a private reusable header and custom `Debug` rendering `BasicAuth([REDACTED])`. Update fixtures to construct it through a checked constructor.
+- [ ] Precompute rule host/forwarding headers, SNI, transport, and stable origin-key fields during `config::resolve`; eliminate per-request Base64 and host-header formatting.
+- [ ] Run config/rewrite/key tests and existing E2E tests. Expected: GREEN with unchanged behavior.
+- [ ] Commit as `refactor(cli): precompute dev proxy upstream identity`.
+
+---
+
+### Task 3: Bounded Manager Actor
+
+**Files:** Create `upstream/manager.rs`; modify `upstream/mod.rs` and CLI Cargo.toml.
+
+- [ ] Add Tokio `test-util` only to the macOS dev-dependency feature set.
+- [ ] With paused time and a test harness that observes `ConnectRequested` commands and manually replies `Connected`, write failing tests for: six live HTTP/1 connections per origin, 64 globally, two idle per origin, 32 idle globally, 32 queued per origin, 128 queued globally, FIFO wakeup, dropped-waiter removal, and 30-second timeout.
+- [ ] Add a test proving origin/global admission is atomic and never reserves one capacity while waiting for the other.
+- [ ] Run manager tests. Expected: RED because the actor is absent.
+- [ ] Implement one bounded command actor:
+
+```rust
+enum Command {
+    Acquire { key: OriginKey, reply: oneshot::Sender<Result<Lease, AcquireError>> },
+    Connected { key: OriginKey, result: Result<IdleConnection, ConnectError> },
+    Return(IdleConnection),
+    DriverClosed(ConnectionId),
+    Cancel(WaiterId),
+    Expire(Instant),
+}
+```
+
+- [ ] Keep all counts and FIFO queues actor-owned. Spawn connection work and report completion; never await network work inside the actor.
+- [ ] Store production defaults in injectable `PoolLimits`; permit harness-only cap variants and pool-disabled baseline mode without adding CLI flags.
+- [ ] Make capacity driver-owned: in actor tests, closing a lease emits an abort request but only a synthetic `DriverClosed(ConnectionId)` decrements live counts. Defer the real socket/upload assertion to Task 7 after the connector and body wrapper exist.
+- [ ] Use one next-deadline timer rather than a task per idle connection. Expiry removes the idle entry and requests driver abort, but does not decrement or admit waiters until `DriverClosed`. Add a paused-time test proving no admission in that interval.
+- [ ] Run manager tests. Expected: GREEN without wall-clock sleeps.
+- [ ] Commit as `feat(cli): add bounded dev proxy upstream manager`.
+
+---
+
+### Task 4: Reusable HTTP/1 Connection Factory
+
+**Files:** Create `upstream/connect.rs`; modify `manager.rs`, `metrics.rs`, and test support.
+
+- [ ] Write failing connector tests for plaintext/TLS separation, exact SNI, secure/insecure validation, `--resolve`, actual peer diagnostics, driver-health transition, and total multi-address timeout.
+- [ ] Fake DNS must consume part of the deadline; prove each remaining address receives at most `remaining / addresses_left` and no attempt extends the original deadline.
+- [ ] Run focused tests. Expected: RED because `ConnectionFactory` is absent.
+- [ ] Define `ProxyRequestBody = BoxBody<Bytes, ProxyBodyError>` in `upstream/mod.rs`, where `ProxyBodyError` wraps `hyper::Error` and represents local cancellation. Then implement a narrow injectable factory returning an opened HTTP/1 sender, driver health, explicit abort handle, driver drop guard, connection ID, and actual peer.
+- [ ] Preserve IP-literal compatibility: DNS identities send SNI and validate DNS SAN; IP identities send no DNS SNI and validate IP SAN. Mark IP rules HTTP/1-required.
+- [ ] Compute one deadline before resolution. Count TCP attempt before `connect`, established after success, TLS handshake after TLS success, and HTTP handshake after Hyper success.
+- [ ] Spawn one Hyper driver per opened connection and report termination to the actor.
+- [ ] Run connector tests and existing `--resolve` E2E coverage. Expected: GREEN.
+- [ ] Commit as `feat(cli): open reusable dev proxy upstream connections`.
+
+---
+
+### Task 5: Streaming Lease State Machine
+
+**Files:** Create `upstream/body.rs`; modify `upstream/{mod.rs,manager.rs}`.
+
+- [ ] Write scripted-body tests proving request state becomes Complete only after terminal EOS including trailers, and Failed on body error or drop before EOS.
+- [ ] Write failing response tests for DATA/trailer passthrough; release after terminal `None`; close intent; driver/body/upload failure; downstream drop; response EOS before upload completion; full/closed return channel; and idempotent finalization.
+- [ ] Run body tests. Expected: RED because adapters are absent.
+- [ ] Implement a streaming request body wrapper and one erased request type:
+
+```rust
+pub type ProxyRequestBody = BoxBody<Bytes, ProxyBodyError>;
+enum UploadState { Streaming, Complete, Failed }
+```
+
+- [ ] Implement `PooledResponseBody: Body<Data = Bytes, Error = hyper::Error>`. It owns an optional lease/abort handle and finalizes once. Return only at response EOS when upload is already Complete, driver healthy, and no close intent.
+- [ ] If response EOS arrives while upload remains Streaming, forward EOF immediately and close; never wait or drain in the background.
+- [ ] Closing invokes driver abort and drops the sender, but does not decrement manager capacity; the driver drop guard reports termination and releases capacity.
+- [ ] Bound the nonblocking return channel to 64; on full/closed, close rather than blocking `poll_frame`.
+- [ ] Run body tests. Expected: GREEN.
+- [ ] Commit as `feat(cli): make pooled response leases streaming-safe`.
+
+---
+
+### Task 6: Integrate HTTP/1 Pooling
+
+**Files:** Modify proxy `mod.rs`, `server.rs`, `upstream/mod.rs`, test support and existing E2E tests; create `proxy_pool_e2e.rs`.
+
+- [ ] Write a failing test that sends 100 sequential GETs over one MITM tunnel and expects 100 responses, one established upstream TCP connection, and one TLS handshake.
+- [ ] Run `proxy_pool_e2e`. Expected: RED with about 100 upstream connections on the current path.
+- [ ] Introduce shared state:
+
+```rust
+pub struct ProxyState {
+    config: Arc<ResolvedConfig>,
+    upstream: UpstreamClient,
+    metrics: Arc<ProxyMetrics>,
+}
+```
+
+- [ ] Build `ProxyState` once in `proxy::run`; pass `Arc<ProxyState>` into `serve_on`. Update test spawning helpers. Hyper service closures clone this Arc, not rules/auth/resolve maps.
+- [ ] Wire initial-head parse duration and manager acquisition/queue timing into the shared metrics at their actual boundaries.
+- [ ] Wire every mandatory metric at its boundary: CA hit/miss/mint; DNS lookup; TCP attempt/established/connect duration; TLS and Hyper handshake; pool hit/miss/stale/retry; request-to-header; request completion/failure. Add a snapshot integration test that drives one success and one failure and checks the expected deltas.
+- [ ] On every clean shutdown path, emit the redacted debug summary after Safari restoration. Add a formatting test proving it contains counts/timings but no URL query, auth value, certificate data, or sensitive headers.
+- [ ] Delegate mapped traffic to `UpstreamClient`. Keep blind tunnels, stray plain-HTTP forwarding, local PAC, Host-based per-request routing, and `421` behavior unchanged.
+- [ ] Capture upstream close intent before response hop-by-hop sanitation, then wrap the response body with its lease.
+- [ ] Run sequential reuse and all existing proxy E2E tests. Expected: one established connection/handshake and unchanged routing/security behavior.
+- [ ] Commit as `feat(cli): reuse upstream HTTP/1 connections`.
+
+---
+
+### Task 7: Concurrency, Cancellation, and Bounds E2E
+
+**Files:** Modify `manager.rs`, `body.rs`, `tests/support/mod.rs`, and `proxy_pool_e2e.rs`.
+
+- [ ] Write a failing test for 100 GETs at concurrency 20 against a 25 ms upstream. Require observed concurrency between two and six, at most six manager-owned live connections, and at most two idle afterward.
+- [ ] Write separate failing tests for upstream `Connection: close`, response body error, response trailers, slow/infinite response cancellation, truncated upload, and an origin responding before consuming the upload.
+- [ ] Add manager-selection/header integration cases: TLS versus plaintext, secure versus insecure, pinned versus DNS, different TO identities, and different ports never share; two FROM rules sharing one TO do share when allowed; Host-preserved and Host-rewritten configurations send exact SNI/Host/forwarding headers; one request's Authorization never persists onto the next reused request.
+- [ ] For every non-reusable case, require the next request to open a fresh connection.
+- [ ] In the early-response case, require immediate browser response, driver abort, upload polling to stop, socket closure, and no live-capacity release until the driver drop guard reports termination.
+- [ ] Run `proxy_pool_e2e`. Task 5 unit tests may make lifecycle cases GREEN immediately; treat that as acceptance evidence. If an integration case fails, verify the failure is the intended missing behavior before changing production code.
+- [ ] Implement only the failing lifecycle transitions. Never background-drain; admit waiters only after driver termination decrements capacity.
+- [ ] Rerun `proxy_pool_e2e`. Expected: GREEN without timing sleeps except controlled upstream delays.
+- [ ] Commit as `test(cli): harden dev proxy pool lifecycle`.
+
+---
+
+### Task 8: Conservative Stale Retry
+
+**Files:** Modify `upstream/{mod.rs,body.rs}`, `metrics.rs`, and `proxy_pool_e2e.rs`.
+
+- [ ] Write failing replayability tests. Capture eligibility from the original request before sanitation. Require GET/HEAD/OPTIONS, absent Content-Length and Transfer-Encoding, exact zero size, `is_end_stream()`, and an empty extension map.
+- [ ] Explicitly reject unknown/lying hints, zero-data trailers, any extension, framed/streaming/truncated bodies, and other methods.
+- [ ] Write failing E2E cases: sender readiness closes before body consumption; reused send fails before headers for eligible GET; ineligible requests do not retry; maximum one retry; final failure returns one `502` without closing the browser tunnel.
+- [ ] Run focused tests. Expected: RED because no retry path exists.
+- [ ] For eligible requests only, retain method, URI, version and headers and substitute a reusable empty body. Do not clone or buffer `Incoming`.
+- [ ] Retry readiness failure with the unconsumed original request. Retry post-dispatch failure only from the retained template and only on a reused connection.
+- [ ] Add stale/retry metrics, rerun focused tests and the full E2E binary. Expected: GREEN.
+- [ ] Commit as `feat(cli): retry stale pooled proxy connections safely`.
+
+---
+
+### Task 9: Normalize and Prewarm Certificates
+
+**Files:** Modify `ca.rs`, proxy `mod.rs`, `server.rs`, metrics, and pool E2E tests.
+
+- [ ] Write a failing test that prewarms lowercase `www.example.com`, CONNECTs as mixed-case `WWW.Example.COM`, and expects one mint total plus a runtime hit.
+- [ ] Add failing tests for duplicate-rule deduplication and prewarm failure before browser launch.
+- [ ] Run focused tests. Expected: RED because raw CONNECT case forms a distinct cache key.
+- [ ] Normalize DNS CONNECT identities to lowercase before rule and CA lookup; preserve parsed IP identity without string-case logic.
+- [ ] Prewarm every unique normalized FROM before listener/browser startup. Instrument hits, misses, and unexpected post-prewarm mints without logging key material.
+- [ ] Run `./scripts/test-cli.sh`. Expected: GREEN.
+- [ ] Commit as `perf(cli): prewarm normalized dev proxy certificates`.
+
+---
+
+### Task 10: Measure and Lock HTTP/1 v1
+
+**Files:** Modify `proxy_perf.rs` and implementation notes.
+
+- [ ] Run deterministic pool tests. Expected: exactly one established connection/handshake for sequential work and all bounds/lifecycle tests pass.
+- [ ] Run two warmups and ten alternating baseline/pooled measurements; record raw runs, median, p95, and median absolute deviation.
+- [ ] Add and run the injectable exact remote model: 100 GETs, concurrency 20, 30 ms connect delay, 30 ms TLS delay, 25 ms response delay. Use harness-only `PoolMode` and `PoolLimits`; expose no CLI flags.
+- [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_http1_comparison -- --ignored --nocapture --test-threads=1`.
+- [ ] Record entry evidence for parser, DNS, and HTTP/2; label those stages `ENTER` or `SKIP`. `TCP_NODELAY` is always measured in Task 14 and is labeled only `RETAIN` or `REJECT`. For HTTP/2, calculate the spec's cold/preconnected and cap-6/cap-20 ratios from median durations.
+- [ ] Run `perf_allocation_comparison` with harness-only `PoolMode::Disabled` for both baseline-compatible and precomputed variants so pooling gains cannot mask allocation effects. Record process CPU and total duration, or a written simplification justification if timing is neutral.
+- [ ] Confirm HTTP/1 pooling does not regress median or p95 more than 5% and adds no failures.
+- [ ] Commit notes as `docs: record dev proxy HTTP/1 performance results`.
+
+---
+
+### Task 11: Conditional Buffered Initial-Head Parsing
+
+**Entry gate:** In a single-threaded workload of 1,000 new loopback connections that each send one local PAC request and read its response, aggregated parse duration is at least 5% of total client-observed duration. Otherwise record `SKIP` and create no parser code.
+
+**Files if entered:** Create `prefixed_io.rs`; modify `server.rs`, metrics, pool E2E, perf harness, and notes.
+
+- [ ] Measure and record the exact entry gate.
+- [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_parser_local -- --ignored --nocapture --test-threads=1` and calculate aggregate parse duration divided by total duration.
+- [ ] If entered, write failing tests for delimiter splits, exactly 8 KiB head, oversized/incomplete head, a valid sub-8-KiB head whose over-read makes the combined buffer exceed 8 KiB, and exact-once prefix delivery.
+- [ ] Write failing path tests proving over-read reaches browser TLS accept, blind tunnel, and plain-HTTP forwarding exactly once.
+- [ ] Implement chunk reads and one `PrefixedIo<T>` owner. Apply the 8 KiB cap only through `\r\n\r\n`; every downstream path consumes the same adapter and no path separately replays bytes.
+- [ ] Run correctness tests and ten alternating performance runs. Retain only if the 5% gate remains satisfied with no regression.
+- [ ] If retained, commit `perf(cli): buffer dev proxy initial request parsing`; otherwise remove experiment code and commit notes as `docs: reject buffered proxy parsing experiment`.
+
+---
+
+### Task 12: Conditional DNS Cache
+
+**Entry gate:** Post-pooling DNS metrics are at least 5% of median request-to-upstream-header time, or a no-cache fixed-delay resolver versus no-cache zero-delay resolver changes the churn workload by at least 5%. Otherwise record `SKIP` and do not create `dns.rs`.
+
+**Files if entered:** Create `upstream/dns.rs`; modify `connect.rs`, `key.rs`, metrics, tests, perf harness, and notes.
+
+- [ ] Evaluate existing post-pooling DNS metrics first. If below 5%, define `perf_dns_lookup_contribution` as 100 requests that force fresh manager connections and compare no-cache fixed-delay resolution with no-cache zero-delay resolution.
+- [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_dns_lookup_contribution -- --ignored --nocapture --test-threads=1`. Only enter implementation if either non-circular entry arm reaches 5%.
+- [ ] With paused time and a fake resolver, write failing tests for 30-second TTL, 64-entry bound, expired-first eviction, non-in-flight LRU eviction, all-in-flight bypass, concurrent miss coalescing, owned error fan-out, no failure caching, and `--resolve` bypass.
+- [ ] Add failing identity tests proving multiple peer IPs share one DNS origin key, different TO identities never share, and healthy idle connections may outlive DNS TTL only until their 60-second idle deadline.
+- [ ] Implement cache state without awaiting resolution under its lock. Store owned address lists; reconstruct equivalent I/O errors for waiters.
+- [ ] Prove one total DNS/connect deadline and fair per-address remaining slices with fake time.
+- [ ] After implementation, run `perf_dns_cache_retention` with cache-disabled/cache-enabled variants for ten alternating measurements. Retain only if the original 5% evidence remains and failures do not increase.
+- [ ] Commit retained code, or remove it and commit notes-only rejection.
+
+---
+
+### Task 13: Conditional Upstream HTTP/2
+
+**Entry gate:** In the exact remote model, the median cold-versus-preconnected setup ratio or cap-6-versus-cap-20 concurrency ratio defined in the spec is at least 10% across ten alternating runs. Otherwise record `SKIP` and do not enable Hyper `http2`.
+
+**Files if entered:** Modify CLI Cargo.toml, all upstream modules, test support, pool E2E, perf harness, and notes.
+
+- [ ] Measure and record the entry gate.
+- [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_h2_entry -- --ignored --nocapture --test-threads=1`; this internally alternates cold/preconnected and cap-6/cap-20 variants.
+- [ ] Temporarily enable Hyper `http2` and add a narrowly scoped `http2_feasibility` test target. This is prerequisite scaffolding, not a production behavior claim.
+- [ ] Prove maintained public APIs can: abort an upload after response headers through `ProxyBodyError`, observe confirmed local stream termination, preserve required informational/trailer frames, and classify GOAWAY/`REFUSED_STREAM` sufficiently for the spec's retries. If any proof is impossible, record `REJECT` immediately.
+- [ ] On feasibility rejection, remove the Cargo feature, proof tests, fixtures, harness variants, and all HTTP/2 scaffolding before committing notes; skip the remaining steps.
+- [ ] If feasible, write failing behavior tests for four TLS configurations, serialized cold discovery, exact authority/SNI/path/query, no cross-name reuse, stream-permit lifecycle, and protocol semantics.
+- [ ] With upload still streaming, test response EOS, downstream cancellation, response body error, and upload failure. Each must request reset, retain its permit until the termination guard fires, and keep a 101st request queued until confirmed termination.
+- [ ] Implement `Vacant`, `Discovering`, `Http1`, `Http2`, and `Draining` manager states with one creator and exact bounds; implement only enough to turn each behavior test green.
+- [ ] After two warmups, run ten alternating HTTP/1/HTTP/2 variants. Retain only with at least 10% median duration/throughput improvement, p95 regression no worse than 5%, and no additional failures.
+- [ ] Run the retained-protocol comparison with `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_h2_retention -- --ignored --nocapture --test-threads=1`.
+- [ ] On any retention rejection, remove HTTP/2 production code, Cargo features, proof/behavior tests, fixtures, harness variants, and scaffolding before committing notes. Do not leave dormant complexity.
+
+---
+
+### Task 14: Conditional `TCP_NODELAY`
+
+**Files if retained:** Modify `server.rs`, `connect.rs`, metrics, perf harness, tests, and notes.
+
+- [ ] Run this task unconditionally; there is no entry-gate `SKIP` outcome.
+- [ ] Write failing injected-option tests proving application immediately after accept/connect and before TLS/HTTP, success/failure counters, one warning per socket class, and nonfatal failure.
+- [ ] Implement independently selectable `off_off`, `browser_on`, `upstream_on`, and `both_on` variants through `TS_PERF_VARIANT`, used only by the harness; add no CLI flag.
+- [ ] After two warmups, run each setting as a separate process ten times in round-robin order. Example command: `/usr/bin/time -p env TS_PERF_VARIANT=browser_on cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_tcp_nodelay -- --ignored --nocapture --test-threads=1`. Repeat with each variant value so CPU evidence is per variant.
+- [ ] Retain browser/upstream settings independently only with at least 3% median improvement, p95 regression no worse than 5%, and per-process CPU regression no worse than 5%.
+- [ ] Remove option abstractions for rejected variants. Commit retained code or notes-only rejection.
+
+---
+
+### Task 15: Final Documentation and Verification
+
+**Files:** Complete implementation notes; modify `docs/guide/ts-dev-proxy.md` only for observable behavior; review every changed CLI/test file.
+
+- [ ] Document exact commands, machine/toolchain, raw results, median/p95/MAD, connection/handshake counts, constants, every entry/retention decision, and rejected-code cleanup.
+- [ ] If existing debug logging exposes the metrics summary, add one concise troubleshooting note; do not document internal pool knobs or promise stable diagnostics.
+- [ ] Run `cargo fmt --all -- --check`. Expected: PASS.
+- [ ] Run `cd docs && npm ci && npm run format`. Expected: dependencies install from the lockfile and formatting passes without unrelated changes.
+- [ ] Run `./scripts/test-cli.sh`. Expected: all CLI tests PASS.
+- [ ] Run host clippy:
+
+```bash
+cargo clippy --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --all-targets -- -D warnings
+```
+
+- [ ] Run the retained ignored performance workloads single-threaded and compare to recorded variability.
+- [ ] Audit all 14 security invariants against code and tests, including DNS/IP reference identity, no cross-SNI reuse, driver-owned capacity, no streaming-body replay, redacted auth, and bounded state.
+- [ ] Commit final docs as `docs: document dev proxy performance results`.
+- [ ] Use `superpowers:requesting-code-review` on the complete branch. Resolve every critical/important issue and rerun affected verification until approved.

--- a/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
@@ -58,8 +58,8 @@ Each comparison test alternates variants internally after two warmups and prints
 
 **Files:** Create `metrics.rs`, `proxy_perf.rs`, and implementation notes; modify `mod.rs` and `tests/support/mod.rs`.
 
-- [ ] Run `./scripts/test-cli.sh`. Expected: baseline PASS; stop if it does not.
-- [ ] Write failing `metrics.rs` tests requiring separate TCP-attempt/established counters and a fixed-size timing histogram.
+- [x] Run `./scripts/test-cli.sh`. Expected: baseline PASS; stop if it does not.
+- [x] Write failing `metrics.rs` tests requiring separate TCP-attempt/established counters and a fixed-size timing histogram.
 
 ```rust
 #[test]
@@ -75,13 +75,13 @@ fn snapshot_separates_attempts_from_established() {
 }
 ```
 
-- [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" metrics::tests`. Expected: RED because metrics do not exist.
-- [ ] Implement `ProxyMetrics` with `AtomicU64` fields and fixed atomic duration buckets, including methods for initial-head parse, pool acquisition, and queue wait. Expose `snapshot`, phase-recording methods, and a redacted debug summary; retain no per-request labels or samples. Task 1 uses fixture counters for the baseline; runtime phase wiring occurs when `ProxyState` reaches `server.rs` in Task 6.
-- [ ] Extend the TLS upstream fixture with shared accepted-connection, request, handshake, and failure counters.
-- [ ] Add baseline `#[ignore = "manual performance workload"]` tests for 100 sequential TLS GETs, 100 delayed GETs at matched concurrency six, and a separate concurrency-20 saturation workload. Add the injectable remote-latency model in Task 10 after the connection factory exists.
-- [ ] Run the ignored harness with `--ignored --nocapture --test-threads=1`. Expected baseline: approximately 100 established upstream connections and handshakes for 100 sequential requests.
-- [ ] Record raw output, machine, OS, Rust version, and command in implementation notes.
-- [ ] Run `./scripts/test-cli.sh` and commit as `Establish dev proxy performance baseline`.
+- [x] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" metrics::tests`. Expected: RED because metrics do not exist.
+- [x] Implement `ProxyMetrics` with `AtomicU64` fields and fixed atomic duration buckets, including methods for initial-head parse, pool acquisition, and queue wait. Expose `snapshot`, phase-recording methods, and a redacted debug summary; retain no per-request labels or samples. Task 1 uses fixture counters for the baseline; runtime phase wiring occurs when `ProxyState` reaches `server.rs` in Task 6.
+- [x] Extend the TLS upstream fixture with shared accepted-connection, request, handshake, and failure counters.
+- [x] Add baseline `#[ignore = "manual performance workload"]` tests for 100 sequential TLS GETs, 100 delayed GETs at matched concurrency six, and a separate concurrency-20 saturation workload. Add the injectable remote-latency model in Task 10 after the connection factory exists.
+- [x] Run the ignored harness with `--ignored --nocapture --test-threads=1`. Expected baseline: approximately 100 established upstream connections and handshakes for 100 sequential requests.
+- [x] Record raw output, machine, OS, Rust version, and command in implementation notes.
+- [x] Run `./scripts/test-cli.sh` and commit as `Establish dev proxy performance baseline`.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
@@ -2,9 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make `ts dev proxy` materially faster by reusing upstream HTTP/1.1 connections, then retain optional parser, DNS, HTTP/2, and socket optimizations only when measurements clear the approved gates.
+**Goal:** Make `ts dev proxy` materially faster against remote/staging upstreams by reusing HTTP/1.1 connections, while treating localhost connection-count reduction as success even when wall-clock change is small; retain optional parser, DNS, HTTP/2, and socket optimizations only when measurements clear the approved gates.
 
 **Architecture:** Create a shared `ProxyState` and bounded upstream-manager actor. The actor owns exact origin-key isolation, FIFO admission, connection opening, sender leases, and idle return; body adapters preserve streaming and return a lease only when request upload and response download both completed successfully. Deterministic counters prove correctness before manual timing comparisons.
+
+The single manager actor is a deliberate serialization point: at developer-proxy request rates its channel hop is negligible, and it makes driver-owned capacity, cancellation, and bounded teardown auditable. Pool-acquisition metrics verify that assumption.
 
 **Tech Stack:** Rust 2024, Tokio, Hyper 1, hyper-util, Rustls 0.23, tokio-rustls, error-stack, macOS CLI integration tests.
 
@@ -79,7 +81,7 @@ fn snapshot_separates_attempts_from_established() {
 - [ ] Add two baseline `#[ignore = "manual performance workload"]` tests: 100 sequential TLS GETs and 100 delayed GETs at concurrency 20. Add the injectable remote-latency model in Task 10 after the connection factory exists.
 - [ ] Run the ignored harness with `--ignored --nocapture --test-threads=1`. Expected baseline: approximately 100 established upstream connections and handshakes for 100 sequential requests.
 - [ ] Record raw output, machine, OS, Rust version, and command in implementation notes.
-- [ ] Run `./scripts/test-cli.sh` and commit as `test(cli): establish dev proxy performance baseline`.
+- [ ] Run `./scripts/test-cli.sh` and commit as `Establish dev proxy performance baseline`.
 
 ---
 
@@ -113,7 +115,7 @@ pub enum ReferenceIdentity { Dns(Arc<str>), Ip(IpAddr) }
 - [ ] Replace `BasicAuth { user, pass }` with a private reusable header and custom `Debug` rendering `BasicAuth([REDACTED])`. Update fixtures to construct it through a checked constructor.
 - [ ] Precompute rule host/forwarding headers, SNI, transport, and stable origin-key fields during `config::resolve`; eliminate per-request Base64 and host-header formatting.
 - [ ] Run config/rewrite/key tests and existing E2E tests. Expected: GREEN with unchanged behavior.
-- [ ] Commit as `refactor(cli): precompute dev proxy upstream identity`.
+- [ ] Commit as `Precompute dev proxy upstream identity`.
 
 ---
 
@@ -122,6 +124,7 @@ pub enum ReferenceIdentity { Dns(Arc<str>), Ip(IpAddr) }
 **Files:** Create `upstream/manager.rs`; modify `upstream/mod.rs` and CLI Cargo.toml.
 
 - [ ] Add Tokio `test-util` only to the macOS dev-dependency feature set.
+- [ ] Note in the code/implementation notes that Cargo feature unification makes `test-util` available in the macOS test build, while pause/advance behavior remains inert unless tests explicitly use it.
 - [ ] With paused time and a test harness that observes `ConnectRequested` commands and manually replies `Connected`, write failing tests for: six live HTTP/1 connections per origin, 64 globally, two idle per origin, 32 idle globally, 32 queued per origin, 128 queued globally, FIFO wakeup, dropped-waiter removal, and 30-second timeout.
 - [ ] Add a test proving origin/global admission is atomic and never reserves one capacity while waiting for the other.
 - [ ] Run manager tests. Expected: RED because the actor is absent.
@@ -135,15 +138,18 @@ enum Command {
     DriverClosed(ConnectionId),
     Cancel(WaiterId),
     Expire(Instant),
+    Shutdown { reply: oneshot::Sender<()> },
 }
 ```
 
 - [ ] Keep all counts and FIFO queues actor-owned. Spawn connection work and report completion; never await network work inside the actor.
 - [ ] Store production defaults in injectable `PoolLimits`; permit harness-only cap variants and pool-disabled baseline mode without adding CLI flags.
 - [ ] Make capacity driver-owned: in actor tests, closing a lease emits an abort request but only a synthetic `DriverClosed(ConnectionId)` decrements live counts. Defer the real socket/upload assertion to Task 7 after the connector and body wrapper exist.
-- [ ] Use one next-deadline timer rather than a task per idle connection. Expiry removes the idle entry and requests driver abort, but does not decrement or admit waiters until `DriverClosed`. Add a paused-time test proving no admission in that interval.
+- [ ] Use one next-deadline timer rather than a task per idle connection. Add paused-time assertions at 59 seconds (still idle) and 60 seconds (expiry requests abort). Expiry removes the entry but does not decrement/admit until `DriverClosed`.
+- [ ] Add actor-shutdown tests proving all waiters are failed, every live driver is aborted, queues/idle maps are cleared, and counts reach zero only through synthetic `DriverClosed` events.
+- [ ] Implement a Closing state: `Shutdown` rejects new Acquire commands, fails queued waiters, aborts every driver, continues processing `DriverClosed`, acknowledges the shutdown reply only at zero live drivers, then exits. Do not rely on command-channel closure because drivers retain senders.
 - [ ] Run manager tests. Expected: GREEN without wall-clock sleeps.
-- [ ] Commit as `feat(cli): add bounded dev proxy upstream manager`.
+- [ ] Commit as `Add bounded dev proxy upstream manager`.
 
 ---
 
@@ -156,10 +162,10 @@ enum Command {
 - [ ] Run focused tests. Expected: RED because `ConnectionFactory` is absent.
 - [ ] Define `ProxyRequestBody = BoxBody<Bytes, ProxyBodyError>` in `upstream/mod.rs`, where `ProxyBodyError` wraps `hyper::Error` and represents local cancellation. Then implement a narrow injectable factory returning an opened HTTP/1 sender, driver health, explicit abort handle, driver drop guard, connection ID, and actual peer.
 - [ ] Preserve IP-literal compatibility: DNS identities send SNI and validate DNS SAN; IP identities send no DNS SNI and validate IP SAN. Mark IP rules HTTP/1-required.
-- [ ] Compute one deadline before resolution. Count TCP attempt before `connect`, established after success, TLS handshake after TLS success, and HTTP handshake after Hyper success.
+- [ ] Compute one deadline before resolution. Record DNS lookup duration, TCP attempt before `connect`, established/connect duration after success, TLS handshake duration after TLS success, and HTTP handshake duration after Hyper success.
 - [ ] Spawn one Hyper driver per opened connection and report termination to the actor.
 - [ ] Run connector tests and existing `--resolve` E2E coverage. Expected: GREEN.
-- [ ] Commit as `feat(cli): open reusable dev proxy upstream connections`.
+- [ ] Commit as `Open reusable dev proxy upstream connections`.
 
 ---
 
@@ -168,6 +174,7 @@ enum Command {
 **Files:** Create `upstream/body.rs`; modify `upstream/{mod.rs,manager.rs}`.
 
 - [ ] Write scripted-body tests proving request state becomes Complete only after terminal EOS including trailers, and Failed on body error or drop before EOS.
+- [ ] Add a backpressure test whose scripted request body counts polls and exposes one frame only when downstream demand arrives; assert the adapter neither pre-polls nor buffers later frames.
 - [ ] Write failing response tests for DATA/trailer passthrough; release after terminal `None`; close intent; driver/body/upload failure; downstream drop; response EOS before upload completion; full/closed return channel; and idempotent finalization.
 - [ ] Run body tests. Expected: RED because adapters are absent.
 - [ ] Implement a streaming request body wrapper and one erased request type:
@@ -182,7 +189,7 @@ enum UploadState { Streaming, Complete, Failed }
 - [ ] Closing invokes driver abort and drops the sender, but does not decrement manager capacity; the driver drop guard reports termination and releases capacity.
 - [ ] Bound the nonblocking return channel to 64; on full/closed, close rather than blocking `poll_frame`.
 - [ ] Run body tests. Expected: GREEN.
-- [ ] Commit as `feat(cli): make pooled response leases streaming-safe`.
+- [ ] Commit as `Make pooled response leases streaming-safe`.
 
 ---
 
@@ -190,8 +197,7 @@ enum UploadState { Streaming, Complete, Failed }
 
 **Files:** Modify proxy `mod.rs`, `server.rs`, `upstream/mod.rs`, test support and existing E2E tests; create `proxy_pool_e2e.rs`.
 
-- [ ] Write a failing test that sends 100 sequential GETs over one MITM tunnel and expects 100 responses, one established upstream TCP connection, and one TLS handshake.
-- [ ] Run `proxy_pool_e2e`. Expected: RED with about 100 upstream connections on the current path.
+- [ ] First write a failing smoke test sending two sequential GETs over one MITM tunnel and expecting one established upstream connection/handshake. Run it and observe RED with two connections.
 - [ ] Introduce shared state:
 
 ```rust
@@ -204,12 +210,13 @@ pub struct ProxyState {
 
 - [ ] Build `ProxyState` once in `proxy::run`; pass `Arc<ProxyState>` into `serve_on`. Update test spawning helpers. Hyper service closures clone this Arc, not rules/auth/resolve maps.
 - [ ] Wire initial-head parse duration and manager acquisition/queue timing into the shared metrics at their actual boundaries.
-- [ ] Wire every mandatory metric at its boundary: CA hit/miss/mint; DNS lookup; TCP attempt/established/connect duration; TLS and Hyper handshake; pool hit/miss/stale/retry; request-to-header; request completion/failure. Add a snapshot integration test that drives one success and one failure and checks the expected deltas.
+- [ ] Wire every core metric at its boundary: accepted browser connections; parsed and rejected initial heads plus parse duration; CA hit/miss; DNS lookup duration; TCP attempt/established/connect duration; TLS and Hyper handshake durations; negotiated HTTP/1 count; pool hit/miss/stale/retry; pool acquisition/queue wait; request-to-header; request completion/failure. Add a snapshot integration test that drives one success, one rejected head, and one failure and checks every core category's expected delta. Task 9 adds mint metrics; Tasks 12/13 add retained-experiment metrics.
 - [ ] On every clean shutdown path, emit the redacted debug summary after Safari restoration. Add a formatting test proving it contains counts/timings but no URL query, auth value, certificate data, or sensitive headers.
 - [ ] Delegate mapped traffic to `UpstreamClient`. Keep blind tunnels, stray plain-HTTP forwarding, local PAC, Host-based per-request routing, and `421` behavior unchanged.
 - [ ] Capture upstream close intent before response hop-by-hop sanitation, then wrap the response body with its lease.
-- [ ] Run sequential reuse and all existing proxy E2E tests. Expected: one established connection/handshake and unchanged routing/security behavior.
-- [ ] Commit as `feat(cli): reuse upstream HTTP/1 connections`.
+- [ ] Make the two-request smoke GREEN, then add the 100-request acceptance case and run all existing proxy E2E tests. Expected: one established connection/handshake and unchanged routing/security behavior.
+- [ ] Add a test around proxy startup/output capture proving `--insecure` still emits its warning before serving. Do not weaken or relocate the warning behind debug logging.
+- [ ] Commit as `Reuse upstream HTTP/1 connections`.
 
 ---
 
@@ -220,12 +227,14 @@ pub struct ProxyState {
 - [ ] Write a failing test for 100 GETs at concurrency 20 against a 25 ms upstream. Require observed concurrency between two and six, at most six manager-owned live connections, and at most two idle afterward.
 - [ ] Write separate failing tests for upstream `Connection: close`, response body error, response trailers, slow/infinite response cancellation, truncated upload, and an origin responding before consuming the upload.
 - [ ] Add manager-selection/header integration cases: TLS versus plaintext, secure versus insecure, pinned versus DNS, different TO identities, and different ports never share; two FROM rules sharing one TO do share when allowed; Host-preserved and Host-rewritten configurations send exact SNI/Host/forwarding headers; one request's Authorization never persists onto the next reused request.
+- [ ] Prove unmatched blind tunnels and stray plain-HTTP forwarding bypass the manager and do not consume/decrement its 64 mapped-connection count.
 - [ ] For every non-reusable case, require the next request to open a fresh connection.
 - [ ] In the early-response case, require immediate browser response, driver abort, upload polling to stop, socket closure, and no live-capacity release until the driver drop guard reports termination.
+- [ ] Add a real proxy-shutdown test proving active/idle mapped drivers are aborted, sockets close, bounded queues are discarded, and the manager task exits without retained state.
 - [ ] Run `proxy_pool_e2e`. Task 5 unit tests may make lifecycle cases GREEN immediately; treat that as acceptance evidence. If an integration case fails, verify the failure is the intended missing behavior before changing production code.
 - [ ] Implement only the failing lifecycle transitions. Never background-drain; admit waiters only after driver termination decrements capacity.
 - [ ] Rerun `proxy_pool_e2e`. Expected: GREEN without timing sleeps except controlled upstream delays.
-- [ ] Commit as `test(cli): harden dev proxy pool lifecycle`.
+- [ ] Commit as `Harden dev proxy pool lifecycle`.
 
 ---
 
@@ -240,7 +249,7 @@ pub struct ProxyState {
 - [ ] For eligible requests only, retain method, URI, version and headers and substitute a reusable empty body. Do not clone or buffer `Incoming`.
 - [ ] Retry readiness failure with the unconsumed original request. Retry post-dispatch failure only from the retained template and only on a reused connection.
 - [ ] Add stale/retry metrics, rerun focused tests and the full E2E binary. Expected: GREEN.
-- [ ] Commit as `feat(cli): retry stale pooled proxy connections safely`.
+- [ ] Commit as `Retry stale pooled proxy connections safely`.
 
 ---
 
@@ -251,10 +260,10 @@ pub struct ProxyState {
 - [ ] Write a failing test that prewarms lowercase `www.example.com`, CONNECTs as mixed-case `WWW.Example.COM`, and expects one mint total plus a runtime hit.
 - [ ] Add failing tests for duplicate-rule deduplication and prewarm failure before browser launch.
 - [ ] Run focused tests. Expected: RED because raw CONNECT case forms a distinct cache key.
-- [ ] Normalize DNS CONNECT identities to lowercase before rule and CA lookup; preserve parsed IP identity without string-case logic.
-- [ ] Prewarm every unique normalized FROM before listener/browser startup. Instrument hits, misses, and unexpected post-prewarm mints without logging key material.
+- [ ] Normalize DNS CONNECT identities to lowercase before CA leaf lookup/cache insertion; `RuleTable::first_match` is already case-insensitive and needs no behavior change. Preserve parsed IP identity without string-case logic.
+- [ ] Prewarm every unique normalized FROM before listener/browser startup. Instrument hits, misses, leaf mint duration, and unexpected post-prewarm mints without logging key material; assert snapshot deltas.
 - [ ] Run `./scripts/test-cli.sh`. Expected: GREEN.
-- [ ] Commit as `perf(cli): prewarm normalized dev proxy certificates`.
+- [ ] Commit as `Prewarm normalized dev proxy certificates`.
 
 ---
 
@@ -264,12 +273,13 @@ pub struct ProxyState {
 
 - [ ] Run deterministic pool tests. Expected: exactly one established connection/handshake for sequential work and all bounds/lifecycle tests pass.
 - [ ] Run two warmups and ten alternating baseline/pooled measurements; record raw runs, median, p95, and median absolute deviation.
-- [ ] Add and run the injectable exact remote model: 100 GETs, concurrency 20, 30 ms connect delay, 30 ms TLS delay, 25 ms response delay. Use harness-only `PoolMode` and `PoolLimits`; expose no CLI flags.
+- [ ] Add and run the injectable exact remote model: 100 zero-body GETs with no `Content-Length` or `Transfer-Encoding`, immediate request EOS, concurrency 20, 30 ms connect delay, 30 ms TLS delay, and 25 ms response delay. Upstream responses use keep-alive plus explicit `Content-Length`; never use close-delimited framing. Use harness-only `PoolMode` and `PoolLimits`; expose no CLI flags.
 - [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_http1_comparison -- --ignored --nocapture --test-threads=1`.
 - [ ] Record entry evidence for parser, DNS, and HTTP/2; label those stages `ENTER` or `SKIP`. `TCP_NODELAY` is always measured in Task 14 and is labeled only `RETAIN` or `REJECT`. For HTTP/2, calculate the spec's cold/preconnected and cap-6/cap-20 ratios from median durations.
 - [ ] Run `perf_allocation_comparison` with harness-only `PoolMode::Disabled` for both baseline-compatible and precomputed variants so pooling gains cannot mask allocation effects. Record process CPU and total duration, or a written simplification justification if timing is neutral.
 - [ ] Confirm HTTP/1 pooling does not regress median or p95 more than 5% and adds no failures.
-- [ ] Commit notes as `docs: record dev proxy HTTP/1 performance results`.
+- [ ] State explicitly in the notes: localhost success is primarily 100-to-1 connection/handshake reduction; material wall-clock gains are expected and judged on the remote/staging latency model.
+- [ ] Commit notes as `Record dev proxy HTTP/1 performance results`.
 
 ---
 
@@ -285,7 +295,7 @@ pub struct ProxyState {
 - [ ] Write failing path tests proving over-read reaches browser TLS accept, blind tunnel, and plain-HTTP forwarding exactly once.
 - [ ] Implement chunk reads and one `PrefixedIo<T>` owner. Apply the 8 KiB cap only through `\r\n\r\n`; every downstream path consumes the same adapter and no path separately replays bytes.
 - [ ] Run correctness tests and ten alternating performance runs. Retain only if the 5% gate remains satisfied with no regression.
-- [ ] If retained, commit `perf(cli): buffer dev proxy initial request parsing`; otherwise remove experiment code and commit notes as `docs: reject buffered proxy parsing experiment`.
+- [ ] If retained, commit `Buffer dev proxy initial request parsing`; otherwise remove experiment code and commit notes as `Reject buffered proxy parsing experiment`.
 
 ---
 
@@ -300,9 +310,10 @@ pub struct ProxyState {
 - [ ] With paused time and a fake resolver, write failing tests for 30-second TTL, 64-entry bound, expired-first eviction, non-in-flight LRU eviction, all-in-flight bypass, concurrent miss coalescing, owned error fan-out, no failure caching, and `--resolve` bypass.
 - [ ] Add failing identity tests proving multiple peer IPs share one DNS origin key, different TO identities never share, and healthy idle connections may outlive DNS TTL only until their 60-second idle deadline.
 - [ ] Implement cache state without awaiting resolution under its lock. Store owned address lists; reconstruct equivalent I/O errors for waiters.
+- [ ] Record DNS cache hits, misses, and lookup duration; add snapshot assertions for retained cache variants.
 - [ ] Prove one total DNS/connect deadline and fair per-address remaining slices with fake time.
 - [ ] After implementation, run `perf_dns_cache_retention` with cache-disabled/cache-enabled variants for ten alternating measurements. Retain only if the original 5% evidence remains and failures do not increase.
-- [ ] Commit retained code, or remove it and commit notes-only rejection.
+- [ ] Commit retained code as `Cache dev proxy DNS results`, or remove it and commit notes as `Reject dev proxy DNS cache experiment`.
 
 ---
 
@@ -318,11 +329,16 @@ pub struct ProxyState {
 - [ ] Prove maintained public APIs can: abort an upload after response headers through `ProxyBodyError`, observe confirmed local stream termination, preserve required informational/trailer frames, and classify GOAWAY/`REFUSED_STREAM` sufficiently for the spec's retries. If any proof is impossible, record `REJECT` immediately.
 - [ ] On feasibility rejection, remove the Cargo feature, proof tests, fixtures, harness variants, and all HTTP/2 scaffolding before committing notes; skip the remaining steps.
 - [ ] If feasible, write failing behavior tests for four TLS configurations, serialized cold discovery, exact authority/SNI/path/query, no cross-name reuse, stream-permit lifecycle, and protocol semantics.
+- [ ] Write explicit failing global-bound tests: a 33rd non-draining h2 connection is not opened; draining connections continue consuming the 64 manager-owned live slots; replacement remains blocked at 64 until a driver-exit event releases capacity.
+- [ ] Test effective stream capacity as `min(100, peer SETTINGS_MAX_CONCURRENT_STREAMS)`: one case with peer max above 100 keeps request 101 queued, and one with peer max 3 keeps request 4 queued.
+- [ ] Test `REFUSED_STREAM` retries for a non-idempotent request only when its complete body is reconstructable; prove a consumed streaming body is never retried.
 - [ ] With upload still streaming, test response EOS, downstream cancellation, response body error, and upload failure. Each must request reset, retain its permit until the termination guard fires, and keep a 101st request queued until confirmed termination.
 - [ ] Implement `Vacant`, `Discovering`, `Http1`, `Http2`, and `Draining` manager states with one creator and exact bounds; implement only enough to turn each behavior test green.
+- [ ] Record negotiated HTTP/2 connections, active/completed streams, and connection replacements; add snapshot assertions before retention measurement.
 - [ ] After two warmups, run ten alternating HTTP/1/HTTP/2 variants. Retain only with at least 10% median duration/throughput improvement, p95 regression no worse than 5%, and no additional failures.
 - [ ] Run the retained-protocol comparison with `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_h2_retention -- --ignored --nocapture --test-threads=1`.
 - [ ] On any retention rejection, remove HTTP/2 production code, Cargo features, proof/behavior tests, fixtures, harness variants, and scaffolding before committing notes. Do not leave dormant complexity.
+- [ ] If retained, commit as `Add upstream HTTP/2 to dev proxy`; if rejected, commit notes as `Reject dev proxy HTTP/2 experiment`.
 
 ---
 
@@ -336,6 +352,7 @@ pub struct ProxyState {
 - [ ] After two warmups, run each setting as a separate process ten times in round-robin order. Example command: `/usr/bin/time -p env TS_PERF_VARIANT=browser_on cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_tcp_nodelay -- --ignored --nocapture --test-threads=1`. Repeat with each variant value so CPU evidence is per variant.
 - [ ] Retain browser/upstream settings independently only with at least 3% median improvement, p95 regression no worse than 5%, and per-process CPU regression no worse than 5%.
 - [ ] Remove option abstractions for rejected variants. Commit retained code or notes-only rejection.
+- [ ] Use `Tune dev proxy TCP latency` for retained settings or `Reject dev proxy TCP_NODELAY experiment` for notes-only rejection.
 
 ---
 
@@ -356,5 +373,5 @@ cargo clippy --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ {
 
 - [ ] Run the retained ignored performance workloads single-threaded and compare to recorded variability.
 - [ ] Audit all 14 security invariants against code and tests, including DNS/IP reference identity, no cross-SNI reuse, driver-owned capacity, no streaming-body replay, redacted auth, and bounded state.
-- [ ] Commit final docs as `docs: document dev proxy performance results`.
+- [ ] Commit final docs as `Document dev proxy performance results`.
 - [ ] Use `superpowers:requesting-code-review` on the complete branch. Resolve every critical/important issue and rerun affected verification until approved.

--- a/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
+++ b/docs/superpowers/plans/2026-07-10-dev-proxy-performance.md
@@ -133,21 +133,27 @@ pub enum ReferenceIdentity { Dns(Arc<str>), Ip(IpAddr) }
 ```rust
 enum Command {
     Acquire { key: OriginKey, reply: oneshot::Sender<Result<Lease, AcquireError>> },
-    Connected { key: OriginKey, result: Result<IdleConnection, ConnectError> },
     Return(IdleConnection),
-    DriverClosed(ConnectionId),
     Cancel(WaiterId),
     Expire(Instant),
     Shutdown { reply: oneshot::Sender<()> },
 }
+
+enum LifecycleEvent {
+    ConnectFinished { id: ConnectionId, key: OriginKey, result: Result<IdleConnection, ConnectError> },
+    DriverClosed(ConnectionId),
+}
 ```
 
 - [ ] Keep all counts and FIFO queues actor-owned. Spawn connection work and report completion; never await network work inside the actor.
+- [ ] Use two lanes: a bounded ordinary `mpsc::channel` for Acquire/Return/Cancel/Shutdown and an unbounded lifecycle channel for `ConnectFinished` and `DriverClosed`. The actor selects both lanes; spawned network completion and synchronous drop never use `try_send` on the bounded lane.
 - [ ] Store production defaults in injectable `PoolLimits`; permit harness-only cap variants and pool-disabled baseline mode without adding CLI flags.
 - [ ] Make capacity driver-owned: in actor tests, closing a lease emits an abort request but only a synthetic `DriverClosed(ConnectionId)` decrements live counts. Defer the real socket/upload assertion to Task 7 after the connector and body wrapper exist.
 - [ ] Use one next-deadline timer rather than a task per idle connection. Add paused-time assertions at 59 seconds (still idle) and 60 seconds (expiry requests abort). Expiry removes the entry but does not decrement/admit until `DriverClosed`.
 - [ ] Add actor-shutdown tests proving all waiters are failed, every live driver is aborted, queues/idle maps are cleared, and counts reach zero only through synthetic `DriverClosed` events.
-- [ ] Implement a Closing state: `Shutdown` rejects new Acquire commands, fails queued waiters, aborts every driver, continues processing `DriverClosed`, acknowledges the shutdown reply only at zero live drivers, then exits. Do not rely on command-channel closure because drivers retain senders.
+- [ ] Implement a Closing state: `Shutdown` rejects new Acquire commands, fails queued waiters, aborts every driver, and continues processing both unbounded lifecycle events. Reconcile every `ConnectFinished` by its reserved `ConnectionId`, never by key; failure releases that exact connecting count, while success publishes nothing, aborts the new driver, and waits for matching `DriverClosed`. Acknowledge only when connecting and driver counts are both zero.
+- [ ] Add shutdown-race tests for both successful and failed `ConnectFinished` after Closing begins; prove no connection reaches a waiter and capacity is reconciled exactly once.
+- [ ] Saturate the bounded ordinary channel in a paused-time actor test, mass-abort drivers, and prove every unbounded lifecycle event is received and zero-live acknowledgment succeeds.
 - [ ] Run manager tests. Expected: GREEN without wall-clock sleeps.
 - [ ] Commit as `Add bounded dev proxy upstream manager`.
 
@@ -161,6 +167,7 @@ enum Command {
 - [ ] Fake DNS must consume part of the deadline; prove each remaining address receives at most `remaining / addresses_left` and no attempt extends the original deadline.
 - [ ] Run focused tests. Expected: RED because `ConnectionFactory` is absent.
 - [ ] Define `ProxyRequestBody = BoxBody<Bytes, ProxyBodyError>` in `upstream/mod.rs`, where `ProxyBodyError` wraps `hyper::Error` and represents local cancellation. Then implement a narrow injectable factory returning an opened HTTP/1 sender, driver health, explicit abort handle, driver drop guard, connection ID, and actual peer.
+- [ ] Allocate `ConnectionId` and register a Connecting reservation in the actor before spawning network work. Include that ID in `ConnectFinished`. Start every successful Hyper driver behind a one-shot latch: enqueue completion, let the actor transition the exact reservation to Live/Closing, then release the latch. With simultaneous connects for one key, prove success/failure affects only its ID; also prove `DriverClosed` cannot arrive first and unknown IDs are never published/reconciled twice.
 - [ ] Preserve IP-literal compatibility: DNS identities send SNI and validate DNS SAN; IP identities send no DNS SNI and validate IP SAN. Mark IP rules HTTP/1-required.
 - [ ] Compute one deadline before resolution. Record DNS lookup duration, TCP attempt before `connect`, established/connect duration after success, TLS handshake duration after TLS success, and HTTP handshake duration after Hyper success.
 - [ ] Spawn one Hyper driver per opened connection and report termination to the actor.
@@ -212,6 +219,7 @@ pub struct ProxyState {
 - [ ] Wire initial-head parse duration and manager acquisition/queue timing into the shared metrics at their actual boundaries.
 - [ ] Wire every core metric at its boundary: accepted browser connections; parsed and rejected initial heads plus parse duration; CA hit/miss; DNS lookup duration; TCP attempt/established/connect duration; TLS and Hyper handshake durations; negotiated HTTP/1 count; pool hit/miss/stale/retry; pool acquisition/queue wait; request-to-header; request completion/failure. Add a snapshot integration test that drives one success, one rejected head, and one failure and checks every core category's expected delta. Task 9 adds mint metrics; Tasks 12/13 add retained-experiment metrics.
 - [ ] On every clean shutdown path, emit the redacted debug summary after Safari restoration. Add a formatting test proving it contains counts/timings but no URL query, auth value, certificate data, or sensitive headers.
+- [ ] Implement Ctrl-C ordering explicitly: restore Safari/system PAC first while the proxy is alive; abort/stop the accept-loop task; send manager `Shutdown`; wait with a fixed two-second Tokio timeout; emit current metrics on success or timeout; then return so runtime teardown reaps leftovers. Never await manager drain before Safari restoration.
 - [ ] Delegate mapped traffic to `UpstreamClient`. Keep blind tunnels, stray plain-HTTP forwarding, local PAC, Host-based per-request routing, and `421` behavior unchanged.
 - [ ] Capture upstream close intent before response hop-by-hop sanitation, then wrap the response body with its lease.
 - [ ] Make the two-request smoke GREEN, then add the 100-request acceptance case and run all existing proxy E2E tests. Expected: one established connection/handshake and unchanged routing/security behavior.
@@ -230,6 +238,8 @@ pub struct ProxyState {
 - [ ] Prove unmatched blind tunnels and stray plain-HTTP forwarding bypass the manager and do not consume/decrement its 64 mapped-connection count.
 - [ ] For every non-reusable case, require the next request to open a fresh connection.
 - [ ] In the early-response case, require immediate browser response, driver abort, upload polling to stop, socket closure, and no live-capacity release until the driver drop guard reports termination.
+- [ ] Add an adversarial shutdown orchestration test with injected hooks: saturate ordinary manager commands and delay one lifecycle close beyond two seconds. Assert Safari restoration is invoked first, new accepts stop next, shutdown returns at the deadline, and current metrics are emitted.
+- [ ] Add bidirectional large streaming E2E cases (for example 2 MiB in small deterministic chunks): a successful chunked upload captured byte-for-byte at the upstream, and a chunked response read byte-for-byte at the browser. Assert incremental polling/backpressure on both paths rather than whole-body buffering.
 - [ ] Add a real proxy-shutdown test proving active/idle mapped drivers are aborted, sockets close, bounded queues are discarded, and the manager task exits without retained state.
 - [ ] Run `proxy_pool_e2e`. Task 5 unit tests may make lifecycle cases GREEN immediately; treat that as acceptance evidence. If an integration case fails, verify the failure is the intended missing behavior before changing production code.
 - [ ] Implement only the failing lifecycle transitions. Never background-drain; admit waiters only after driver termination decrements capacity.
@@ -326,11 +336,12 @@ pub struct ProxyState {
 - [ ] Measure and record the entry gate.
 - [ ] Run `cargo test --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --test proxy_perf perf_h2_entry -- --ignored --nocapture --test-threads=1`; this internally alternates cold/preconnected and cap-6/cap-20 variants.
 - [ ] Temporarily enable Hyper `http2` and add a narrowly scoped `http2_feasibility` test target. This is prerequisite scaffolding, not a production behavior claim.
-- [ ] Prove maintained public APIs can: abort an upload after response headers through `ProxyBodyError`, observe confirmed local stream termination, preserve required informational/trailer frames, and classify GOAWAY/`REFUSED_STREAM` sufficiently for the spec's retries. If any proof is impossible, record `REJECT` immediately.
+- [ ] Prove maintained public APIs can: abort an upload after response headers through `ProxyBodyError`; observe confirmed local stream termination; preserve required informational/trailer frames; classify GOAWAY/`REFUSED_STREAM`; and expose current/dynamically lowered peer stream capacity (or an equivalent protocol signal) so combined manager plus Hyper-internal waiters can be kept within 32 per origin and 128 globally. `SendRequest::ready()` is insufficient. If any proof is impossible, record `REJECT` immediately.
 - [ ] On feasibility rejection, remove the Cargo feature, proof tests, fixtures, harness variants, and all HTTP/2 scaffolding before committing notes; skip the remaining steps.
 - [ ] If feasible, write failing behavior tests for four TLS configurations, serialized cold discovery, exact authority/SNI/path/query, no cross-name reuse, stream-permit lifecycle, and protocol semantics.
 - [ ] Write explicit failing global-bound tests: a 33rd non-draining h2 connection is not opened; draining connections continue consuming the 64 manager-owned live slots; replacement remains blocked at 64 until a driver-exit event releases capacity.
-- [ ] Test effective stream capacity as `min(100, peer SETTINGS_MAX_CONCURRENT_STREAMS)`: one case with peer max above 100 keeps request 101 queued, and one with peer max 3 keeps request 4 queued.
+- [ ] Only if feasibility exposes adequate peer-capacity accounting, implement candidate active capacity `min(100, peer limit)` and keep all remaining requests in the bounded manager queues rather than a hidden Hyper queue. Hold active permits through response/reset termination and react to dynamic SETTINGS reductions.
+- [ ] Test both layers: with peer max above 100, request 101 stays in the manager queue; with peer max 3, request 4 stays in the manager queue; dynamic lowering moves no extra work into an unbounded internal queue. Assert combined per-origin/global waiter bounds and cancellation.
 - [ ] Test `REFUSED_STREAM` retries for a non-idempotent request only when its complete body is reconstructable; prove a consumed streaming body is never retried.
 - [ ] With upload still streaming, test response EOS, downstream cancellation, response body error, and upload failure. Each must request reset, retain its permit until the termination guard fires, and keep a 101st request queued until confirmed termination.
 - [ ] Implement `Vacant`, `Discovering`, `Http1`, `Http2`, and `Draining` manager states with one creator and exact bounds; implement only enough to turn each behavior test green.

--- a/docs/superpowers/plans/2026-07-12-dev-proxy-review-backfill.md
+++ b/docs/superpowers/plans/2026-07-12-dev-proxy-review-backfill.md
@@ -1,0 +1,181 @@
+# Dev Proxy Review Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct dev-proxy outcome metrics and stale-readiness recovery, remove rejected HTTP/2 state, and backfill the lifecycle/security integration coverage identified in the final review.
+
+**Architecture:** Keep response delivery outcome separate from connection poolability: terminal response EOS counts as completion even when the connection must close. Reused-sender readiness failure switches acquisition into an explicit fresh-only path. HTTP/1 remains the sole application protocol, so the origin key and TLS cache contain only fields that affect retained runtime behavior. Test-only raw upstreams exercise malformed, cancelled, and pipelined byte streams without changing production APIs.
+
+**Tech Stack:** Rust 2024, Tokio, Hyper 1.x, rustls/tokio-rustls, error-stack, macOS host-target integration tests.
+
+---
+
+## File map
+
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs`: response outcome accounting versus poolability.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs`: reused-sender readiness recovery.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs`: retained HTTP/1 origin identity.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs`: HTTP/1 TLS configuration tests.
+- `crates/trusted-server-cli/src/commands/dev/proxy/rewrite.rs`: construct the simplified origin key.
+- `crates/trusted-server-cli/src/commands/dev/proxy/config.rs`: update key expectations after HTTP/2-state removal.
+- `crates/trusted-server-cli/src/commands/dev/proxy/server.rs`: unit coverage for warning/header/over-read helpers only if required by the integration harness.
+- `crates/trusted-server-cli/tests/support/mod.rs`: deterministic raw upstream and client fixtures.
+- `crates/trusted-server-cli/tests/proxy_e2e.rs`: lifecycle, security, and three-path over-read coverage.
+- `docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md`: align the retained architecture with the rejected HTTP/2 experiment.
+- `docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md`: correct the no-dormant-code claim and record backfilled gates.
+
+### Task 1: Separate response outcome from connection reuse
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs`
+- Test: `crates/trusted-server-cli/src/commands/dev/proxy/upstream/body.rs`
+
+- [ ] Add failing unit cases proving terminal response EOS records `requests_completed = 1` and `requests_failed = 0` when `Connection: close`, a streaming/failed upload, or a finished driver prevents reuse, while body error/drop before EOS records failure and never completion.
+- [ ] Run `cargo test --package trusted-server-cli --target aarch64-apple-darwin upstream::body::tests::complete_unpoolable_response_is_not_a_request_failure` and confirm the current code reports a failure.
+- [ ] Change finalization so `response_complete` alone selects completed versus failed metrics; independently use `can_reuse` to return or abort the lease.
+- [ ] Re-run the focused body tests and commit with `Correct dev proxy request outcome metrics`.
+
+### Task 2: Force a fresh connection after readiness failure
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs`
+- Test: `crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs`
+- Test: `crates/trusted-server-cli/tests/proxy_e2e.rs`
+- Modify: `crates/trusted-server-cli/tests/support/mod.rs`
+
+- [ ] Behavior-preserving refactor: route initial manager acquisition through a private `AcquisitionMode` boundary whose `Normal` and `FreshAfterReadinessFailure` variants both initially call `acquire`; run the existing manager and stale-retry tests green.
+- [ ] Add a failing upstream-client policy test with two idle senders and a cap of two. Invoke the `FreshAfterReadinessFailure` boundary and assert it discards idle senders and remains pending until driver reconciliation permits an `Open` reservation. Confirm current behavior incorrectly returns `Reused`.
+- [ ] Change only `FreshAfterReadinessFailure` to call `acquire_fresh`, and switch the reused readiness-error branch to that mode while preserving exactly one stale retry.
+- [ ] Retain the post-dispatch stale E2E as the wire-observable fallback; document that driver-guard priority normally removes closed idle senders before a second request can deterministically observe `ready()` failure.
+- [ ] Run focused manager/upstream tests and the existing post-dispatch stale E2E.
+- [ ] Commit with `Use a fresh connection after stale readiness`.
+
+### Task 3: Remove rejected HTTP/2 application state
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs`
+- Modify: `crates/trusted-server-cli/src/commands/dev/proxy/rewrite.rs`
+- Modify: `crates/trusted-server-cli/src/commands/dev/proxy/config.rs`
+- Modify: `crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs`
+- Modify: `docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md`
+- Modify: `docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md`
+
+- [ ] Add a failing behavioral test that builds two retained HTTP/1 rules for the same logical TO—one preserving `Host: FROM`, one rewriting `Host: TO`—and asserts their origin keys are equal. Confirm `ApplicationMode` currently makes them unequal even though Host is request-local.
+- [ ] Remove `ApplicationMode`, its `OriginKey` field/accessor/constructor argument, and rewrite/config branches that manufacture `Http2Eligible`.
+- [ ] Keep TLS configuration keyed by `VerifyMode`; document that this is complete because retained runtime advertises only HTTP/1.1.
+- [ ] Update the design spec wherever it still treats application mode as a retained key field or requires HTTP/2-mode separation; preserve the historical experiment section as rejected evidence.
+- [ ] Run config, rewrite, key, and manager tests.
+- [ ] Commit with `Remove rejected HTTP2 origin state`.
+
+### Task 4: Add connector and TLS-cache unit coverage
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs`
+
+- [ ] Add characterization tests asserting secure configs are cached together, insecure configs are cached together, secure/insecure configs are distinct, and both advertise only `http/1.1`.
+- [ ] Add a paused-time cancellation test with an IP origin and injected `connect_delay`: reserve one manager slot, spawn/register `PendingConnection`, drop it and the reservation before time advances, then assert the abort handle finishes and a replacement reservation is admitted exactly once without DNS/TCP.
+- [ ] Add an unwind test that moves the reservation and delayed `PendingConnection` into a spawned task that panics. Assert task unwind drops both guards, manager shutdown/reacquisition completes, and capacity is not decremented twice.
+- [ ] Run all `upstream::connect` and manager connector tests.
+- [ ] Commit with `Cover dev proxy connector configuration`.
+
+### Task 5: Prove credentials do not persist and insecure mode warns
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/tests/support/mod.rs`
+- Modify: `crates/trusted-server-cli/tests/proxy_e2e.rs`
+
+- [ ] Add the neutral two-request client fixture first, then a characterization test that sends `Authorization` only on the first request over one pooled upstream connection and asserts the gated upstream returns `200` then `401` on one TCP/TLS session.
+- [ ] Add a CLI-process characterization test that reserves the configured listen port, launches `ts dev proxy --insecure` with a temporary CA directory, and asserts stderr contains the explicit verification-disabled warning before bind failure.
+- [ ] Run both focused E2E tests.
+- [ ] Commit with `Backfill dev proxy credential safety tests`.
+
+### Task 6: Cover early response, cancellation, and response-body failure
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/tests/support/mod.rs`
+- Modify: `crates/trusted-server-cli/tests/proxy_e2e.rs`
+
+- [ ] Add a raw TLS upstream that sends a complete response immediately after the chunked request head without draining the upload. Assert the browser receives the response promptly, upload polling/socket activity stops, metrics count completion rather than failure, and the lease is not pooled.
+- [ ] Add a slow chunked-response upstream. Drop the browser tunnel after one body chunk; assert `requests_failed` increments, the driver closes, and manager shutdown completes within one second.
+- [ ] Add a truncated-response upstream that advertises a larger `Content-Length` than it sends; assert the browser sees truncation and metrics count one failure.
+- [ ] Add a chunked response with DATA plus trailers followed by a second request on the same browser tunnel. Assert trailers are forwarded and the upstream connection is reused only after terminal EOS.
+- [ ] Run each new E2E independently before proceeding to the next.
+- [ ] Commit with `Cover dev proxy streaming failure lifecycles`.
+
+### Task 7: Prove blind and plain forwarding bypass mapped pool accounting
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/tests/support/mod.rs`
+- Modify: `crates/trusted-server-cli/tests/proxy_e2e.rs`
+
+- [ ] Add a raw loopback echo upstream and hold more than 64 unmatched CONNECT tunnels open through one proxy.
+- [ ] While those tunnels remain open, issue a mapped request and assert it succeeds with a normal upstream connection, proving blind tunnels do not consume the manager global-live bound.
+- [ ] Repeat with more than 64 stray absolute-form plain-HTTP forwarding connections held open, then assert a mapped request still obtains upstream capacity.
+- [ ] Close all tunnels and assert bounded proxy shutdown completes.
+- [ ] Run the focused integration test.
+- [ ] Commit with `Prove blind tunnels bypass pool limits`.
+
+### Task 8: Exercise CONNECT over-read through all three consumers
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/tests/support/mod.rs`
+- Modify: `crates/trusted-server-cli/tests/proxy_e2e.rs`
+
+- [ ] Add a blind-tunnel client that writes CONNECT head plus payload in one buffered write; assert the raw upstream receives the payload exactly once.
+- [ ] Add an absolute-form plain-HTTP client that writes head plus body in one buffered write; assert the raw upstream receives head and body exactly once.
+- [ ] Add a test-only browser IO wrapper that buffers the CONNECT head with rustls first-flight bytes and strips the proxy HTTP 200 response before exposing TLS records. Use the normal `TlsConnector` above that wrapper, then assert a mapped HTTPS request succeeds. This deterministically drives TLS ClientHello bytes through `PrefixedIo`.
+- [ ] Run the three focused tests and the existing `prefixed_io` unit test.
+- [ ] Commit with `Cover dev proxy overread consumers`.
+
+### Task 9: Backfill adversarial shutdown at the integration boundary
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/src/commands/dev/proxy/mod.rs`
+- Modify: `crates/trusted-server-cli/tests/proxy_e2e.rs`
+- Modify: `crates/trusted-server-cli/tests/support/mod.rs` only if a delayed fixture is required.
+
+- [ ] Keep the existing direct-channel unit test as the deterministic proof that priority shutdown overtakes all 64 occupied ordinary slots; do not attempt to reproduce channel fullness through the continuously draining public actor.
+- [ ] Add an integration-boundary test with a live connector/driver whose lifecycle completion is deliberately delayed. Assert shutdown stays pending until reconciliation and an external one-second timeout bounds the caller.
+- [ ] Behavior-preserving refactor the Ctrl-C cleanup into a private async helper that takes distinct restoration and accept-loop-stop closures plus the drain future. Add a test proving the exact order is restore Safari/system settings → stop/abort the accept loop → first poll manager drain, and that a delayed drain is capped at two seconds, without touching real system settings.
+- [ ] Run the focused shutdown integration test.
+- [ ] Commit with `Backfill adversarial proxy shutdown coverage`.
+
+### Task 10: Cover feasible origin-key isolation at the integration boundary
+
+**Files:**
+
+- Modify: `crates/trusted-server-cli/tests/support/mod.rs`
+- Modify: `crates/trusted-server-cli/tests/proxy_e2e.rs`
+- Test: `crates/trusted-server-cli/src/commands/dev/proxy/upstream/key.rs`
+
+- [ ] Add a multi-rule proxy fixture proving two distinct FROM hosts mapped to the same TO reuse one HTTP/1 connection while per-request Host and forwarding headers remain correct.
+- [ ] Add distinct TO/port mappings and assert they never share connections.
+- [ ] Retain unit-level independent variation for transport and verification mode because `--upstream-plaintext` and `--insecure` are process-global and cannot coexist in one proxy invocation; document this feasibility boundary in the test.
+- [ ] Run the focused key and multi-rule E2E tests.
+- [ ] Commit with `Cover dev proxy pool key isolation`.
+
+### Task 11: Final verification and PR update
+
+**Files:**
+
+- Modify: `docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md`
+
+- [ ] Update implementation notes with corrected metric semantics, HTTP/1-only keying, and the added lifecycle/security tests.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo check --package trusted-server-cli --target aarch64-apple-darwin --tests`.
+- [ ] Run `cargo clippy --package trusted-server-cli --target aarch64-apple-darwin --all-targets -- -D warnings`.
+- [ ] Run `./scripts/test-cli.sh` and all six ignored `proxy_perf` workloads with one test thread.
+- [ ] Run the complete repository CI matrix from `CLAUDE.md`: `cargo clippy-fastly`, `cargo clippy-axum`, `cargo clippy-cloudflare`, `cargo clippy-cloudflare-wasm`, `cargo clippy-spin-native`, `cargo clippy-spin-wasm`, `cargo test-fastly`, `cargo test-axum`, `cargo test-cloudflare`, `cargo test-spin`, and the cross-adapter parity test.
+- [ ] Run JS build/tests/format (`node build-all.mjs`, `npx vitest run`, `npm run format`) and docs format (`cd docs && npm run format`).
+- [ ] Run `git diff --check`.
+- [ ] Perform a final self-review of the complete diff against the feedback list.
+- [ ] Commit with `Complete dev proxy review backfill`, push `perf/dev-proxy-optimization`, and verify PR #896 is mergeable with CI restarted.

--- a/docs/superpowers/plans/2026-07-14-dev-proxy-pr-feedback.md
+++ b/docs/superpowers/plans/2026-07-14-dev-proxy-pr-feedback.md
@@ -1,0 +1,94 @@
+# Dev Proxy PR Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring PR #896 back into conformance with the approved dev-proxy performance design and address every review comment with regression coverage and individual review replies.
+
+**Architecture:** Keep the approved two-lane manager actor, bounded pool, acquire-ticket state machine, and origin identity. Move connecting-capacity ownership into the connector task until cancellation has actually completed, make returned-connection delivery recoverable across cancelled waiters, and centralize pre-response failure accounting. Preserve HTTP trailer semantics explicitly at the request-leg boundary; keep the remaining fixes local to DNS notification, aggregate diagnostics, performance-fixture selection, and documentation.
+
+**Tech Stack:** Rust 2024, Tokio, Hyper HTTP/1, rustls/aws-lc-rs, error-stack, GitHub CLI.
+
+**Primary specification:** `docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md`
+
+---
+
+## File map
+
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/connect.rs`: connector-task ownership, cancellation reconciliation, rustls scheme caching.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/manager.rs`: recoverable FIFO handoff and connection reservation registration.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/mod.rs`: exactly-once send outcome accounting, acquisition timing, stale POST safety documentation.
+- `crates/trusted-server-cli/src/commands/dev/proxy/upstream/dns.rs`: retained completion publication after receiver cancellation.
+- `crates/trusted-server-cli/src/commands/dev/proxy/server.rs`: safe upstream request `Trailer` and `TE: trailers` regeneration.
+- `crates/trusted-server-cli/src/commands/dev/proxy/metrics.rs`: complete aggregate latency summary.
+- `crates/trusted-server-cli/tests/support/mod.rs`: raw upstream fixtures for request trailers and unreachable origins.
+- `crates/trusted-server-cli/tests/proxy_e2e.rs`: end-to-end trailer and terminal setup-failure assertions.
+- `crates/trusted-server-cli/tests/proxy_perf.rs`: self-validating remote workload.
+- `docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md`: exact remote benchmark commands and review corrections.
+
+### Task 1: Tie connector capacity to actual task termination
+
+- [ ] Add paused-time tests in `upstream/connect.rs` that drop the current caller-owned `Reservation` together with `PendingConnection`, then use a connector-task barrier to prove replacement acquisition and shutdown remain pending until the aborted connector future executes its reservation-drop cleanup.
+- [ ] Run the focused connector tests and confirm the new tests fail because dropping the caller-owned `Reservation` releases capacity immediately.
+- [ ] Change `PendingConnection::spawn` to consume the `Reservation`; keep it inside the spawned connector future and return it only with a successful opened connection. Let cancellation, connector error, and unwind drop it inside the task; consume/disarm it only when registering the successful driver.
+- [ ] Update both connection-open call sites in `upstream/mod.rs` and the connector tests to use the task-owned reservation.
+- [ ] Run the connector and manager test modules and confirm all tests pass.
+
+Focused command:
+
+```bash
+cargo test --package trusted-server-cli --target aarch64-apple-darwin commands::dev::proxy::upstream::connect -- --nocapture
+```
+
+### Task 2: Continue FIFO handoff after cancellation races
+
+- [ ] Add a deterministic two-waiter actor test in `upstream/manager.rs` by constructing actor requests directly: drop the first request's oneshot receiver while deliberately leaving its ticket `Pending`, queue a live second request, return one matching connection, and assert the first `ticket.resolve()` succeeds but failed delivery is recovered and the second waiter receives that exact lease.
+- [ ] Run the test and confirm it fails with the second waiter unresolved.
+- [ ] Make `return_connection` loop over same-origin reusable waiters. If ticket resolution loses, continue. If oneshot delivery fails, recover `Acquired::Reused(Lease)` from the send error and continue with its connection payload.
+- [ ] Run all manager tests and confirm FIFO, limits, cancellation, and shutdown remain green.
+
+### Task 3: Preserve request trailers end to end
+
+- [ ] Add a header-unit test in `server.rs` proving sanitation regenerates only Hyper-valid request trailer declarations and regenerates `TE: trailers` plus `Connection: TE` only when the browser advertised trailer acceptance.
+- [ ] Add an E2E fixture that receives a chunked request with a declared request trailer, observes the trailer at the origin, and returns a response trailer only when upstream `TE: trailers` is present. Assert both trailers cross the proxy.
+- [ ] Run the tests and confirm the request trailer/conditional response assertion fails because `rewrite_headers` removes `Trailer` and `TE`.
+- [ ] Capture trailer declarations and trailer acceptance before hop-by-hop stripping, filter declarations with Hyper's valid-trailer field rules, and regenerate new upstream-leg metadata after authoritative header rewriting.
+- [ ] Re-run the focused header and E2E tests and confirm they pass.
+
+### Task 4: Record every terminal send failure exactly once
+
+- [ ] Add an E2E test using a reserved but unreachable loopback port. Assert the browser receives `502`, `requests_completed == 0`, and `requests_failed == 1`.
+- [ ] Add unit coverage showing acquisition duration is recorded on both `Ok` and `Err` manager outcomes.
+- [ ] Run the tests and confirm connector/acquisition errors currently leave `requests_failed` and failed acquisition samples at zero.
+- [ ] Add a scoped send-outcome guard at the `UpstreamClient::send` boundary. It records one failure unless ownership is handed to `PooledResponseBody`; remove branch-local failure increments that would double-count.
+- [ ] Record pool-acquisition elapsed time immediately after each await and before propagating its result, including stale-replacement acquisition.
+- [ ] Re-run focused upstream and E2E tests and assert exact counts.
+
+### Task 5: Retain DNS completion without receivers
+
+- [ ] Add a multi-threaded DNS test that starts one miss, cancels every receiver, holds the cache-state mutex to pause state replacement, completes the resolver, and subscribes late to the still-loading entry. Assert the published result is already retained.
+- [ ] Run the test and confirm `watch::Sender::send` leaves the late subscriber without the completed value.
+- [ ] Replace publication with `send_replace(Some(shared.clone()))`.
+- [ ] Run all DNS tests and confirm success/failure fan-out, TTL, cancellation, and bounds remain green.
+
+### Task 6: Complete diagnostics, benchmark validation, and cleanup feedback
+
+- [ ] Extend the metrics summary test first to require totals and buckets for request-to-headers, DNS, TLS, HTTP handshake, and CA mint latency; confirm it fails.
+- [ ] Emit sample count, total microseconds, and fixed buckets for every advertised latency phase without adding request labels or sensitive values.
+- [ ] Add a remote-workload variant validator test and make `perf_http1_remote_model` reject any value except `remote_baseline` or `remote_pooled`.
+- [ ] Document the exact alternating remote commands used for the recorded measurements.
+- [ ] Cache `NoVerifier::supported_verify_schemes` in a `OnceLock<Vec<SignatureScheme>>` and add/extend configuration coverage.
+- [ ] Document why stale post-dispatch replay excludes non-idempotent requests.
+- [ ] Add missing documentation to public items touched by the PR where CLAUDE.md requires it.
+- [ ] Run metrics, performance-fixture, connector, and upstream unit tests.
+
+### Task 7: Full verification and GitHub review closure
+
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo check --tests --target aarch64-apple-darwin` from `crates/trusted-server-cli`.
+- [ ] Run `cargo clippy --all-targets --target aarch64-apple-darwin -- -D warnings` from `crates/trusted-server-cli`.
+- [ ] Run `./scripts/test-cli.sh` and record the exact test totals.
+- [ ] Run `npm run format` from `docs` and confirm it makes no changes.
+- [ ] Review `git diff --check`, the full diff, and the approved spec invariants. Confirm the pre-existing blind-tunnel logging commit remains untouched.
+- [ ] Commit focused changes with imperative, non-semantic messages and push `perf/dev-proxy-optimization`.
+- [ ] Reply individually to all ten inline comments: seven actionable findings, the signature-scheme cleanup, the deliberate non-idempotent replay trade-off, and the lifecycle praise thread. Include the implementing commit and regression-test name where applicable; resolve threads only after the pushed diff contains the fix or acknowledgement.
+- [ ] Refresh PR checks and report any external CI failure without claiming completion until required checks are green.

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -19,6 +19,11 @@ TCP connection, performs a new TLS and Hyper handshake, sends one request, and
 drops the sender. A page with many assets therefore repeats network setup that
 should be amortized across requests.
 
+The material wall-clock win is expected against remote and staging upstreams,
+where TCP and TLS setup carry real latency. For localhost, success is primarily
+the deterministic reduction from one setup per request to one reusable
+connection; a flat local duration is not by itself a failure.
+
 ## Goals
 
 1. Reuse upstream connections safely across forwarded requests.
@@ -165,6 +170,12 @@ Hyper-util's general client pool does not expose all of those policies as one
 auditable state machine. The custom manager still uses Hyper's maintained
 HTTP/1.1 and HTTP/2 connection drivers, but owns leasing, limits, and the
 complete origin key itself.
+
+The manager actor is intentionally a single serialization point for
+acquire/return/accounting commands. This channel hop is proportionate at local
+developer-proxy request rates and buys auditable driver-owned capacity and
+teardown. Pool-acquisition and queue-wait metrics verify that it does not become
+a meaningful bottleneck.
 
 The HTTP/1.1 pool obeys these rules:
 
@@ -666,6 +677,7 @@ corresponding experiment clears its entry gate and its code is retained.
   `is_end_stream() == false`, non-empty extensions, zero-data bodies with
   trailers, unexpected frames, and mid-body errors.
 - Metrics counters and bounded timing buckets.
+- Backpressure without adapter pre-buffering.
 
 ### Integration Tests
 
@@ -692,6 +704,9 @@ gate and its code is retained.
 - Multi-address connection attempts share one total deadline and record the
   actual selected peer without fragmenting logical pool identity.
 - TLS, plaintext, secure, insecure, and `--resolve` pools remain isolated.
+- `--insecure` still emits its warning; blind tunnels and stray plain-HTTP
+  forwarding bypass mapped pool accounting; manager shutdown aborts drivers,
+  closes sockets, fails waiters, and discards all bounded state.
 - Origin-key tests vary protocol, TO reference identity, port, address policy,
   verification mode, and application mode independently, including combinations
   that cannot arise in one CLI invocation because `--insecure` and `--resolve`

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -552,6 +552,11 @@ TLS handshake count, and request failures. Timing assertions are not placed in
 ordinary CI tests. Correctness tests assert deterministic connection/handshake
 counts; performance comparisons are run deliberately and documented.
 
+Harness-only construction may inject pool-disabled mode, alternate pool limits,
+and phase delays so variants can run against one binary in alternating order.
+These controls are not CLI flags and production construction always uses the
+approved defaults.
+
 ### Acceptance Criteria
 
 The named sequential workload is 100 zero-body GET requests over one

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -247,6 +247,45 @@ guard that reports `DriverClosed(ConnectionId)` even when its task is aborted;
 only that event releases origin/global capacity and admits waiters. Therefore an
 upload or socket cannot remain active after accounting says capacity is free.
 
+Network lifecycle events use a dedicated unbounded Tokio channel separate from
+the bounded acquire/return command channel. Connection-attempt completion and a
+synchronous driver drop guard can therefore report `ConnectFinished` and
+`DriverClosed` during mass abort without blocking or losing accounting behind
+ordinary queued commands. Failure to send means the manager has already exited
+and no acknowledgment is still waiting.
+
+The actor allocates each `ConnectionId` and records a Connecting reservation
+before opening begins. On successful handshake, the connector creates a driver
+task behind a one-shot start latch and sends `ConnectFinished` containing its
+ID and control handles. The actor first transitions that exact reservation to Live (or
+marks it for immediate shutdown), then releases the latch. Consequently
+`DriverClosed` cannot precede registration, and unknown IDs are treated as an
+invariant violation rather than later publishing a dead connection.
+
+### Shutdown Choreography
+
+Ctrl-C preserves Safari recovery as the first operation. While the proxy is
+still alive, synchronously restore the prior Safari/system PAC setting using the
+existing interactive behavior. Only after restoration returns does shutdown:
+
+1. stop the accept-loop task so no new browser connections enter;
+2. send `Shutdown` to the upstream manager, which rejects acquisition, fails
+   waiters, aborts every driver, and continues consuming lifecycle events;
+3. wait at most two seconds for the manager to observe all `DriverClosed` events
+   and acknowledge zero live manager-owned connections;
+4. on success or timeout, emit the redacted metrics summary from current state
+   and return, allowing Tokio runtime teardown to reap anything remaining.
+
+The manager drain is diagnostic/graceful behavior, not a precondition for Safari
+restoration or process exit. A wedged driver or saturated ordinary command queue
+cannot strand the system proxy or hang Ctrl-C indefinitely.
+
+If a pending connection attempt reports `ConnectFinished` while Closing, a
+failure releases its connecting count immediately; a success is never published
+to a waiter and its new driver is aborted, with live capacity retained until the
+subsequent `DriverClosed`. Closing acknowledges only after both connecting and
+driver counts reach zero.
+
 Upstream `Connection: close` and equivalent HTTP/1 connection intent are
 captured before hop-by-hop response sanitation. The sanitized header is still
 not forwarded to the reusable browser tunnel. Returning a lease is idempotent:
@@ -314,6 +353,15 @@ normal HTTP/1.1 pool under the eligible-mode origin key. For eligible rules:
   upload failure follows the same reset-then-confirm rule. A GOAWAY/draining connection retains its global
   live-connection capacity until the driver exits, using the same driver-owned
   accounting rule as HTTP/1.1;
+- before candidate production work, the feasibility proof must find a maintained
+  public API or equivalent protocol signal that lets the manager account for the
+  peer's current and dynamically lowered `SETTINGS_MAX_CONCURRENT_STREAMS`.
+  `SendRequest::ready()` is explicitly insufficient. The combined manager queue
+  and any requests queued inside Hyper must respect the 32-per-origin and
+  128-global waiter bounds with testable cancellation. If hidden Hyper queuing
+  cannot be observed and bounded, reject HTTP/2 at feasibility and remove all
+  experiment code. Only after this proof may the manager implement the candidate
+  `min(100, peer limit)` active-stream policy and queue the remainder itself;
 - the connection remains keyed by the complete upstream origin key;
 - before dispatch, the client constructs an HTTP/2 request URI whose authority
   is the TO hostname plus any non-default port. Hyper therefore emits
@@ -697,6 +745,9 @@ gate and its code is retained.
   pooling, that upstream connection. The test asserts upload polling stops, the
   socket closes, and manager live capacity is released only after the driver
   drop guard reports termination.
+- Large chunked request and response bodies traverse the pooled wrappers end to
+  end with exactly identical bytes and incremental polling, without whole-body
+  buffering.
 - A server-closed idle connection is retried once on a fresh connection.
 - Sender-readiness failure preserves an unconsumed request; post-send failure
   retries only an eligible idempotent empty request. Streaming and truncated
@@ -707,6 +758,9 @@ gate and its code is retained.
 - `--insecure` still emits its warning; blind tunnels and stray plain-HTTP
   forwarding bypass mapped pool accounting; manager shutdown aborts drivers,
   closes sockets, fails waiters, and discards all bounded state.
+- Ctrl-C shutdown restores Safari before manager drain, completes within the
+  two-second drain deadline when a driver delays termination, and still receives
+  all driver lifecycle events when the ordinary command channel is saturated.
 - Origin-key tests vary protocol, TO reference identity, port, address policy,
   verification mode, and application mode independently, including combinations
   that cannot arise in one CLI invocation because `--insecure` and `--resolve`

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -118,25 +118,21 @@ reference identity: normalized DNS TO | IP TO
 port
 address policy: logical DNS policy or concrete --resolve pin
 TLS verification: secure | insecure
-application mode: HTTP/1 required | HTTP/2 eligible
 ```
 
 The rewritten HTTP `Host` value is not itself an HTTP/1.1 transport key because
 sequential requests may carry different Host values over a connection to the
-same logical TO origin. HTTP/2 is stricter: it is eligible only when
-`--rewrite-host` makes the request authority equal the TO hostname authenticated
-by TLS. A default rule that sends `Host: FROM` forces HTTP/1.1, preserving the
-existing deliberate separation between SNI (`TO`) and Host (`FROM`) without
-relying on cross-origin HTTP/2 behavior.
+same logical TO origin. The retained implementation is HTTP/1.1-only, so
+rewritten versus preserved Host values do not split a pool whose transport and
+authenticated TO identity are otherwise equal.
 
 The TO reference identity is either a normalized DNS hostname or an IP literal,
 matching Rustls `ServerName`. For DNS identities, TLS sends SNI equal to TO. For
 IP identities, TLS sends no DNS SNI and secure mode validates an IP SAN, matching
-current behavior. IP-literal rules are HTTP/1-required; HTTP/2 eligibility is
-limited to DNS TO identities whose rewritten authority equals TO.
+current behavior.
 
-The stable pool key is `(transport, normalized TO reference identity, port, verification
-mode, application mode, address policy)`. For `--resolve`, address policy
+The stable pool key is `(transport, normalized TO reference identity, port,
+verification mode, address policy)`. For `--resolve`, address policy
 contains the pinned IP. For DNS, address policy is the logical DNS policy, not a
 fallback-varying peer IP. Each connection record stores its actual peer address
 and DNS generation for diagnostics, but multi-address fallback does not create a
@@ -158,18 +154,16 @@ Create a dedicated `upstream` module responsible for:
 - opening TCP sockets under the configured connect timeout;
 - applying measured socket options;
 - performing TLS negotiation and verification;
-- selecting HTTP/1.1 or HTTP/2 from ALPN;
 - leasing and returning reusable HTTP/1.1 connections;
-- multiplexing requests over HTTP/2 connections;
 - tracking connection lifecycle metrics.
 
 Use a small custom transport manager because the design requires explicit live
 and waiter bounds, response-body-controlled lease return, exact SNI-host
-isolation, address-policy identity, and serialized HTTP/2 protocol discovery.
+isolation, address-policy identity, and deterministic lifecycle reconciliation.
 Hyper-util's general client pool does not expose all of those policies as one
 auditable state machine. The custom manager still uses Hyper's maintained
-HTTP/1.1 and HTTP/2 connection drivers, but owns leasing, limits, and the
-complete origin key itself.
+HTTP/1.1 connection driver, but owns leasing, limits, and the complete origin
+key itself.
 
 The manager actor is intentionally a single serialization point for
 acquire/return/accounting commands. This channel hop is proportionate at local
@@ -367,6 +361,10 @@ it never assumes a consumed streaming body is reconstructable.
 
 ### Upstream HTTP/2
 
+This section records the conditional experiment design. The feasibility gate
+failed, so none of the application-mode keying, ALPN discovery, multiplexing, or
+HTTP/2 retry machinery described below is retained in production.
+
 An HTTP/2-eligible TLS client configuration advertises `h2` followed by
 `http/1.1`. ALPN selects the protocol; absence of ALPN falls back to HTTP/1.1.
 
@@ -439,12 +437,10 @@ responses supported by Hyper. If required trailers or informational responses
 cannot be preserved with the selected Hyper APIs, HTTP/2 is not shipped; the
 proxy does not silently weaken semantics to retain a benchmark win.
 
-TLS client configurations are cached on two independent axes: verification mode
-(`secure` or `insecure`) and application mode (`HTTP/1 required` or `HTTP/2
-eligible`). This yields up to four immutable configurations. HTTP/1-required
-configurations advertise only `http/1.1`; eligible configurations advertise
-`h2, http/1.1`. A cache keyed only by `--insecure` is prohibited because it could
-advertise HTTP/2 on a `Host: FROM` rule.
+The experiment would have required TLS client configurations cached on both
+verification and application mode. Because HTTP/2 was rejected, retained TLS
+client configurations are keyed only by verification mode (`secure` or
+`insecure`) and both advertise only `http/1.1`.
 
 HTTP/2 is not part of the initial HTTP/1 pooling delivery. Its entry gate uses
 the named remote-latency workload and two controlled variants after two warmups:
@@ -768,8 +764,8 @@ corresponding experiment clears its entry gate and its code is retained.
 - Origin-key equality and separation across every security-relevant field.
 - DNS and IP TO reference identities, including DNS SNI, no DNS SNI for IP,
   DNS-SAN/IP-SAN verification, and IP rules remaining HTTP/1-required.
-- TLS client configuration separation across secure/insecure and HTTP/1
-  required/HTTP/2 eligible modes.
+- TLS client configuration separation across secure/insecure modes, with both
+  configurations advertising only HTTP/1.1.
 - DNS cache hit, expiry, eviction, multi-address fallback, and `--resolve`
   bypass, including concurrent miss coalescing and error fan-out.
 - Buffered head parsing at chunk boundaries, exact limit, oversized input,
@@ -829,13 +825,13 @@ gate and its code is retained.
   acquire, cancellation while queued, and atomic races against admission and
   timeout; each resolves the ticket and accounting exactly once.
 - Origin-key tests vary protocol, TO reference identity, port, address policy,
-  verification mode, and application mode independently, including combinations
-  that cannot arise in one CLI invocation because `--insecure` and `--resolve`
-  are global. Cross-rule integration tests use feasible same-process cases:
+  and verification mode independently, including combinations that cannot arise
+  in one CLI invocation because `--insecure` and `--resolve` are global.
+  Cross-rule integration tests use feasible same-process cases:
   shared TO with different FROM values, rewritten versus preserved Host in
   separate proxy configurations, and distinct TO/port mappings. They assert
-  intended HTTP/1.1 reuse, prohibited cross-key reuse, correct SNI/Host and
-  HTTP/2 authority, authoritative forwarding headers, and that per-request
+  intended HTTP/1.1 reuse, prohibited cross-key reuse, correct SNI/Host,
+  authoritative forwarding headers, and that per-request
   Authorization values do not persist onto later requests on a reused
   connection.
 - HTTP/2 multiplexes concurrent requests and falls back to HTTP/1.1.

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -22,8 +22,8 @@ should be amortized across requests.
 ## Goals
 
 1. Reuse upstream connections safely across forwarded requests.
-2. Support upstream HTTP/2 multiplexing when the origin negotiates it, with
-   transparent HTTP/1.1 fallback.
+2. Evaluate upstream HTTP/2 multiplexing after HTTP/1 pooling and retain it only
+   when its entry, compatibility, and performance gates pass.
 3. Establish objective before-and-after measurements for latency, connection
    count, handshake count, throughput, and CPU-sensitive proxy overhead.
 4. Remove avoidable per-request cloning, parsing, encoding, and allocation.
@@ -109,7 +109,7 @@ affect transport identity or security:
 
 ```text
 protocol: plaintext | TLS
-logical host: normalized TO hostname
+reference identity: normalized DNS TO | IP TO
 port
 address policy: logical DNS policy or concrete --resolve pin
 TLS verification: secure | insecure
@@ -124,7 +124,13 @@ by TLS. A default rule that sends `Host: FROM` forces HTTP/1.1, preserving the
 existing deliberate separation between SNI (`TO`) and Host (`FROM`) without
 relying on cross-origin HTTP/2 behavior.
 
-The stable pool key is `(transport, normalized SNI/TO host, port, verification
+The TO reference identity is either a normalized DNS hostname or an IP literal,
+matching Rustls `ServerName`. For DNS identities, TLS sends SNI equal to TO. For
+IP identities, TLS sends no DNS SNI and secure mode validates an IP SAN, matching
+current behavior. IP-literal rules are HTTP/1-required; HTTP/2 eligibility is
+limited to DNS TO identities whose rewritten authority equals TO.
+
+The stable pool key is `(transport, normalized TO reference identity, port, verification
 mode, application mode, address policy)`. For `--resolve`, address policy
 contains the pinned IP. For DNS, address policy is the logical DNS policy, not a
 fallback-varying peer IP. Each connection record stores its actual peer address
@@ -136,7 +142,8 @@ The custom manager performs exact-key lookup only. It never coalesces across TO
 hostnames, even if two names resolve to one IP or a certificate contains both
 names. Hyper and Rustls drive a connection but do not select a pool entry; only
 the manager does. Thus every secure connection was authenticated for the exact
-TO/SNI hostname in its key before carrying a request.
+TO reference identity in its key before carrying a request; SNI is present only
+for DNS identities.
 
 ### Upstream Client and HTTP/1.1 Pool
 
@@ -170,10 +177,13 @@ The HTTP/1.1 pool obeys these rules:
   termination is never returned to the pool. The response wrapper records
   connection-close intent before the existing hop-by-hop sanitation removes the
   header from the browser-facing response.
-- At most six live HTTP/1.1 connections exist per origin and 64 live upstream
-  connections exist globally. “Live” includes connecting, leased, idle, and
-  draining connections. Admission of both limits is atomic under the transport
-  manager; it must not hold one capacity permit while waiting for the other.
+- At most six live HTTP/1.1 connections exist per origin and 64 live
+  **manager-owned mapped** upstream connections exist globally. Blind tunnels
+  and stray plain-HTTP forwarding keep their existing bypass behavior and do not
+  count toward this pool bound. “Live” includes connecting, leased, idle, and
+  driver-closing connections. Admission of both limits is atomic under the
+  transport manager; it must not hold one capacity permit while waiting for the
+  other.
   Requests at the limit wait in FIFO order. The wait queue is bounded to 32 per
   origin and 128 globally; excess requests receive `502`. Dropping the browser
   request cancels and removes its waiter. An internal 30-second acquisition
@@ -188,7 +198,8 @@ The HTTP/1.1 pool obeys these rules:
 ### HTTP/1.1 Lease State Machine
 
 Connection return is part of the core design, not an implementation detail. A
-leased HTTP/1.1 sender and its driver-health signal remain owned by a
+leased HTTP/1.1 sender, its driver-health signal, and an explicit driver abort
+handle remain owned by a
 `PooledResponseBody` until the response terminates or an earlier close condition
 occurs. Reuse requires both request upload and response download to have
 completed successfully; an early response closes instead of waiting for the
@@ -216,8 +227,14 @@ The response-body adapter follows this state machine:
    downstream cancellation/drop before terminal end-of-stream, or upstream close
    intent. Also enter `Closed` when response end-of-stream arrives while request
    upload is still `Streaming`; forward response EOF immediately, without waiting
-   for or draining the upload. Drop the sender and capacity lease; never drain in
-   the background.
+   for or draining the upload. Drop the sender and invoke the driver abort handle;
+   never drain in the background.
+
+Manager live capacity is driver-owned, not body-owned. Closing a lease requests
+driver abort but does not decrement live counts. The spawned driver owns a drop
+guard that reports `DriverClosed(ConnectionId)` even when its task is aborted;
+only that event releases origin/global capacity and admits waiters. Therefore an
+upload or socket cannot remain active after accounting says capacity is free.
 
 Upstream `Connection: close` and equivalent HTTP/1 connection intent are
 captured before hop-by-hop response sanitation. The sanitized header is still
@@ -241,17 +258,24 @@ the next write. Two HTTP/1 failure classes are distinct:
 Initially, replayable means `GET`, `HEAD`, or `OPTIONS` with no
 `Content-Length`, no `Transfer-Encoding`, and an `Incoming` body whose size hint
 is exactly zero **and** `Body::is_end_stream()` is true before the first attempt.
+Capture method, framing headers, body state, and `Request::extensions().is_empty()`
+from the original inbound request before hop-by-hop sanitation. Any extension
+makes the request ineligible; there is no inferred notion of an
+“extension-dependent” request.
 Both conditions are required: a zero-byte size hint alone can still precede
 trailers and must not cause the original body to be discarded. For eligible
 requests, the proxy converts the body to Hyper's reusable empty body and retains
-cloned method, URI, version, and headers for one reconstruction. Proxy request
-extensions are not part of wire behavior and are not forwarded today; no
-extension-dependent request is eligible for retry. Unknown or misleading size
+cloned method, URI, version, and headers for one reconstruction. Request
+extensions are not forwarded or reconstructed. Unknown or misleading size
 hints, `is_end_stream() == false`, trailers, a body error, or any observed body
 frame make a request non-replayable. All other methods and all streaming uploads
 are attempted once. The retry opens a fresh connection and preserves the
 original wire-visible request head and security settings. There is never more
 than one automatic retry.
+
+HTTP/2 retry, if that experiment is retained, uses this same retained empty-body
+representation unless a later explicitly tested replay representation is added;
+it never assumes a consumed streaming body is reconstructable.
 
 ### Upstream HTTP/2
 
@@ -269,8 +293,16 @@ normal HTTP/1.1 pool under the eligible-mode origin key. For eligible rules:
   streams. A draining GOAWAY connection and its replacement may temporarily
   coexist, but only the replacement accepts new streams. No more than 32
   non-draining HTTP/2 connections exist globally. Draining connections still
-  count toward the 64-live-connection global transport limit. Stream waiters use
+  count toward the 64-live-connection global manager-owned limit. Stream waiters use
   the same bounded per-origin/global queue and cancellation rules as HTTP/1.1;
+- acquire one stream permit before dispatch. Reuse requires both request-upload
+  completion and response EOS. If response EOS, downstream drop, or body error
+  occurs while upload remains streaming, invoke an explicit stream-reset handle
+  and retain the permit until a stream-termination guard confirms local reset or
+  closure. Response headers and a reset request alone do not release it. Request-
+  upload failure follows the same reset-then-confirm rule. A GOAWAY/draining connection retains its global
+  live-connection capacity until the driver exits, using the same driver-owned
+  accounting rule as HTTP/1.1;
 - the connection remains keyed by the complete upstream origin key;
 - before dispatch, the client constructs an HTTP/2 request URI whose authority
   is the TO hostname plus any non-default port. Hyper therefore emits
@@ -317,10 +349,20 @@ configurations advertise only `http/1.1`; eligible configurations advertise
 `h2, http/1.1`. A cache keyed only by `--insecure` is prohibited because it could
 advertise HTTP/2 on a `Host: FROM` rule.
 
-HTTP/2 is not part of the initial HTTP/1 pooling delivery. Build the focused
-protocol-discovery/translation proof only if post-pooling metrics show connection
-setup or the six-connection HTTP/1 concurrency ceiling consumes at least 10% of
-the named concurrent remote-latency workload. HTTP/2 is then retained only if
+HTTP/2 is not part of the initial HTTP/1 pooling delivery. Its entry gate uses
+the named remote-latency workload and two controlled variants after two warmups:
+
+- setup contribution is `(cold_duration - preconnected_duration) /
+  cold_duration`, comparing the normal cold pool with an otherwise identical run
+  whose HTTP/1 connections are established before timing;
+- concurrency-ceiling contribution is `(cap6_duration - cap20_duration) /
+  cap6_duration`, comparing the production cap with an internal harness-only cap
+  of 20.
+
+Use the median of ten alternating runs for each comparison. Enter the HTTP/2
+proof if either contribution is at least 10%. Runtime metrics also record pool
+acquisition and queue-wait duration for diagnosis, but overlapping aggregate
+timers are not used as the gate denominator. HTTP/2 is then retained only if
 the benchmark suite shows a meaningful improvement
 over pooled HTTP/1.1 for the representative concurrent workload and the added
 complexity does not weaken correctness. After two unrecorded warmups, run each
@@ -393,7 +435,7 @@ The prefixed-I/O adapter is the single owner of over-read bytes and yields each
 byte exactly once before delegating to the socket. The TLS acceptor, blind tunnel,
 and plain-HTTP forwarder all consume that same adapter; no path separately
 replays the bytes. Buffered parsing is deferred unless initial metrics attribute
-at least 5% of the local proxy-overhead workload to CONNECT/PAC head parsing. If
+at least 5% of the named local-overhead workload to CONNECT/PAC head parsing. If
 it misses that gate, retain the exact byte reader and record the rejected
 optimization rather than accepting new protocol risk for a marginal gain.
 
@@ -402,7 +444,7 @@ optimization rather than accepting new protocol risk for a marginal gain.
 During configuration resolution, each rule precomputes validated immutable data:
 
 - normalized FROM hostname;
-- parsed logical TO hostname and port;
+- parsed TO reference identity and port;
 - TLS `ServerName` for TLS upstreams;
 - upstream `Host` header value;
 - `X-Forwarded-Host` and `X-Orig-Host` values;
@@ -461,7 +503,7 @@ in implementation notes.
 Use low-overhead atomics and scoped timers. Collect at least:
 
 - accepted browser connections;
-- CONNECT heads parsed and rejected;
+- initial request heads parsed/rejected and parse duration;
 - leaf cache hits, misses, unexpected post-prewarm mints, and mint duration;
 - DNS cache hits, misses, and lookup duration;
 - upstream TCP connection attempts, established connections, and connect
@@ -469,6 +511,7 @@ Use low-overhead atomics and scoped timers. Collect at least:
 - upstream TLS handshakes and handshake duration;
 - negotiated HTTP/1.1 and HTTP/2 connection counts;
 - HTTP/1 pool hits, misses, stale failures, and retries;
+- pool acquisition and queue-wait duration;
 - HTTP/2 stream count and connection replacements;
 - request time to upstream response headers;
 - completed and failed requests.
@@ -490,13 +533,19 @@ selected. Keep its mandatory scope to the workloads that gate decisions:
    reuse and handshake count.
 2. One hundred requests at concurrency 20 to a delayed HTTP/1.1 upstream,
    measuring pool bounds and total duration.
-3. A remote-latency model with injectable DNS/connect/TLS/response delays,
-   measuring where remaining time is spent without public network access.
+3. A remote-latency model of 100 zero-body GETs at concurrency 20 with injectable
+   30 ms connection setup, 30 ms TLS setup, and 25 ms response delay, measuring
+   where remaining time is spent without public network access.
 
-Cold/warm certificate, DNS/`--resolve`, HTTP/2, parser, and socket-option variants
+DNS/`--resolve`, HTTP/2, parser, and socket-option variants
 are added only for the corresponding stage after it clears its entry gate. The
 benchmark harness must remain smaller than the transport implementation it
 evaluates.
+
+The parser entry measurement, when reached, is a named local-overhead workload:
+1,000 new loopback connections each send one valid local PAC request and read its
+response, single-threaded. The gate denominator is total client-observed workload
+duration; aggregated initial-head parse duration must be at least 5%.
 
 The harness records median, p95, total duration, upstream TCP connection count,
 TLS handshake count, and request failures. Timing assertions are not placed in
@@ -531,7 +580,7 @@ against an HTTP/1.1 upstream that holds each response for 25 milliseconds:
 
 For allocation changes:
 
-- CPU or duration improves measurably in the local overhead workload, or the
+- CPU or duration improves measurably in the named sequential TLS workload, or the
   change is retained only when it materially simplifies the code without
   weakening correctness.
 
@@ -561,12 +610,14 @@ All new fallible paths continue using `error-stack` with concrete contexts.
 
 The optimized implementation must preserve these invariants:
 
-1. TLS SNI is always the TO hostname and never includes a port.
-2. Secure mode validates the upstream certificate against the TO hostname.
+1. TLS reference identity is always TO and never includes a port. DNS TO values
+   send SNI equal to the normalized hostname; IP TO values send no DNS SNI.
+2. Secure mode validates the upstream certificate against the TO reference
+   identity (DNS SAN or IP SAN).
 3. `--insecure` remains explicit, global, and loudly warned.
 4. `--resolve` changes only the connection address, never SNI or Host semantics.
 5. Plaintext and TLS connections are never pooled together.
-6. Connections authenticated for different TO hostnames are never shared.
+6. Connections authenticated for different TO reference identities are never shared.
    Cross-name HTTP/2 coalescing is disabled even when IP addresses and
    certificate SANs overlap.
 7. Forwarding-header sanitation is unchanged: inbound `Forwarded` and
@@ -588,7 +639,13 @@ All behavior changes follow test-driven development.
 
 ### Unit Tests
 
+Core HTTP/1 and certificate-prewarm unit tests always run. DNS,
+buffered-parser, HTTP/2, and socket-option unit tests are required only when the
+corresponding experiment clears its entry gate and its code is retained.
+
 - Origin-key equality and separation across every security-relevant field.
+- DNS and IP TO reference identities, including DNS SNI, no DNS SNI for IP,
+  DNS-SAN/IP-SAN verification, and IP rules remaining HTTP/1-required.
 - TLS client configuration separation across secure/insecure and HTTP/1
   required/HTTP/2 eligible modes.
 - DNS cache hit, expiry, eviction, multi-address fallback, and `--resolve`
@@ -601,8 +658,8 @@ All behavior changes follow test-driven development.
   FROM hosts, mixed-case CONNECT reuse, and the unexpected runtime-miss metric.
 - Retry eligibility for reused connections and replayable bodies, including
   absent framing, misleading/unknown size hints, `exact == 0` with
-  `is_end_stream() == false`, zero-data bodies with trailers, unexpected frames,
-  and mid-body errors.
+  `is_end_stream() == false`, non-empty extensions, zero-data bodies with
+  trailers, unexpected frames, and mid-body errors.
 - Metrics counters and bounded timing buckets.
 
 ### Integration Tests
@@ -620,7 +677,9 @@ gate and its code is retained.
   end-of-stream and otherwise closes without unbounded draining.
 - An upstream that returns an early response without consuming the full
   streaming upload reaches the browser without delay and closes, rather than
-  pooling, that upstream connection.
+  pooling, that upstream connection. The test asserts upload polling stops, the
+  socket closes, and manager live capacity is released only after the driver
+  drop guard reports termination.
 - A server-closed idle connection is retried once on a fresh connection.
 - Sender-readiness failure preserves an unconsumed request; post-send failure
   retries only an eligible idempotent empty request. Streaming and truncated
@@ -628,7 +687,7 @@ gate and its code is retained.
 - Multi-address connection attempts share one total deadline and record the
   actual selected peer without fragmenting logical pool identity.
 - TLS, plaintext, secure, insecure, and `--resolve` pools remain isolated.
-- Origin-key tests vary protocol, TO hostname, port, address policy,
+- Origin-key tests vary protocol, TO reference identity, port, address policy,
   verification mode, and application mode independently, including combinations
   that cannot arise in one CLI invocation because `--insecure` and `--resolve`
   are global. Cross-rule integration tests use feasible same-process cases:
@@ -639,6 +698,10 @@ gate and its code is retained.
   Authorization values do not persist onto later requests on a reused
   connection.
 - HTTP/2 multiplexes concurrent requests and falls back to HTTP/1.1.
+- With upload still streaming, response EOS, downstream cancellation, response
+  body error, and upload failure each request stream reset and retain the stream
+  permit until the termination guard fires. A 101st request remains queued until
+  confirmed termination, proving the 100-stream cap cannot be released early.
 - Concurrent cold HTTP/2-eligible requests perform exactly one ALPN discovery
   connection; HTTP/1 fallback then expands only within the six-connection bound.
 - `Host: FROM` rules advertise only HTTP/1.1; HTTP/2-eligible rules expose

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -203,14 +203,18 @@ The response-body adapter follows this state machine:
 
 1. `Streaming`: forward DATA and trailer frames unchanged. A trailer frame is
    not terminal by itself; wait for the following successful end-of-stream.
-2. `Reusable`: enter only after response end-of-stream, request upload
-   `Complete`, a healthy connection driver, and no upstream close intent. Send
-   the lease back through the manager's non-blocking return channel. The channel
-   is bounded to the 64-live-connection global limit; if it is unexpectedly
-   full or closed, close the connection instead of blocking a body poll.
+2. `Reusable`: when response end-of-stream is polled, enter only if request
+   upload is **already** `Complete`, the connection driver is healthy, and there
+   is no upstream close intent. Send the lease back through the manager's
+   non-blocking return channel. The channel is bounded to the
+   64-live-connection global limit; if it is unexpectedly full or closed, close
+   the connection instead of blocking a body poll.
 3. `Closed`: enter on body error, driver failure, request-upload failure,
    downstream cancellation/drop before terminal end-of-stream, or upstream close
-   intent. Drop the sender and capacity lease; never drain in the background.
+   intent. Also enter `Closed` when response end-of-stream arrives while request
+   upload is still `Streaming`; forward response EOF immediately, without waiting
+   for or draining the upload. Drop the sender and capacity lease; never drain in
+   the background.
 
 Upstream `Connection: close` and equivalent HTTP/1 connection intent are
 captured before hop-by-hop response sanitation. The sanitized header is still
@@ -611,6 +615,9 @@ gate and its code is retained.
 - Browser cancellation, slow or infinite response bodies, body errors, and
   trailers prove that an HTTP/1.1 lease is returned only after successful
   end-of-stream and otherwise closes without unbounded draining.
+- An upstream that returns an early response without consuming the full
+  streaming upload reaches the browser without delay and closes, rather than
+  pooling, that upstream connection.
 - A server-closed idle connection is retried once on a fresh connection.
 - Sender-readiness failure preserves an unconsumed request; post-send failure
   retries only an eligible idempotent empty request. Streaming and truncated

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -186,15 +186,18 @@ the next write. The upstream client retries once when all of these are true:
 
 Initially, replayable means `GET`, `HEAD`, or `OPTIONS` with no
 `Content-Length`, no `Transfer-Encoding`, and an `Incoming` body whose size hint
-is exactly zero before the first attempt. For these requests, the proxy converts
-the body to Hyper's reusable empty body and retains cloned method, URI, version,
-and headers for one reconstruction. Proxy request extensions are not part of
-wire behavior and are not forwarded today; no extension-dependent request is
-eligible for retry. Unknown or misleading size hints, trailers, a body error,
-or any observed body frame make a request non-replayable. All other methods and
-all streaming uploads are attempted once. The retry opens a fresh connection
-and preserves the original wire-visible request head and security settings.
-There is never more than one automatic retry.
+is exactly zero **and** `Body::is_end_stream()` is true before the first attempt.
+Both conditions are required: a zero-byte size hint alone can still precede
+trailers and must not cause the original body to be discarded. For eligible
+requests, the proxy converts the body to Hyper's reusable empty body and retains
+cloned method, URI, version, and headers for one reconstruction. Proxy request
+extensions are not part of wire behavior and are not forwarded today; no
+extension-dependent request is eligible for retry. Unknown or misleading size
+hints, `is_end_stream() == false`, trailers, a body error, or any observed body
+frame make a request non-replayable. All other methods and all streaming uploads
+are attempted once. The retry opens a fresh connection and preserves the
+original wire-visible request head and security settings. There is never more
+than one automatic retry.
 
 ### Upstream HTTP/2
 
@@ -463,7 +466,8 @@ All behavior changes follow test-driven development.
 - Certificate prewarm success, startup failure, deduplication of configured
   FROM hosts, and the unexpected runtime-miss metric.
 - Retry eligibility for reused connections and replayable bodies, including
-  absent framing, misleading/unknown size hints, unexpected frames, trailers,
+  absent framing, misleading/unknown size hints, `exact == 0` with
+  `is_end_stream() == false`, zero-data bodies with trailers, unexpected frames,
   and mid-body errors.
 - Metrics counters and bounded timing buckets.
 

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -189,7 +189,10 @@ The HTTP/1.1 pool obeys these rules:
 
 Connection return is part of the core design, not an implementation detail. A
 leased HTTP/1.1 sender and its driver-health signal remain owned by a
-`PooledResponseBody` until both request upload and response download finish.
+`PooledResponseBody` until the response terminates or an earlier close condition
+occurs. Reuse requires both request upload and response download to have
+completed successfully; an early response closes instead of waiting for the
+upload.
 
 The request-body adapter records one of `Streaming`, `Complete`, or `Failed`:
 

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -111,7 +111,7 @@ affect transport identity or security:
 protocol: plaintext | TLS
 logical host: normalized TO hostname
 port
-connect address: DNS-derived address or --resolve pin
+address policy: logical DNS policy or concrete --resolve pin
 TLS verification: secure | insecure
 application mode: HTTP/1 required | HTTP/2 eligible
 ```
@@ -124,9 +124,19 @@ by TLS. A default rule that sends `Host: FROM` forces HTTP/1.1, preserving the
 existing deliberate separation between SNI (`TO`) and Host (`FROM`) without
 relying on cross-origin HTTP/2 behavior.
 
-If DNS returns multiple addresses, each live connection is associated with the
-specific selected address. DNS refresh may create connections to a new address;
-existing healthy connections may live until their idle deadline.
+The stable pool key is `(transport, normalized SNI/TO host, port, verification
+mode, application mode, address policy)`. For `--resolve`, address policy
+contains the pinned IP. For DNS, address policy is the logical DNS policy, not a
+fallback-varying peer IP. Each connection record stores its actual peer address
+and DNS generation for diagnostics, but multi-address fallback does not create a
+different logical pool. Existing healthy connections may remain reusable until
+their 60-second idle deadline even when the 30-second DNS entry expires.
+
+The custom manager performs exact-key lookup only. It never coalesces across TO
+hostnames, even if two names resolve to one IP or a certificate contains both
+names. Hyper and Rustls drive a connection but do not select a pool entry; only
+the manager does. Thus every secure connection was authenticated for the exact
+TO/SNI hostname in its key before carrying a request.
 
 ### Upstream Client and HTTP/1.1 Pool
 
@@ -141,13 +151,13 @@ Create a dedicated `upstream` module responsible for:
 - multiplexing requests over HTTP/2 connections;
 - tracking connection lifecycle metrics.
 
-Use a small custom transport manager because the required key includes the
-selected socket address. Hyper-util's maintained client pool keys by logical
-request destination and a connector selects the IP only while opening a
-connection; it cannot reliably separate old and refreshed DNS addresses or two
-address-selection policies for the same URI. The custom manager still uses
-Hyper's maintained HTTP/1.1 and HTTP/2 connection drivers, but owns leasing,
-limits, and the complete origin key itself.
+Use a small custom transport manager because the design requires explicit live
+and waiter bounds, response-body-controlled lease return, exact SNI-host
+isolation, address-policy identity, and serialized HTTP/2 protocol discovery.
+Hyper-util's general client pool does not expose all of those policies as one
+auditable state machine. The custom manager still uses Hyper's maintained
+HTTP/1.1 and HTTP/2 connection drivers, but owns leasing, limits, and the
+complete origin key itself.
 
 The HTTP/1.1 pool obeys these rules:
 
@@ -175,14 +185,51 @@ The HTTP/1.1 pool obeys these rules:
 - Pool configuration remains internal in the first release. No user-facing
   tuning flags are added without demonstrated need.
 
+### HTTP/1.1 Lease State Machine
+
+Connection return is part of the core design, not an implementation detail. A
+leased HTTP/1.1 sender and its driver-health signal remain owned by a
+`PooledResponseBody` until both request upload and response download finish.
+
+The request-body adapter records one of `Streaming`, `Complete`, or `Failed`:
+
+- it becomes `Complete` only after the browser body returns terminal
+  end-of-stream, including any trailers;
+- an input error or dropping the browser request before upload completion marks
+  it `Failed` and makes the connection permanently non-reusable;
+- backpressure is preserved; the adapter never pre-buffers a streaming upload.
+
+The response-body adapter follows this state machine:
+
+1. `Streaming`: forward DATA and trailer frames unchanged. A trailer frame is
+   not terminal by itself; wait for the following successful end-of-stream.
+2. `Reusable`: enter only after response end-of-stream, request upload
+   `Complete`, a healthy connection driver, and no upstream close intent. Send
+   the lease back through the manager's non-blocking return channel. The channel
+   is bounded to the 64-live-connection global limit; if it is unexpectedly
+   full or closed, close the connection instead of blocking a body poll.
+3. `Closed`: enter on body error, driver failure, request-upload failure,
+   downstream cancellation/drop before terminal end-of-stream, or upstream close
+   intent. Drop the sender and capacity lease; never drain in the background.
+
+Upstream `Connection: close` and equivalent HTTP/1 connection intent are
+captured before hop-by-hop response sanitation. The sanitized header is still
+not forwarded to the reusable browser tunnel. Returning a lease is idempotent:
+drop after `Reusable` cannot return it twice.
+
 ### Stale-connection Retry
 
 Servers may close idle HTTP/1.1 connections without the proxy noticing until
-the next write. The upstream client retries once when all of these are true:
+the next write. Two HTTP/1 failure classes are distinct:
 
-- the request was attempted on a reused connection;
-- failure occurred before any response headers were received;
-- the request body is safely replayable.
+- If the leased sender reports closed during readiness, before `send_request`
+  takes the request body, discard the connection and retry once on a fresh
+  connection. The original request has not been consumed.
+- If `send_request` fails before yielding response headers, retry once only when
+  the request was attempted on a reused connection **and** the request is in the
+  replayable class below. Hyper does not prove that the origin saw no bytes, so
+  this class is deliberately limited to idempotent methods with a reconstructable
+  empty body.
 
 Initially, replayable means `GET`, `HEAD`, or `OPTIONS` with no
 `Content-Length`, no `Transfer-Encoding`, and an `Incoming` body whose size hint
@@ -201,8 +248,8 @@ than one automatic retry.
 
 ### Upstream HTTP/2
 
-TLS client configuration advertises `h2` followed by `http/1.1`. ALPN selects
-the protocol; absence of ALPN falls back to HTTP/1.1.
+An HTTP/2-eligible TLS client configuration advertises `h2` followed by
+`http/1.1`. ALPN selects the protocol; absence of ALPN falls back to HTTP/1.1.
 
 HTTP/2 is attempted only for TLS rules whose rewritten authority is the TO
 hostname (`--rewrite-host`). Rules that retain `Host: FROM`, all plaintext
@@ -226,11 +273,48 @@ normal HTTP/1.1 pool under the eligible-mode origin key. For eligible rules:
 - stream failure affects only that request where possible;
 - GOAWAY stops new streams, permits eligible in-flight streams to complete, and
   causes future requests to establish a replacement connection;
+- when Hyper exposes a peer `REFUSED_STREAM`, or a GOAWAY proves that a stream ID
+  is greater than the peer's last processed stream, the manager may retry once
+  on a replacement connection only if the full request body is reconstructable.
+  The peer guarantee permits non-idempotent methods, but the proxy still cannot
+  replay a consumed streaming `Incoming` body. Unclassified HTTP/2 failures are
+  not retried;
 - connection-level failure removes the connection from the pool;
 - plaintext upstreams remain HTTP/1.1 unless explicit h2c support is designed
   later.
 
-HTTP/2 is retained only if the benchmark suite shows a meaningful improvement
+Cold protocol discovery is serialized per origin. An HTTP/2-eligible origin
+starts in `Vacant`; the first requester transitions it to `Discovering` and
+opens one TCP/TLS connection. Concurrent cold requests join the bounded waiter
+queue rather than opening duplicate handshakes. ALPN transitions the origin to
+one of:
+
+- `Http2`, publishing the single multiplexed connection to waiters; or
+- `Http1`, publishing the first connection and allowing additional HTTP/1.1
+  connections up to the six-connection origin limit.
+
+Discovery failure removes the state and wakes one waiter to attempt the next
+discovery. GOAWAY replacement uses the same single-creator rule, so concurrent
+requests cannot create a replacement stampede.
+
+HTTP/2 translation must preserve method, path, query, response DATA, trailers,
+and final status across the HTTP/1 browser leg. Tests also cover informational
+responses supported by Hyper. If required trailers or informational responses
+cannot be preserved with the selected Hyper APIs, HTTP/2 is not shipped; the
+proxy does not silently weaken semantics to retain a benchmark win.
+
+TLS client configurations are cached on two independent axes: verification mode
+(`secure` or `insecure`) and application mode (`HTTP/1 required` or `HTTP/2
+eligible`). This yields up to four immutable configurations. HTTP/1-required
+configurations advertise only `http/1.1`; eligible configurations advertise
+`h2, http/1.1`. A cache keyed only by `--insecure` is prohibited because it could
+advertise HTTP/2 on a `Host: FROM` rule.
+
+HTTP/2 is not part of the initial HTTP/1 pooling delivery. Build the focused
+protocol-discovery/translation proof only if post-pooling metrics show connection
+setup or the six-connection HTTP/1 concurrency ceiling consumes at least 10% of
+the named concurrent remote-latency workload. HTTP/2 is then retained only if
+the benchmark suite shows a meaningful improvement
 over pooled HTTP/1.1 for the representative concurrent workload and the added
 complexity does not weaken correctness. After two unrecorded warmups, run each
 variant ten times on the same machine with alternating variant order. HTTP/2
@@ -249,23 +333,39 @@ handles connection creation when no `--resolve` pin applies.
 - Use a conservative 30-second TTL because Tokio's basic resolver API does not
   expose authoritative DNS TTLs.
 - Bound the cache to 64 entries; evict expired entries before applying a simple
-  least-recently-used or oldest-entry policy.
+  least-recently-used policy. If all entries are unexpired, evict the least
+  recently used entry that has no lookup in flight. If every entry has an active
+  lookup, perform the new lookup without caching its result rather than exceeding
+  the bound.
 - Never cache lookup failures.
 - Coalesce concurrent cache misses for the same hostname and port into one
   lookup. Waiters receive an owned address list or a newly constructed
   equivalent I/O error; resolver error objects are not shared by reference.
 - On connection failure, try the remaining resolved addresses before failing.
+  One monotonic connect deadline covers DNS resolution and every address attempt.
+  After DNS completes, each address receives a fair slice of the remaining
+  budget (`remaining / addresses_left`), and no attempt may extend the total
+  deadline. TLS handshake time remains outside the existing `--connect-timeout`
+  semantics.
 - A `--resolve` entry bypasses DNS and the DNS cache entirely.
 - Do not let cached DNS state alter TLS SNI or the HTTP Host header.
 
-If benchmarks show no measurable resolver cost after pooling, the DNS cache may
-be omitted and that decision documented. This avoids adding state without value.
+DNS caching is not part of the initial HTTP/1 pooling delivery. Proceed to its
+implementation only if post-pooling metrics show DNS lookup accounts for at
+least 5% of median request-to-upstream-header time or repeated connection churn
+performs enough lookups to affect the named workload by at least 5%. Otherwise
+omit it and document the result. This explicit prior avoids adding state without
+value for a proxy that normally targets one origin.
 
 ### Buffered Initial Request Parsing
 
 Replace one-byte reads with bounded chunk reads into `BytesMut` or an equivalent
 buffer. Search incrementally for `\r\n\r\n` and enforce the existing 8 KiB head
 limit.
+
+The 8 KiB limit applies only to bytes through the `\r\n\r\n` terminator. Bytes
+read beyond a valid terminator are protocol over-read and cannot turn a valid
+small head into `400`, regardless of the chunk size.
 
 The parser returns both:
 
@@ -281,6 +381,14 @@ Over-read bytes must be replayed before subsequent socket bytes in every path:
 A prefixed-I/O wrapper or explicit replay buffer will preserve ordering. This is
 required for correctness even though common browsers usually wait for the
 CONNECT response before sending TLS data.
+
+The prefixed-I/O adapter is the single owner of over-read bytes and yields each
+byte exactly once before delegating to the socket. The TLS acceptor, blind tunnel,
+and plain-HTTP forwarder all consume that same adapter; no path separately
+replays the bytes. Buffered parsing is deferred unless initial metrics attribute
+at least 5% of the local proxy-overhead workload to CONNECT/PAC head parsing. If
+it misses that gate, retain the exact byte reader and record the rejected
+optimization rather than accepting new protocol risk for a marginal gain.
 
 ### Precomputed Rule Data
 
@@ -308,6 +416,11 @@ state and ordering complexity for no practical gain.
 Before launching browsers, generate the leaf server configuration for every
 unique configured FROM hostname. Startup fails with the existing CA error
 context if prewarming fails.
+
+Normalize CONNECT authority hosts to lowercase ASCII before rule lookup and
+`CertAuthority::server_config`, and keep prewarm keys in the same normalized
+form. Certificate cache identity is case-insensitive DNS identity, so mixed-case
+CONNECT authorities cannot cause a second mint or a false post-prewarm miss.
 
 Only configured FROM hosts enter the MITM path; unmatched hosts are blind
 tunneled or rejected. Prewarming therefore removes the legitimate runtime cache
@@ -344,7 +457,8 @@ Use low-overhead atomics and scoped timers. Collect at least:
 - CONNECT heads parsed and rejected;
 - leaf cache hits, misses, unexpected post-prewarm mints, and mint duration;
 - DNS cache hits, misses, and lookup duration;
-- upstream TCP connections opened and connect duration;
+- upstream TCP connection attempts, established connections, and connect
+  duration;
 - upstream TLS handshakes and handshake duration;
 - negotiated HTTP/1.1 and HTTP/2 connection counts;
 - HTTP/1 pool hits, misses, stale failures, and retries;
@@ -363,17 +477,19 @@ than retaining one sample per request.
 
 Add a deterministic local benchmark/integration harness, not a flaky CI
 microbenchmark. It runs outside the normal blocking test suite unless explicitly
-selected and supports:
+selected. Keep its mandatory scope to the workloads that gate decisions:
 
-1. One local plaintext request to measure the proxy overhead floor.
-2. One hundred sequential requests over one browser-side keep-alive tunnel.
-3. One hundred requests at browser-like concurrency.
-4. Local TLS upstream requests with connection and handshake counters.
-5. Artificially delayed upstream setup to model a remote service without
-   requiring public network access.
-6. Cold and warm certificate-cache runs.
-7. DNS and `--resolve` variants.
-8. HTTP/1.1-only and HTTP/2-capable upstreams.
+1. One hundred sequential requests to a local TLS keep-alive upstream, measuring
+   reuse and handshake count.
+2. One hundred requests at concurrency 20 to a delayed HTTP/1.1 upstream,
+   measuring pool bounds and total duration.
+3. A remote-latency model with injectable DNS/connect/TLS/response delays,
+   measuring where remaining time is spent without public network access.
+
+Cold/warm certificate, DNS/`--resolve`, HTTP/2, parser, and socket-option variants
+are added only for the corresponding stage after it clears its entry gate. The
+benchmark harness must remain smaller than the transport implementation it
+evaluates.
 
 The harness records median, p95, total duration, upstream TCP connection count,
 TLS handshake count, and request failures. Timing assertions are not placed in
@@ -386,8 +502,9 @@ The named sequential workload is 100 zero-body GET requests over one
 browser-side keep-alive tunnel to a local TLS upstream that keeps connections
 open. After HTTP/1 pooling:
 
-- exactly one upstream TCP connection and one upstream TLS handshake after
-  warm-up, compared with 100 of each at baseline;
+- exactly one established upstream TCP connection and one upstream TLS handshake
+  after warm-up, compared with 100 of each at baseline. Failed multi-address
+  attempts are counted separately and do not change logical reuse;
 - no increase in request failures;
 - streamed bodies remain unbuffered and byte-identical.
 
@@ -405,12 +522,14 @@ against an HTTP/1.1 upstream that holds each response for 25 milliseconds:
   more than 5% regression in median total duration or p95 and no additional
   failures. Median absolute deviation is recorded.
 
-For parser and allocation changes:
+For allocation changes:
 
-- deterministic tests prove over-read preservation;
 - CPU or duration improves measurably in the local overhead workload, or the
   change is retained only when it materially simplifies the code without
   weakening correctness.
+
+Buffered parsing is retained only after clearing its 5% entry gate and passing
+all over-read and 8 KiB head-limit tests. Otherwise it is not implemented.
 
 HTTP/2 and `TCP_NODELAY` use their specific retain/remove evidence gates. Raw
 benchmark output and a short interpretation are saved with the implementation
@@ -441,8 +560,13 @@ The optimized implementation must preserve these invariants:
 4. `--resolve` changes only the connection address, never SNI or Host semantics.
 5. Plaintext and TLS connections are never pooled together.
 6. Connections authenticated for different TO hostnames are never shared.
-7. Inbound spoofable forwarding headers remain stripped and authoritative
-   headers remain stamped.
+   Cross-name HTTP/2 coalescing is disabled even when IP addresses and
+   certificate SANs overlap.
+7. Forwarding-header sanitation is unchanged: inbound `Forwarded` and
+   `Fastly-SSL` are removed; `X-Forwarded-Host`, `X-Orig-Host`, and
+   `X-Forwarded-Proto` are overwritten authoritatively. Existing
+   `X-Forwarded-For` pass-through behavior is unchanged by this performance
+   work.
 8. Basic auth remains restricted on non-loopback listeners and is never logged.
 9. Unmatched CONNECT behavior remains unchanged.
 10. Hop-by-hop headers remain stripped in both directions.
@@ -458,13 +582,16 @@ All behavior changes follow test-driven development.
 ### Unit Tests
 
 - Origin-key equality and separation across every security-relevant field.
+- TLS client configuration separation across secure/insecure and HTTP/1
+  required/HTTP/2 eligible modes.
 - DNS cache hit, expiry, eviction, multi-address fallback, and `--resolve`
   bypass, including concurrent miss coalescing and error fan-out.
 - Buffered head parsing at chunk boundaries, exact limit, oversized input,
-  incomplete input, and over-read data.
+  incomplete input, and over-read data, including a valid head below 8 KiB with
+  an over-read chunk that takes the combined buffer above 8 KiB.
 - Precomputed header/SNI/auth values.
 - Certificate prewarm success, startup failure, deduplication of configured
-  FROM hosts, and the unexpected runtime-miss metric.
+  FROM hosts, mixed-case CONNECT reuse, and the unexpected runtime-miss metric.
 - Retry eligibility for reused connections and replayable bodies, including
   absent framing, misleading/unknown size hints, `exact == 0` with
   `is_end_stream() == false`, zero-data bodies with trailers, unexpected frames,
@@ -472,6 +599,10 @@ All behavior changes follow test-driven development.
 - Metrics counters and bounded timing buckets.
 
 ### Integration Tests
+
+Core HTTP/1 tests always run. DNS, buffered-parser, HTTP/2, and socket-option
+tests become required only when the corresponding experiment clears its entry
+gate and its code is retained.
 
 - Multiple sequential requests reuse one upstream HTTP/1.1 connection.
 - Concurrent requests open enough HTTP/1.1 connections to avoid serialization
@@ -481,9 +612,13 @@ All behavior changes follow test-driven development.
   trailers prove that an HTTP/1.1 lease is returned only after successful
   end-of-stream and otherwise closes without unbounded draining.
 - A server-closed idle connection is retried once on a fresh connection.
-- Streaming upload is not retried.
+- Sender-readiness failure preserves an unconsumed request; post-send failure
+  retries only an eligible idempotent empty request. Streaming and truncated
+  uploads are never retried or pooled.
+- Multi-address connection attempts share one total deadline and record the
+  actual selected peer without fragmenting logical pool identity.
 - TLS, plaintext, secure, insecure, and `--resolve` pools remain isolated.
-- Origin-key tests vary protocol, TO hostname, port, selected address,
+- Origin-key tests vary protocol, TO hostname, port, address policy,
   verification mode, and application mode independently, including combinations
   that cannot arise in one CLI invocation because `--insecure` and `--resolve`
   are global. Cross-rule integration tests use feasible same-process cases:
@@ -494,6 +629,8 @@ All behavior changes follow test-driven development.
   Authorization values do not persist onto later requests on a reused
   connection.
 - HTTP/2 multiplexes concurrent requests and falls back to HTTP/1.1.
+- Concurrent cold HTTP/2-eligible requests perform exactly one ALPN discovery
+  connection; HTTP/1 fallback then expands only within the six-connection bound.
 - `Host: FROM` rules advertise only HTTP/1.1; HTTP/2-eligible rules expose
   `:authority = TO[:non-default-port]` at the test upstream.
 - GOAWAY and connection failure trigger safe replacement.
@@ -521,18 +658,21 @@ suite is the primary gate.
 
 1. **Measurement foundation:** metrics, deterministic connection counters, and
    benchmark harness.
-2. **HTTP/1.1 connection reuse:** shared upstream state, connector, pooling,
-   stale retry, and streaming correctness.
+2. **HTTP/1.1 connection reuse (v1):** shared upstream state, bounded custom
+   manager, lease state machine, connector, pooling, conservative stale retry,
+   and streaming correctness.
 3. **Hot-path cleanup:** shared immutable configuration, precomputed rules/auth,
    and allocation removal.
-4. **Buffered CONNECT parsing:** chunked parsing and over-read replay.
-5. **Certificate cold-start:** unique-host prewarming and defensive miss
+4. **Certificate cold-start:** normalized unique-host prewarming and defensive miss
    metrics.
-6. **DNS behavior:** measure after pooling; add the bounded cache only if useful.
-7. **Upstream HTTP/2:** ALPN, multiplexing, fallback, GOAWAY handling, and
+5. **Buffered CONNECT parsing experiment:** implement chunked parsing and
+   over-read replay only after its entry gate.
+6. **DNS behavior experiment:** add the bounded cache only after its entry gate.
+7. **Upstream HTTP/2 experiment:** after its entry gate, prove ALPN discovery,
+   translation, multiplexing, fallback, GOAWAY handling, and
    benchmark retain/remove gate.
-8. **Socket tuning:** independently measure `TCP_NODELAY` and retain only useful
-   settings.
+8. **Socket tuning experiment:** independently measure `TCP_NODELAY` and retain
+   only useful settings.
 9. **Final verification and documentation:** record benchmark results, update
    developer documentation for diagnostics only where user-visible behavior
    changed, and run all quality gates.
@@ -552,17 +692,16 @@ developer-facing performance note containing:
 - retained and rejected optimizations;
 - pool/cache constants and the evidence supporting them.
 
-## Open Implementation Decisions
+## Implementation Validation Decisions
 
-The implementation plan must resolve these with small proof tests before broad
-code changes:
+The connection-return state machine, origin identity, retry boundary, and
+HTTP/2 eligibility are fixed design requirements above. The implementation plan
+may resolve only these representation/evidence decisions with small proof tests:
 
-1. The cleanest response-body wrapper or client API for returning HTTP/1.1
-   connections only after body completion.
-2. The exact Hyper body erasure used to represent streaming `Incoming` bodies
+1. The exact Hyper body erasure used to represent streaming `Incoming` bodies
    and reconstructable empty retry bodies without buffering.
-3. Whether Tokio's resolver behavior makes the bounded DNS cache measurable
+2. Whether Tokio's resolver behavior makes the bounded DNS cache measurable
    after pooling.
-4. Whether `TCP_NODELAY` helps the target workloads on macOS.
+3. Whether `TCP_NODELAY` helps the target workloads on macOS.
 
 These are validation tasks, not reasons to weaken the invariants above.

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -113,13 +113,16 @@ logical host: normalized TO hostname
 port
 connect address: DNS-derived address or --resolve pin
 TLS verification: secure | insecure
+application mode: HTTP/1 required | HTTP/2 eligible
 ```
 
-The rewritten HTTP `Host` value is not itself a transport key: HTTP/1.1 and
-HTTP/2 may carry different valid Host/authority values over a connection to the
-same logical upstream origin. The logical TO hostname and TLS policy are always
-part of the key, so a connection authenticated for one SNI cannot be reused for
-another.
+The rewritten HTTP `Host` value is not itself an HTTP/1.1 transport key because
+sequential requests may carry different Host values over a connection to the
+same logical TO origin. HTTP/2 is stricter: it is eligible only when
+`--rewrite-host` makes the request authority equal the TO hostname authenticated
+by TLS. A default rule that sends `Host: FROM` forces HTTP/1.1, preserving the
+existing deliberate separation between SNI (`TO`) and Host (`FROM`) without
+relying on cross-origin HTTP/2 behavior.
 
 If DNS returns multiple addresses, each live connection is associated with the
 specific selected address. DNS refresh may create connections to a new address;
@@ -138,26 +141,37 @@ Create a dedicated `upstream` module responsible for:
 - multiplexing requests over HTTP/2 connections;
 - tracking connection lifecycle metrics.
 
-The preferred implementation is Hyper's maintained pooled client machinery
-through `hyper-util`, with a custom connector that honors `--resolve`, SNI,
-plaintext, and `--insecure`. Before implementation, a focused spike/test must
-prove that this connector can preserve origin-form requests and existing header
-rewrites without losing streaming bodies.
+Use a small custom transport manager because the required key includes the
+selected socket address. Hyper-util's maintained client pool keys by logical
+request destination and a connector selects the IP only while opening a
+connection; it cannot reliably separate old and refreshed DNS addresses or two
+address-selection policies for the same URI. The custom manager still uses
+Hyper's maintained HTTP/1.1 and HTTP/2 connection drivers, but owns leasing,
+limits, and the complete origin key itself.
 
-If the maintained pool cannot meet those requirements cleanly, implement a
-small bounded pool rather than bending request semantics around it. A custom
-HTTP/1.1 pool must obey these rules:
+The HTTP/1.1 pool obeys these rules:
 
-- A connection is eligible for reuse only after the prior response body is
-  completely consumed or explicitly drained.
+- A connection is eligible for reuse only after the prior response body reaches
+  successful end-of-stream, including trailers. The proxy does not drain a body
+  after the downstream browser cancels or drops it; dropping the wrapper closes
+  that upstream connection. A body error also closes it. This trades a new
+  connection after cancellation for strict bounds and simple backpressure.
 - A connection reporting `Connection: close`, EOF, protocol failure, or driver
-  termination is never returned to the pool.
-- Concurrent requests may open multiple connections for an origin up to the
-  configured internal limit; they must not serialize behind one long response.
+  termination is never returned to the pool. The response wrapper records
+  connection-close intent before the existing hop-by-hop sanitation removes the
+  header from the browser-facing response.
+- At most six live HTTP/1.1 connections exist per origin and 64 live upstream
+  connections exist globally. “Live” includes connecting, leased, idle, and
+  draining connections. Admission of both limits is atomic under the transport
+  manager; it must not hold one capacity permit while waiting for the other.
+  Requests at the limit wait in FIFO order. The wait queue is bounded to 32 per
+  origin and 128 globally; excess requests receive `502`. Dropping the browser
+  request cancels and removes its waiter. An internal 30-second acquisition
+  timeout returns `502` so a saturated or wedged origin cannot wait forever.
 - Idle connections expire after a fixed short duration, initially 60 seconds.
-- Per-origin and global idle limits prevent unbounded state. Initial values are
-  two idle HTTP/1.1 connections per origin and 32 globally, subject to
-  benchmark adjustment.
+- Per-origin and global idle limits prevent inactive connections from consuming
+  all permits. Initial values are two idle HTTP/1.1 connections per origin and
+  32 globally, subject to benchmark adjustment.
 - Pool configuration remains internal in the first release. No user-facing
   tuning flags are added without demonstrated need.
 
@@ -170,22 +184,42 @@ the next write. The upstream client retries once when all of these are true:
 - failure occurred before any response headers were received;
 - the request body is safely replayable.
 
-Initially, replayable means an empty body or a fully available body type that
-can be reconstructed without buffering. Streaming uploads are not retried. The
-retry opens a fresh connection and preserves the original request headers and
-security settings. There is never more than one automatic retry.
+Initially, replayable means `GET`, `HEAD`, or `OPTIONS` with no
+`Content-Length`, no `Transfer-Encoding`, and an `Incoming` body whose size hint
+is exactly zero before the first attempt. For these requests, the proxy converts
+the body to Hyper's reusable empty body and retains cloned method, URI, version,
+and headers for one reconstruction. Proxy request extensions are not part of
+wire behavior and are not forwarded today; no extension-dependent request is
+eligible for retry. Unknown or misleading size hints, trailers, a body error,
+or any observed body frame make a request non-replayable. All other methods and
+all streaming uploads are attempted once. The retry opens a fresh connection
+and preserves the original wire-visible request head and security settings.
+There is never more than one automatic retry.
 
 ### Upstream HTTP/2
 
 TLS client configuration advertises `h2` followed by `http/1.1`. ALPN selects
 the protocol; absence of ALPN falls back to HTTP/1.1.
 
-For HTTP/2:
+HTTP/2 is attempted only for TLS rules whose rewritten authority is the TO
+hostname (`--rewrite-host`). Rules that retain `Host: FROM`, all plaintext
+rules, and any rule whose authority cannot be proven equal to the authenticated
+TO origin use a TLS configuration advertising only `http/1.1`. Eligible rules
+advertise `h2` followed by `http/1.1`; an origin selecting HTTP/1.1 enters the
+normal HTTP/1.1 pool under the eligible-mode origin key. For eligible rules:
 
-- one healthy connection may carry multiple concurrent streams;
+- one healthy HTTP/2 connection per origin may carry up to 100 concurrent
+  streams. A draining GOAWAY connection and its replacement may temporarily
+  coexist, but only the replacement accepts new streams. No more than 32
+  non-draining HTTP/2 connections exist globally. Draining connections still
+  count toward the 64-live-connection global transport limit. Stream waiters use
+  the same bounded per-origin/global queue and cancellation rules as HTTP/1.1;
 - the connection remains keyed by the complete upstream origin key;
-- request `Host` semantics are translated correctly to HTTP/2 authority by the
-  Hyper client without forwarding prohibited hop-by-hop headers;
+- before dispatch, the client constructs an HTTP/2 request URI whose authority
+  is the TO hostname plus any non-default port. Hyper therefore emits
+  `:authority` equal to the origin authenticated by TLS; it does not depend on
+  translating an origin-form HTTP/1.1 Host header. Tests inspect the received
+  HTTP/2 authority and prove that `Host: FROM` rules never enter this path;
 - stream failure affects only that request where possible;
 - GOAWAY stops new streams, permits eligible in-flight streams to complete, and
   causes future requests to establish a replacement connection;
@@ -195,9 +229,12 @@ For HTTP/2:
 
 HTTP/2 is retained only if the benchmark suite shows a meaningful improvement
 over pooled HTTP/1.1 for the representative concurrent workload and the added
-complexity does not weaken correctness. The initial meaningful-improvement gate
-is at least 10% lower median total duration or at least 20% fewer upstream
-connections for the concurrent remote-style workload. Results are recorded in
+complexity does not weaken correctness. After two unrecorded warmups, run each
+variant ten times on the same machine with alternating variant order. HTTP/2
+must improve median total duration or throughput by at least 10%, must not
+regress p95 total duration by more than 5%, and must produce no additional
+request failures. Connection reduction is recorded but is not sufficient by
+itself to retain HTTP/2. Results and median absolute deviation are recorded in
 the implementation notes.
 
 ### DNS Cache
@@ -211,6 +248,9 @@ handles connection creation when no `--resolve` pin applies.
 - Bound the cache to 64 entries; evict expired entries before applying a simple
   least-recently-used or oldest-entry policy.
 - Never cache lookup failures.
+- Coalesce concurrent cache misses for the same hostname and port into one
+  lookup. Waiters receive an owned address list or a newly constructed
+  equivalent I/O error; resolver error objects are not shared by reference.
 - On connection failure, try the remaining resolved addresses before failing.
 - A `--resolve` entry bypasses DNS and the DNS cache entirely.
 - Do not let cached DNS state alter TLS SNI or the HTTP Host header.
@@ -252,35 +292,41 @@ During configuration resolution, each rule precomputes validated immutable data:
 - stable portions of the upstream origin key.
 
 Basic authentication is encoded and validated once into a reusable
-`HeaderValue`. Request processing clones cheap reference-counted or header
-values rather than allocating strings or Base64-encoding credentials.
+`HeaderValue` held by a credential wrapper whose `Debug` implementation is
+redacted. Request processing clones cheap reference-counted or header values
+rather than allocating strings or Base64-encoding credentials.
 
 Rule lookup remains linear initially because expected rule counts are small.
 Replacing it with a map requires benchmark evidence; otherwise it adds duplicate
 state and ordering complexity for no practical gain.
 
-### Certificate Prewarming and Single Flight
+### Certificate Prewarming
 
 Before launching browsers, generate the leaf server configuration for every
 unique configured FROM hostname. Startup fails with the existing CA error
 context if prewarming fails.
 
-The cache also prevents duplicate work for hosts requested concurrently:
-
-- different hostnames may mint concurrently;
-- only one mint operation occurs for a given hostname;
-- waiters receive the same cached `Arc<ServerConfig>` or the same failure;
-- a failed mint does not permanently poison future attempts.
-
-Prewarming removes normal browser cold-start contention; single-flight behavior
-keeps the cache correct for future dynamic access and direct tests.
+Only configured FROM hosts enter the MITM path; unmatched hosts are blind
+tunneled or rejected. Prewarming therefore removes the legitimate runtime cache
+miss without introducing asynchronous single-flight error sharing. The existing
+synchronous cache remains as a defensive fallback. Runtime metrics flag any
+unexpected mint after prewarming so a future dynamic-rule feature cannot make
+the assumption silently false.
 
 ### Socket Options
 
-Evaluate `TCP_NODELAY` independently for browser-facing and upstream sockets.
-It is enabled only where repeated benchmark runs show a meaningful latency
-improvement without an unacceptable increase in packet/CPU overhead. Socket
-option failure is logged at debug level and does not abort the proxy.
+Evaluate `TCP_NODELAY` independently immediately after accepting browser-facing
+TCP sockets and immediately after opening upstream TCP sockets, before TLS or
+HTTP handshakes. Record successful and failed applications separately. An
+unexpected failure is warned once per socket class and counted, but does not
+abort an otherwise usable local proxy.
+
+After two warmups, run each setting ten times in alternating order. Retain a
+setting only if it improves median total duration by at least 3%, does not
+regress p95 by more than 5%, and does not regress process CPU time reported by
+`/usr/bin/time -p` by more than 5%. Median absolute deviation is recorded. Packet
+count is not used as a gate because the repository has no portable deterministic
+packet-count harness.
 
 No user-facing flag is planned. The accepted setting and evidence are recorded
 in implementation notes.
@@ -293,7 +339,7 @@ Use low-overhead atomics and scoped timers. Collect at least:
 
 - accepted browser connections;
 - CONNECT heads parsed and rejected;
-- leaf cache hits, misses, waits, and mint duration;
+- leaf cache hits, misses, unexpected post-prewarm mints, and mint duration;
 - DNS cache hits, misses, and lookup duration;
 - upstream TCP connections opened and connect duration;
 - upstream TLS handshakes and handshake duration;
@@ -333,19 +379,28 @@ counts; performance comparisons are run deliberately and documented.
 
 ### Acceptance Criteria
 
-For the sequential local-TLS workload after HTTP/1 pooling:
+The named sequential workload is 100 zero-body GET requests over one
+browser-side keep-alive tunnel to a local TLS upstream that keeps connections
+open. After HTTP/1 pooling:
 
-- at least 90% fewer upstream TCP connections after warm-up;
-- at least 90% fewer upstream TLS handshakes after warm-up;
+- exactly one upstream TCP connection and one upstream TLS handshake after
+  warm-up, compared with 100 of each at baseline;
 - no increase in request failures;
 - streamed bodies remain unbuffered and byte-identical.
 
-For the concurrent workload:
+The named concurrent workload is 100 zero-body GET requests with concurrency 20
+against an HTTP/1.1 upstream that holds each response for 25 milliseconds:
 
-- total duration must not regress by more than 5% across repeated runs;
-- the pool must permit concurrency rather than forcing all work through one
-  HTTP/1.1 connection;
-- no unbounded growth in live or idle connections.
+- deterministic tests observe at least two and no more than six simultaneous
+  upstream requests;
+- no more than six live connections exist for the origin and no more than two
+  remain idle afterward;
+- a separate saturation test proves the 32-per-origin and 128-global waiter
+  bounds, FIFO admission, cancellation removal, and 30-second timeout using
+  paused Tokio time rather than wall-clock sleeps;
+- after two warmups, ten alternating before/after benchmark runs must show no
+  more than 5% regression in median total duration or p95 and no additional
+  failures. Median absolute deviation is recorded.
 
 For parser and allocation changes:
 
@@ -401,12 +456,15 @@ All behavior changes follow test-driven development.
 
 - Origin-key equality and separation across every security-relevant field.
 - DNS cache hit, expiry, eviction, multi-address fallback, and `--resolve`
-  bypass.
+  bypass, including concurrent miss coalescing and error fan-out.
 - Buffered head parsing at chunk boundaries, exact limit, oversized input,
   incomplete input, and over-read data.
 - Precomputed header/SNI/auth values.
-- Certificate single-flight success, failure, and retry.
-- Retry eligibility for reused connections and replayable bodies.
+- Certificate prewarm success, startup failure, deduplication of configured
+  FROM hosts, and the unexpected runtime-miss metric.
+- Retry eligibility for reused connections and replayable bodies, including
+  absent framing, misleading/unknown size hints, unexpected frames, trailers,
+  and mid-body errors.
 - Metrics counters and bounded timing buckets.
 
 ### Integration Tests
@@ -415,12 +473,30 @@ All behavior changes follow test-driven development.
 - Concurrent requests open enough HTTP/1.1 connections to avoid serialization
   while respecting bounds.
 - `Connection: close` prevents reuse.
+- Browser cancellation, slow or infinite response bodies, body errors, and
+  trailers prove that an HTTP/1.1 lease is returned only after successful
+  end-of-stream and otherwise closes without unbounded draining.
 - A server-closed idle connection is retried once on a fresh connection.
 - Streaming upload is not retried.
 - TLS, plaintext, secure, insecure, and `--resolve` pools remain isolated.
+- Origin-key tests vary protocol, TO hostname, port, selected address,
+  verification mode, and application mode independently, including combinations
+  that cannot arise in one CLI invocation because `--insecure` and `--resolve`
+  are global. Cross-rule integration tests use feasible same-process cases:
+  shared TO with different FROM values, rewritten versus preserved Host in
+  separate proxy configurations, and distinct TO/port mappings. They assert
+  intended HTTP/1.1 reuse, prohibited cross-key reuse, correct SNI/Host and
+  HTTP/2 authority, authoritative forwarding headers, and that per-request
+  Authorization values do not persist onto later requests on a reused
+  connection.
 - HTTP/2 multiplexes concurrent requests and falls back to HTTP/1.1.
+- `Host: FROM` rules advertise only HTTP/1.1; HTTP/2-eligible rules expose
+  `:authority = TO[:non-default-port]` at the test upstream.
 - GOAWAY and connection failure trigger safe replacement.
 - CONNECT over-read bytes reach the TLS or blind-tunnel consumer intact.
+- Browser-facing and upstream `TCP_NODELAY` application is observable through
+  counters, while injected option failures remain non-fatal and warn once per
+  socket class.
 - Existing routing, header sanitation, Basic auth, PAC, and non-loopback tests
   continue to pass.
 
@@ -429,7 +505,8 @@ All behavior changes follow test-driven development.
 Run the repository-prescribed CLI tests using `./scripts/test-cli.sh`, plus:
 
 - `cargo fmt --all -- --check`
-- the relevant host-target clippy invocation with warnings denied;
+- `cargo clippy --package trusted-server-cli --target "$(rustc -vV | awk
+  '/host:/ { print $2 }')" --all-targets -- -D warnings`;
 - the explicit performance harness for before-and-after results.
 
 The full repository adapter test matrix is required only if shared core or
@@ -445,7 +522,8 @@ suite is the primary gate.
 3. **Hot-path cleanup:** shared immutable configuration, precomputed rules/auth,
    and allocation removal.
 4. **Buffered CONNECT parsing:** chunked parsing and over-read replay.
-5. **Certificate cold-start:** prewarming and per-host single flight.
+5. **Certificate cold-start:** unique-host prewarming and defensive miss
+   metrics.
 6. **DNS behavior:** measure after pooling; add the bounded cache only if useful.
 7. **Upstream HTTP/2:** ALPN, multiplexing, fallback, GOAWAY handling, and
    benchmark retain/remove gate.
@@ -475,15 +553,12 @@ developer-facing performance note containing:
 The implementation plan must resolve these with small proof tests before broad
 code changes:
 
-1. Whether `hyper-util`'s pooled client can accept the existing streaming
-   `Incoming` request body and custom connector without forcing URI or buffering
-   changes.
-2. The cleanest response-body wrapper or client API for returning HTTP/1.1
+1. The cleanest response-body wrapper or client API for returning HTTP/1.1
    connections only after body completion.
-3. Whether HTTP/2 authority translation preserves the deliberately rewritten
-   Host behavior for all rule forms.
-4. Whether Tokio's resolver behavior makes the bounded DNS cache measurable
+2. The exact Hyper body erasure used to represent streaming `Incoming` bodies
+   and reconstructable empty retry bodies without buffering.
+3. Whether Tokio's resolver behavior makes the bounded DNS cache measurable
    after pooling.
-5. Whether `TCP_NODELAY` helps the target workloads on macOS.
+4. Whether `TCP_NODELAY` helps the target workloads on macOS.
 
 These are validation tasks, not reasons to weaken the invariants above.

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -763,7 +763,7 @@ corresponding experiment clears its entry gate and its code is retained.
 
 - Origin-key equality and separation across every security-relevant field.
 - DNS and IP TO reference identities, including DNS SNI, no DNS SNI for IP,
-  DNS-SAN/IP-SAN verification, and IP rules remaining HTTP/1-required.
+  DNS-SAN/IP-SAN verification, with all retained rules remaining HTTP/1-only.
 - TLS client configuration separation across secure/insecure modes, with both
   configurations advertising only HTTP/1.1.
 - DNS cache hit, expiry, eviction, multi-address fallback, and `--resolve`
@@ -812,10 +812,11 @@ gate and its code is retained.
 - `--insecure` still emits its warning; blind tunnels and stray plain-HTTP
   forwarding bypass mapped pool accounting; manager shutdown aborts drivers,
   closes sockets, fails waiters, and discards all bounded state.
-- Ctrl-C shutdown restores Safari before manager drain, completes within the
-  two-second drain deadline when a driver delays termination, and still receives
-  the priority `Shutdown` plus all connector/driver lifecycle events when the
-  ordinary command channel is saturated.
+- Ctrl-C shutdown restores Safari, stops the accept loop, and then drains the
+  manager. It completes within the two-second drain deadline when a driver delays
+  termination, and still receives the priority `Shutdown` plus all
+  connector/driver lifecycle events when the ordinary command channel is
+  saturated.
 - Connector abort, cancellation, and unwind each reconcile a Connecting
   reservation exactly once. Lifecycle-priority reordering of `DriverClosed`
   before `Return` discards the stale return without double-decrementing capacity;
@@ -824,7 +825,7 @@ gate and its code is retained.
   when the ordinary lane is saturated. Tests cover cancellation overtaking its
   acquire, cancellation while queued, and atomic races against admission and
   timeout; each resolves the ticket and accounting exactly once.
-- Origin-key tests vary protocol, TO reference identity, port, address policy,
+- Origin-key tests vary transport, TO reference identity, port, address policy,
   and verification mode independently, including combinations that cannot arise
   in one CLI invocation because `--insecure` and `--resolve` are global.
   Cross-rule integration tests use feasible same-process cases:
@@ -834,16 +835,10 @@ gate and its code is retained.
   authoritative forwarding headers, and that per-request
   Authorization values do not persist onto later requests on a reused
   connection.
-- HTTP/2 multiplexes concurrent requests and falls back to HTTP/1.1.
-- With upload still streaming, response EOS, downstream cancellation, response
-  body error, and upload failure each request stream reset and retain the stream
-  permit until the termination guard fires. A 101st request remains queued until
-  confirmed termination, proving the 100-stream cap cannot be released early.
-- Concurrent cold HTTP/2-eligible requests perform exactly one ALPN discovery
-  connection; HTTP/1 fallback then expands only within the six-connection bound.
-- `Host: FROM` rules advertise only HTTP/1.1; HTTP/2-eligible rules expose
-  `:authority = TO[:non-default-port]` at the test upstream.
-- GOAWAY and connection failure trigger safe replacement.
+- The rejected HTTP/2 experiment would additionally have required multiplexing,
+  stream-permit lifecycle, serialized ALPN discovery, authority, fallback,
+  GOAWAY, and replacement tests. These are historical acceptance criteria only;
+  no HTTP/2 production code or active test obligation remains.
 - CONNECT over-read bytes reach the TLS or blind-tunnel consumer intact.
 - Browser-facing and upstream `TCP_NODELAY` application is observable through
   counters, while injected option failures remain non-fatal and warn once per

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -1,0 +1,489 @@
+# Dev Proxy Performance Optimization Design
+
+**Date:** 2026-07-10
+
+**Status:** Proposed
+
+## Summary
+
+Optimize `ts dev proxy` for realistic browser page loads without changing its
+routing, security, or failure-isolation semantics. The work begins with
+repeatable measurements, then removes repeated upstream connection setup,
+reduces request-path allocation and parsing costs, prevents duplicate
+certificate work, and evaluates HTTP/2 and socket tuning against explicit
+performance gates.
+
+The principal known bottleneck is structural: the browser-facing connection
+supports HTTP/1.1 keep-alive, but every forwarded request opens a new upstream
+TCP connection, performs a new TLS and Hyper handshake, sends one request, and
+drops the sender. A page with many assets therefore repeats network setup that
+should be amortized across requests.
+
+## Goals
+
+1. Reuse upstream connections safely across forwarded requests.
+2. Support upstream HTTP/2 multiplexing when the origin negotiates it, with
+   transparent HTTP/1.1 fallback.
+3. Establish objective before-and-after measurements for latency, connection
+   count, handshake count, throughput, and CPU-sensitive proxy overhead.
+4. Remove avoidable per-request cloning, parsing, encoding, and allocation.
+5. Reduce cold-start work when a browser opens several concurrent tunnels.
+6. Preserve every existing security and routing guarantee.
+7. Keep the implementation maintainable and proportionate to a local developer
+   tool rather than turning it into a general-purpose production proxy.
+
+## Non-goals
+
+- Production proxy deployment or load-balancer behavior.
+- Response or asset caching.
+- Request coalescing, speculative prefetching, or content modification.
+- Browser-facing HTTP/2 in the initial implementation. It may be evaluated
+  separately after upstream optimizations are measured.
+- HTTP/3 or QUIC.
+- WebSocket proxying, which remains out of scope.
+- Persisting DNS or connection state across process restarts.
+- Changing the semantics of `--map`, `--rewrite-host`, `--resolve`,
+  `--upstream-plaintext`, `--insecure`, or Basic authentication.
+
+## Current Architecture and Cost
+
+For a mapped HTTPS request, the proxy currently performs:
+
+1. Browser TCP accept.
+2. Byte-at-a-time parsing of the initial CONNECT request head.
+3. Browser-facing TLS termination using a cached per-host leaf configuration.
+4. HTTP/1.1 request parsing on a reusable browser tunnel.
+5. Per request, cloning of rules, Basic-auth configuration, and the resolution
+   map.
+6. Per request, hostname lookup or `--resolve` selection.
+7. Per request, a new upstream TCP connection.
+8. Per request, a new upstream TLS handshake for HTTPS.
+9. Per request, a new Hyper HTTP/1.1 handshake and connection driver.
+10. Streaming of one response, after which the upstream sender is dropped.
+
+Steps 6–9 dominate remote-origin latency. Steps 2 and 5 are smaller but occur
+often enough to matter after connection reuse removes the larger cost.
+
+## Design Principles
+
+- **Evidence before tuning.** Instrument a cost before attempting to optimize it.
+- **Correctness before reuse.** Never send a request on a connection whose
+  origin, TLS policy, or pinned destination differs from the request.
+- **Bounded state.** Pools and caches must have capacity and lifetime bounds.
+- **Streaming remains streaming.** Do not buffer request or response bodies to
+  simplify pooling.
+- **Failure remains local.** A dead pooled connection produces a controlled
+  retry or one request-level `502`; it never terminates the accept loop or an
+  unrelated browser tunnel.
+- **No silent security downgrade.** HTTP/2 fallback, retry, DNS caching, and
+  pooling must preserve certificate verification and SNI.
+- **Incremental delivery.** Each optimization is independently tested and
+  benchmarked so its effect is attributable and reversible.
+
+## Architecture
+
+### Shared Proxy State
+
+Introduce a shared immutable/runtime state object, conceptually:
+
+```rust
+struct ProxyState {
+    config: Arc<ResolvedConfig>,
+    upstream: UpstreamClient,
+    metrics: Arc<ProxyMetrics>,
+}
+```
+
+The state is created once after configuration resolution and shared by accepted
+browser connections. Hyper service closures clone an `Arc<ProxyState>` rather
+than cloning the rule table, DNS pins, and credentials for every request.
+
+`ResolvedConfig` remains immutable after listener binding updates the effective
+listen address. Values needed in the hot path are validated and precomputed
+during resolution.
+
+### Upstream Origin Key
+
+Every reusable connection is indexed by a key containing all properties that
+affect transport identity or security:
+
+```text
+protocol: plaintext | TLS
+logical host: normalized TO hostname
+port
+connect address: DNS-derived address or --resolve pin
+TLS verification: secure | insecure
+```
+
+The rewritten HTTP `Host` value is not itself a transport key: HTTP/1.1 and
+HTTP/2 may carry different valid Host/authority values over a connection to the
+same logical upstream origin. The logical TO hostname and TLS policy are always
+part of the key, so a connection authenticated for one SNI cannot be reused for
+another.
+
+If DNS returns multiple addresses, each live connection is associated with the
+specific selected address. DNS refresh may create connections to a new address;
+existing healthy connections may live until their idle deadline.
+
+### Upstream Client and HTTP/1.1 Pool
+
+Create a dedicated `upstream` module responsible for:
+
+- resolving or pinning connection addresses;
+- opening TCP sockets under the configured connect timeout;
+- applying measured socket options;
+- performing TLS negotiation and verification;
+- selecting HTTP/1.1 or HTTP/2 from ALPN;
+- leasing and returning reusable HTTP/1.1 connections;
+- multiplexing requests over HTTP/2 connections;
+- tracking connection lifecycle metrics.
+
+The preferred implementation is Hyper's maintained pooled client machinery
+through `hyper-util`, with a custom connector that honors `--resolve`, SNI,
+plaintext, and `--insecure`. Before implementation, a focused spike/test must
+prove that this connector can preserve origin-form requests and existing header
+rewrites without losing streaming bodies.
+
+If the maintained pool cannot meet those requirements cleanly, implement a
+small bounded pool rather than bending request semantics around it. A custom
+HTTP/1.1 pool must obey these rules:
+
+- A connection is eligible for reuse only after the prior response body is
+  completely consumed or explicitly drained.
+- A connection reporting `Connection: close`, EOF, protocol failure, or driver
+  termination is never returned to the pool.
+- Concurrent requests may open multiple connections for an origin up to the
+  configured internal limit; they must not serialize behind one long response.
+- Idle connections expire after a fixed short duration, initially 60 seconds.
+- Per-origin and global idle limits prevent unbounded state. Initial values are
+  two idle HTTP/1.1 connections per origin and 32 globally, subject to
+  benchmark adjustment.
+- Pool configuration remains internal in the first release. No user-facing
+  tuning flags are added without demonstrated need.
+
+### Stale-connection Retry
+
+Servers may close idle HTTP/1.1 connections without the proxy noticing until
+the next write. The upstream client retries once when all of these are true:
+
+- the request was attempted on a reused connection;
+- failure occurred before any response headers were received;
+- the request body is safely replayable.
+
+Initially, replayable means an empty body or a fully available body type that
+can be reconstructed without buffering. Streaming uploads are not retried. The
+retry opens a fresh connection and preserves the original request headers and
+security settings. There is never more than one automatic retry.
+
+### Upstream HTTP/2
+
+TLS client configuration advertises `h2` followed by `http/1.1`. ALPN selects
+the protocol; absence of ALPN falls back to HTTP/1.1.
+
+For HTTP/2:
+
+- one healthy connection may carry multiple concurrent streams;
+- the connection remains keyed by the complete upstream origin key;
+- request `Host` semantics are translated correctly to HTTP/2 authority by the
+  Hyper client without forwarding prohibited hop-by-hop headers;
+- stream failure affects only that request where possible;
+- GOAWAY stops new streams, permits eligible in-flight streams to complete, and
+  causes future requests to establish a replacement connection;
+- connection-level failure removes the connection from the pool;
+- plaintext upstreams remain HTTP/1.1 unless explicit h2c support is designed
+  later.
+
+HTTP/2 is retained only if the benchmark suite shows a meaningful improvement
+over pooled HTTP/1.1 for the representative concurrent workload and the added
+complexity does not weaken correctness. The initial meaningful-improvement gate
+is at least 10% lower median total duration or at least 20% fewer upstream
+connections for the concurrent remote-style workload. Results are recorded in
+the implementation notes.
+
+### DNS Cache
+
+Connection reuse naturally reduces DNS calls. A bounded in-process DNS cache
+handles connection creation when no `--resolve` pin applies.
+
+- Cache normalized hostname and port to all resolved socket addresses.
+- Use a conservative 30-second TTL because Tokio's basic resolver API does not
+  expose authoritative DNS TTLs.
+- Bound the cache to 64 entries; evict expired entries before applying a simple
+  least-recently-used or oldest-entry policy.
+- Never cache lookup failures.
+- On connection failure, try the remaining resolved addresses before failing.
+- A `--resolve` entry bypasses DNS and the DNS cache entirely.
+- Do not let cached DNS state alter TLS SNI or the HTTP Host header.
+
+If benchmarks show no measurable resolver cost after pooling, the DNS cache may
+be omitted and that decision documented. This avoids adding state without value.
+
+### Buffered Initial Request Parsing
+
+Replace one-byte reads with bounded chunk reads into `BytesMut` or an equivalent
+buffer. Search incrementally for `\r\n\r\n` and enforce the existing 8 KiB head
+limit.
+
+The parser returns both:
+
+- the exact complete HTTP request head; and
+- any bytes read beyond the header terminator.
+
+Over-read bytes must be replayed before subsequent socket bytes in every path:
+
+- browser TLS after CONNECT;
+- blind TLS tunnel;
+- plain HTTP forwarding.
+
+A prefixed-I/O wrapper or explicit replay buffer will preserve ordering. This is
+required for correctness even though common browsers usually wait for the
+CONNECT response before sending TLS data.
+
+### Precomputed Rule Data
+
+During configuration resolution, each rule precomputes validated immutable data:
+
+- normalized FROM hostname;
+- parsed logical TO hostname and port;
+- TLS `ServerName` for TLS upstreams;
+- upstream `Host` header value;
+- `X-Forwarded-Host` and `X-Orig-Host` values;
+- scheme and transport policy;
+- stable portions of the upstream origin key.
+
+Basic authentication is encoded and validated once into a reusable
+`HeaderValue`. Request processing clones cheap reference-counted or header
+values rather than allocating strings or Base64-encoding credentials.
+
+Rule lookup remains linear initially because expected rule counts are small.
+Replacing it with a map requires benchmark evidence; otherwise it adds duplicate
+state and ordering complexity for no practical gain.
+
+### Certificate Prewarming and Single Flight
+
+Before launching browsers, generate the leaf server configuration for every
+unique configured FROM hostname. Startup fails with the existing CA error
+context if prewarming fails.
+
+The cache also prevents duplicate work for hosts requested concurrently:
+
+- different hostnames may mint concurrently;
+- only one mint operation occurs for a given hostname;
+- waiters receive the same cached `Arc<ServerConfig>` or the same failure;
+- a failed mint does not permanently poison future attempts.
+
+Prewarming removes normal browser cold-start contention; single-flight behavior
+keeps the cache correct for future dynamic access and direct tests.
+
+### Socket Options
+
+Evaluate `TCP_NODELAY` independently for browser-facing and upstream sockets.
+It is enabled only where repeated benchmark runs show a meaningful latency
+improvement without an unacceptable increase in packet/CPU overhead. Socket
+option failure is logged at debug level and does not abort the proxy.
+
+No user-facing flag is planned. The accepted setting and evidence are recorded
+in implementation notes.
+
+## Metrics and Benchmarking
+
+### Runtime Metrics
+
+Use low-overhead atomics and scoped timers. Collect at least:
+
+- accepted browser connections;
+- CONNECT heads parsed and rejected;
+- leaf cache hits, misses, waits, and mint duration;
+- DNS cache hits, misses, and lookup duration;
+- upstream TCP connections opened and connect duration;
+- upstream TLS handshakes and handshake duration;
+- negotiated HTTP/1.1 and HTTP/2 connection counts;
+- HTTP/1 pool hits, misses, stale failures, and retries;
+- HTTP/2 stream count and connection replacements;
+- request time to upstream response headers;
+- completed and failed requests.
+
+Metrics are summarized on clean shutdown when verbose/debug diagnostics are
+enabled. They must not print credentials, query strings, certificate material,
+or sensitive headers. Normal output remains concise.
+
+Timing uses monotonic `Instant`. Histograms may use bounded fixed buckets rather
+than retaining one sample per request.
+
+### Benchmark Harness
+
+Add a deterministic local benchmark/integration harness, not a flaky CI
+microbenchmark. It runs outside the normal blocking test suite unless explicitly
+selected and supports:
+
+1. One local plaintext request to measure the proxy overhead floor.
+2. One hundred sequential requests over one browser-side keep-alive tunnel.
+3. One hundred requests at browser-like concurrency.
+4. Local TLS upstream requests with connection and handshake counters.
+5. Artificially delayed upstream setup to model a remote service without
+   requiring public network access.
+6. Cold and warm certificate-cache runs.
+7. DNS and `--resolve` variants.
+8. HTTP/1.1-only and HTTP/2-capable upstreams.
+
+The harness records median, p95, total duration, upstream TCP connection count,
+TLS handshake count, and request failures. Timing assertions are not placed in
+ordinary CI tests. Correctness tests assert deterministic connection/handshake
+counts; performance comparisons are run deliberately and documented.
+
+### Acceptance Criteria
+
+For the sequential local-TLS workload after HTTP/1 pooling:
+
+- at least 90% fewer upstream TCP connections after warm-up;
+- at least 90% fewer upstream TLS handshakes after warm-up;
+- no increase in request failures;
+- streamed bodies remain unbuffered and byte-identical.
+
+For the concurrent workload:
+
+- total duration must not regress by more than 5% across repeated runs;
+- the pool must permit concurrency rather than forcing all work through one
+  HTTP/1.1 connection;
+- no unbounded growth in live or idle connections.
+
+For parser and allocation changes:
+
+- deterministic tests prove over-read preservation;
+- CPU or duration improves measurably in the local overhead workload, or the
+  change is retained only when it materially simplifies the code without
+  weakening correctness.
+
+HTTP/2 and `TCP_NODELAY` use their specific retain/remove evidence gates. Raw
+benchmark output and a short interpretation are saved with the implementation
+notes rather than asserted as fragile wall-clock CI thresholds.
+
+## Error Handling
+
+All new fallible paths continue using `error-stack` with concrete contexts.
+
+- Pool acquisition/open failures become request-level `502` responses.
+- One eligible stale-connection retry is transparent; its final failure is
+  logged once with origin and phase, without sensitive request data.
+- DNS failures include the logical hostname and resolution phase.
+- TLS failures distinguish negotiation, certificate verification, and protocol
+  handshake phases where the underlying error permits it.
+- Background connection-driver failures remove their connection and increment a
+  metric; they do not panic.
+- Metrics failure or debug-summary formatting must never affect proxy behavior.
+- Certificate prewarm failures abort startup before browsers launch.
+
+## Security and Compatibility Invariants
+
+The optimized implementation must preserve these invariants:
+
+1. TLS SNI is always the TO hostname and never includes a port.
+2. Secure mode validates the upstream certificate against the TO hostname.
+3. `--insecure` remains explicit, global, and loudly warned.
+4. `--resolve` changes only the connection address, never SNI or Host semantics.
+5. Plaintext and TLS connections are never pooled together.
+6. Connections authenticated for different TO hostnames are never shared.
+7. Inbound spoofable forwarding headers remain stripped and authoritative
+   headers remain stamped.
+8. Basic auth remains restricted on non-loopback listeners and is never logged.
+9. Unmatched CONNECT behavior remains unchanged.
+10. Hop-by-hop headers remain stripped in both directions.
+11. Streaming request and response bodies remain bounded by backpressure.
+12. A retry never duplicates a non-replayable request body.
+13. Pool and cache state is process-local, bounded, and discarded on exit.
+14. Safari proxy restoration and CA trust behavior remain unchanged.
+
+## Testing Strategy
+
+All behavior changes follow test-driven development.
+
+### Unit Tests
+
+- Origin-key equality and separation across every security-relevant field.
+- DNS cache hit, expiry, eviction, multi-address fallback, and `--resolve`
+  bypass.
+- Buffered head parsing at chunk boundaries, exact limit, oversized input,
+  incomplete input, and over-read data.
+- Precomputed header/SNI/auth values.
+- Certificate single-flight success, failure, and retry.
+- Retry eligibility for reused connections and replayable bodies.
+- Metrics counters and bounded timing buckets.
+
+### Integration Tests
+
+- Multiple sequential requests reuse one upstream HTTP/1.1 connection.
+- Concurrent requests open enough HTTP/1.1 connections to avoid serialization
+  while respecting bounds.
+- `Connection: close` prevents reuse.
+- A server-closed idle connection is retried once on a fresh connection.
+- Streaming upload is not retried.
+- TLS, plaintext, secure, insecure, and `--resolve` pools remain isolated.
+- HTTP/2 multiplexes concurrent requests and falls back to HTTP/1.1.
+- GOAWAY and connection failure trigger safe replacement.
+- CONNECT over-read bytes reach the TLS or blind-tunnel consumer intact.
+- Existing routing, header sanitation, Basic auth, PAC, and non-loopback tests
+  continue to pass.
+
+### Quality Gates
+
+Run the repository-prescribed CLI tests using `./scripts/test-cli.sh`, plus:
+
+- `cargo fmt --all -- --check`
+- the relevant host-target clippy invocation with warnings denied;
+- the explicit performance harness for before-and-after results.
+
+The full repository adapter test matrix is required only if shared core or
+workspace dependency changes affect adapters; otherwise the CLI host-target
+suite is the primary gate.
+
+## Delivery Stages
+
+1. **Measurement foundation:** metrics, deterministic connection counters, and
+   benchmark harness.
+2. **HTTP/1.1 connection reuse:** shared upstream state, connector, pooling,
+   stale retry, and streaming correctness.
+3. **Hot-path cleanup:** shared immutable configuration, precomputed rules/auth,
+   and allocation removal.
+4. **Buffered CONNECT parsing:** chunked parsing and over-read replay.
+5. **Certificate cold-start:** prewarming and per-host single flight.
+6. **DNS behavior:** measure after pooling; add the bounded cache only if useful.
+7. **Upstream HTTP/2:** ALPN, multiplexing, fallback, GOAWAY handling, and
+   benchmark retain/remove gate.
+8. **Socket tuning:** independently measure `TCP_NODELAY` and retain only useful
+   settings.
+9. **Final verification and documentation:** record benchmark results, update
+   developer documentation for diagnostics only where user-visible behavior
+   changed, and run all quality gates.
+
+Each stage must leave the proxy working and tested. No stage depends on accepting
+an optimization that fails its evidence gate.
+
+## Documentation
+
+User-facing flags should remain unchanged. Update the dev-proxy guide only if
+new diagnostics are exposed or behavior visible to users changes. Add a short
+developer-facing performance note containing:
+
+- benchmark command;
+- workload definitions;
+- before-and-after results;
+- retained and rejected optimizations;
+- pool/cache constants and the evidence supporting them.
+
+## Open Implementation Decisions
+
+The implementation plan must resolve these with small proof tests before broad
+code changes:
+
+1. Whether `hyper-util`'s pooled client can accept the existing streaming
+   `Incoming` request body and custom connector without forcing URI or buffering
+   changes.
+2. The cleanest response-body wrapper or client API for returning HTTP/1.1
+   connections only after body completion.
+3. Whether HTTP/2 authority translation preserves the deliberately rewritten
+   Host behavior for all rule forms.
+4. Whether Tokio's resolver behavior makes the bounded DNS cache measurable
+   after pooling.
+5. Whether `TCP_NODELAY` helps the target workloads on macOS.
+
+These are validation tasks, not reasons to weaken the invariants above.

--- a/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-dev-proxy-performance-design.md
@@ -195,11 +195,24 @@ The HTTP/1.1 pool obeys these rules:
   driver-closing connections. Admission of both limits is atomic under the
   transport manager; it must not hold one capacity permit while waiting for the
   other.
-  Requests at the limit wait in FIFO order. The wait queue is bounded to 32 per
-  origin and 128 globally; excess requests receive `502`. Dropping the browser
-  request cancels and removes its waiter. An internal 30-second acquisition
-  timeout returns `502` so a saturated or wedged origin cannot wait forever.
+  Requests at the limit preserve FIFO order within each origin. When global
+  capacity becomes available, the manager admits the oldest admissible
+  per-origin head, so an origin that is still at its own limit cannot
+  head-of-line-block unrelated origins. The wait queue is bounded to 32 per
+  origin and 128 globally; excess requests receive `502`. Each acquire carries a
+  unique waiter ID and a shared atomic ticket in `Pending`. After the ordinary
+  acquire command is enqueued, dropping its future races `Pending -> Cancelled`
+  against the manager's terminal `Pending -> Resolved` transition for a lease or
+  acquisition error. A winning cancellation enqueues one priority `Cancel`; a
+  winning resolution suppresses cancellation. The manager checks the ticket
+  before queueing and again before admission or timeout, so a priority cancel
+  may safely overtake its ordinary acquire without creating a stranded waiter.
+  An internal 30-second acquisition timeout returns `502` so a saturated or
+  wedged origin cannot wait forever.
 - Idle connections expire after a fixed short duration, initially 60 seconds.
+- One actor-owned next-deadline timer covers both waiter acquisition deadlines
+  and idle expiry. Timeouts are handled as an internal select branch, not as
+  ordinary channel messages or one spawned task per entry.
 - Per-origin and global idle limits prevent inactive connections from consuming
   all permits. Initial values are two idle HTTP/1.1 connections per origin and
   32 globally, subject to benchmark adjustment.
@@ -247,20 +260,44 @@ guard that reports `DriverClosed(ConnectionId)` even when its task is aborted;
 only that event releases origin/global capacity and admits waiters. Therefore an
 upload or socket cannot remain active after accounting says capacity is free.
 
-Network lifecycle events use a dedicated unbounded Tokio channel separate from
-the bounded acquire/return command channel. Connection-attempt completion and a
-synchronous driver drop guard can therefore report `ConnectFinished` and
-`DriverClosed` during mass abort without blocking or losing accounting behind
-ordinary queued commands. Failure to send means the manager has already exited
-and no acknowledgment is still waiting.
+The actor has two input lanes. A bounded ordinary Tokio channel carries
+`Acquire` and `Return`. A non-blocking unbounded control/lifecycle channel
+carries exactly-once waiter `Cancel`, the single owner-issued `Shutdown`,
+connection-attempt `ConnectFinished`, and synchronous driver-drop
+`DriverClosed` events. The actor uses a biased select that drains the
+control/lifecycle lane first, so cancellation, shutdown delivery, and capacity
+reconciliation cannot be stranded behind ordinary work. Failure to send means
+the manager has already exited and no acknowledgment is still waiting.
 
-The actor allocates each `ConnectionId` and records a Connecting reservation
-before opening begins. On successful handshake, the connector creates a driver
-task behind a one-shot start latch and sends `ConnectFinished` containing its
-ID and control handles. The actor first transitions that exact reservation to Live (or
-marks it for immediate shutdown), then releases the latch. Consequently
-`DriverClosed` cannot precede registration, and unknown IDs are treated as an
-invariant violation rather than later publishing a dead connection.
+The control/lifecycle channel is unbounded at the Tokio API level only to make
+synchronous drop reporting infallible. Its producers are logically bounded by
+successfully enqueued ordinary acquires plus the 128 admitted waiter IDs, 64
+manager-owned live connection IDs, and one manager owner. An acquire guard is
+armed only after its bounded ordinary send succeeds and its ticket emits at most
+one `Cancel`; after resolution it cannot emit. A successful connection ID
+cannot emit `DriverClosed` until the actor consumes its `ConnectFinished` and
+releases the driver start latch, so each connection ID has at most one lifecycle
+event outstanding. The manager owner emits at most one `Shutdown`. Thus queued
+control state cannot grow with request volume and does not weaken the
+bounded-state invariant.
+
+The actor allocates each `ConnectionId`, records a Connecting reservation, and
+retains a connector abort handle before opening begins. Every connector owns an
+exactly-once completion guard: normal completion sends its result and disarms
+the guard; cancellation, abort, or unwind sends a cancelled `ConnectFinished`
+from the guard's synchronous drop path. On successful handshake, the connector
+creates a driver task behind a one-shot start latch and sends `ConnectFinished`
+containing its ID and control handles. The actor first transitions that exact
+reservation to Live (or marks it for immediate shutdown), then releases the
+latch. Consequently `DriverClosed` cannot precede registration, and an unknown
+or duplicate lifecycle ID is an invariant violation rather than later
+publishing a dead connection.
+
+The priority control/lifecycle lane may deliver `DriverClosed` before an earlier
+ordinary `Return` is processed. `DriverClosed` releases capacity exactly once;
+a later `Return` for that no-longer-live ID discards its sender as stale and
+does not change accounting. The reverse order returns the connection to idle
+first and lets the subsequent `DriverClosed` remove it normally.
 
 ### Shutdown Choreography
 
@@ -269,10 +306,11 @@ still alive, synchronously restore the prior Safari/system PAC setting using the
 existing interactive behavior. Only after restoration returns does shutdown:
 
 1. stop the accept-loop task so no new browser connections enter;
-2. send `Shutdown` to the upstream manager, which rejects acquisition, fails
-   waiters, aborts every driver, and continues consuming lifecycle events;
-3. wait at most two seconds for the manager to observe all `DriverClosed` events
-   and acknowledge zero live manager-owned connections;
+2. enqueue `Shutdown` without waiting on the priority control/lifecycle lane;
+   the manager rejects acquisition, fails waiters, aborts every pending
+   connector and live driver, and continues consuming lifecycle events;
+3. wait at most two seconds for the manager to reconcile all connector/driver
+   lifecycle events and acknowledge zero live manager-owned connections;
 4. on success or timeout, emit the redacted metrics summary from current state
    and return, allowing Tokio runtime teardown to reap anything remaining.
 
@@ -280,11 +318,11 @@ The manager drain is diagnostic/graceful behavior, not a precondition for Safari
 restoration or process exit. A wedged driver or saturated ordinary command queue
 cannot strand the system proxy or hang Ctrl-C indefinitely.
 
-If a pending connection attempt reports `ConnectFinished` while Closing, a
-failure releases its connecting count immediately; a success is never published
-to a waiter and its new driver is aborted, with live capacity retained until the
-subsequent `DriverClosed`. Closing acknowledges only after both connecting and
-driver counts reach zero.
+Aborting a pending connection attempt during Closing triggers its completion
+guard. A failed or cancelled `ConnectFinished` releases its connecting count
+immediately; a raced success is never published to a waiter and its new driver
+is aborted, with live capacity retained until the subsequent `DriverClosed`.
+Closing acknowledges only after both connecting and driver counts reach zero.
 
 Upstream `Connection: close` and equivalent HTTP/1 connection intent are
 captured before hop-by-hop response sanitation. The sanitized header is still
@@ -411,12 +449,13 @@ advertise HTTP/2 on a `Host: FROM` rule.
 HTTP/2 is not part of the initial HTTP/1 pooling delivery. Its entry gate uses
 the named remote-latency workload and two controlled variants after two warmups:
 
-- setup contribution is `(cold_duration - preconnected_duration) /
-  cold_duration`, comparing the normal cold pool with an otherwise identical run
-  whose HTTP/1 connections are established before timing;
-- concurrency-ceiling contribution is `(cap6_duration - cap20_duration) /
-  cap6_duration`, comparing the production cap with an internal harness-only cap
-  of 20.
+- setup contribution is
+  `(cold_duration - preconnected_duration) / cold_duration`, comparing the
+  normal cold pool with an otherwise identical run whose HTTP/1 connections are
+  established before timing;
+- concurrency-ceiling contribution is
+  `(cap6_duration - cap20_duration) / cap6_duration`, comparing the production
+  cap with an internal harness-only cap of 20.
 
 Use the median of ten alternating runs for each comparison. Enter the HTTP/2
 proof if either contribution is at least 10%. Runtime metrics also record pool
@@ -545,12 +584,17 @@ HTTP handshakes. Record successful and failed applications separately. An
 unexpected failure is warned once per socket class and counted, but does not
 abort an otherwise usable local proxy.
 
-After two warmups, run each setting ten times in alternating order. Retain a
-setting only if it improves median total duration by at least 3%, does not
-regress p95 by more than 5%, and does not regress process CPU time reported by
-`/usr/bin/time -p` by more than 5%. Median absolute deviation is recorded. Packet
-count is not used as a gate because the repository has no portable deterministic
-packet-count harness.
+Use the named sequential TLS workload with four harness-only variants:
+`off_off`, `browser_on`, `upstream_on`, and `both_on`. After two complete warmup
+rounds, run every variant ten times in round-robin order. Compare each one-sided
+variant with `off_off`; retain that socket-class setting only if it improves
+median total duration by at least 3%, does not regress p95 by more than 5%, and
+does not regress process CPU time reported by `/usr/bin/time -p` by more than
+5%. If both one-sided settings pass, `both_on` must also pass those regression
+limits and preserve at least a 3% median improvement over `off_off`; otherwise
+retain only the passing one-sided variant with the larger median benefit. Median
+absolute deviation is recorded. Packet count is not used as a gate because the
+repository has no portable deterministic packet-count harness.
 
 No user-facing flag is planned. The accepted setting and evidence are recorded
 in implementation notes.
@@ -590,9 +634,13 @@ selected. Keep its mandatory scope to the workloads that gate decisions:
 
 1. One hundred sequential requests to a local TLS keep-alive upstream, measuring
    reuse and handshake count.
-2. One hundred requests at concurrency 20 to a delayed HTTP/1.1 upstream,
-   measuring pool bounds and total duration.
-3. A remote-latency model of 100 zero-body GETs at concurrency 20 with injectable
+2. One hundred requests at concurrency six to a delayed HTTP/1.1 upstream,
+   comparing baseline and pooled total duration at the production per-origin
+   concurrency ceiling.
+3. A separate 100-request concurrency-20 saturation variant against that
+   upstream, measuring pool bounds and queueing without using the unbounded
+   baseline as a latency-retention gate.
+4. A remote-latency model of 100 zero-body GETs at concurrency 20 with injectable
    30 ms connection setup, 30 ms TLS setup, and 25 ms response delay, measuring
    where remaining time is spent without public network access.
 
@@ -623,12 +671,13 @@ browser-side keep-alive tunnel to a local TLS upstream that keeps connections
 open. After HTTP/1 pooling:
 
 - exactly one established upstream TCP connection and one upstream TLS handshake
-  after warm-up, compared with 100 of each at baseline. Failed multi-address
+  in each measured 100-request run, compared with 100 of each at baseline. The
+  two unrecorded warmups are complete separate runs. Failed multi-address
   attempts are counted separately and do not change logical reuse;
 - no increase in request failures;
 - streamed bodies remain unbuffered and byte-identical.
 
-The named concurrent workload is 100 zero-body GET requests with concurrency 20
+The named saturation workload is 100 zero-body GET requests with concurrency 20
 against an HTTP/1.1 upstream that holds each response for 25 milliseconds:
 
 - deterministic tests observe at least two and no more than six simultaneous
@@ -636,10 +685,19 @@ against an HTTP/1.1 upstream that holds each response for 25 milliseconds:
 - no more than six live connections exist for the origin and no more than two
   remain idle afterward;
 - a separate saturation test proves the 32-per-origin and 128-global waiter
-  bounds, FIFO admission, cancellation removal, and 30-second timeout using
-  paused Tokio time rather than wall-clock sleeps;
-- after two warmups, ten alternating before/after benchmark runs must show no
-  more than 5% regression in median total duration or p95 and no additional
+  bounds, FIFO admission within each origin, oldest-admissible cross-origin
+  admission without head-of-line blocking, cancellation removal, and 30-second
+  timeout using paused Tokio time rather than wall-clock sleeps;
+- no requests fail. Its wall-clock duration is diagnostic only: comparing a
+  six-connection production cap with the current unbounded connection-per-request
+  baseline at concurrency 20 would measure the intentional cap, not manager
+  overhead.
+
+The matched-concurrency performance workload uses the same delayed upstream and
+100 requests but client concurrency six. After two warmups, ten alternating
+before/after benchmark runs must show:
+
+- no more than 5% regression in median total duration or p95 and no additional
   failures. Median absolute deviation is recorded.
 
 For allocation changes:
@@ -760,7 +818,16 @@ gate and its code is retained.
   closes sockets, fails waiters, and discards all bounded state.
 - Ctrl-C shutdown restores Safari before manager drain, completes within the
   two-second drain deadline when a driver delays termination, and still receives
-  all driver lifecycle events when the ordinary command channel is saturated.
+  the priority `Shutdown` plus all connector/driver lifecycle events when the
+  ordinary command channel is saturated.
+- Connector abort, cancellation, and unwind each reconcile a Connecting
+  reservation exactly once. Lifecycle-priority reordering of `DriverClosed`
+  before `Return` discards the stale return without double-decrementing capacity;
+  the reverse order also reconciles exactly once.
+- Dropped acquisition futures enqueue exactly one priority cancellation even
+  when the ordinary lane is saturated. Tests cover cancellation overtaking its
+  acquire, cancellation while queued, and atomic races against admission and
+  timeout; each resolves the ticket and accounting exactly once.
 - Origin-key tests vary protocol, TO reference identity, port, address policy,
   verification mode, and application mode independently, including combinations
   that cannot arise in one CLI invocation because `--insecure` and `--resolve`
@@ -793,8 +860,12 @@ gate and its code is retained.
 Run the repository-prescribed CLI tests using `./scripts/test-cli.sh`, plus:
 
 - `cargo fmt --all -- --check`
-- `cargo clippy --package trusted-server-cli --target "$(rustc -vV | awk
-  '/host:/ { print $2 }')" --all-targets -- -D warnings`;
+- host-target CLI clippy:
+
+  ```bash
+  cargo clippy --package trusted-server-cli --target "$(rustc -vV | awk '/host:/ { print $2 }')" --all-targets -- -D warnings
+  ```
+
 - the explicit performance harness for before-and-after results.
 
 The full repository adapter test matrix is required only if shared core or


### PR DESCRIPTION
Closes #895

## Summary

- Add repeatable dev-proxy performance metrics and benchmark workloads for sequential, matched-concurrency, saturation, DNS, parser, and remote-latency scenarios.
- Add a bounded HTTP/1.1 upstream connection manager with safe streaming lease return, cancellation, stale-connection retry, connector ownership, and bounded shutdown.
- Retain evidence-backed CONNECT-head parsing and DNS caching while rejecting HTTP/2 and `TCP_NODELAY` experiments that did not satisfy their retention gates.
- Precompute upstream identities and preserve TLS, Host, `--resolve`, Basic authentication, hop-by-hop sanitation, and blind-tunnel isolation.

## Final review corrections

- Count complete responses as successful independently from whether their upstream connection is reusable, including already-empty and `Connection: close` responses.
- Force stale-readiness recovery through a fresh reservation instead of selecting another idle sender.
- Remove the rejected HTTP/2 application-mode key state; retained TLS configurations advertise only HTTP/1.1.
- Forward response trailers before lease reconciliation and preserve every downstream trailer declaration.
- Backfill connector cancellation/unwind, early-response, browser-cancellation, truncated-body, trailer, credential-isolation, insecure-warning, forwarding-capacity, over-read, shutdown-order, and origin-key integration coverage.

## Performance results

- Sequential TLS: 100 connections and handshakes reduced to 1, with a 59.7% median duration improvement in the recorded alternating runs.
- DNS churn workload: 13.6% median improvement with one miss and 99 cache hits.
- Concurrency-20 saturation: bounded to six upstream connections and handshakes.
- Remote saturation diagnostic: six pooled connections reduce connection and handshake churn by 94%; the six-connection safety cap intentionally trades 9.0% duration versus the unbounded baseline at concurrency 20.

Full measurements and experiment decisions are recorded in `docs/superpowers/implementation-notes/2026-07-10-dev-proxy-performance.md`.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] CLI `cargo check --tests` and Clippy with `-D warnings`
- [x] `./scripts/test-cli.sh` — 147 unit + 26 E2E tests
- [x] All six ignored `proxy_perf` workloads with one test thread
- [x] Fastly, Axum, Cloudflare, Spin, and 13 cross-adapter parity tests
- [x] Native/Wasm Clippy matrices for Fastly, Axum, Cloudflare, and Spin with zero warnings
- [x] JS build + 405 Vitest tests + JS/docs Prettier checks
