### PR TITLE
Inherit shared package metadata from the workspace

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Run host-target CLI clippy
         run: cargo clippy --package trusted-server-cli --target x86_64-unknown-linux-gnu --all-targets --all-features -- -D warnings
 
+      # The codegen crate is a workspace member but is not a default member and
+      # is not covered by any adapter-scoped alias, so lint it explicitly.
+      - name: Run host-target OpenRTB codegen clippy
+        run: cargo clippy --package trusted-server-openrtb-codegen --target x86_64-unknown-linux-gnu --all-targets -- -D warnings
+
   format-typescript:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,12 @@ jobs:
       - name: Run host-target CLI tests
         run: ./scripts/test-cli.sh
 
+      # The codegen crate is not a default member and no adapter alias builds it,
+      # so its tests only run if invoked explicitly on the host target.
+      - name: Run host-target OpenRTB codegen tests
+        run: |
+          cargo test --package trusted-server-openrtb-codegen --target "$(rustc -vV | sed -n 's/host: //p')"
+
       - name: Verify Fastly WASM release build
         run: cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,8 +454,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic",
  "tonic-prost",
  "ureq",
@@ -471,7 +471,7 @@ dependencies = [
  "bollard-buildkit-proto",
  "bytes",
  "chrono",
- "prost",
+ "prost 0.14.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -767,7 +767,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1677,7 +1677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1821,6 +1821,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2559,7 +2565,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2948,6 +2954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,6 +3304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,12 +3579,55 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.13.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.118",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3572,10 +3637,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -3584,7 +3658,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -4018,7 +4092,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4086,7 +4160,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4734,7 +4808,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5051,7 +5125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -5367,6 +5441,13 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "trusted-server-openrtb-codegen"
+version = "0.1.0"
+dependencies = [
+ "prost-build",
 ]
 
 [[package]]
@@ -5813,7 +5894,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
     "crates/trusted-server-integration-tests",
     "crates/trusted-server-js",
     "crates/trusted-server-openrtb",
+    # Manual protobuf codegen tool — a member so it shares workspace settings,
+    # but no default member or alias builds it. Run it explicitly with `-p`.
+    "crates/trusted-server-openrtb-codegen",
 ]
 
 # Viceroy (cargo test-fastly runner) calls `cargo run --bin trusted-server-adapter-fastly`
@@ -24,6 +27,13 @@ default-members = [
 
 [profile.release]
 debug = 1
+
+[workspace.package]
+authors = []
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+version = "0.1.0"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -72,6 +82,7 @@ log-fastly = "0.12"
 lol_html = "2.7.2"
 matchit = "0.9"
 mime = "0.3"
+prost-build = "0.13"
 rand = "0.8"
 rcgen = { version = "0.13", features = ["x509-parser"] }
 regex = "1.12.3"

--- a/crates/trusted-server-adapter-axum/Cargo.toml
+++ b/crates/trusted-server-adapter-axum/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "trusted-server-adapter-axum"
-version = "0.1.0"
-edition = "2024"
-publish = false
+description = "Axum entry point for Trusted Server — native dev server."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/trusted-server-adapter-cloudflare/Cargo.toml
+++ b/crates/trusted-server-adapter-cloudflare/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "trusted-server-adapter-cloudflare"
-version = "0.1.0"
-edition = "2024"
-publish = false
+description = "Cloudflare Workers entry point for Trusted Server."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/trusted-server-adapter-fastly/Cargo.toml
+++ b/crates/trusted-server-adapter-fastly/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "trusted-server-adapter-fastly"
-version = "0.1.0"
-edition = "2021"
+description = "Fastly Compute entry point for Trusted Server."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -89,21 +89,21 @@ use edgezero_core::app::{App, Hooks};
 use edgezero_core::context::RequestContext;
 use edgezero_core::error::EdgeError;
 use edgezero_core::http::{
-    header, HandlerFuture, HeaderValue, Method, Request, Response, StatusCode,
+    HandlerFuture, HeaderValue, Method, Request, Response, StatusCode, header,
 };
 use edgezero_core::router::RouterService;
 use error_stack::Report;
-use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::AuctionTelemetrySink;
-use trusted_server_core::auction::{build_orchestrator, AuctionOrchestrator};
+use trusted_server_core::auction::endpoints::handle_auction;
+use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 use trusted_server_core::constants::{COOKIE_SHAREDID, COOKIE_TS_EIDS};
+use trusted_server_core::ec::EcContext;
 use trusted_server_core::ec::batch_sync::handle_batch_sync;
 use trusted_server_core::ec::consent::ec_consent_withdrawn;
 use trusted_server_core::ec::device::DeviceSignals;
 use trusted_server_core::ec::identify::{cors_preflight_identify, handle_identify};
 use trusted_server_core::ec::kv::KvIdentityGraph;
 use trusted_server_core::ec::registry::PartnerRegistry;
-use trusted_server_core::ec::EcContext;
 use trusted_server_core::error::{IntoHttpResponse as _, TrustedServerError};
 use trusted_server_core::http_util::is_navigation_request;
 use trusted_server_core::integrations::{
@@ -112,12 +112,12 @@ use trusted_server_core::integrations::{
 };
 use trusted_server_core::platform::{ClientInfo, GeoInfo, PlatformKvStore, RuntimeServices};
 use trusted_server_core::proxy::{
-    handle_asset_proxy_request, handle_first_party_click, handle_first_party_proxy,
-    handle_first_party_proxy_rebuild, handle_first_party_proxy_sign, AssetProxyCachePolicy,
+    AssetProxyCachePolicy, handle_asset_proxy_request, handle_first_party_click,
+    handle_first_party_proxy, handle_first_party_proxy_rebuild, handle_first_party_proxy_sign,
 };
 use trusted_server_core::publisher::{
-    buffer_publisher_response_async, handle_page_bids, handle_publisher_request,
-    handle_tsjs_dynamic, page_bids_preflight_denied, AuctionDispatch,
+    AuctionDispatch, buffer_publisher_response_async, handle_page_bids, handle_publisher_request,
+    handle_tsjs_dynamic, page_bids_preflight_denied,
 };
 use trusted_server_core::request_signing::{
     handle_deactivate_key, handle_rotate_key, handle_trusted_server_discovery,
@@ -131,8 +131,8 @@ use trusted_server_core::tester_cookie::{handle_clear_tester, handle_set_tester}
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware};
 use crate::platform::{
-    open_kv_store, FastlyPlatformBackend, FastlyPlatformConfigStore, FastlyPlatformGeo,
-    FastlyPlatformHttpClient, FastlyPlatformSecretStore, UnavailableKvStore,
+    FastlyPlatformBackend, FastlyPlatformConfigStore, FastlyPlatformGeo, FastlyPlatformHttpClient,
+    FastlyPlatformSecretStore, UnavailableKvStore, open_kv_store,
 };
 
 // ---------------------------------------------------------------------------
@@ -758,13 +758,13 @@ async fn dispatch_fallback(
         // Generate an EC ID if needed — mirrors the legacy catch-all arm.
         // Only for document navigations by recognised browsers; subresource
         // requests may lack consent signals such as Sec-GPC.
-        if ec.is_real_browser && is_navigation_request(&req) {
-            if let Err(err) = ec
+        if ec.is_real_browser
+            && is_navigation_request(&req)
+            && let Err(err) = ec
                 .ec_context
                 .generate_if_needed(&state.settings, ec.kv_graph.as_ref())
-            {
-                log::warn!("EC generation failed for publisher proxy: {err:?}");
-            }
+        {
+            log::warn!("EC generation failed for publisher proxy: {err:?}");
         }
 
         // Publisher pages read consent data, so the consent KV store must be
@@ -871,10 +871,10 @@ async fn dispatch_asset_fallback(
             // client. HEAD and bodiless statuses (204, 304) advertise the origin
             // Content-Length but carry no body, so their stream is dropped to
             // preserve that header and avoid a length/body mismatch.
-            if let Some(body) = stream_body {
-                if asset_response_carries_body(&method, response.status()) {
-                    *response.body_mut() = body;
-                }
+            if let Some(body) = stream_body
+                && asset_response_carries_body(&method, response.status())
+            {
+                *response.body_mut() = body;
             }
 
             response.extensions_mut().insert(cache_policy);
@@ -1211,12 +1211,12 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        build_state_from_settings, startup_error_router, AppState, NamedRouteHandler,
-        TrustedServerApp, NAMED_ROUTES,
+        AppState, NAMED_ROUTES, NamedRouteHandler, TrustedServerApp, build_state_from_settings,
+        startup_error_router,
     };
     use bytes::Bytes;
     use edgezero_core::body::Body;
-    use edgezero_core::http::{header, request_builder, Method, Response, StatusCode};
+    use edgezero_core::http::{Method, Response, StatusCode, header, request_builder};
     use edgezero_core::key_value_store::NoopKvStore;
     use edgezero_core::router::RouterService;
     use std::net::{IpAddr, Ipv4Addr};
@@ -1822,7 +1822,10 @@ mod tests {
         let response = route(&router, empty_request(Method::GET, "/some-page"));
 
         assert!(
-            response.extensions().get::<super::EcFinalizeState>().is_some(),
+            response
+                .extensions()
+                .get::<super::EcFinalizeState>()
+                .is_some(),
             "publisher fallback responses should carry EcFinalizeState for entry-point EC finalization"
         );
     }

--- a/crates/trusted-server-adapter-fastly/src/backend.rs
+++ b/crates/trusted-server-adapter-fastly/src/backend.rs
@@ -350,7 +350,7 @@ impl<'a> BackendConfig<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{compute_host_header, BackendConfig};
+    use super::{BackendConfig, compute_host_header};
 
     // Tests for compute_host_header - the fix for port preservation in Host header
     #[test]

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -15,14 +15,14 @@ use trusted_server_core::ec::device::DeviceSignals;
 use trusted_server_core::ec::finalize::ec_finalize_response;
 use trusted_server_core::ec::kv::KvIdentityGraph;
 use trusted_server_core::ec::pull_sync::{
-    build_pull_sync_context, dispatch_pull_sync, PullSyncContext,
+    PullSyncContext, build_pull_sync_context, dispatch_pull_sync,
 };
 use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::error::TrustedServerError;
 use trusted_server_core::integrations::RequestFilterEffects;
 use trusted_server_core::platform::PlatformGeo as _;
 use trusted_server_core::platform::RuntimeServices;
-use trusted_server_core::proxy::{stream_asset_body, AssetProxyCachePolicy};
+use trusted_server_core::proxy::{AssetProxyCachePolicy, stream_asset_body};
 use trusted_server_core::settings::Settings;
 
 mod app;
@@ -36,10 +36,10 @@ mod platform;
 mod rate_limiter;
 mod tinybird;
 
-use crate::app::{load_settings_from_config_store, EcFinalizeState, TrustedServerApp};
+use crate::app::{EcFinalizeState, TrustedServerApp, load_settings_from_config_store};
 use crate::ec_kv::FastlyEcKvStore;
-use crate::middleware::{apply_finalize_headers, resolve_geo_for_response, HEADER_X_TS_FINALIZED};
-use crate::platform::{client_info_from_request, FastlyPlatformGeo};
+use crate::middleware::{HEADER_X_TS_FINALIZED, apply_finalize_headers, resolve_geo_for_response};
+use crate::platform::{FastlyPlatformGeo, client_info_from_request};
 use crate::rate_limiter::{FastlyRateLimiter, RATE_COUNTER_NAME};
 
 const TRUSTED_SERVER_CONFIG_STORE: &str = "trusted_server_config";
@@ -312,10 +312,10 @@ fn run_edgezero_pull_sync_after_send(
     partner_registry: &PartnerRegistry,
     ec_state: &EcFinalizeState,
 ) {
-    if ec_state.is_real_browser {
-        if let Some(context) = build_pull_sync_context(&ec_state.ec_context) {
-            run_pull_sync_after_send(settings, partner_registry, &context, &ec_state.services);
-        }
+    if ec_state.is_real_browser
+        && let Some(context) = build_pull_sync_context(&ec_state.ec_context)
+    {
+        run_pull_sync_after_send(settings, partner_registry, &context, &ec_state.services);
     }
 }
 
@@ -458,10 +458,10 @@ pub(crate) fn extract_cookie_value(req: &HttpRequest, name: &str) -> Option<Stri
     let cookie_header = req.headers().get("cookie").and_then(|v| v.to_str().ok())?;
     for pair in cookie_header.split(';') {
         let pair = pair.trim();
-        if let Some((key, value)) = pair.split_once('=') {
-            if key.trim() == name {
-                return Some(value.trim().to_owned());
-            }
+        if let Some((key, value)) = pair.split_once('=')
+            && key.trim() == name
+        {
+            return Some(value.trim().to_owned());
         }
     }
     None
@@ -483,8 +483,8 @@ pub(crate) fn derive_device_signals(req: &FastlyRequest) -> DeviceSignals {
 mod tests {
     use super::*;
     use edgezero_core::body::Body as EdgeBody;
-    use edgezero_core::http::response_builder;
     use edgezero_core::http::HeaderValue;
+    use edgezero_core::http::response_builder;
     use fastly::mime;
 
     fn test_settings() -> Settings {

--- a/crates/trusted-server-adapter-fastly/src/management_api.rs
+++ b/crates/trusted-server-adapter-fastly/src/management_api.rs
@@ -18,7 +18,7 @@
 
 use std::io::Read;
 
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use error_stack::{Report, ResultExt};
 use fastly::http::{Method, StatusCode};
 use fastly::{Request, Response};

--- a/crates/trusted-server-adapter-fastly/src/middleware.rs
+++ b/crates/trusted-server-adapter-fastly/src/middleware.rs
@@ -252,7 +252,7 @@ mod tests {
     use edgezero_core::body::Body;
     use edgezero_core::context::RequestContext;
     use edgezero_core::error::EdgeError;
-    use edgezero_core::http::{request_builder, response_builder, HeaderName, Method, StatusCode};
+    use edgezero_core::http::{HeaderName, Method, StatusCode, request_builder, response_builder};
     use edgezero_core::middleware::Next;
     use edgezero_core::params::PathParams;
     use error_stack::Report;

--- a/crates/trusted-server-adapter-fastly/src/platform.rs
+++ b/crates/trusted-server-adapter-fastly/src/platform.rs
@@ -9,7 +9,7 @@ use bytes::Bytes;
 use edgezero_adapter_fastly::key_value_store::FastlyKvStore;
 use edgezero_core::key_value_store::KvError;
 use error_stack::{Report, ResultExt};
-use fastly::geo::{geo_lookup, Geo};
+use fastly::geo::{Geo, geo_lookup};
 use fastly::{ConfigStore, Request, SecretStore};
 
 use crate::backend::BackendConfig;
@@ -364,19 +364,17 @@ fn fastly_response_to_platform(
     // Pre-flight: reject oversized responses before copying bytes into WASM heap.
     // Content-Length is advisory but covers most origin responses; chunked
     // responses without it fall through to the post-materialization check below.
-    if !stream_response {
-        if let Some(claimed_len) = resp
+    if !stream_response
+        && let Some(claimed_len) = resp
             .get_header("content-length")
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.trim().parse::<usize>().ok())
-        {
-            if claimed_len > MAX_PLATFORM_RESPONSE_BODY_BYTES {
-                return Err(Report::new(PlatformError::HttpClient).attach(format!(
-                    "origin Content-Length {claimed_len} exceeds \
+        && claimed_len > MAX_PLATFORM_RESPONSE_BODY_BYTES
+    {
+        return Err(Report::new(PlatformError::HttpClient).attach(format!(
+            "origin Content-Length {claimed_len} exceeds \
                      {MAX_PLATFORM_RESPONSE_BODY_BYTES}-byte response body limit"
-                )));
-            }
-        }
+        )));
     }
 
     let status = resp.get_status();
@@ -467,7 +465,7 @@ impl PlatformHttpClient for FastlyPlatformHttpClient {
         &self,
         pending_requests: Vec<PlatformPendingRequest>,
     ) -> Result<PlatformSelectResult, Report<PlatformError>> {
-        use fastly::http::request::{select, PendingRequest};
+        use fastly::http::request::{PendingRequest, select};
 
         if pending_requests.is_empty() {
             return Err(Report::new(PlatformError::HttpClient)

--- a/crates/trusted-server-adapter-fastly/src/tinybird.rs
+++ b/crates/trusted-server-adapter-fastly/src/tinybird.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use edgezero_core::body::Body;
-use edgezero_core::http::{header, request_builder, HeaderValue, Method};
+use edgezero_core::http::{HeaderValue, Method, header, request_builder};
 use error_stack::{Report, ResultExt as _};
 use trusted_server_core::auction::telemetry::{
     AuctionEventBatch, AuctionTelemetrySink, NoopAuctionTelemetrySink,

--- a/crates/trusted-server-adapter-spin/Cargo.toml
+++ b/crates/trusted-server-adapter-spin/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "trusted-server-adapter-spin"
-version = "0.1.0"
-edition = "2024"
-publish = false
+description = "Fermyon Spin entry point for Trusted Server."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/trusted-server-cli/Cargo.toml
+++ b/crates/trusted-server-cli/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "trusted-server-cli"
-version = "0.1.0"
-authors = []
-edition = "2024"
-publish = false
-license = "Apache-2.0"
+description = "Operator CLI (`ts`) for Trusted Server."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [[bin]]
 name = "ts"

--- a/crates/trusted-server-core/Cargo.toml
+++ b/crates/trusted-server-core/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "trusted-server-core"
-version = "0.1.0"
-authors = []
-edition = "2021"
-# Remove this line if you want to be able to publish this crate as open source on crates.io.
-# Otherwise, `publish = false` prevents an accidental `cargo publish` from revealing private source.
-publish = false
-license = "Apache-2.0"
+description = "Core Trusted Server library — shared logic, integrations, HTML processing."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/trusted-server-core/benches/consent_decode.rs
+++ b/crates/trusted-server-core/benches/consent_decode.rs
@@ -6,9 +6,9 @@
 //!
 //! Run with: `cargo bench -p trusted-server-core`
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 
 use trusted_server_core::consent::tcf::decode_tc_string;
 use trusted_server_core::consent::types::RawConsentSignals;

--- a/crates/trusted-server-core/benches/html_processor_bench.rs
+++ b/crates/trusted-server-core/benches/html_processor_bench.rs
@@ -1,5 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use trusted_server_core::html_processor::{create_html_processor, HtmlProcessorConfig};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use trusted_server_core::html_processor::{HtmlProcessorConfig, create_html_processor};
 use trusted_server_core::integrations::IntegrationRegistry;
 use trusted_server_core::streaming_processor::StreamProcessor as _;
 

--- a/crates/trusted-server-core/src/auction/endpoints.rs
+++ b/crates/trusted-server-core/src/auction/endpoints.rs
@@ -4,32 +4,32 @@ use std::collections::HashMap;
 
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::{header, Request, Response, StatusCode};
+use http::{Request, Response, StatusCode, header};
 use serde_json::Value as JsonValue;
 
 use crate::auction::formats::AdRequest;
 use crate::auction::orchestrator::OrchestrationResult;
 use crate::consent::{consent_allows_server_side_auction, gate_eids_by_consent};
 use crate::constants::COOKIE_TS_EIDS;
+use crate::ec::EcContext;
 use crate::ec::eids::{resolve_partner_ids, to_eids};
 use crate::ec::kv::KvIdentityGraph;
 use crate::ec::kv_types::MAX_UID_LENGTH;
 use crate::ec::log_id;
 use crate::ec::prebid_eids::parse_prebid_eids_cookie;
 use crate::ec::registry::PartnerRegistry;
-use crate::ec::EcContext;
 use crate::error::TrustedServerError;
 use crate::openrtb::{Eid, Uid};
 use crate::platform::RuntimeServices;
 use crate::settings::Settings;
 
+use super::AuctionOrchestrator;
 use super::formats::{convert_to_openrtb_response, convert_tsjs_to_auction_request};
 use super::telemetry::{
-    build_auction_events, emit_auction_events_best_effort_lazy, AuctionObservationContext,
-    AuctionSource, AuctionTerminalOutcome,
+    AuctionObservationContext, AuctionSource, AuctionTerminalOutcome, build_auction_events,
+    emit_auction_events_best_effort_lazy,
 };
 use super::types::AuctionContext;
-use super::AuctionOrchestrator;
 
 const MAX_CLIENT_EID_SOURCES: usize = 64;
 const MAX_CLIENT_UIDS_PER_SOURCE: usize = 32;
@@ -381,10 +381,10 @@ fn extract_cookie_value(req: &Request<EdgeBody>, name: &str) -> Option<String> {
         .and_then(|v| v.to_str().ok())?;
     for pair in cookie_header.split(';') {
         let pair = pair.trim();
-        if let Some((key, value)) = pair.split_once('=') {
-            if key.trim() == name {
-                return Some(value.trim().to_owned());
-            }
+        if let Some((key, value)) = pair.split_once('=')
+            && key.trim() == name
+        {
+            return Some(value.trim().to_owned());
         }
     }
     None
@@ -454,11 +454,7 @@ fn parse_client_auction_eids(raw: Option<&JsonValue>) -> Option<Vec<Eid>> {
         eids.push(Eid { source, uids });
     }
 
-    if eids.is_empty() {
-        None
-    } else {
-        Some(eids)
-    }
+    if eids.is_empty() { None } else { Some(eids) }
 }
 
 fn parse_client_auction_uid(raw: &JsonValue) -> Option<Uid> {
@@ -557,12 +553,12 @@ mod tests {
     use crate::consent::types::ConsentContext;
     use crate::openrtb::Uid;
     use crate::platform::test_support::{
-        noop_services, NoopBackend, NoopConfigStore, NoopGeo, NoopHttpClient, NoopSecretStore,
+        NoopBackend, NoopConfigStore, NoopGeo, NoopHttpClient, NoopSecretStore, noop_services,
     };
     use crate::platform::{ClientInfo, PlatformPendingRequest, PlatformResponse};
     use crate::test_support::tests::create_test_settings;
-    use base64::engine::general_purpose::STANDARD as BASE64;
     use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as BASE64;
     use serde_json::json;
     use std::sync::{Arc, Mutex};
 

--- a/crates/trusted-server-core/src/auction/formats.rs
+++ b/crates/trusted-server-core/src/auction/formats.rs
@@ -5,8 +5,8 @@
 //! - Converting internal auction results to `OpenRTB` 2.x responses
 
 use edgezero_core::body::Body as EdgeBody;
-use error_stack::{ensure, Report, ResultExt};
-use http::{header, HeaderValue, Request, Response, StatusCode};
+use error_stack::{Report, ResultExt, ensure};
+use http::{HeaderValue, Request, Response, StatusCode, header};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ use crate::creative;
 use crate::ec::eids::encode_eids_header;
 use crate::error::TrustedServerError;
 use crate::geo::GeoInfo;
-use crate::openrtb::{to_openrtb_i32, OpenRtbBid, OpenRtbResponse, ResponseExt, SeatBid, ToExt};
+use crate::openrtb::{OpenRtbBid, OpenRtbResponse, ResponseExt, SeatBid, ToExt, to_openrtb_i32};
 use crate::platform::RuntimeServices;
 use crate::settings::Settings;
 
@@ -112,40 +112,40 @@ pub fn convert_tsjs_to_auction_request(
     // Convert ad units to slots
     let mut slots = Vec::new();
     for unit in &body.ad_units {
-        if let Some(media_types) = &unit.media_types {
-            if let Some(banner) = &media_types.banner {
-                let mut formats = Vec::new();
-                for size in &banner.sizes {
-                    ensure!(
-                        size.len() == 2,
-                        TrustedServerError::BadRequest {
-                            message: "Invalid banner size; expected [width, height]".to_string(),
-                        }
-                    );
-
-                    formats.push(AdFormat {
-                        width: size[0],
-                        height: size[1],
-                        media_type: MediaType::Banner,
-                    });
-                }
-
-                // Extract bidder params from the bids array
-                let mut bidders = HashMap::new();
-                if let Some(bids) = &unit.bids {
-                    for bid in bids {
-                        bidders.insert(bid.bidder.clone(), bid.params.clone());
+        if let Some(media_types) = &unit.media_types
+            && let Some(banner) = &media_types.banner
+        {
+            let mut formats = Vec::new();
+            for size in &banner.sizes {
+                ensure!(
+                    size.len() == 2,
+                    TrustedServerError::BadRequest {
+                        message: "Invalid banner size; expected [width, height]".to_string(),
                     }
-                }
+                );
 
-                slots.push(AdSlot {
-                    id: unit.code.clone(),
-                    formats,
-                    floor_price: None,
-                    targeting: HashMap::new(),
-                    bidders,
+                formats.push(AdFormat {
+                    width: size[0],
+                    height: size[1],
+                    media_type: MediaType::Banner,
                 });
             }
+
+            // Extract bidder params from the bids array
+            let mut bidders = HashMap::new();
+            if let Some(bids) = &unit.bids {
+                for bid in bids {
+                    bidders.insert(bid.bidder.clone(), bid.params.clone());
+                }
+            }
+
+            slots.push(AdSlot {
+                id: unit.code.clone(),
+                formats,
+                floor_price: None,
+                targeting: HashMap::new(),
+                bidders,
+            });
         }
     }
 
@@ -165,32 +165,32 @@ pub fn convert_tsjs_to_auction_request(
     // unrecognised keys are silently dropped to prevent injection of
     // arbitrary data by a malicious client payload.
     let mut context = HashMap::new();
-    if let Some(ref config) = body.config {
-        if let Some(obj) = config.as_object() {
-            for (key, value) in obj {
-                if settings.auction.allowed_context_keys.contains(key) {
-                    match serde_json::from_value::<ContextValue>(value.clone()) {
-                        Ok(cv) => {
-                            context.insert(key.clone(), cv);
-                        }
-                        Err(_) => {
-                            log::debug!(
-                                "Auction context: dropping key '{}' with unsupported type",
-                                key
-                            );
-                        }
+    if let Some(ref config) = body.config
+        && let Some(obj) = config.as_object()
+    {
+        for (key, value) in obj {
+            if settings.auction.allowed_context_keys.contains(key) {
+                match serde_json::from_value::<ContextValue>(value.clone()) {
+                    Ok(cv) => {
+                        context.insert(key.clone(), cv);
                     }
-                } else {
-                    log::debug!("Auction context: dropping disallowed key '{}'", key);
+                    Err(_) => {
+                        log::debug!(
+                            "Auction context: dropping key '{}' with unsupported type",
+                            key
+                        );
+                    }
                 }
+            } else {
+                log::debug!("Auction context: dropping disallowed key '{}'", key);
             }
-            if !context.is_empty() {
-                log::debug!(
-                    "Auction request context: {} entries ({})",
-                    context.len(),
-                    context.keys().cloned().collect::<Vec<_>>().join(", ")
-                );
-            }
+        }
+        if !context.is_empty() {
+            log::debug!(
+                "Auction request context: {} entries ({})",
+                context.len(),
+                context.keys().cloned().collect::<Vec<_>>().join(", ")
+            );
         }
     }
 

--- a/crates/trusted-server-core/src/auction/mod.rs
+++ b/crates/trusted-server-core/src/auction/mod.rs
@@ -25,13 +25,13 @@ pub(crate) mod test_support;
 pub mod types;
 
 pub use config::AuctionConfig;
-pub use context::{build_url_with_context_params, ContextQueryParams, ContextValue};
+pub use context::{ContextQueryParams, ContextValue, build_url_with_context_params};
 pub use orchestrator::AuctionOrchestrator;
 pub use provider::AuctionProvider;
 pub use telemetry::{
-    build_auction_events, emit_auction_events_best_effort, emit_auction_events_best_effort_lazy,
     AbandonedProviderCall, AuctionEventBatch, AuctionEventRow, AuctionObservationContext,
     AuctionSource, AuctionTelemetrySink, AuctionTerminalOutcome, NoopAuctionTelemetrySink,
+    build_auction_events, emit_auction_events_best_effort, emit_auction_events_best_effort_lazy,
 };
 pub use types::{
     AdFormat, AuctionContext, AuctionRequest, AuctionResponse, Bid, BidStatus, MediaType,

--- a/crates/trusted-server-core/src/auction/orchestrator.rs
+++ b/crates/trusted-server-core/src/auction/orchestrator.rs
@@ -1116,7 +1116,9 @@ impl AuctionOrchestrator {
 
         for (provider_name, start_time, _) in backend_to_provider.values() {
             let response_time_ms = start_time.elapsed().as_millis() as u64;
-            log::warn!("Provider '{provider_name}' timed out before dispatched auction collection completed");
+            log::warn!(
+                "Provider '{provider_name}' timed out before dispatched auction collection completed"
+            );
             responses.push(provider_timeout_response(provider_name, response_time_ms));
         }
         backend_to_provider.clear();
@@ -1327,7 +1329,7 @@ mod tests {
         MediaType, PublisherInfo, UserInfo,
     };
     use crate::error::TrustedServerError;
-    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
+    use crate::platform::test_support::{StubHttpClient, build_services_with_http_client};
     use crate::platform::{
         PlatformHttpRequest, PlatformPendingRequest, PlatformResponse, RuntimeServices,
     };

--- a/crates/trusted-server-core/src/auction/test_support.rs
+++ b/crates/trusted-server-core/src/auction/test_support.rs
@@ -4,7 +4,7 @@ use edgezero_core::body::Body as EdgeBody;
 use http::Request;
 
 use super::AuctionContext;
-use crate::platform::{test_support::noop_services, RuntimeServices};
+use crate::platform::{RuntimeServices, test_support::noop_services};
 use crate::settings::Settings;
 
 static TEST_SERVICES: LazyLock<RuntimeServices> = LazyLock::new(noop_services);

--- a/crates/trusted-server-core/src/auth.rs
+++ b/crates/trusted-server-core/src/auth.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::STANDARD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::Report;
 use http::header;
@@ -98,7 +98,7 @@ fn unauthorized_response() -> Response<EdgeBody> {
 mod tests {
     use super::*;
     use base64::engine::general_purpose::STANDARD;
-    use http::{header, HeaderValue, Method};
+    use http::{HeaderValue, Method, header};
 
     use crate::test_support::tests::{crate_test_settings_str, create_test_settings};
 
@@ -122,9 +122,11 @@ mod tests {
         let settings = create_test_settings();
         let req = build_request(Method::GET, "https://example.com/open");
 
-        assert!(enforce_basic_auth(&settings, &req)
-            .expect("should evaluate auth")
-            .is_none());
+        assert!(
+            enforce_basic_auth(&settings, &req)
+                .expect("should evaluate auth")
+                .is_none()
+        );
     }
 
     #[test]
@@ -150,9 +152,11 @@ mod tests {
         let token = STANDARD.encode("user:pass");
         set_authorization(&mut req, &format!("Basic {token}"));
 
-        assert!(enforce_basic_auth(&settings, &req)
-            .expect("should evaluate auth")
-            .is_none());
+        assert!(
+            enforce_basic_auth(&settings, &req)
+                .expect("should evaluate auth")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/consent/gpp.rs
+++ b/crates/trusted-server-core/src/consent/gpp.rs
@@ -145,8 +145,8 @@ fn decode_us_sale_opt_out(parsed: &iab_gpp::v1::GPPString) -> Option<bool> {
 }
 
 fn us_sale_opt_out_from_section(section: &iab_gpp::sections::Section) -> Option<bool> {
-    use iab_gpp::sections::us_common::OptOut;
     use iab_gpp::sections::Section;
+    use iab_gpp::sections::us_common::OptOut;
 
     // Keep this match in sync with new US-state variants added by `iab_gpp`.
     let sale_opt_out = match section {
@@ -204,11 +204,7 @@ pub fn parse_gpp_sid_cookie(raw: &str) -> Option<Vec<u16>> {
         })
         .collect();
 
-    if ids.is_empty() {
-        None
-    } else {
-        Some(ids)
-    }
+    if ids.is_empty() { None } else { Some(ids) }
 }
 
 #[cfg(test)]

--- a/crates/trusted-server-core/src/consent/jurisdiction.rs
+++ b/crates/trusted-server-core/src/consent/jurisdiction.rs
@@ -64,17 +64,15 @@ pub fn detect_jurisdiction(geo: Option<&GeoInfo>, config: &ConsentConfig) -> Jur
     }
 
     // For US users, check if the region is a state with a privacy law.
-    if geo.country.eq_ignore_ascii_case("US") {
-        if let Some(region) = &geo.region {
-            if config
-                .us_states
-                .privacy_states
-                .iter()
-                .any(|state| state.eq_ignore_ascii_case(region))
-            {
-                return Jurisdiction::UsState(region.to_uppercase());
-            }
-        }
+    if geo.country.eq_ignore_ascii_case("US")
+        && let Some(region) = &geo.region
+        && config
+            .us_states
+            .privacy_states
+            .iter()
+            .any(|state| state.eq_ignore_ascii_case(region))
+    {
+        return Jurisdiction::UsState(region.to_uppercase());
     }
 
     Jurisdiction::NonRegulated
@@ -86,7 +84,7 @@ pub fn detect_jurisdiction(geo: Option<&GeoInfo>, config: &ConsentConfig) -> Jur
 
 #[cfg(test)]
 mod tests {
-    use super::{detect_jurisdiction, Jurisdiction};
+    use super::{Jurisdiction, detect_jurisdiction};
     use crate::consent_config::ConsentConfig;
     use crate::geo::GeoInfo;
 

--- a/crates/trusted-server-core/src/consent/mod.rs
+++ b/crates/trusted-server-core/src/consent/mod.rs
@@ -124,16 +124,15 @@ pub fn build_consent_context(input: &ConsentPipelineInput<'_>) -> ConsentContext
 
     // Read fallback: when the request carries no consent signals, fall back
     // to consent persisted in KV for this EC ID (when persistence is wired).
-    if signals.is_empty() {
-        if let (Some(ec_id), Some(store)) = (input.ec_id, input.kv_store) {
-            if let Some(mut ctx) = kv::load_consent_from_kv(store, ec_id) {
-                // Jurisdiction is request-local: derive it from the current
-                // geo rather than the value stored with the persisted entry.
-                ctx.jurisdiction = jurisdiction::detect_jurisdiction(input.geo, input.config);
-                log_consent_context(&ctx);
-                return ctx;
-            }
-        }
+    if signals.is_empty()
+        && let (Some(ec_id), Some(store)) = (input.ec_id, input.kv_store)
+        && let Some(mut ctx) = kv::load_consent_from_kv(store, ec_id)
+    {
+        // Jurisdiction is request-local: derive it from the current
+        // geo rather than the value stored with the persisted entry.
+        ctx.jurisdiction = jurisdiction::detect_jurisdiction(input.geo, input.config);
+        log_consent_context(&ctx);
+        return ctx;
     }
 
     // In proxy mode, skip decoding entirely.
@@ -572,10 +571,10 @@ pub fn allows_ec_creation(ctx: &ConsentContext) -> bool {
                 return tcf.has_storage_consent();
             }
             // GPP US sale_opt_out=false is an explicit non-opt-out signal.
-            if let Some(gpp) = &ctx.gpp {
-                if let Some(opted_out) = gpp.us_sale_opt_out {
-                    return !opted_out;
-                }
+            if let Some(gpp) = &ctx.gpp
+                && let Some(opted_out) = gpp.us_sale_opt_out
+            {
+                return !opted_out;
             }
             // Check US Privacy string when no TCF decision is present.
             if let Some(usp) = &ctx.us_privacy {
@@ -702,9 +701,9 @@ mod tests {
     use http::Request;
 
     use super::{
-        allows_ec_creation, apply_expiration_check, apply_tcf_conflict_resolution,
-        build_consent_context, build_context_from_signals, consent_allows_server_side_auction,
-        has_explicit_ec_withdrawal, ConsentPipelineInput,
+        ConsentPipelineInput, allows_ec_creation, apply_expiration_check,
+        apply_tcf_conflict_resolution, build_consent_context, build_context_from_signals,
+        consent_allows_server_side_auction, has_explicit_ec_withdrawal,
     };
     use crate::consent::jurisdiction::Jurisdiction;
     use crate::consent::types::{

--- a/crates/trusted-server-core/src/consent/tcf.rs
+++ b/crates/trusted-server-core/src/consent/tcf.rs
@@ -39,8 +39,8 @@
 //!
 //! - [IAB TCF v2.0 specification](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md)
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use error_stack::Report;
 
 use super::types::{ConsentDecodeError, TcfConsent};

--- a/crates/trusted-server-core/src/consent/types.rs
+++ b/crates/trusted-server-core/src/consent/types.rs
@@ -356,11 +356,7 @@ impl fmt::Display for PrivacyFlag {
 
 impl From<bool> for PrivacyFlag {
     fn from(value: bool) -> Self {
-        if value {
-            Self::Yes
-        } else {
-            Self::No
-        }
+        if value { Self::Yes } else { Self::No }
     }
 }
 

--- a/crates/trusted-server-core/src/cookies.rs
+++ b/crates/trusted-server-core/src/cookies.rs
@@ -6,8 +6,8 @@
 use cookie::{Cookie, CookieJar};
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt as _};
-use http::header;
 use http::Request;
+use http::header;
 
 use crate::constants::{COOKIE_EUCONSENT_V2, COOKIE_GPP, COOKIE_GPP_SID, COOKIE_US_PRIVACY};
 use crate::error::TrustedServerError;
@@ -112,10 +112,10 @@ pub fn forward_cookie_header(
         match cookie_value.to_str() {
             Ok(s) => {
                 let stripped = strip_cookies(s, CONSENT_COOKIE_NAMES);
-                if !stripped.is_empty() {
-                    if let Ok(value) = http::HeaderValue::from_str(&stripped) {
-                        to.headers_mut().append(header::COOKIE, value);
-                    }
+                if !stripped.is_empty()
+                    && let Ok(value) = http::HeaderValue::from_str(&stripped)
+                {
+                    to.headers_mut().append(header::COOKIE, value);
                 }
             }
             Err(_) => {

--- a/crates/trusted-server-core/src/creative.rs
+++ b/crates/trusted-server-core/src/creative.rs
@@ -41,7 +41,7 @@ use crate::http_util::compute_encrypted_sha256_token;
 use crate::settings::Settings;
 use crate::streaming_processor::StreamProcessor;
 use crate::tsjs;
-use lol_html::{element, html_content::ContentType, text, HtmlRewriter, Settings as HtmlSettings};
+use lol_html::{HtmlRewriter, Settings as HtmlSettings, element, html_content::ContentType, text};
 use std::io;
 
 /// Maximum size of response body that can be buffered for rewriting.
@@ -92,7 +92,7 @@ pub(super) fn rewrite_style_urls(settings: &Settings, style: &str) -> String {
     while let Some(off) = lower[scan..].find("url(") {
         let start = scan + off;
         let open = start + 4; // after 'url('
-                              // write prefix including 'url('
+        // write prefix including 'url('
         out.push_str(&style[write_pos..open]);
         // find closing ')'
         let close = if let Some(c) = lower[open..].find(')') {
@@ -520,15 +520,15 @@ pub fn rewrite_creative_html(settings: &Settings, markup: &str) -> String {
                 }),
                 // Image src + data-src
                 element!("img", |el| {
-                    if let Some(src) = el.get_attribute("src") {
-                        if let Some(p) = proxy_if_abs(settings, &src) {
-                            let _ = el.set_attribute("src", &p);
-                        }
+                    if let Some(src) = el.get_attribute("src")
+                        && let Some(p) = proxy_if_abs(settings, &src)
+                    {
+                        let _ = el.set_attribute("src", &p);
                     }
-                    if let Some(dsrc) = el.get_attribute("data-src") {
-                        if let Some(p) = proxy_if_abs(settings, &dsrc) {
-                            let _ = el.set_attribute("data-src", &p);
-                        }
+                    if let Some(dsrc) = el.get_attribute("data-src")
+                        && let Some(p) = proxy_if_abs(settings, &dsrc)
+                    {
+                        let _ = el.set_attribute("data-src", &p);
                     }
                     Ok(())
                 }),
@@ -609,12 +609,12 @@ pub fn rewrite_creative_html(settings: &Settings, markup: &str) -> String {
                 ),
                 // Click-through links
                 element!("a[href], area[href]", |el| {
-                    if let Some(href) = el.get_attribute("href") {
-                        if let Some(abs) = to_abs(settings, &href) {
-                            let click = build_click_url(settings, &abs);
-                            let _ = el.set_attribute("href", &click);
-                            let _ = el.set_attribute("data-tsclick", &click);
-                        }
+                    if let Some(href) = el.get_attribute("href")
+                        && let Some(abs) = to_abs(settings, &href)
+                    {
+                        let click = build_click_url(settings, &abs);
+                        let _ = el.set_attribute("href", &click);
+                        let _ = el.set_attribute("data-tsclick", &click);
                     }
                     Ok(())
                 }),
@@ -639,10 +639,10 @@ pub fn rewrite_creative_html(settings: &Settings, markup: &str) -> String {
                 }),
                 // iframes
                 element!("iframe", |el| {
-                    if let Some(src) = el.get_attribute("src") {
-                        if let Some(p) = proxy_if_abs(settings, src.as_str()) {
-                            let _ = el.set_attribute("src", &p);
-                        }
+                    if let Some(src) = el.get_attribute("src")
+                        && let Some(p) = proxy_if_abs(settings, src.as_str())
+                    {
+                        let _ = el.set_attribute("src", &p);
                     }
                     Ok(())
                 }),

--- a/crates/trusted-server-core/src/creative_opportunities.rs
+++ b/crates/trusted-server-core/src/creative_opportunities.rs
@@ -146,13 +146,13 @@ impl CreativeOpportunitySlot {
         // A negative floor silently disables minimum-price enforcement, and a
         // non-finite floor (NaN/infinity) produces surprising all-pass/all-drop
         // comparisons and an invalid OpenRTB `bidfloor`.
-        if let Some(floor_price) = self.floor_price {
-            if !floor_price.is_finite() || floor_price < 0.0 {
-                return Err(format!(
-                    "slot `{}` floor_price must be a finite value >= 0.0, got {floor_price}",
-                    self.id
-                ));
-            }
+        if let Some(floor_price) = self.floor_price
+            && (!floor_price.is_finite() || floor_price < 0.0)
+        {
+            return Err(format!(
+                "slot `{}` floor_price must be a finite value >= 0.0, got {floor_price}",
+                self.id
+            ));
         }
 
         // An explicit empty/whitespace `div_id` override is rejected: the

--- a/crates/trusted-server-core/src/ec/cookies.rs
+++ b/crates/trusted-server-core/src/ec/cookies.rs
@@ -16,7 +16,7 @@
 use std::borrow::Cow;
 
 use edgezero_core::body::Body as EdgeBody;
-use http::{header, HeaderValue, Response};
+use http::{HeaderValue, Response, header};
 
 use crate::constants::COOKIE_TS_EC;
 use crate::settings::Settings;

--- a/crates/trusted-server-core/src/ec/eids.rs
+++ b/crates/trusted-server-core/src/ec/eids.rs
@@ -4,7 +4,7 @@
 //! keyed IDs from KV entries, convert them to `OpenRTB` EID structures, and
 //! build base64-encoded response headers.
 
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use error_stack::{Report, ResultExt as _};
 
 use crate::error::TrustedServerError;

--- a/crates/trusted-server-core/src/ec/finalize.rs
+++ b/crates/trusted-server-core/src/ec/finalize.rs
@@ -11,13 +11,13 @@ use http::Response;
 use super::consent::{ec_consent_granted, ec_consent_withdrawn};
 use crate::settings::Settings;
 
+use super::EcContext;
 use super::cookies::{expire_ec_cookie, set_ec_cookie};
 use super::generation::is_valid_ec_id;
 use super::kv::KvIdentityGraph;
 use super::log_id;
 use super::prebid_eids::ingest_eid_cookies;
 use super::registry::PartnerRegistry;
-use super::EcContext;
 
 /// TS-managed response headers tied to EC identity output.
 const EC_RESPONSE_HEADERS: &[&str] = &[
@@ -155,16 +155,16 @@ pub fn clear_ec_on_response(settings: &Settings, response: &mut Response<EdgeBod
 fn withdrawal_ec_ids(ec_context: &EcContext) -> HashSet<String> {
     let mut hashes = HashSet::new();
 
-    if let Some(cookie_ec_id) = ec_context.existing_cookie_ec_id() {
-        if is_valid_ec_id(cookie_ec_id) {
-            hashes.insert(cookie_ec_id.to_owned());
-        }
+    if let Some(cookie_ec_id) = ec_context.existing_cookie_ec_id()
+        && is_valid_ec_id(cookie_ec_id)
+    {
+        hashes.insert(cookie_ec_id.to_owned());
     }
 
-    if let Some(active_ec_id) = ec_context.ec_value() {
-        if is_valid_ec_id(active_ec_id) {
-            hashes.insert(active_ec_id.to_owned());
-        }
+    if let Some(active_ec_id) = ec_context.ec_value()
+        && is_valid_ec_id(active_ec_id)
+    {
+        hashes.insert(active_ec_id.to_owned());
     }
 
     hashes

--- a/crates/trusted-server-core/src/ec/identify.rs
+++ b/crates/trusted-server-core/src/ec/identify.rs
@@ -15,10 +15,10 @@ use crate::error::TrustedServerError;
 use crate::openrtb::{Eid, Uid};
 use crate::settings::Settings;
 
+use super::EcContext;
 use super::kv::KvIdentityGraph;
 use super::log_id;
 use super::registry::PartnerRegistry;
-use super::EcContext;
 
 /// Handles `GET /_ts/api/v1/identify`.
 ///
@@ -96,10 +96,10 @@ pub fn handle_identify(
                 log::trace!("Identify found tombstone for '{}'", log_id(ec_id));
             } else {
                 // Extract only this partner's UID.
-                if let Some(partner_uid) = entry.ids.get(&partner.source_domain) {
-                    if !partner_uid.uid.is_empty() {
-                        uid = Some(partner_uid.uid.clone());
-                    }
+                if let Some(partner_uid) = entry.ids.get(&partner.source_domain)
+                    && !partner_uid.uid.is_empty()
+                {
+                    uid = Some(partner_uid.uid.clone());
                 }
 
                 // Evaluate cluster size lazily for identify responses. Existing

--- a/crates/trusted-server-core/src/ec/kv.rs
+++ b/crates/trusted-server-core/src/ec/kv.rs
@@ -346,12 +346,12 @@ impl KvIdentityGraph {
                     // Re-read immediately to get a fresh generation. Sleeping in
                     // the CAS loop would block the edge compute request worker.
                     match self.get(ec_id)? {
-                        Some((refreshed, gen)) => {
+                        Some((refreshed, generation)) => {
                             if refreshed.consent.ok {
                                 // Someone else revived it — done.
                                 return Ok(());
                             }
-                            current_gen = gen;
+                            current_gen = generation;
                         }
                         None => return self.create(ec_id, entry),
                     }
@@ -870,8 +870,8 @@ mod tests {
     // CAS-conflict injection tests
     // -----------------------------------------------------------------------
 
-    use crate::ec::kv_backend::test_support::InMemoryEcKv;
     use crate::ec::kv_backend::EcKvLookup;
+    use crate::ec::kv_backend::test_support::InMemoryEcKv;
 
     /// [`EcKvStore`] wrapper that injects generation conflicts: the first
     /// `conflicts_remaining` `IfGenerationMatch` inserts return

--- a/crates/trusted-server-core/src/ec/prebid_eids.rs
+++ b/crates/trusted-server-core/src/ec/prebid_eids.rs
@@ -8,7 +8,7 @@
 //! compatibility we also accept the earlier flattened payload shape
 //! (`{source, id, atype}` per entry).
 
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use error_stack::Report;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
@@ -150,10 +150,10 @@ fn ingest_eid_cookies_with_writer(
     if let Some(cookie) = eids_cookie {
         updates.extend(collect_prebid_eid_updates(cookie, registry));
     }
-    if let Some(cookie) = sharedid_cookie {
-        if let Some(update) = collect_sharedid_update(cookie, registry) {
-            updates.push(update);
-        }
+    if let Some(cookie) = sharedid_cookie
+        && let Some(update) = collect_sharedid_update(cookie, registry)
+    {
+        updates.push(update);
     }
 
     let updates = dedupe_partner_updates(updates);

--- a/crates/trusted-server-core/src/ec/pull_sync.rs
+++ b/crates/trusted-server-core/src/ec/pull_sync.rs
@@ -9,13 +9,13 @@
 //! the entry no longer stores per-partner sync timestamps.
 
 use edgezero_core::body::Body as EdgeBody;
-use http::{header, Method, StatusCode};
+use http::{Method, StatusCode, header};
 use serde::Deserialize;
 use url::Url;
 
 use crate::platform::{
-    PlatformBackendSpec, PlatformHttpRequest, PlatformPendingRequest, PlatformResponse,
-    RuntimeServices, DEFAULT_FIRST_BYTE_TIMEOUT,
+    DEFAULT_FIRST_BYTE_TIMEOUT, PlatformBackendSpec, PlatformHttpRequest, PlatformPendingRequest,
+    PlatformResponse, RuntimeServices,
 };
 use crate::settings::Settings;
 
@@ -26,8 +26,8 @@ use super::rate_limiter::RateLimiter;
 use super::registry::{PartnerConfig, PartnerRegistry};
 
 // `current_timestamp` is defined in the parent `ec` module.
-use super::current_timestamp;
 use super::EcContext;
+use super::current_timestamp;
 
 /// Inputs needed to dispatch pull sync after response flush.
 #[derive(Debug, Clone)]

--- a/crates/trusted-server-core/src/edge_cookie.rs
+++ b/crates/trusted-server-core/src/edge_cookie.rs
@@ -138,7 +138,7 @@ pub fn get_or_generate_ec_id(
 mod tests {
     use super::*;
     use edgezero_core::body::Body as EdgeBody;
-    use http::{header, HeaderName};
+    use http::{HeaderName, header};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     use crate::platform::test_support::{noop_services, noop_services_with_client_ip};

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -4,13 +4,13 @@
 use std::cell::Cell;
 use std::io;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use lol_html::{
-    element,
+    EndTagHandler, Settings as RewriterSettings, element,
     html_content::{ContentType, EndTag},
-    text, EndTagHandler, Settings as RewriterSettings,
+    text,
 };
 
 use crate::integrations::{
@@ -975,9 +975,9 @@ mod tests {
 
     #[test]
     fn test_real_publisher_html_with_gzip() {
+        use flate2::Compression as GzCompression;
         use flate2::read::GzDecoder;
         use flate2::write::GzEncoder;
-        use flate2::Compression as GzCompression;
         use std::io::{Read as _, Write as _};
 
         let html = include_str!("html_processor.test.html");

--- a/crates/trusted-server-core/src/http_util.rs
+++ b/crates/trusted-server-core/src/http_util.rs
@@ -1,8 +1,8 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use chacha20poly1305::{aead::Aead as _, aead::KeyInit as _, XChaCha20Poly1305, XNonce};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce, aead::Aead as _, aead::KeyInit as _};
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::Report;
-use http::{header, Request, Response, StatusCode};
+use http::{Request, Response, StatusCode, header};
 use sha2::{Digest as _, Sha256};
 use subtle::ConstantTimeEq as _;
 
@@ -232,36 +232,31 @@ fn detect_request_scheme(
     }
 
     // 2. Try the Forwarded header (RFC 7239)
-    if let Some(forwarded) = req.headers().get("forwarded") {
-        if let Ok(forwarded_str) = forwarded.to_str() {
-            if let Some(proto) = parse_forwarded_param(forwarded_str, "proto") {
-                if let Some(scheme) = normalize_scheme(proto) {
-                    return scheme;
-                }
-            }
-        }
+    if let Some(forwarded) = req.headers().get("forwarded")
+        && let Ok(forwarded_str) = forwarded.to_str()
+        && let Some(proto) = parse_forwarded_param(forwarded_str, "proto")
+        && let Some(scheme) = normalize_scheme(proto)
+    {
+        return scheme;
     }
 
     // 3. Try X-Forwarded-Proto header
-    if let Some(proto) = req.headers().get("x-forwarded-proto") {
-        if let Ok(proto_str) = proto.to_str() {
-            if let Some(value) = parse_list_header_value(proto_str) {
-                if let Some(scheme) = normalize_scheme(value) {
-                    return scheme;
-                }
-            }
-        }
+    if let Some(proto) = req.headers().get("x-forwarded-proto")
+        && let Ok(proto_str) = proto.to_str()
+        && let Some(value) = parse_list_header_value(proto_str)
+        && let Some(scheme) = normalize_scheme(value)
+    {
+        return scheme;
     }
 
     // 4. Check Fastly-SSL header. On the `EdgeZero` path this is injected from
     //    authoritative Fastly TLS metadata after spoofable headers are stripped,
     //    so it is reliable. On direct or legacy paths it can be spoofed by clients.
-    if let Some(ssl) = req.headers().get("fastly-ssl") {
-        if let Ok(ssl_str) = ssl.to_str() {
-            if ssl_str == "1" || ssl_str.to_lowercase() == "true" {
-                return "https".to_owned();
-            }
-        }
+    if let Some(ssl) = req.headers().get("fastly-ssl")
+        && let Ok(ssl_str) = ssl.to_str()
+        && (ssl_str == "1" || ssl_str.to_lowercase() == "true")
+    {
+        return "https".to_owned();
     }
 
     // Default to HTTP
@@ -289,9 +284,9 @@ pub fn serve_static_with_etag(
         .headers()
         .get(header::IF_NONE_MATCH)
         .and_then(|h| h.to_str().ok())
+        && if_none_match == etag
     {
-        if if_none_match == etag {
-            return Response::builder()
+        return Response::builder()
                 .status(StatusCode::NOT_MODIFIED)
                 .header(header::ETAG, &etag)
                 .header(
@@ -302,7 +297,6 @@ pub fn serve_static_with_etag(
                 .header(header::VARY, "Accept-Encoding")
                 .body(EdgeBody::empty())
                 .expect("should build 304 static response");
-        }
     }
 
     Response::builder()

--- a/crates/trusted-server-core/src/integrations/adserver_mock.rs
+++ b/crates/trusted-server-core/src/integrations/adserver_mock.rs
@@ -7,23 +7,23 @@
 use async_trait::async_trait;
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::{header, Method};
+use http::{Method, header};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value as Json};
+use serde_json::{Value as Json, json};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 use validator::Validate;
 
-use crate::auction::context::{build_url_with_context_params, ContextQueryParams};
+use crate::auction::context::{ContextQueryParams, build_url_with_context_params};
 use crate::auction::provider::AuctionProvider;
 use crate::auction::types::{
     AuctionContext, AuctionRequest, AuctionResponse, Bid, BidStatus, MediaType,
 };
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    collect_response_bounded, ensure_integration_backend_with_timeout,
-    predict_integration_backend_name, UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+    UPSTREAM_RTB_MAX_RESPONSE_BYTES, collect_response_bounded,
+    ensure_integration_backend_with_timeout, predict_integration_backend_name,
 };
 use crate::platform::{
     PlatformHttpRequest, PlatformPendingRequest, PlatformResponse, RuntimeServices,
@@ -429,24 +429,24 @@ impl AuctionProvider for AdServerMockProvider {
             })?;
 
         // Set Host header with port to ensure mocktioneer generates correct iframe URLs
-        if let Ok(url) = url::Url::parse(&self.config.endpoint) {
-            if let Some(host) = url.host_str() {
-                let host_with_port = if let Some(port) = url.port() {
-                    format!("{}:{}", host, port)
-                } else {
-                    host.to_string()
-                };
-                match header::HeaderValue::from_str(&host_with_port) {
-                    Ok(value) => {
-                        req.headers_mut().insert(header::HOST, value);
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to build Host header for '{}': {}",
-                            host_with_port,
-                            e
-                        );
-                    }
+        if let Ok(url) = url::Url::parse(&self.config.endpoint)
+            && let Some(host) = url.host_str()
+        {
+            let host_with_port = if let Some(port) = url.port() {
+                format!("{}:{}", host, port)
+            } else {
+                host.to_string()
+            };
+            match header::HeaderValue::from_str(&host_with_port) {
+                Ok(value) => {
+                    req.headers_mut().insert(header::HOST, value);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Failed to build Host header for '{}': {}",
+                        host_with_port,
+                        e
+                    );
                 }
             }
         }

--- a/crates/trusted-server-core/src/integrations/aps.rs
+++ b/crates/trusted-server-core/src/integrations/aps.rs
@@ -5,9 +5,9 @@
 use async_trait::async_trait;
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::{header, Method};
+use http::{Method, header};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value as Json};
+use serde_json::{Value as Json, json};
 use std::collections::HashMap;
 use std::time::Duration;
 use validator::Validate;
@@ -16,8 +16,8 @@ use crate::auction::provider::AuctionProvider;
 use crate::auction::types::{AuctionContext, AuctionRequest, AuctionResponse, Bid, MediaType};
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    collect_response_bounded, ensure_integration_backend_with_timeout,
-    predict_integration_backend_name, UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+    UPSTREAM_RTB_MAX_RESPONSE_BYTES, collect_response_bounded,
+    ensure_integration_backend_with_timeout, predict_integration_backend_name,
 };
 use crate::platform::{
     PlatformHttpRequest, PlatformPendingRequest, PlatformResponse, RuntimeServices,
@@ -407,10 +407,10 @@ impl ApsAuctionProvider {
     /// Parse size string (e.g., "300x250") into width and height.
     fn parse_size(size: &str) -> Option<(u32, u32)> {
         let parts: Vec<&str> = size.split('x').collect();
-        if parts.len() == 2 {
-            if let (Ok(w), Ok(h)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
-                return Some((w, h));
-            }
+        if parts.len() == 2
+            && let (Ok(w), Ok(h)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>())
+        {
+            return Some((w, h));
         }
         None
     }

--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -70,11 +70,11 @@ use validator::Validate;
 
 use crate::error::TrustedServerError;
 use crate::integrations::{
+    AttributeRewriteAction, INTEGRATION_MAX_BODY_BYTES, IntegrationAttributeContext,
+    IntegrationAttributeRewriter, IntegrationEndpoint, IntegrationHeadInjector,
+    IntegrationHtmlContext, IntegrationProxy, IntegrationRegistration, IntegrationRequestFilter,
+    RequestFilterDecision, RequestFilterInput, UPSTREAM_SDK_MAX_RESPONSE_BYTES,
     collect_body_bounded, collect_response_bounded, ensure_integration_backend,
-    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
-    IntegrationRegistration, IntegrationRequestFilter, RequestFilterDecision, RequestFilterInput,
-    INTEGRATION_MAX_BODY_BYTES, UPSTREAM_SDK_MAX_RESPONSE_BYTES,
 };
 use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
@@ -879,7 +879,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
+    use crate::platform::test_support::{StubHttpClient, build_services_with_http_client};
     use crate::test_support::tests::create_test_settings;
 
     fn test_config() -> DataDomeConfig {

--- a/crates/trusted-server-core/src/integrations/datadome/protection.rs
+++ b/crates/trusted-server-core/src/integrations/datadome/protection.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
 use edgezero_core::body::Body as EdgeBody;
-use edgezero_core::http::{request_builder, HeaderMap, HeaderName};
+use edgezero_core::http::{HeaderMap, HeaderName, request_builder};
 use error_stack::{Report, ResultExt};
-use http::{header, Method, Request, Response, StatusCode};
+use http::{Method, Request, Response, StatusCode, header};
 use url::Url;
 
 use crate::error::TrustedServerError;
@@ -13,8 +13,8 @@ use crate::integrations::{
 use crate::platform::{PlatformBackendSpec, PlatformHttpRequest, RuntimeServices, StoreName};
 use crate::redacted::Redacted;
 
-use super::protection_scope::{ProtectionRequestFacts, ProtectionScopeDecision};
 use super::DataDomeIntegration;
+use super::protection_scope::{ProtectionRequestFacts, ProtectionScopeDecision};
 
 const VALIDATE_REQUEST_PATH: &str = "/validate-request";
 const REQUEST_MODULE_NAME: &str = "Trusted-Server-Rust";
@@ -648,7 +648,7 @@ mod tests {
 
     use crate::integrations::datadome::DataDomeConfig;
     use crate::platform::test_support::{
-        build_services_with_config_and_secret, HashMapSecretStore, NoopConfigStore, NoopSecretStore,
+        HashMapSecretStore, NoopConfigStore, NoopSecretStore, build_services_with_config_and_secret,
     };
     use crate::settings::Settings;
 

--- a/crates/trusted-server-core/src/integrations/datadome/protection_scope.rs
+++ b/crates/trusted-server-core/src/integrations/datadome/protection_scope.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use crate::error::TrustedServerError;
 use crate::platform::{RuntimeServices, StoreName};
 
-use super::{DataDomeConfig, DATADOME_INTEGRATION_ID};
+use super::{DATADOME_INTEGRATION_ID, DataDomeConfig};
 
 /// Configured source for dynamic IP CIDR bypass lists.
 #[derive(Debug, Clone, Deserialize)]
@@ -398,10 +398,10 @@ impl ProtectionExclusionRule {
         services: &RuntimeServices,
         cache_ttl: Duration,
     ) -> bool {
-        if let Some(methods) = &self.methods {
-            if !methods.matches(facts.method) {
-                return false;
-            }
+        if let Some(methods) = &self.methods
+            && !methods.matches(facts.method)
+        {
+            return false;
         }
 
         self.matcher.matches(facts, services, cache_ttl)
@@ -657,7 +657,7 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use crate::platform::test_support::{
-        build_services_with_config_and_secret, HashMapConfigStore, NoopSecretStore,
+        HashMapConfigStore, NoopSecretStore, build_services_with_config_and_secret,
     };
 
     use super::*;
@@ -713,16 +713,20 @@ mod tests {
         let cidr = "2001:db8::/32"
             .parse::<IpCidr>()
             .expect("should parse CIDR");
-        assert!(cidr.contains(IpAddr::V6(
-            "2001:db8::1"
-                .parse::<Ipv6Addr>()
-                .expect("should parse IPv6")
-        )));
-        assert!(!cidr.contains(IpAddr::V6(
-            "2001:db9::1"
-                .parse::<Ipv6Addr>()
-                .expect("should parse IPv6")
-        )));
+        assert!(
+            cidr.contains(IpAddr::V6(
+                "2001:db8::1"
+                    .parse::<Ipv6Addr>()
+                    .expect("should parse IPv6")
+            ))
+        );
+        assert!(
+            !cidr.contains(IpAddr::V6(
+                "2001:db9::1"
+                    .parse::<Ipv6Addr>()
+                    .expect("should parse IPv6")
+            ))
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/integrations/didomi.rs
+++ b/crates/trusted-server-core/src/integrations/didomi.rs
@@ -3,16 +3,17 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::header::{self, HeaderMap, HeaderValue};
 use http::Method;
+use http::header::{self, HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use validator::{Validate, ValidationError};
 
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    collect_body_bounded, ensure_integration_backend, IntegrationEndpoint, IntegrationHeadInjector,
-    IntegrationHtmlContext, IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
+    INTEGRATION_MAX_BODY_BYTES, IntegrationEndpoint, IntegrationHeadInjector,
+    IntegrationHtmlContext, IntegrationProxy, IntegrationRegistration, collect_body_bounded,
+    ensure_integration_backend,
 };
 use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
@@ -367,7 +368,7 @@ mod tests {
 
     use super::*;
     use crate::integrations::{IntegrationDocumentState, IntegrationRegistry};
-    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
+    use crate::platform::test_support::{StubHttpClient, build_services_with_http_client};
     use crate::test_support::tests::create_test_settings;
     use http::Method;
     use std::net::{IpAddr, Ipv4Addr};

--- a/crates/trusted-server-core/src/integrations/google_tag_manager.rs
+++ b/crates/trusted-server-core/src/integrations/google_tag_manager.rs
@@ -18,20 +18,20 @@ use async_trait::async_trait;
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
 use futures::StreamExt as _;
-use http::{header, Method, Request, Response, StatusCode};
+use http::{Method, Request, Response, StatusCode, header};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    collect_response_bounded, AttributeRewriteAction, IntegrationAttributeContext,
-    IntegrationAttributeRewriter, IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
-    IntegrationScriptContext, IntegrationScriptRewriter, ScriptRewriteAction,
-    UPSTREAM_SDK_MAX_RESPONSE_BYTES,
+    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
+    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration, IntegrationScriptContext,
+    IntegrationScriptRewriter, ScriptRewriteAction, UPSTREAM_SDK_MAX_RESPONSE_BYTES,
+    collect_response_bounded,
 };
 use crate::platform::RuntimeServices;
-use crate::proxy::{proxy_request, ProxyRequestConfig};
+use crate::proxy::{ProxyRequestConfig, proxy_request};
 use crate::settings::{IntegrationConfig, Settings};
 
 const GTM_INTEGRATION_ID: &str = "google_tag_manager";
@@ -461,44 +461,41 @@ impl IntegrationProxy for GoogleTagManagerIntegration {
 
         // Validate body size for POST requests to prevent memory pressure
         // Check Content-Length header if present for early rejection
-        if method == Method::POST {
-            if let Some(content_length_str) = req
+        if method == Method::POST
+            && let Some(content_length_str) = req
                 .headers()
                 .get(header::CONTENT_LENGTH)
                 .and_then(|value| value.to_str().ok())
-            {
-                match content_length_str.parse::<usize>() {
-                    Ok(content_length) => {
-                        // Early rejection based on Content-Length
-                        if content_length > self.config.max_beacon_body_size {
-                            log::warn!(
-                                "Rejecting POST beacon with Content-Length {} exceeding max {}",
-                                content_length,
-                                self.config.max_beacon_body_size
-                            );
-                            return Response::builder()
-                                .status(StatusCode::PAYLOAD_TOO_LARGE)
-                                .body(EdgeBody::empty())
-                                .change_context(Self::error(
-                                    "Failed to build GTM payload-too-large response",
-                                ));
-                        }
-                    }
-                    Err(_) => {
-                        // Invalid Content-Length header
-                        log::warn!("POST request with malformed Content-Length header");
+        {
+            match content_length_str.parse::<usize>() {
+                Ok(content_length) => {
+                    // Early rejection based on Content-Length
+                    if content_length > self.config.max_beacon_body_size {
+                        log::warn!(
+                            "Rejecting POST beacon with Content-Length {} exceeding max {}",
+                            content_length,
+                            self.config.max_beacon_body_size
+                        );
                         return Response::builder()
-                            .status(StatusCode::BAD_REQUEST)
+                            .status(StatusCode::PAYLOAD_TOO_LARGE)
                             .body(EdgeBody::empty())
                             .change_context(Self::error(
-                                "Failed to build GTM bad-request response",
+                                "Failed to build GTM payload-too-large response",
                             ));
                     }
                 }
+                Err(_) => {
+                    // Invalid Content-Length header
+                    log::warn!("POST request with malformed Content-Length header");
+                    return Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(EdgeBody::empty())
+                        .change_context(Self::error("Failed to build GTM bad-request response"));
+                }
             }
-            // If Content-Length is missing, we'll check actual size after read
-            // This maintains compatibility with HTTP/2 and intermediaries
         }
+        // If Content-Length is missing, we'll check actual size after read
+        // This maintains compatibility with HTTP/2 and intermediaries
 
         let Some(target_url) = self.build_target_url(&req, &path) else {
             return Response::builder()
@@ -668,7 +665,7 @@ impl IntegrationScriptRewriter for GoogleTagManagerIntegration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::html_processor::{create_html_processor, HtmlProcessorConfig};
+    use crate::html_processor::{HtmlProcessorConfig, create_html_processor};
     use crate::integrations::{
         AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
         IntegrationDocumentState, IntegrationRegistry, IntegrationScriptContext,
@@ -1073,21 +1070,31 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         // GTM.js, Gtag.js (/js and .js), and 4 Collect endpoints (GET/POST for standard & dual-tagging)
         assert_eq!(routes.len(), 7);
 
-        assert!(routes
-            .iter()
-            .any(|r| r.path == "/integrations/google_tag_manager/gtm.js"));
-        assert!(routes
-            .iter()
-            .any(|r| r.path == "/integrations/google_tag_manager/gtag/js"));
-        assert!(routes
-            .iter()
-            .any(|r| r.path == "/integrations/google_tag_manager/gtag.js"));
-        assert!(routes
-            .iter()
-            .any(|r| r.path == "/integrations/google_tag_manager/collect"));
-        assert!(routes
-            .iter()
-            .any(|r| r.path == "/integrations/google_tag_manager/g/collect"));
+        assert!(
+            routes
+                .iter()
+                .any(|r| r.path == "/integrations/google_tag_manager/gtm.js")
+        );
+        assert!(
+            routes
+                .iter()
+                .any(|r| r.path == "/integrations/google_tag_manager/gtag/js")
+        );
+        assert!(
+            routes
+                .iter()
+                .any(|r| r.path == "/integrations/google_tag_manager/gtag.js")
+        );
+        assert!(
+            routes
+                .iter()
+                .any(|r| r.path == "/integrations/google_tag_manager/collect")
+        );
+        assert!(
+            routes
+                .iter()
+                .any(|r| r.path == "/integrations/google_tag_manager/g/collect")
+        );
     }
 
     #[test]
@@ -1439,9 +1446,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             });
 
             assert!(
-            has_header_override,
-            "collect routes should strip client IP by overriding X-Forwarded-For with empty string"
-        );
+                has_header_override,
+                "collect routes should strip client IP by overriding X-Forwarded-For with empty string"
+            );
         });
     }
 

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::{header, Request, Response};
+use http::{Request, Response, header};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use validator::Validate;
@@ -50,7 +50,7 @@ use crate::integrations::{
     IntegrationRegistration,
 };
 use crate::platform::RuntimeServices;
-use crate::proxy::{proxy_request, ProxyRequestConfig};
+use crate::proxy::{ProxyRequestConfig, proxy_request};
 use crate::settings::{IntegrationConfig, Settings};
 
 const GPT_INTEGRATION_ID: &str = "gpt";
@@ -1073,7 +1073,9 @@ mod tests {
         );
         assert_eq!(
             url.as_deref(),
-            Some("https://securepubads.g.doubleclick.net/pagead/managed/js/gpt/m202603020101/pubads_impl.js"),
+            Some(
+                "https://securepubads.g.doubleclick.net/pagead/managed/js/gpt/m202603020101/pubads_impl.js"
+            ),
             "should strip the integration prefix and build the upstream URL"
         );
     }
@@ -1086,7 +1088,9 @@ mod tests {
         );
         assert_eq!(
             url.as_deref(),
-            Some("https://securepubads.g.doubleclick.net/pagead/managed/js/gpt/m202603020101/pubads_impl.js?cb=123&foo=bar"),
+            Some(
+                "https://securepubads.g.doubleclick.net/pagead/managed/js/gpt/m202603020101/pubads_impl.js?cb=123&foo=bar"
+            ),
             "should preserve the query string in the upstream URL"
         );
     }

--- a/crates/trusted-server-core/src/integrations/lockr.rs
+++ b/crates/trusted-server-core/src/integrations/lockr.rs
@@ -20,10 +20,10 @@ use validator::Validate;
 use crate::constants::INTERNAL_HEADERS;
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    collect_body_bounded, collect_response_bounded, ensure_integration_backend,
-    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
-    UPSTREAM_SDK_MAX_RESPONSE_BYTES,
+    AttributeRewriteAction, INTEGRATION_MAX_BODY_BYTES, IntegrationAttributeContext,
+    IntegrationAttributeRewriter, IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
+    UPSTREAM_SDK_MAX_RESPONSE_BYTES, collect_body_bounded, collect_response_bounded,
+    ensure_integration_backend,
 };
 use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
@@ -437,7 +437,7 @@ mod tests {
     use edgezero_core::http::Method as HttpMethod;
     use serde_json::json;
 
-    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
+    use crate::platform::test_support::{StubHttpClient, build_services_with_http_client};
     use crate::test_support::tests::create_test_settings;
 
     fn test_config() -> LockrConfig {

--- a/crates/trusted-server-core/src/integrations/mod.rs
+++ b/crates/trusted-server-core/src/integrations/mod.rs
@@ -8,7 +8,7 @@ use futures::StreamExt as _;
 use url::Url;
 
 use crate::error::TrustedServerError;
-use crate::platform::{PlatformBackendSpec, RuntimeServices, DEFAULT_FIRST_BYTE_TIMEOUT};
+use crate::platform::{DEFAULT_FIRST_BYTE_TIMEOUT, PlatformBackendSpec, RuntimeServices};
 use crate::settings::Settings;
 
 pub mod adserver_mock;

--- a/crates/trusted-server-core/src/integrations/nextjs/html_post_process.rs
+++ b/crates/trusted-server-core/src/integrations/nextjs/html_post_process.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use lol_html::{text, Settings as RewriterSettings};
+use lol_html::{Settings as RewriterSettings, text};
 
 use crate::integrations::{IntegrationHtmlContext, IntegrationHtmlPostProcessor};
 
@@ -11,8 +11,8 @@ use super::rsc::rewrite_rsc_scripts_combined_with_limit;
 use super::rsc_placeholders::{
     NextJsRscPostProcessState, RSC_PAYLOAD_PLACEHOLDER_PREFIX, RSC_PAYLOAD_PLACEHOLDER_SUFFIX,
 };
-use super::shared::{find_rsc_push_payload_range, RscUrlRewriter};
-use super::{NextJsIntegrationConfig, NEXTJS_INTEGRATION_ID};
+use super::shared::{RscUrlRewriter, find_rsc_push_payload_range};
+use super::{NEXTJS_INTEGRATION_ID, NextJsIntegrationConfig};
 
 pub(crate) struct NextJsHtmlPostProcessor {
     config: Arc<NextJsIntegrationConfig>,
@@ -319,8 +319,7 @@ fn find_rsc_push_scripts(html: &str) -> Vec<RscPushScriptRange> {
         return Vec::new();
     }
 
-    let result = std::mem::take(&mut *ranges.borrow_mut());
-    result
+    std::mem::take(&mut *ranges.borrow_mut())
 }
 
 /// Rewrite RSC payload URLs in HTML by re-parsing the document.
@@ -737,31 +736,30 @@ mod tests {
 
                     if esc == b'u' && pos + 5 < bytes.len() {
                         let hex = &s[pos + 2..pos + 6];
-                        if hex.chars().all(|c| c.is_ascii_hexdigit()) {
-                            if let Ok(code_unit) = u16::from_str_radix(hex, 16) {
-                                // Surrogate pairs use UTF-16 and expand to 4 bytes in UTF-8.
-                                if (0xD800..=0xDBFF).contains(&code_unit)
-                                    && pos + 11 < bytes.len()
-                                    && bytes[pos + 6] == b'\\'
-                                    && bytes[pos + 7] == b'u'
+                        if hex.chars().all(|c| c.is_ascii_hexdigit())
+                            && let Ok(code_unit) = u16::from_str_radix(hex, 16)
+                        {
+                            // Surrogate pairs use UTF-16 and expand to 4 bytes in UTF-8.
+                            if (0xD800..=0xDBFF).contains(&code_unit)
+                                && pos + 11 < bytes.len()
+                                && bytes[pos + 6] == b'\\'
+                                && bytes[pos + 7] == b'u'
+                            {
+                                let hex2 = &s[pos + 8..pos + 12];
+                                if hex2.chars().all(|c| c.is_ascii_hexdigit())
+                                    && let Ok(code_unit2) = u16::from_str_radix(hex2, 16)
+                                    && (0xDC00..=0xDFFF).contains(&code_unit2)
                                 {
-                                    let hex2 = &s[pos + 8..pos + 12];
-                                    if hex2.chars().all(|c| c.is_ascii_hexdigit()) {
-                                        if let Ok(code_unit2) = u16::from_str_radix(hex2, 16) {
-                                            if (0xDC00..=0xDFFF).contains(&code_unit2) {
-                                                pos += 12;
-                                                count += 4;
-                                                continue;
-                                            }
-                                        }
-                                    }
+                                    pos += 12;
+                                    count += 4;
+                                    continue;
                                 }
-
-                                let c = char::from_u32(u32::from(code_unit)).unwrap_or('\u{FFFD}');
-                                pos += 6;
-                                count += c.len_utf8();
-                                continue;
                             }
+
+                            let c = char::from_u32(u32::from(code_unit)).unwrap_or('\u{FFFD}');
+                            pos += 6;
+                            count += c.len_utf8();
+                            continue;
                         }
                     }
                 }

--- a/crates/trusted-server-core/src/integrations/nextjs/mod.rs
+++ b/crates/trusted-server-core/src/integrations/nextjs/mod.rs
@@ -121,7 +121,7 @@ fn build(
 mod tests {
     use super::rsc_placeholders::RSC_PAYLOAD_PLACEHOLDER_PREFIX;
     use super::*;
-    use crate::html_processor::{create_html_processor, HtmlProcessorConfig};
+    use crate::html_processor::{HtmlProcessorConfig, create_html_processor};
     use crate::integrations::IntegrationRegistry;
     use crate::streaming_processor::{Compression, PipelineConfig, StreamingPipeline};
     use crate::test_support::tests::create_test_settings;

--- a/crates/trusted-server-core/src/integrations/nextjs/rsc.rs
+++ b/crates/trusted-server-core/src/integrations/nextjs/rsc.rs
@@ -96,13 +96,12 @@ impl Iterator for EscapeSequenceIter<'_> {
             return None;
         }
 
-        if let Some(marker) = self.skip_marker {
-            if self.pos + marker.len() <= self.bytes.len()
-                && &self.bytes[self.pos..self.pos + marker.len()] == marker
-            {
-                self.pos += marker.len();
-                return Some(EscapeElement { byte_count: 0 });
-            }
+        if let Some(marker) = self.skip_marker
+            && self.pos + marker.len() <= self.bytes.len()
+            && &self.bytes[self.pos..self.pos + marker.len()] == marker
+        {
+            self.pos += marker.len();
+            return Some(EscapeElement { byte_count: 0 });
         }
 
         if self.bytes[self.pos] == b'\\' && self.pos + 1 < self.bytes.len() {
@@ -123,30 +122,29 @@ impl Iterator for EscapeSequenceIter<'_> {
 
             if esc == b'u' && self.pos + 5 < self.bytes.len() {
                 let hex = &self.str_ref[self.pos + 2..self.pos + 6];
-                if hex.chars().all(|c| c.is_ascii_hexdigit()) {
-                    if let Ok(code_unit) = u16::from_str_radix(hex, 16) {
-                        if (0xD800..=0xDBFF).contains(&code_unit)
-                            && self.pos + 11 < self.bytes.len()
-                            && self.bytes[self.pos + 6] == b'\\'
-                            && self.bytes[self.pos + 7] == b'u'
+                if hex.chars().all(|c| c.is_ascii_hexdigit())
+                    && let Ok(code_unit) = u16::from_str_radix(hex, 16)
+                {
+                    if (0xD800..=0xDBFF).contains(&code_unit)
+                        && self.pos + 11 < self.bytes.len()
+                        && self.bytes[self.pos + 6] == b'\\'
+                        && self.bytes[self.pos + 7] == b'u'
+                    {
+                        let hex2 = &self.str_ref[self.pos + 8..self.pos + 12];
+                        if hex2.chars().all(|c| c.is_ascii_hexdigit())
+                            && let Ok(code_unit2) = u16::from_str_radix(hex2, 16)
+                            && (0xDC00..=0xDFFF).contains(&code_unit2)
                         {
-                            let hex2 = &self.str_ref[self.pos + 8..self.pos + 12];
-                            if hex2.chars().all(|c| c.is_ascii_hexdigit()) {
-                                if let Ok(code_unit2) = u16::from_str_radix(hex2, 16) {
-                                    if (0xDC00..=0xDFFF).contains(&code_unit2) {
-                                        self.pos += 12;
-                                        return Some(EscapeElement { byte_count: 4 });
-                                    }
-                                }
-                            }
+                            self.pos += 12;
+                            return Some(EscapeElement { byte_count: 4 });
                         }
-
-                        let c = char::from_u32(u32::from(code_unit)).unwrap_or('\u{FFFD}');
-                        self.pos += 6;
-                        return Some(EscapeElement {
-                            byte_count: c.len_utf8(),
-                        });
                     }
+
+                    let c = char::from_u32(u32::from(code_unit)).unwrap_or('\u{FFFD}');
+                    self.pos += 6;
+                    return Some(EscapeElement {
+                        byte_count: c.len_utf8(),
+                    });
                 }
             }
         }

--- a/crates/trusted-server-core/src/integrations/nextjs/rsc_placeholders.rs
+++ b/crates/trusted-server-core/src/integrations/nextjs/rsc_placeholders.rs
@@ -5,7 +5,7 @@ use crate::integrations::{
 };
 
 use super::shared::find_rsc_push_payload_range;
-use super::{NextJsIntegrationConfig, NEXTJS_INTEGRATION_ID};
+use super::{NEXTJS_INTEGRATION_ID, NextJsIntegrationConfig};
 
 pub(super) const RSC_PAYLOAD_PLACEHOLDER_PREFIX: &str = "__ts_rsc_payload_";
 pub(super) const RSC_PAYLOAD_PLACEHOLDER_SUFFIX: &str = "__";

--- a/crates/trusted-server-core/src/integrations/nextjs/script_rewriter.rs
+++ b/crates/trusted-server-core/src/integrations/nextjs/script_rewriter.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use error_stack::Report;
-use regex::{escape, Regex};
+use regex::{Regex, escape};
 
 use crate::error::TrustedServerError;
 use crate::integrations::{
@@ -9,7 +9,7 @@ use crate::integrations::{
 };
 
 use super::shared::strip_origin_host_with_optional_port;
-use super::{NextJsIntegrationConfig, NEXTJS_INTEGRATION_ID};
+use super::{NEXTJS_INTEGRATION_ID, NextJsIntegrationConfig};
 
 pub(super) struct NextJsNextDataRewriter {
     config: Arc<NextJsIntegrationConfig>,
@@ -257,7 +257,9 @@ mod tests {
                 assert!(value.contains("ts.example.com") && value.contains("/reviews"));
                 assert!(value.contains("ts.example.com") && value.contains("/sign-in"));
                 assert!(value.contains(r#""fallbackHref":"http://origin.example.com/legacy""#));
-                assert!(value.contains(r#""protoRelative":"//origin.example.com/assets/logo.png""#));
+                assert!(
+                    value.contains(r#""protoRelative":"//origin.example.com/assets/logo.png""#)
+                );
             }
             _ => panic!("Expected rewrite to update payload"),
         }

--- a/crates/trusted-server-core/src/integrations/nextjs/shared.rs
+++ b/crates/trusted-server-core/src/integrations/nextjs/shared.rs
@@ -145,16 +145,10 @@ impl RscUrlRewriter {
         // recompiling the pattern on each call. regex::escape() guarantees validity, but
         // treat compilation failure as non-fatal rather than panic.
         let cached = self.cached_pattern.borrow();
-        if let Some((ref host, ref regex)) = *cached {
-            if host == origin_host {
-                return Self::apply_rewrite(
-                    input,
-                    regex,
-                    origin_host,
-                    request_host,
-                    request_scheme,
-                );
-            }
+        if let Some((ref host, ref regex)) = *cached
+            && host == origin_host
+        {
+            return Self::apply_rewrite(input, regex, origin_host, request_host, request_scheme);
         }
         drop(cached);
 

--- a/crates/trusted-server-core/src/integrations/osano.rs
+++ b/crates/trusted-server-core/src/integrations/osano.rs
@@ -53,7 +53,7 @@ pub fn register(
 mod tests {
     use serde_json::json;
 
-    use super::{register, OsanoConfig};
+    use super::{OsanoConfig, register};
     use crate::test_support::tests::create_test_settings;
 
     #[test]

--- a/crates/trusted-server-core/src/integrations/permutive.rs
+++ b/crates/trusted-server-core/src/integrations/permutive.rs
@@ -16,10 +16,10 @@ use validator::Validate;
 use crate::constants::INTERNAL_HEADERS;
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    collect_body_bounded, collect_response_bounded, ensure_integration_backend,
-    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
-    UPSTREAM_SDK_MAX_RESPONSE_BYTES,
+    AttributeRewriteAction, INTEGRATION_MAX_BODY_BYTES, IntegrationAttributeContext,
+    IntegrationAttributeRewriter, IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
+    UPSTREAM_SDK_MAX_RESPONSE_BYTES, collect_body_bounded, collect_response_bounded,
+    ensure_integration_backend,
 };
 use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
@@ -474,7 +474,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
+    use crate::platform::test_support::{StubHttpClient, build_services_with_http_client};
     use crate::test_support::tests::create_test_settings;
 
     #[test]
@@ -512,8 +512,10 @@ mod tests {
         let integration = PermutiveIntegration::new(config);
 
         // Should match edge.permutive.app URLs
-        assert!(integration
-            .is_permutive_sdk_url("https://myorg.edge.permutive.app/workspace-123-web.js"));
+        assert!(
+            integration
+                .is_permutive_sdk_url("https://myorg.edge.permutive.app/workspace-123-web.js")
+        );
 
         // Should match cdn.permutive.com URLs
         assert!(integration.is_permutive_sdk_url("https://cdn.permutive.com/myworkspace-web.js"));

--- a/crates/trusted-server-core/src/integrations/prebid.rs
+++ b/crates/trusted-server-core/src/integrations/prebid.rs
@@ -4,15 +4,15 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use base64::{
+    Engine as _,
     engine::general_purpose::{
         STANDARD as BASE64_STANDARD, STANDARD_NO_PAD as BASE64_STANDARD_NO_PAD,
     },
-    Engine as _,
 };
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
 use http::header::HeaderValue;
-use http::{header, Method, StatusCode};
+use http::{Method, StatusCode, header};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
 use url::{Url, Url as ParsedUrl};
@@ -23,26 +23,25 @@ use crate::auction::types::{
     AuctionContext, AuctionRequest, AuctionResponse, Bid as AuctionBid, MediaType,
 };
 use crate::consent_config::ConsentForwardingMode;
-use crate::cookies::{strip_cookies, CONSENT_COOKIE_NAMES};
+use crate::cookies::{CONSENT_COOKIE_NAMES, strip_cookies};
 use crate::error::TrustedServerError;
 use crate::http_util::RequestInfo;
 use crate::integrations::{
-    collect_response_bounded, ensure_integration_backend_with_timeout,
-    predict_integration_backend_name, AttributeRewriteAction, IntegrationAttributeContext,
-    IntegrationAttributeRewriter, IntegrationEndpoint, IntegrationHeadInjector,
-    IntegrationHtmlContext, IntegrationProxy, IntegrationRegistration,
-    UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
+    IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
+    IntegrationRegistration, UPSTREAM_RTB_MAX_RESPONSE_BYTES, collect_response_bounded,
+    ensure_integration_backend_with_timeout, predict_integration_backend_name,
 };
 use crate::openrtb::{
-    to_openrtb_i32, Banner, ConsentedProvidersSettings, Device, Format, Geo, Imp, ImpExt,
-    ImpStoredRequest, OpenRtbRequest, PrebidExt, PrebidImpExt, Publisher, Regs, RegsExt,
-    RequestExt, Site, ToExt, TrustedServerExt, User, UserExt,
+    Banner, ConsentedProvidersSettings, Device, Format, Geo, Imp, ImpExt, ImpStoredRequest,
+    OpenRtbRequest, PrebidExt, PrebidImpExt, Publisher, Regs, RegsExt, RequestExt, Site, ToExt,
+    TrustedServerExt, User, UserExt, to_openrtb_i32,
 };
 use crate::platform::{
     PlatformHttpRequest, PlatformPendingRequest, PlatformResponse, RuntimeServices,
 };
-use crate::proxy::{is_host_allowed, proxy_request, ProxyRequestConfig};
-use crate::request_signing::{RequestSigner, SigningParams, SIGNING_VERSION};
+use crate::proxy::{ProxyRequestConfig, is_host_allowed, proxy_request};
+use crate::request_signing::{RequestSigner, SIGNING_VERSION, SigningParams};
 use crate::settings::{IntegrationConfig, Settings};
 
 const PREBID_INTEGRATION_ID: &str = "prebid";
@@ -1178,16 +1177,16 @@ impl CompiledBidParamOverrideRule {
     }
 
     fn matches(&self, facts: BidParamOverrideFacts<'_>) -> bool {
-        if let Some(expected_bidder) = self.bidder.as_deref() {
-            if expected_bidder != facts.bidder {
-                return false;
-            }
+        if let Some(expected_bidder) = self.bidder.as_deref()
+            && expected_bidder != facts.bidder
+        {
+            return false;
         }
 
-        if let Some(expected_zone) = self.zone.as_deref() {
-            if facts.zone != Some(expected_zone) {
-                return false;
-            }
+        if let Some(expected_zone) = self.zone.as_deref()
+            && facts.zone != Some(expected_zone)
+        {
+            return false;
         }
 
         true
@@ -1279,11 +1278,11 @@ fn copy_request_headers(
         }
     }
 
-    if let Some(ip) = client_ip {
-        if let Ok(value) = HeaderValue::from_str(&ip.to_string()) {
-            to.headers_mut()
-                .insert(header::HeaderName::from_static("x-forwarded-for"), value);
-        }
+    if let Some(ip) = client_ip
+        && let Ok(value) = HeaderValue::from_str(&ip.to_string())
+    {
+        to.headers_mut()
+            .insert(header::HeaderName::from_static("x-forwarded-for"), value);
     }
 
     let Some(cookie_value) = from.headers().get(header::COOKIE) else {
@@ -2238,13 +2237,13 @@ mod tests {
 
     use crate::consent::{ConsentContext, ConsentSource};
     use crate::geo::GeoInfo;
-    use crate::html_processor::{create_html_processor, HtmlProcessorConfig};
+    use crate::html_processor::{HtmlProcessorConfig, create_html_processor};
     use crate::integrations::{
         AttributeRewriteAction, IntegrationDocumentState, IntegrationRegistry,
     };
     use crate::platform::test_support::{
-        build_services_with_http_client, NoopConfigStore, NoopGeo, NoopHttpClient, NoopSecretStore,
-        StubHttpClient,
+        NoopConfigStore, NoopGeo, NoopHttpClient, NoopSecretStore, StubHttpClient,
+        build_services_with_http_client,
     };
     use crate::platform::{
         ClientInfo, PlatformBackend, PlatformBackendSpec, PlatformError, RuntimeServices,
@@ -2683,9 +2682,11 @@ script_patterns = ["/prebid.js", "/custom/prebid.min.js"]
 
         assert_eq!(config.script_patterns.len(), 2);
         assert!(config.script_patterns.contains(&"/prebid.js".to_string()));
-        assert!(config
-            .script_patterns
-            .contains(&"/custom/prebid.min.js".to_string()));
+        assert!(
+            config
+                .script_patterns
+                .contains(&"/custom/prebid.min.js".to_string())
+        );
     }
 
     #[test]
@@ -2700,9 +2701,11 @@ server_url = "https://prebid.example"
 
         assert!(!config.script_patterns.is_empty());
         assert!(config.script_patterns.contains(&"/prebid.js".to_string()));
-        assert!(config
-            .script_patterns
-            .contains(&"/prebid.min.js".to_string()));
+        assert!(
+            config
+                .script_patterns
+                .contains(&"/prebid.min.js".to_string())
+        );
     }
 
     #[test]
@@ -5722,8 +5725,7 @@ set = { placementId = "explicit_header" }
                 let actual = engine.rules.iter().map(rule_signature).collect::<Vec<_>>();
 
                 assert_eq!(
-                    actual,
-                    expected,
+                    actual, expected,
                     "compatibility rules should compile in sorted matcher order on iteration {iteration}"
                 );
             }

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -9,8 +9,8 @@ use http::{Method, Request, Response};
 use matchit::Router;
 
 use crate::constants::HEADER_X_TS_EC;
-use crate::ec::kv::KvIdentityGraph;
 use crate::ec::EcContext;
+use crate::ec::kv::KvIdentityGraph;
 use crate::error::TrustedServerError;
 use crate::geo::GeoInfo;
 use crate::http_util::is_navigation_request;
@@ -159,10 +159,10 @@ impl IntegrationDocumentState {
             .lock()
             .expect("should lock integration document state");
 
-        if let Some(existing) = guard.get(integration_id) {
-            if let Ok(downcast) = Arc::clone(existing).downcast::<T>() {
-                return downcast;
-            }
+        if let Some(existing) = guard.get(integration_id)
+            && let Ok(downcast) = Arc::clone(existing).downcast::<T>()
+        {
+            return downcast;
         }
 
         let value: Arc<T> = Arc::new(init());
@@ -1313,7 +1313,7 @@ mod tests {
     use super::*;
     use crate::constants::COOKIE_TS_EC;
     use crate::platform::test_support::noop_services;
-    use http::{header, HeaderValue, StatusCode};
+    use http::{HeaderValue, StatusCode, header};
 
     // Mock integration proxy for testing
     struct MockProxy;

--- a/crates/trusted-server-core/src/integrations/sourcepoint.rs
+++ b/crates/trusted-server-core/src/integrations/sourcepoint.rs
@@ -34,10 +34,10 @@ use validator::{Validate, ValidationError};
 
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    collect_body_bounded, collect_response_bounded, ensure_integration_backend,
-    AttributeRewriteAction, IntegrationAttributeContext, IntegrationAttributeRewriter,
-    IntegrationEndpoint, IntegrationHeadInjector, IntegrationHtmlContext, IntegrationProxy,
-    IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
+    AttributeRewriteAction, INTEGRATION_MAX_BODY_BYTES, IntegrationAttributeContext,
+    IntegrationAttributeRewriter, IntegrationEndpoint, IntegrationHeadInjector,
+    IntegrationHtmlContext, IntegrationProxy, IntegrationRegistration, collect_body_bounded,
+    collect_response_bounded, ensure_integration_backend,
 };
 use crate::platform::{PlatformHttpRequest, RuntimeServices};
 use crate::settings::{IntegrationConfig, Settings};
@@ -368,10 +368,10 @@ impl SourcepointIntegration {
         original_req: &Request<EdgeBody>,
         proxy_req: &mut Request<EdgeBody>,
     ) -> bool {
-        if let Some(client_ip) = client_ip {
-            if let Ok(val) = HeaderValue::from_str(&client_ip.to_string()) {
-                proxy_req.headers_mut().insert("x-forwarded-for", val);
-            }
+        if let Some(client_ip) = client_ip
+            && let Ok(val) = HeaderValue::from_str(&client_ip.to_string())
+        {
+            proxy_req.headers_mut().insert("x-forwarded-for", val);
         }
 
         // Accept-Encoding is deliberately omitted here and handled in the
@@ -659,13 +659,13 @@ impl SourcepointIntegration {
         // from the passthrough path's `apply_cache_headers` (which only sets a
         // default when upstream omitted Cache-Control). Responses that set
         // cookies are kept private.
-        if !Self::apply_cookie_safety(response) {
-            if let Ok(val) = HeaderValue::from_str(&format!(
+        if !Self::apply_cookie_safety(response)
+            && let Ok(val) = HeaderValue::from_str(&format!(
                 "public, max-age={}",
                 self.config.cache_ttl_seconds
-            )) {
-                response.headers_mut().insert(header::CACHE_CONTROL, val);
-            }
+            ))
+        {
+            response.headers_mut().insert(header::CACHE_CONTROL, val);
         }
     }
 
@@ -855,12 +855,12 @@ impl IntegrationProxy for SourcepointIntegration {
                 .insert(header::ACCEPT_ENCODING, ae.clone());
         }
 
-        if method == Method::POST {
-            if let Some(content_type) = source_req.headers().get(header::CONTENT_TYPE) {
-                proxy_req
-                    .headers_mut()
-                    .insert(header::CONTENT_TYPE, content_type.clone());
-            }
+        if method == Method::POST
+            && let Some(content_type) = source_req.headers().get(header::CONTENT_TYPE)
+        {
+            proxy_req
+                .headers_mut()
+                .insert(header::CONTENT_TYPE, content_type.clone());
         }
 
         let backend_name = ensure_integration_backend(
@@ -890,12 +890,11 @@ impl IntegrationProxy for SourcepointIntegration {
                 .headers()
                 .get(header::LOCATION)
                 .and_then(|h| h.to_str().ok())
+                && let Some(rewritten) = Self::rewrite_redirect_location(location, &target_url)
             {
-                if let Some(rewritten) = Self::rewrite_redirect_location(location, &target_url) {
-                    log::info!("Sourcepoint: rewrote redirect Location to {rewritten}");
-                    if let Ok(val) = HeaderValue::from_str(&rewritten) {
-                        response.headers_mut().insert(header::LOCATION, val);
-                    }
+                log::info!("Sourcepoint: rewrote redirect Location to {rewritten}");
+                if let Ok(val) = HeaderValue::from_str(&rewritten) {
+                    response.headers_mut().insert(header::LOCATION, val);
                 }
             }
             // Redirects without Set-Cookie intentionally keep upstream cache

--- a/crates/trusted-server-core/src/integrations/testlight.rs
+++ b/crates/trusted-server-core/src/integrations/testlight.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::header::{self, HeaderValue};
 use http::Response;
+use http::header::{self, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use validator::Validate;
@@ -12,13 +12,12 @@ use validator::Validate;
 use crate::edge_cookie::get_ec_id;
 use crate::error::TrustedServerError;
 use crate::integrations::{
-    collect_body_bounded, collect_response_bounded, AttributeRewriteAction,
-    IntegrationAttributeContext, IntegrationAttributeRewriter, IntegrationEndpoint,
-    IntegrationProxy, IntegrationRegistration, INTEGRATION_MAX_BODY_BYTES,
-    UPSTREAM_RTB_MAX_RESPONSE_BYTES,
+    AttributeRewriteAction, INTEGRATION_MAX_BODY_BYTES, IntegrationAttributeContext,
+    IntegrationAttributeRewriter, IntegrationEndpoint, IntegrationProxy, IntegrationRegistration,
+    UPSTREAM_RTB_MAX_RESPONSE_BYTES, collect_body_bounded, collect_response_bounded,
 };
 use crate::platform::RuntimeServices;
-use crate::proxy::{proxy_request, ProxyRequestConfig};
+use crate::proxy::{ProxyRequestConfig, proxy_request};
 use crate::settings::{IntegrationConfig, Settings};
 use crate::tsjs;
 
@@ -277,8 +276,8 @@ fn default_enabled() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::platform::test_support::{build_services_with_http_client, StubHttpClient};
-    use crate::test_support::tests::{create_test_settings, VALID_SYNTHETIC_ID};
+    use crate::platform::test_support::{StubHttpClient, build_services_with_http_client};
+    use crate::test_support::tests::{VALID_SYNTHETIC_ID, create_test_settings};
     use crate::tsjs;
     use http::Method;
     use serde_json::json;

--- a/crates/trusted-server-core/src/platform/http.rs
+++ b/crates/trusted-server-core/src/platform/http.rs
@@ -4,8 +4,8 @@ use std::fmt;
 use edgezero_core::http::{Request as EdgeRequest, Response as EdgeResponse};
 use error_stack::Report;
 
-use super::image_optimizer::PlatformImageOptimizerOptions;
 use super::PlatformError;
+use super::image_optimizer::PlatformImageOptimizerOptions;
 
 /// Outbound HTTP request paired with a pre-resolved backend name.
 ///

--- a/crates/trusted-server-core/src/platform/test_support.rs
+++ b/crates/trusted-server-core/src/platform/test_support.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use ed25519_dalek::SigningKey;
 use error_stack::{Report, ResultExt as _};
 use rand::rngs::OsRng;

--- a/crates/trusted-server-core/src/proxy.rs
+++ b/crates/trusted-server-core/src/proxy.rs
@@ -1,9 +1,9 @@
 use crate::http_util::{compute_encrypted_sha256_token, ct_str_eq, enforce_max_body_size};
 use edgezero_core::body::Body as EdgeBody;
-use edgezero_core::http::{request_builder as edge_request_builder, Uri as EdgeUri};
+use edgezero_core::http::{Uri as EdgeUri, request_builder as edge_request_builder};
 use error_stack::{Report, ResultExt};
 use futures::StreamExt as _;
-use http::{header, HeaderValue, Method, Request, Response, StatusCode};
+use http::{HeaderValue, Method, Request, Response, StatusCode, header};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{Cursor, Write};
@@ -19,8 +19,8 @@ use crate::creative::{CreativeCssProcessor, CreativeHtmlProcessor};
 use crate::edge_cookie::get_ec_id;
 use crate::error::TrustedServerError;
 use crate::platform::{
-    PlatformBackendSpec, PlatformHttpRequest, PlatformResponse, RuntimeServices, StoreName,
-    DEFAULT_FIRST_BYTE_TIMEOUT,
+    DEFAULT_FIRST_BYTE_TIMEOUT, PlatformBackendSpec, PlatformHttpRequest, PlatformResponse,
+    RuntimeServices, StoreName,
 };
 use crate::redacted::Redacted;
 use crate::s3_sigv4::{self, S3Credentials};
@@ -571,10 +571,9 @@ fn apply_image_passthrough_metadata(
         .get(header::CONTENT_LENGTH)
         .and_then(|h| h.to_str().ok())
         .and_then(|s| s.parse::<u64>().ok())
+        && cl <= 256
     {
-        if cl <= 256 {
-            is_pixel = true;
-        }
+        is_pixel = true;
     }
     if !is_pixel {
         let lower = target_url.to_ascii_lowercase();
@@ -1112,8 +1111,8 @@ pub async fn handle_asset_proxy_request(
     }
     outbound_headers.insert(header::HOST, asset_origin_host_header(&target_url)?);
 
-    if should_preflight_s3(route, image_optimizer.is_some(), req.method()) {
-        if let Some(response) = preflight_s3_origin_for_image_optimizer(
+    if should_preflight_s3(route, image_optimizer.is_some(), req.method())
+        && let Some(response) = preflight_s3_origin_for_image_optimizer(
             services,
             route,
             &target_url,
@@ -1122,9 +1121,8 @@ pub async fn handle_asset_proxy_request(
             &backend_name,
         )
         .await?
-        {
-            return Ok(response);
-        }
+    {
+        return Ok(response);
     }
 
     if let Some(auth) = &route.auth {
@@ -2029,20 +2027,20 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::{
-        asset_origin_host_header, asset_path_skips_image_optimizer, build_asset_proxy_target_url,
-        clear_s3_credentials_cache_for_tests, handle_asset_proxy_request, handle_first_party_click,
-        handle_first_party_proxy, handle_first_party_proxy_rebuild, handle_first_party_proxy_sign,
-        is_host_allowed, proxy_request, rebuild_response_with_body,
-        reconstruct_and_validate_signed_target, redirect_is_permitted, stream_asset_body,
-        AssetProxyCachePolicy, ProxyRequestConfig, IMAGE_FALLBACK_CONTENT_TYPE,
-        SUPPORTED_ENCODINGS,
+        AssetProxyCachePolicy, IMAGE_FALLBACK_CONTENT_TYPE, ProxyRequestConfig,
+        SUPPORTED_ENCODINGS, asset_origin_host_header, asset_path_skips_image_optimizer,
+        build_asset_proxy_target_url, clear_s3_credentials_cache_for_tests,
+        handle_asset_proxy_request, handle_first_party_click, handle_first_party_proxy,
+        handle_first_party_proxy_rebuild, handle_first_party_proxy_sign, is_host_allowed,
+        proxy_request, rebuild_response_with_body, reconstruct_and_validate_signed_target,
+        redirect_is_permitted, stream_asset_body,
     };
     use crate::constants::{HEADER_ACCEPT, HEADER_X_FORWARDED_FOR};
     use crate::creative;
     use crate::error::{IntoHttpResponse, TrustedServerError};
     use crate::platform::test_support::{
-        build_services_with_http_client, build_services_with_secret_and_http_client, noop_services,
-        HashMapSecretStore, StubHttpClient,
+        HashMapSecretStore, StubHttpClient, build_services_with_http_client,
+        build_services_with_secret_and_http_client, noop_services,
     };
     use crate::platform::{
         PlatformError, PlatformHttpClient, PlatformHttpRequest, PlatformPendingRequest,
@@ -2058,7 +2056,7 @@ mod tests {
     use edgezero_core::body::Body as EdgeBody;
     use edgezero_core::http::response_builder as edge_response_builder;
     use error_stack::Report;
-    use http::{header, HeaderValue, Method, Request as HttpRequest, Response, StatusCode};
+    use http::{HeaderValue, Method, Request as HttpRequest, Response, StatusCode, header};
 
     #[test]
     fn test_rebuild_response_with_body_preserves_multiple_headers() {
@@ -2782,7 +2780,7 @@ mod tests {
             let settings = create_test_settings();
             // Intentionally malformed target (host missing) but signed consistently
             let tsurl = "https://"; // invalid URL
-                                    // Manually construct first-party URL matching creative's format
+            // Manually construct first-party URL matching creative's format
             let full_for_token = tsurl.to_string();
             let sig = crate::http_util::compute_encrypted_sha256_token(&settings, &full_for_token);
             let url = format!(
@@ -2977,9 +2975,9 @@ mod tests {
 
     #[test]
     fn html_gzip_response_is_processed_with_compression_preserved() {
+        use flate2::Compression;
         use flate2::read::GzDecoder;
         use flate2::write::GzEncoder;
-        use flate2::Compression;
         use std::io::{Read, Write};
 
         let settings = create_test_settings();
@@ -3033,8 +3031,8 @@ mod tests {
 
     #[test]
     fn css_brotli_response_is_processed_with_compression_preserved() {
-        use brotli::enc::writer::CompressorWriter;
         use brotli::Decompressor;
+        use brotli::enc::writer::CompressorWriter;
         use std::io::{Read, Write};
 
         let settings = create_test_settings();

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use cookie::CookieJar;
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::{header, HeaderValue, Method, Request, Response, StatusCode, Uri};
+use http::{HeaderValue, Method, Request, Response, StatusCode, Uri, header};
 
 use crate::auction::endpoints::{
     merge_auction_eids, resolve_auction_eids, resolve_client_auction_eids,
@@ -34,8 +34,8 @@ use crate::auction::orchestrator::{
     AuctionOrchestrator, DispatchAuctionOutcome, DispatchedAuction,
 };
 use crate::auction::telemetry::{
-    build_auction_events, emit_auction_events_best_effort_lazy, AuctionObservationContext,
-    AuctionSource, AuctionTerminalOutcome,
+    AuctionObservationContext, AuctionSource, AuctionTerminalOutcome, build_auction_events,
+    emit_auction_events_best_effort_lazy,
 };
 use crate::auction::types::{
     AuctionContext, AuctionRequest, Bid, DeviceInfo, PublisherInfo, SiteInfo, UserInfo,
@@ -43,14 +43,14 @@ use crate::auction::types::{
 use crate::consent::{consent_allows_server_side_auction, gate_eids_by_consent};
 use crate::constants::{COOKIE_TS_EIDS, HEADER_X_COMPRESS_HINT};
 use crate::cookies::handle_request_cookies;
+use crate::ec::EcContext;
 use crate::ec::kv::KvIdentityGraph;
 use crate::ec::registry::PartnerRegistry;
-use crate::ec::EcContext;
 use crate::error::TrustedServerError;
-use crate::http_util::{is_navigation_request, serve_static_with_etag, RequestInfo};
+use crate::http_util::{RequestInfo, is_navigation_request, serve_static_with_etag};
 use crate::integrations::IntegrationRegistry;
 use crate::platform::{GeoInfo, PlatformBackendSpec, PlatformHttpRequest, RuntimeServices};
-use crate::price_bucket::{price_bucket, PriceGranularity};
+use crate::price_bucket::{PriceGranularity, price_bucket};
 use crate::rsc_flight::RscFlightUrlRewriter;
 use crate::settings::Settings;
 use crate::streaming_processor::{Compression, PipelineConfig, StreamProcessor, StreamingPipeline};
@@ -135,10 +135,10 @@ fn accept_encoding_qvalue(header_value: &str, target: &str) -> Option<f32> {
             let Some((name, value)) = parameter.trim().split_once('=') else {
                 continue;
             };
-            if name.trim().eq_ignore_ascii_case("q") {
-                if let Ok(parsed_qvalue) = value.trim().parse::<f32>() {
-                    qvalue = parsed_qvalue;
-                }
+            if name.trim().eq_ignore_ascii_case("q")
+                && let Ok(parsed_qvalue) = value.trim().parse::<f32>()
+            {
+                qvalue = parsed_qvalue;
             }
         }
 
@@ -316,7 +316,7 @@ fn create_html_stream_processor(
     ad_slots_script: Option<String>,
     ad_bids_state: Arc<Mutex<Option<String>>>,
 ) -> Result<impl StreamProcessor, Report<TrustedServerError>> {
-    use crate::html_processor::{create_html_processor, HtmlProcessorConfig};
+    use crate::html_processor::{HtmlProcessorConfig, create_html_processor};
 
     let config = HtmlProcessorConfig::from_settings(
         settings,
@@ -926,9 +926,9 @@ async fn stream_html_with_auction_hold<W: Write, P: StreamProcessor>(
     compression: Compression,
     ctx: AuctionCollectCtx<'_>,
 ) -> Result<(), Report<TrustedServerError>> {
-    use brotli::enc::writer::CompressorWriter;
-    use brotli::enc::BrotliEncoderParams;
     use brotli::Decompressor;
+    use brotli::enc::BrotliEncoderParams;
+    use brotli::enc::writer::CompressorWriter;
     use flate2::read::{GzDecoder, ZlibDecoder};
     use flate2::write::{GzEncoder, ZlibEncoder};
 
@@ -2431,8 +2431,8 @@ mod tests {
     use std::io::{self, Read as _, Write as _};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use brotli::enc::writer::CompressorWriter;
     use brotli::Decompressor;
+    use brotli::enc::writer::CompressorWriter;
     use flate2::read::GzDecoder;
     use flate2::write::GzEncoder;
 
@@ -2440,11 +2440,11 @@ mod tests {
     use crate::auction::types::{AdFormat, AdSlot, MediaType};
     use crate::integrations::IntegrationRegistry;
     use crate::platform::test_support::{
-        build_services_with_http_client, noop_services, StubHttpClient,
+        StubHttpClient, build_services_with_http_client, noop_services,
     };
     use crate::test_support::tests::create_test_settings;
     use edgezero_core::body::Body as EdgeBody;
-    use http::{header, Method, Request as HttpRequest, StatusCode};
+    use http::{Method, Request as HttpRequest, StatusCode, header};
     use std::sync::Arc;
 
     struct ChunkedReader {
@@ -3925,8 +3925,8 @@ mod tests {
     #[cfg(test)]
     mod creative_opportunities_tests {
         use super::super::{
-            build_ad_slots_script, build_auction_request, build_bid_map, build_bids_script,
-            html_escape_for_script, MatchedSlotsContext,
+            MatchedSlotsContext, build_ad_slots_script, build_auction_request, build_bid_map,
+            build_bids_script, html_escape_for_script,
         };
         use crate::auction::types::{Bid, MediaType};
         use crate::consent::ConsentContext;

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -307,6 +307,11 @@ fn process_response_streaming<W: Write>(
 /// [`HtmlProcessorConfig::with_ad_state`], so the canonical builder stays the
 /// single source of truth: a future field added to `from_settings` is
 /// inherited here automatically.
+///
+/// The returned processor owns its state and borrows none of the arguments.
+/// `use<>` states that explicitly: without it, Rust 2024 would have the opaque
+/// type capture every input lifetime, forcing callers to keep the settings and
+/// registry alive for as long as the processor.
 fn create_html_stream_processor(
     origin_host: &str,
     request_host: &str,
@@ -315,7 +320,7 @@ fn create_html_stream_processor(
     integration_registry: &IntegrationRegistry,
     ad_slots_script: Option<String>,
     ad_bids_state: Arc<Mutex<Option<String>>>,
-) -> Result<impl StreamProcessor, Report<TrustedServerError>> {
+) -> Result<impl StreamProcessor + use<>, Report<TrustedServerError>> {
     use crate::html_processor::{HtmlProcessorConfig, create_html_processor};
 
     let config = HtmlProcessorConfig::from_settings(

--- a/crates/trusted-server-core/src/request_signing/endpoints.rs
+++ b/crates/trusted-server-core/src/request_signing/endpoints.rs
@@ -5,7 +5,7 @@
 
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::{header, Request, Response, StatusCode};
+use http::{Request, Response, StatusCode, header};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{IntoHttpResponse, TrustedServerError};
@@ -502,12 +502,12 @@ mod tests {
     use bytes::Bytes;
     use edgezero_core::body::Body as EdgeBody;
     use error_stack::Report;
-    use http::{header, Method, Request as HttpRequest, StatusCode};
+    use http::{Method, Request as HttpRequest, StatusCode, header};
 
     use crate::error::IntoHttpResponse;
     use crate::platform::{
-        test_support::{build_request_signing_services, build_services_with_config, noop_services},
         PlatformConfigStore, PlatformError, StoreId, StoreName,
+        test_support::{build_request_signing_services, build_services_with_config, noop_services},
     };
 
     use super::*;

--- a/crates/trusted-server-core/src/request_signing/jwks.rs
+++ b/crates/trusted-server-core/src/request_signing/jwks.rs
@@ -6,14 +6,14 @@
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use error_stack::{Report, ResultExt as _};
 use jose_jwk::{
-    jose_jwa::{Algorithm, Signing},
     Jwk, Key, Okp, OkpCurves, Parameters,
+    jose_jwa::{Algorithm, Signing},
 };
 use rand::rngs::OsRng;
 
 use crate::error::TrustedServerError;
 use crate::platform::RuntimeServices;
-use crate::request_signing::{read_active_kids, JWKS_STORE_NAME};
+use crate::request_signing::{JWKS_STORE_NAME, read_active_kids};
 
 /// An Ed25519 keypair used for request signing.
 pub struct Keypair {
@@ -93,8 +93,8 @@ mod tests {
     use jose_jwk::Key;
 
     use crate::platform::{
-        test_support::build_services_with_config, PlatformConfigStore, PlatformError, StoreId,
-        StoreName,
+        PlatformConfigStore, PlatformError, StoreId, StoreName,
+        test_support::build_services_with_config,
     };
 
     use super::*;

--- a/crates/trusted-server-core/src/request_signing/rotation.rs
+++ b/crates/trusted-server-core/src/request_signing/rotation.rs
@@ -4,14 +4,14 @@
 //! lifecycle, and storing keys via platform store primitives through
 //! [`RuntimeServices`].
 
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use chrono::Utc;
 use ed25519_dalek::SigningKey;
 use error_stack::{Report, ResultExt as _};
 use jose_jwk::Jwk;
 use uuid::Uuid;
 
-use super::{read_active_kids, Keypair};
+use super::{Keypair, read_active_kids};
 use crate::error::TrustedServerError;
 use crate::platform::{RuntimeServices, StoreId};
 use crate::request_signing::JWKS_STORE_NAME;

--- a/crates/trusted-server-core/src/request_signing/signing.rs
+++ b/crates/trusted-server-core/src/request_signing/signing.rs
@@ -3,7 +3,7 @@
 //! This module provides Ed25519-based signing and verification of HTTP requests
 //! using keys stored via platform store primitives.
 
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use ed25519_dalek::{Signature, Signer as _, SigningKey, Verifier as _, VerifyingKey};
 use error_stack::{Report, ResultExt as _};
 use serde::Serialize;

--- a/crates/trusted-server-core/src/response_privacy.rs
+++ b/crates/trusted-server-core/src/response_privacy.rs
@@ -9,7 +9,7 @@
 //! cache such as Cloudflare would otherwise serve an operator/origin
 //! `Cache-Control: public` on a cookie-bearing response as-is.
 
-use edgezero_core::http::{header, HeaderName, HeaderValue, Response};
+use edgezero_core::http::{HeaderName, HeaderValue, Response, header};
 
 use crate::settings::Settings;
 

--- a/crates/trusted-server-core/src/s3_sigv4.rs
+++ b/crates/trusted-server-core/src/s3_sigv4.rs
@@ -15,7 +15,7 @@ use std::time::SystemTime;
 use chrono::{DateTime, Utc};
 use error_stack::Report;
 use hmac::{Hmac, Mac as _};
-use http::{header, HeaderMap, HeaderValue, Method};
+use http::{HeaderMap, HeaderValue, Method, header};
 use sha2::{Digest as _, Sha256};
 use url::Url;
 

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -2,7 +2,7 @@
 use config::{Config, Environment, File, FileFormat};
 use error_stack::{Report, ResultExt};
 use regex::Regex;
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
@@ -1211,8 +1211,9 @@ fn validate_image_optimizer_format(
     value: &str,
 ) -> Result<(), Report<TrustedServerError>> {
     match value.trim().to_ascii_lowercase().as_str() {
-        "auto" | "avif" | "gif" | "jpeg" | "jpg" | "jxl" | "jpegxl" | "mp4" | "png"
-        | "webp" => Ok(()),
+        "auto" | "avif" | "gif" | "jpeg" | "jpg" | "jxl" | "jpegxl" | "mp4" | "png" | "webp" => {
+            Ok(())
+        }
         _ => Err(Report::new(TrustedServerError::Configuration {
             message: format!(
                 "image_optimizer.profile_sets `{set_name}` profile `{profile_name}` has unsupported format `{value}`"
@@ -2591,12 +2592,12 @@ mod tests {
 
     use crate::auction::build_orchestrator;
     use crate::integrations::{
+        IntegrationRegistry,
         datadome::{DataDomeConfig, ProtectionMatcherConfig},
         gpt::GptConfig,
         nextjs::NextJsIntegrationConfig,
         prebid::PrebidIntegrationConfig,
         testlight::TestlightConfig,
-        IntegrationRegistry,
     };
     use crate::redacted::Redacted;
     use crate::test_support::tests::{crate_test_settings_str, create_test_settings};
@@ -3367,10 +3368,7 @@ origin_host_header_overide = "www.example.com""#,
             [
                 (origin_key, Some("https://origin.test-publisher.com")),
                 (format!("{datadome_prefix}ENABLED"), Some("true")),
-                (
-                    format!("{datadome_prefix}ENABLE_PROTECTION"),
-                    Some("true"),
-                ),
+                (format!("{datadome_prefix}ENABLE_PROTECTION"), Some("true")),
                 (
                     format!("{datadome_prefix}PROTECTION_EXCLUDED_METHODS{separator}0"),
                     Some("OPTIONS"),
@@ -3404,19 +3402,27 @@ origin_host_header_overide = "www.example.com""#,
                     Some("legacy-static-get-head"),
                 ),
                 (
-                    format!("{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}0{separator}METHODS{separator}0"),
+                    format!(
+                        "{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}0{separator}METHODS{separator}0"
+                    ),
                     Some("GET"),
                 ),
                 (
-                    format!("{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}0{separator}METHODS{separator}1"),
+                    format!(
+                        "{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}0{separator}METHODS{separator}1"
+                    ),
                     Some("HEAD"),
                 ),
                 (
-                    format!("{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}0{separator}TYPE"),
+                    format!(
+                        "{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}0{separator}TYPE"
+                    ),
                     Some("path_regex"),
                 ),
                 (
-                    format!("{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}0{separator}PATTERNS{separator}0"),
+                    format!(
+                        "{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}0{separator}PATTERNS{separator}0"
+                    ),
                     Some(r"(?i)\.(css|js)$"),
                 ),
                 (
@@ -3424,11 +3430,15 @@ origin_host_header_overide = "www.example.com""#,
                     Some("next-rsc"),
                 ),
                 (
-                    format!("{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}1{separator}TYPE"),
+                    format!(
+                        "{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}1{separator}TYPE"
+                    ),
                     Some("query_param_non_empty"),
                 ),
                 (
-                    format!("{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}1{separator}NAMES{separator}0"),
+                    format!(
+                        "{datadome_prefix}PROTECTION_EXCLUSION_RULES{separator}1{separator}NAMES{separator}0"
+                    ),
                     Some("_rsc"),
                 ),
             ],
@@ -3456,8 +3466,7 @@ origin_host_header_overide = "www.example.com""#,
                     "should parse indexed IP CIDR list"
                 );
                 assert_eq!(
-                    cfg.protection_excluded_ip_cidr_sources[0].key,
-                    "googlebot_ips",
+                    cfg.protection_excluded_ip_cidr_sources[0].key, "googlebot_ips",
                     "should parse indexed CIDR source list"
                 );
                 assert!(matches!(
@@ -4721,67 +4730,99 @@ origin_host_header_overide = "www.example.com""#,
         let separator = ENVIRONMENT_VARIABLE_SEPARATOR;
         let vars = [
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}PREFIX"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}PREFIX"
+                ),
                 Some("/.image/"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}ORIGIN_URL"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}ORIGIN_URL"
+                ),
                 Some("https://bucket.s3.us-west-2.amazonaws.com"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}TYPE"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}TYPE"
+                ),
                 Some("s3_sigv4"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}REGION"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}REGION"
+                ),
                 Some("us-west-2"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}ORIGIN_QUERY"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}AUTH{separator}ORIGIN_QUERY"
+                ),
                 Some("strip"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}ENABLED"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}ENABLED"
+                ),
                 Some("true"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}REGION"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}REGION"
+                ),
                 Some("us_west"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}PROFILE_SET"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}PROXY{separator}ASSET_ROUTES{separator}0{separator}IMAGE_OPTIMIZER{separator}PROFILE_SET"
+                ),
                 Some("default_images"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}BASE_PARAMS"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}BASE_PARAMS"
+                ),
                 Some("quality=70&resize-filter=bicubic"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}DEFAULT_PROFILE"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}DEFAULT_PROFILE"
+                ),
                 Some("w828"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}PROFILES{separator}W828"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}PROFILES{separator}W828"
+                ),
                 Some("format=auto&width=828"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}PROFILES{separator}W1536"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}PROFILES{separator}W1536"
+                ),
                 Some("format=auto&width=1536"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}ASPECT_RATIOS{separator}ALLOWED"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}ASPECT_RATIOS{separator}ALLOWED"
+                ),
                 Some("[\"1-1\",\"16-9\"]"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}ASPECT_RATIOS{separator}PROFILES"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}ASPECT_RATIOS{separator}PROFILES"
+                ),
                 Some("[\"w828\",\"w1536\"]"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}CROP_OFFSETS{separator}ENABLED"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}CROP_OFFSETS{separator}ENABLED"
+                ),
                 Some("true"),
             ),
             (
-                format!("{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}CROP_OFFSETS{separator}BUCKETS"),
+                format!(
+                    "{ENVIRONMENT_VARIABLE_PREFIX}{separator}IMAGE_OPTIMIZER{separator}PROFILE_SETS{separator}DEFAULT_IMAGES{separator}CROP_OFFSETS{separator}BUCKETS"
+                ),
                 Some("[10,30,50,70,90]"),
             ),
         ];

--- a/crates/trusted-server-core/src/streaming_processor.rs
+++ b/crates/trusted-server-core/src/streaming_processor.rs
@@ -23,9 +23,9 @@ use std::cell::RefCell;
 use std::io::{self, Read, Write};
 use std::rc::Rc;
 
-use brotli::enc::writer::CompressorWriter;
-use brotli::enc::BrotliEncoderParams;
 use brotli::Decompressor;
+use brotli::enc::BrotliEncoderParams;
+use brotli::enc::writer::CompressorWriter;
 use error_stack::{Report, ResultExt as _};
 use flate2::read::{GzDecoder, ZlibDecoder};
 use flate2::write::{GzEncoder, ZlibEncoder};
@@ -320,13 +320,11 @@ impl StreamProcessor for HtmlRewriterAdapter {
             _ => {}
         }
 
-        if is_last {
-            if let Some(rewriter) = self.rewriter.take() {
-                rewriter.end().map_err(|e| {
-                    log::error!("Failed to finalize HTML: {e}");
-                    io::Error::other(format!("HTML finalization failed: {e}"))
-                })?;
-            }
+        if is_last && let Some(rewriter) = self.rewriter.take() {
+            rewriter.end().map_err(|e| {
+                log::error!("Failed to finalize HTML: {e}");
+                io::Error::other(format!("HTML finalization failed: {e}"))
+            })?;
         }
 
         // Drain whatever lol_html produced since the last call
@@ -455,7 +453,7 @@ mod tests {
 
     #[test]
     fn test_html_rewriter_adapter_streams_incrementally() {
-        use lol_html::{element, Settings};
+        use lol_html::{Settings, element};
 
         // Create a simple HTML rewriter that replaces text
         let settings = Settings {
@@ -716,8 +714,8 @@ mod tests {
 
     #[test]
     fn test_brotli_round_trip_produces_valid_output() {
-        use brotli::enc::writer::CompressorWriter;
         use brotli::Decompressor;
+        use brotli::enc::writer::CompressorWriter;
         use std::io::{Read as _, Write as _};
 
         let input_data = b"<html><body>hello world</body></html>";
@@ -811,14 +809,14 @@ mod tests {
 
     #[test]
     fn test_streaming_pipeline_with_html_rewriter() {
-        use lol_html::{element, Settings};
+        use lol_html::{Settings, element};
 
         let settings = Settings {
             element_content_handlers: vec![element!("a[href]", |el| {
-                if let Some(href) = el.get_attribute("href") {
-                    if href.contains("example.com") {
-                        el.set_attribute("href", &href.replace("example.com", "test.com"))?;
-                    }
+                if let Some(href) = el.get_attribute("href")
+                    && href.contains("example.com")
+                {
+                    el.set_attribute("href", &href.replace("example.com", "test.com"))?;
                 }
                 Ok(())
             })],
@@ -851,15 +849,15 @@ mod tests {
     fn test_gzip_pipeline_with_html_rewriter() {
         use flate2::read::GzDecoder;
         use flate2::write::GzEncoder;
-        use lol_html::{element, Settings};
+        use lol_html::{Settings, element};
         use std::io::{Read as _, Write as _};
 
         let settings = Settings {
             element_content_handlers: vec![element!("a[href]", |el| {
-                if let Some(href) = el.get_attribute("href") {
-                    if href.contains("example.com") {
-                        el.set_attribute("href", &href.replace("example.com", "test.com"))?;
-                    }
+                if let Some(href) = el.get_attribute("href")
+                    && href.contains("example.com")
+                {
+                    el.set_attribute("href", &href.replace("example.com", "test.com"))?;
                 }
                 Ok(())
             })],

--- a/crates/trusted-server-core/src/streaming_replacer.rs
+++ b/crates/trusted-server-core/src/streaming_replacer.rs
@@ -433,7 +433,11 @@ mod tests {
                 replacer: create_url_replacer("test.com", "https://test.com", "new.com", "https"),
                 content: "Some text \u{601d}\u{6019}\u{154f}\u{6d4b}\u{8bd5} more text with \u{1f389} emoji",
                 chunk_size: 8,
-                expected_fragments: &["Some text", "\u{601d}\u{6019}\u{154f}\u{6d4b}\u{8bd5}", "\u{1f389} emoji"],
+                expected_fragments: &[
+                    "Some text",
+                    "\u{601d}\u{6019}\u{154f}\u{6d4b}\u{8bd5}",
+                    "\u{1f389} emoji",
+                ],
             },
         ];
 

--- a/crates/trusted-server-core/src/tester_cookie.rs
+++ b/crates/trusted-server-core/src/tester_cookie.rs
@@ -8,7 +8,7 @@
 
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt};
-use http::{header, HeaderValue, Response, StatusCode};
+use http::{HeaderValue, Response, StatusCode, header};
 
 use crate::constants::COOKIE_TS_TESTER;
 use crate::error::TrustedServerError;

--- a/crates/trusted-server-integration-tests/Cargo.toml
+++ b/crates/trusted-server-integration-tests/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "trusted-server-integration-tests"
-version = "0.1.0"
-edition = "2024"
-publish = false
+description = "Cross-adapter parity and integration tests for Trusted Server."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [[test]]
 name = "integration"

--- a/crates/trusted-server-js/Cargo.toml
+++ b/crates/trusted-server-js/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "trusted-server-js"
-version = "0.1.0"
-edition = "2021"
 description = "Trusted Server tsjs — TypeScript-built JS embedded in a Rust crate."
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 build = "build.rs"
 
 [lints]

--- a/crates/trusted-server-js/build.rs
+++ b/crates/trusted-server-js/build.rs
@@ -44,45 +44,43 @@ fn main() {
     }
 
     // Install deps if node_modules missing
-    if !skip {
-        if let Some(npm_path) = npm.as_deref() {
-            if !ts_dir.join("node_modules").exists() {
-                let status = Command::new(npm_path)
-                    .arg("ci")
-                    .current_dir(&ts_dir)
-                    .status();
-                if !status.as_ref().is_ok_and(ExitStatus::success) {
-                    warn!("tsjs: npm ci failed; using existing dist if available");
-                }
-            }
+    if !skip
+        && let Some(npm_path) = npm.as_deref()
+        && !ts_dir.join("node_modules").exists()
+    {
+        let status = Command::new(npm_path)
+            .arg("ci")
+            .current_dir(&ts_dir)
+            .status();
+        if !status.as_ref().is_ok_and(ExitStatus::success) {
+            warn!("tsjs: npm ci failed; using existing dist if available");
         }
     }
 
     // Run tests if requested
-    if !skip && env::var("TSJS_TEST").is_ok_and(|value| value == "1") {
-        if let Some(npm_path) = npm.as_deref() {
-            Command::new(npm_path)
-                .args(["run", "test", "--", "--run"])
-                .current_dir(&ts_dir)
-                .status()
-                .expect("should run requested TSJS tests");
-        }
+    if !skip
+        && env::var("TSJS_TEST").is_ok_and(|value| value == "1")
+        && let Some(npm_path) = npm.as_deref()
+    {
+        Command::new(npm_path)
+            .args(["run", "test", "--", "--run"])
+            .current_dir(&ts_dir)
+            .status()
+            .expect("should run requested TSJS tests");
     }
 
     // Build all module files
-    if !skip {
-        if let Some(npm_path) = npm.as_deref() {
-            info!("tsjs: Building per-module bundles");
+    if !skip && let Some(npm_path) = npm.as_deref() {
+        info!("tsjs: Building per-module bundles");
 
-            let status = Command::new(npm_path)
-                .args(["run", "build"])
-                .current_dir(&ts_dir)
-                .status();
-            assert!(
-                status.as_ref().is_ok_and(ExitStatus::success),
-                "tsjs: npm run build failed - refusing to use stale bundles"
-            );
-        }
+        let status = Command::new(npm_path)
+            .args(["run", "build"])
+            .current_dir(&ts_dir)
+            .status();
+        assert!(
+            status.as_ref().is_ok_and(ExitStatus::success),
+            "tsjs: npm run build failed - refusing to use stale bundles"
+        );
     }
 
     // Discover all tsjs-*.js files in dist/

--- a/crates/trusted-server-openrtb-codegen/Cargo.toml
+++ b/crates/trusted-server-openrtb-codegen/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "trusted-server-openrtb-codegen"
-version = "0.1.0"
-edition = "2024"
-publish = false
-license = "Apache-2.0"
+description = "Protobuf codegen for the Trusted Server OpenRTB types."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
-prost-build = "0.13"
+prost-build = { workspace = true }

--- a/crates/trusted-server-openrtb-codegen/src/main.rs
+++ b/crates/trusted-server-openrtb-codegen/src/main.rs
@@ -11,9 +11,6 @@
 use std::fs;
 use std::path::PathBuf;
 
-// Pull in postprocess() and helpers from the openrtb crate's codegen module.
-include!("../../trusted-server-openrtb/src/codegen.rs");
-
 fn main() {
     let openrtb_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../trusted-server-openrtb");
     let proto_path = openrtb_dir.join("proto/openrtb.proto");
@@ -55,3 +52,8 @@ fn main() {
     // Clean up temp files.
     let _ = fs::remove_dir_all(&tmp);
 }
+
+// Pull in postprocess() and helpers from the openrtb crate's codegen module.
+// Placed after `main` because the included module carries a `#[cfg(test)]`
+// module, and items may not follow a test module.
+include!("../../trusted-server-openrtb/src/codegen.rs");

--- a/crates/trusted-server-openrtb/Cargo.toml
+++ b/crates/trusted-server-openrtb/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "trusted-server-openrtb"
-version = "0.1.0"
-authors = []
-edition = "2024"
-publish = false
-license = "Apache-2.0"
+description = "OpenRTB types for Trusted Server."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lib]
 doctest = false


### PR DESCRIPTION
Closes #904.

## What

Adds a `[workspace.package]` table with `authors`, `edition`, `license`, `publish`, and `version`, and has all ten crates inherit every one of them. Each `[package]` section now follows the same shape:

```toml
[package]
name = "..."
description = "..."
authors = { workspace = true }
edition = { workspace = true }
license = { workspace = true }
publish = { workspace = true }
version = { workspace = true }
```

`trusted-server-openrtb-codegen` joins the workspace `members` so it shares those settings and can use workspace dependencies (`prost-build`). It stays out of default builds: `default-members` is still just the Fastly adapter, and every alias in `.cargo/config.toml` selects packages explicitly with `-p`, so no `build` / `check` / `test` / `clippy` command reaches it.

Nine crates gained a `description`; they had none before.

## Why the diff is 82 files

Inheriting `edition` moves `trusted-server-core`, `-adapter-fastly`, and `-js` from 2021 to 2024, joining the seven crates already there. Two mechanical consequences:

- **`gen` is a reserved keyword in edition 2024.** One binding renamed in `ec/kv.rs`.
- **Edition 2024 stabilizes let-chains**, so clippy `collapsible_if` now fires on nested `if` / `if let`. 41 sites collapsed via `cargo clippy --fix`, then reviewed.

The rest of the churn is `rustfmt` reordering imports, because its style edition follows the crate edition. No semantic change. (A `rustfmt.toml` with `style_edition = "2021"` would suppress that churn, at the cost of holding formatting deliberately out of step with the edition — happy to add it if preferred.)

## Verification

All green locally:

- `cargo fmt --all -- --check`
- clippy across all seven target/feature combos (fastly wasm, axum, cloudflare native + wasm, spin native + wasm, cli)
- `cargo test` for fastly (1,624 core tests + 99 + 21 + 2), axum, cloudflare, spin, and cli — 0 failures