### PR TITLE
Emit absolute creative rewrite URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Creative rewrite proxy, click, CSS, `srcset`, sign-response, rebuild-response, and injected creative TSJS URLs are now absolute on optional `publisher.public_origin` (falling back to `https://{publisher.domain}`). Existing root-relative signed proxy and click inputs remain accepted.
 - **Breaking** — `bid_param_zone_overrides` inner values must now be JSON objects; previously non-object or empty values (`"header" = "x"`, `"header" = {}`) were accepted and silently produced a dead rule at runtime. They now fail at startup with a configuration error. Operators upgrading should audit their `bid_param_zone_overrides` config for non-object zone entries.
 - **Breaking** — Sourcepoint browser module inclusion now requires explicit `[integrations.sourcepoint].enabled = true`; operators relying on the previous unconditional Sourcepoint module should enable the integration before upgrading.
 

--- a/crates/trusted-server-adapter-axum/src/app.rs
+++ b/crates/trusted-server-adapter-axum/src/app.rs
@@ -349,7 +349,7 @@ fn named_routes() -> [NamedRoute; 12] {
         },
         NamedRoute {
             path: "/first-party/proxy-rebuild",
-            primary_methods: &[Method::POST],
+            primary_methods: &[Method::GET, Method::POST],
             handler: NamedRouteHandler::FirstPartyProxyRebuild,
         },
     ]

--- a/crates/trusted-server-adapter-axum/tests/routes.rs
+++ b/crates/trusted-server-adapter-axum/tests/routes.rs
@@ -81,6 +81,7 @@ fn all_explicit_routes_are_registered() {
         ("GET", "/first-party/click"),
         ("GET", "/first-party/sign"),
         ("POST", "/first-party/sign"),
+        ("GET", "/first-party/proxy-rebuild"),
         ("POST", "/first-party/proxy-rebuild"),
     ];
 

--- a/crates/trusted-server-adapter-cloudflare/src/app.rs
+++ b/crates/trusted-server-adapter-cloudflare/src/app.rs
@@ -526,6 +526,12 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
                     handle_first_party_proxy_sign(&s.settings, &services, req).await
                 }),
             )
+            .get(
+                "/first-party/proxy-rebuild",
+                make_handler(Arc::clone(&state), |s, services, req| async move {
+                    handle_first_party_proxy_rebuild(&s.settings, &services, req).await
+                }),
+            )
             .post(
                 "/first-party/proxy-rebuild",
                 make_handler(Arc::clone(&state), |s, services, req| async move {

--- a/crates/trusted-server-adapter-cloudflare/tests/routes.rs
+++ b/crates/trusted-server-adapter-cloudflare/tests/routes.rs
@@ -220,6 +220,7 @@ fn all_explicit_routes_are_registered() {
         ("GET", "/first-party/click"),
         ("GET", "/first-party/sign"),
         ("POST", "/first-party/sign"),
+        ("GET", "/first-party/proxy-rebuild"),
         ("POST", "/first-party/proxy-rebuild"),
     ];
 

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -32,7 +32,7 @@
 //! | GET | `/first-party/click` | [`handle_first_party_click`] |
 //! | GET | `/first-party/sign` | [`handle_first_party_proxy_sign`] |
 //! | POST | `/first-party/sign` | [`handle_first_party_proxy_sign`] |
-//! | POST | `/first-party/proxy-rebuild` | [`handle_first_party_proxy_rebuild`] |
+//! | GET, POST | `/first-party/proxy-rebuild` | [`handle_first_party_proxy_rebuild`] |
 //! | GET | `/` and `/{*rest}` | tsjs (if `/static/tsjs=` prefix), integration proxy, or publisher fallback |
 //! | POST, HEAD, OPTIONS, PUT, PATCH, DELETE | `/` and `/{*rest}` | integration proxy or publisher fallback |
 //! | POST, HEAD, OPTIONS, PUT, PATCH, DELETE | named paths above | publisher fallback (legacy parity for non-primary methods) |
@@ -1104,7 +1104,7 @@ const NAMED_ROUTES: &[NamedRoute] = &[
     },
     NamedRoute {
         path: "/first-party/proxy-rebuild",
-        primary_methods: &[Method::POST],
+        primary_methods: &[Method::GET, Method::POST],
         handler: NamedRouteHandler::FirstPartyProxyRebuild,
     },
 ];
@@ -1559,6 +1559,20 @@ mod tests {
             Some("false"),
             "FinalizeResponseMiddleware must run even for auth-rejected responses"
         );
+    }
+
+    #[test]
+    fn proxy_rebuild_registers_get_and_post() {
+        let route = NAMED_ROUTES
+            .iter()
+            .find(|route| route.path == "/first-party/proxy-rebuild")
+            .expect("should register proxy rebuild route");
+        assert!(matches!(
+            route.handler,
+            NamedRouteHandler::FirstPartyProxyRebuild
+        ));
+        assert!(route.primary_methods.contains(&Method::GET));
+        assert!(route.primary_methods.contains(&Method::POST));
     }
 
     #[test]

--- a/crates/trusted-server-adapter-spin/src/app.rs
+++ b/crates/trusted-server-adapter-spin/src/app.rs
@@ -154,7 +154,7 @@ fn named_fallback_paths() -> [(&'static str, &'static [Method]); 12] {
         ("/first-party/proxy", &[Method::GET]),
         ("/first-party/click", &[Method::GET]),
         ("/first-party/sign", &[Method::GET, Method::POST]),
-        ("/first-party/proxy-rebuild", &[Method::POST]),
+        ("/first-party/proxy-rebuild", &[Method::GET, Method::POST]),
     ]
 }
 
@@ -608,7 +608,7 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
         };
         let fp_sign_post_handler = fp_sign_handler.clone();
 
-        // /first-party/proxy-rebuild
+        // GET + POST /first-party/proxy-rebuild — identical handler, cloned for both bindings.
         let s = Arc::clone(&state);
         let fp_rebuild_handler = move |ctx: RequestContext| {
             let s = Arc::clone(&s);
@@ -622,6 +622,7 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
                 )
             }
         };
+        let fp_rebuild_post_handler = fp_rebuild_handler.clone();
 
         // Shared fallback dispatch: routes to tsjs (GET only), integration proxy, or publisher.
         async fn dispatch(
@@ -741,7 +742,8 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             .get("/first-party/click", fp_click_handler)
             .get("/first-party/sign", fp_sign_handler)
             .post("/first-party/sign", fp_sign_post_handler)
-            .post("/first-party/proxy-rebuild", fp_rebuild_handler);
+            .get("/first-party/proxy-rebuild", fp_rebuild_handler)
+            .post("/first-party/proxy-rebuild", fp_rebuild_post_handler);
 
         for method in LEGACY_ADMIN_DENY_METHODS {
             builder = builder.route("/admin/keys/rotate", method.clone(), legacy_admin_deny);

--- a/crates/trusted-server-adapter-spin/tests/routes.rs
+++ b/crates/trusted-server-adapter-spin/tests/routes.rs
@@ -467,6 +467,22 @@ async fn first_party_proxy_rebuild_is_routed() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn first_party_proxy_rebuild_get_is_routed() {
+    let router = test_router();
+    let req = request_builder()
+        .method("GET")
+        .uri("/first-party/proxy-rebuild")
+        .body(edgezero_core::body::Body::empty())
+        .expect("should build request");
+    let resp = route(router, req).await;
+    assert_ne!(
+        resp.status().as_u16(),
+        404,
+        "GET /first-party/proxy-rebuild must be routed"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // First-party absolute-URI regression — Spin delivers a path-only request URI
 // (built from IncomingRequest::path_with_query), so the shared proxy/click/sign
@@ -548,21 +564,25 @@ async fn first_party_proxy_round_trip_through_spin_router() {
             .to_vec(),
     )
     .expect("sign response body should be UTF-8");
-    let href = json_string_field(&sign_body, "href")
-        .expect("sign response must include a signed href path");
+    let href =
+        json_string_field(&sign_body, "href").expect("sign response must include a signed href");
+    let (_, authority_and_path) = href
+        .split_once("://")
+        .expect("signed href should be absolute");
+    let (_, path_and_query) = authority_and_path
+        .split_once('/')
+        .expect("signed href should include a path");
+    let href_path_and_query = format!("/{path_and_query}");
     assert!(
-        href.starts_with("/first-party/proxy?"),
-        "signed href must target the proxy path, got: {href}"
+        href_path_and_query.starts_with("/first-party/proxy?"),
+        "signed href must target the proxy path"
     );
 
     let router = test_router();
     let proxy_req = request_builder()
         .method("GET")
-        .uri(href.clone())
-        .header(
-            "spin-full-url",
-            format!("https://www.publisher.example{href}"),
-        )
+        .uri(href_path_and_query)
+        .header("spin-full-url", href)
         .body(edgezero_core::body::Body::empty())
         .expect("should build proxy request");
     let proxy_resp = route(router, proxy_req).await;

--- a/crates/trusted-server-core/src/auction/README.md
+++ b/crates/trusted-server-core/src/auction/README.md
@@ -248,7 +248,7 @@ The orchestrator collects all bids and creates an OpenRTB response:
 }
 ```
 
-Note that creative HTML is rewritten to use the first-party proxy (`/first-party/proxy`) for privacy and security.
+Note that creative HTML is rewritten to use the configured browser-facing public origin, for example `https://ads.publisher.example/first-party/proxy`, for privacy and security.
 
 ## Route Registration & Endpoints
 
@@ -262,7 +262,7 @@ The trusted-server handles several types of routes defined in `crates/trusted-se
 | `/first-party/proxy`      | GET    | `handle_first_party_proxy()`   | Proxy creatives through first-party domain       | 84   |
 | `/first-party/click`      | GET    | `handle_first_party_click()`   | Track clicks on ads                              | 85   |
 | `/first-party/sign`       | GET/POST | `handle_first_party_proxy_sign()` | Generate signed URLs for creatives            | 86   |
-| `/first-party/proxy-rebuild` | POST | `handle_first_party_proxy_rebuild()` | Rebuild creative HTML with new settings     | 89   |
+| `/first-party/proxy-rebuild` | GET/POST | `handle_first_party_proxy_rebuild()` | Rebuild signed creative click URLs     | 89   |
 | `/static/tsjs=*`          | GET    | `handle_tsjs_dynamic()`        | Serve tsjs library (Prebid.js alternative)       | 66   |
 | `/.well-known/ts.jwks.json` | GET  | `handle_jwks_endpoint()`       | Public key distribution for request signing      | 71   |
 | `/verify-signature`       | POST   | `handle_verify_signature()`    | Verify signed requests                           | 74   |

--- a/crates/trusted-server-core/src/auction/formats.rs
+++ b/crates/trusted-server-core/src/auction/formats.rs
@@ -933,6 +933,29 @@ mod tests {
     }
 
     #[test]
+    fn convert_to_openrtb_response_uses_public_origin_for_creative_rewrites() {
+        let mut settings = make_settings();
+        settings.publisher.public_origin = Some("https://ads.publisher.example:8443".to_string());
+        let auction_request = make_auction_request();
+        let mut bid = make_bid("div-gpt-top", "appnexus", Some(2.75));
+        bid.creative = Some(
+            r#"<body><img src="https://cdn.example.com/ad.png"><a href="https://advertiser.example.com/landing">ad</a></body>"#
+                .to_string(),
+        );
+        let result = make_result(bid);
+
+        let response = convert_to_openrtb_response(&result, &settings, &auction_request, true)
+            .expect("should convert rewritten creative");
+        let json = response_json(response);
+        let adm = json["seatbid"][0]["bid"][0]["adm"]
+            .as_str()
+            .expect("should serialize creative HTML");
+        assert!(adm.contains("https://ads.publisher.example:8443/first-party/proxy?"));
+        assert!(adm.contains("https://ads.publisher.example:8443/first-party/click?"));
+        assert!(adm.contains("https://ads.publisher.example:8443/static/tsjs="));
+    }
+
+    #[test]
     fn convert_to_openrtb_response_serializes_missing_creative_as_empty_adm() {
         let settings = make_settings();
         let auction_request = make_auction_request();

--- a/crates/trusted-server-core/src/config_payload.rs
+++ b/crates/trusted-server-core/src/config_payload.rs
@@ -79,6 +79,27 @@ mod tests {
     }
 
     #[test]
+    fn legacy_blob_without_public_origin_uses_domain_fallback() {
+        let mut original = test_settings();
+        original.publisher.public_origin = Some("https://ads.example.com:8443".to_string());
+        let mut data = serde_json::to_value(&original).expect("should serialize settings to JSON");
+        data["publisher"]
+            .as_object_mut()
+            .expect("should serialize publisher as an object")
+            .remove("public_origin");
+        let envelope = BlobEnvelope::new(data, "2026-01-01T00:00:00Z".to_string());
+        let json = serde_json::to_string(&envelope).expect("should serialize legacy envelope");
+
+        let reconstructed = settings_from_config_blob(&json)
+            .expect("should reconstruct settings without public_origin");
+        assert_eq!(
+            reconstructed.publisher.effective_public_origin(),
+            format!("https://{}", original.publisher.domain),
+            "should fall back to the publisher domain"
+        );
+    }
+
+    #[test]
     fn strings_that_look_like_json_scalars_round_trip_as_strings() {
         let mut original = test_settings();
         original.publisher.proxy_secret = Redacted::new("1234567890".to_string());

--- a/crates/trusted-server-core/src/creative.rs
+++ b/crates/trusted-server-core/src/creative.rs
@@ -7,7 +7,7 @@
 //!
 //! Key behaviors:
 //! - Absolute and protocol-relative URLs (http/https or `//`) are proxied to
-//!   `/first-party/proxy?tsurl=<base-url>&<original-query-params>&tstoken=<sig>` across these locations:
+//!   `{public_origin}/first-party/proxy?tsurl=<base-url>&<original-query-params>&tstoken=<sig>` across these locations:
 //!   - `<img src>`, `data-src`, `[srcset]`, `[imagesrcset]`
 //!   - `<script src>`
 //!   - `<video src>`, `<audio src>`, `<source src>`
@@ -140,6 +140,13 @@ pub(super) fn rewrite_style_urls(settings: &Settings, style: &str) -> String {
     out
 }
 
+/// Prefixes a controlled root-relative Trusted Server endpoint with its browser-facing origin.
+#[inline]
+pub(crate) fn first_party_url(settings: &Settings, path: &str) -> String {
+    debug_assert!(path.starts_with('/'));
+    format!("{}{}", settings.publisher.effective_public_origin(), path)
+}
+
 #[inline]
 fn build_signed_url_for(
     settings: &Settings,
@@ -183,7 +190,7 @@ fn build_signed_url_for(
         qs.append_pair(k, v);
     }
     qs.append_pair("tstoken", &token);
-    format!("{}?{}", base_path, qs.finish())
+    first_party_url(settings, &format!("{}?{}", base_path, qs.finish()))
 }
 
 #[inline]
@@ -493,11 +500,11 @@ pub fn sanitize_creative_html(markup: &str) -> String {
 }
 
 /// Rewrite ad creative HTML to first-party endpoints.
-/// - 1x1 `<img>` pixels → `/first-party/proxy?tsurl=&lt;base-url&gt;&lt;params&gt;&tstoken=&lt;sig&gt;`
-/// - Non-pixel absolute images → `/first-party/proxy?tsurl=&lt;base-url&gt;&lt;params&gt;&tstoken=&lt;sig&gt;`
-/// - `<iframe src>` (absolute or protocol-relative) → `/first-party/proxy?tsurl=&lt;base-url&gt;&lt;params&gt;&tstoken=&lt;sig&gt;`
+/// - 1x1 `<img>` pixels → `{public_origin}/first-party/proxy?tsurl=&lt;base-url&gt;&lt;params&gt;&tstoken=&lt;sig&gt;`
+/// - Non-pixel absolute images → `{public_origin}/first-party/proxy?tsurl=&lt;base-url&gt;&lt;params&gt;&tstoken=&lt;sig&gt;`
+/// - `<iframe src>` (absolute or protocol-relative) → `{public_origin}/first-party/proxy?tsurl=&lt;base-url&gt;&lt;params&gt;&tstoken=&lt;sig&gt;`
 /// - Injects the `tsjs-creative` script once at the top of `<body>` to safeguard click URLs inside creatives
-///   (served from `/static/tsjs=tsjs-creative.min.js`).
+///   (served from `{public_origin}/static/tsjs=tsjs-creative.min.js`).
 #[must_use]
 pub fn rewrite_creative_html(settings: &Settings, markup: &str) -> String {
     // No size parsing needed now; all absolute/protocol-relative URLs are proxied uniformly.
@@ -511,7 +518,11 @@ pub fn rewrite_creative_html(settings: &Settings, markup: &str) -> String {
                     let injected = injected_ts_creative.clone();
                     move |el| {
                         if !injected.get() {
-                            let script_tag = tsjs::tsjs_unified_script_tag();
+                            let script_src = tsjs::tsjs_unified_script_src();
+                            let script_tag = format!(
+                                "<script src=\"{}\" id=\"trustedserver-js\"></script>",
+                                first_party_url(settings, &script_src)
+                            );
                             el.prepend(&script_tag, ContentType::Html);
                             injected.set(true);
                         }
@@ -769,7 +780,8 @@ impl StreamProcessor for CreativeCssProcessor<'_> {
 #[cfg(test)]
 mod tests {
     use super::{
-        rewrite_creative_html, rewrite_srcset, rewrite_style_urls, sanitize_creative_html, to_abs,
+        build_click_url, build_proxy_url, rewrite_creative_html, rewrite_srcset,
+        rewrite_style_urls, sanitize_creative_html, to_abs,
     };
 
     fn rewrite_srcset_attr(attr_name: &str, attr_value: &str) -> String {
@@ -1306,7 +1318,7 @@ mod tests {
           <img data-srcset="https://cdn.example/img-1x.png 1x, //cdn.example/img-2x.png 2x, /local/img.png 1x">
         "#;
         let out = rewrite_creative_html(&settings, html);
-        assert!(out.contains("data-src=\"/first-party/proxy?tsurl="));
+        assert!(out.contains("data-src=\"https://test-publisher.com/first-party/proxy?tsurl="));
         assert!(out.matches("/first-party/proxy?tsurl=").count() >= 1);
         // relative candidate remains
         assert!(out.contains("/local/img.png 1x"));
@@ -1439,7 +1451,46 @@ mod tests {
         // Non-excluded should be rewritten and SHOULD have data-tsclick
         assert!(out.contains("/first-party/click?tsurl="));
         assert!(out.contains("advertiser.example.com"));
-        assert!(out.contains("data-tsclick=\"/first-party/click"));
+        assert!(out.contains("data-tsclick=\"https://test-publisher.com/first-party/click"));
+    }
+
+    #[test]
+    fn generated_first_party_urls_use_public_origin() {
+        let mut settings = crate::test_support::tests::create_test_settings();
+        settings.publisher.public_origin = Some("https://ads.publisher.example:8443".to_string());
+
+        let proxy = build_proxy_url(&settings, "https://cdn.example.com/ad.png?campaign=1");
+        let click = build_click_url(&settings, "https://advertiser.example.com/landing");
+        for generated in [&proxy, &click] {
+            let parsed = url::Url::parse(generated).expect("should build an absolute URL");
+            assert_eq!(
+                parsed.origin().ascii_serialization(),
+                "https://ads.publisher.example:8443"
+            );
+        }
+
+        let out = rewrite_creative_html(
+            &settings,
+            r#"<body><img src="https://cdn.example.com/ad.png" srcset="https://cdn.example.com/ad-2x.png 2x" style="background:url(https://cdn.example.com/bg.png)"><a href="https://advertiser.example.com/landing">ad</a></body>"#,
+        );
+        assert!(out.contains("https://ads.publisher.example:8443/first-party/proxy?"));
+        assert!(out.contains("https://ads.publisher.example:8443/first-party/click?"));
+        assert_eq!(
+            out.matches("https://ads.publisher.example:8443/first-party/proxy?")
+                .count(),
+            3,
+            "should qualify resource, srcset, and CSS rewrites"
+        );
+        assert!(out.contains("https://ads.publisher.example:8443/static/tsjs="));
+        assert!(!out.contains("origin.test-publisher.com"));
+        assert!(!out.contains("https://test-publisher.com/first-party"));
+    }
+
+    #[test]
+    fn generated_first_party_urls_fall_back_to_publisher_domain() {
+        let settings = crate::test_support::tests::create_test_settings();
+        let proxy = build_proxy_url(&settings, "https://cdn.example.com/ad.png");
+        assert!(proxy.starts_with("https://test-publisher.com/first-party/proxy?"));
     }
 
     // ── sanitize_creative_html tests ────────────────────────────────────────

--- a/crates/trusted-server-core/src/proxy.rs
+++ b/crates/trusted-server-core/src/proxy.rs
@@ -15,7 +15,7 @@ use crate::constants::{
     HEADER_ACCEPT, HEADER_ACCEPT_ENCODING, HEADER_ACCEPT_LANGUAGE, HEADER_REFERER,
     HEADER_USER_AGENT, HEADER_X_FORWARDED_FOR,
 };
-use crate::creative::{CreativeCssProcessor, CreativeHtmlProcessor};
+use crate::creative::{CreativeCssProcessor, CreativeHtmlProcessor, first_party_url};
 use crate::edge_cookie::get_ec_id;
 use crate::error::TrustedServerError;
 use crate::platform::{
@@ -1695,7 +1695,7 @@ struct ProxyRebuildResp {
 }
 
 /// Proxy rebuild endpoint.
-/// POST /first-party/proxy-rebuild
+/// POST or GET /first-party/proxy-rebuild
 /// Body: { tsclick: "/first-party/click?tsurl=...&a=1", add: {"b":"2"}, del: ["c"] }
 /// - Only allows adding new parameters or removing existing ones.
 /// - Base tsurl cannot change.
@@ -1757,13 +1757,16 @@ pub async fn handle_first_party_proxy_rebuild(
         }
     };
 
-    let base = "https://edge.local"; // dummy origin to parse relative path
-    let c_url = url::Url::parse(&format!("{}{}", base, payload.tsclick)).change_context(
-        TrustedServerError::Proxy {
-            message: "invalid tsclick".to_string(),
-        },
-    )?;
-    if c_url.path() != "/first-party/click" {
+    let qualified_tsclick =
+        if payload.tsclick.starts_with('/') && !payload.tsclick.starts_with("//") {
+            first_party_url(settings, &payload.tsclick)
+        } else {
+            payload.tsclick.clone()
+        };
+    let c_url = url::Url::parse(&qualified_tsclick).change_context(TrustedServerError::Proxy {
+        message: "invalid tsclick".to_string(),
+    })?;
+    if !matches!(c_url.scheme(), "http" | "https") || c_url.path() != "/first-party/click" {
         return Err(Report::new(TrustedServerError::Proxy {
             message: "invalid tsclick path".to_string(),
         }));
@@ -1771,7 +1774,7 @@ pub async fn handle_first_party_proxy_rebuild(
     // Validate the tstoken on the original click URL before applying any changes.
     // Without this, an attacker could submit an unsigned tsclick and mint valid
     // click redirects to arbitrary URLs.
-    reconstruct_and_validate_signed_target(settings, &format!("{}{}", base, payload.tsclick))?;
+    reconstruct_and_validate_signed_target(settings, &qualified_tsclick)?;
 
     // Extract tsurl and original params (exclude tstoken if present)
     let mut tsurl: Option<String> = None;
@@ -1857,7 +1860,7 @@ pub async fn handle_first_party_proxy_rebuild(
         qs.append_pair(k, v);
     }
     qs.append_pair("tstoken", &token);
-    let href = format!("/first-party/click?{}", qs.finish());
+    let href = first_party_url(settings, &format!("/first-party/click?{}", qs.finish()));
 
     // Compute diagnostics: added and removed
     let mut added: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
@@ -2353,7 +2356,9 @@ mod tests {
     #[test]
     fn proxy_sign_returns_signed_url() {
         futures::executor::block_on(async {
-            let settings = create_test_settings();
+            let mut settings = create_test_settings();
+            settings.publisher.public_origin =
+                Some("https://ads.publisher.example:8443".to_string());
             let body = serde_json::json!({
                 "url": "https://cdn.example/asset.js?c=3&b=2",
             });
@@ -2363,7 +2368,11 @@ mod tests {
                 .expect("sign ok");
             assert_eq!(resp.status(), StatusCode::OK);
             let json = response_body_string(resp);
-            assert!(json.contains("/first-party/proxy?tsurl="), "{}", json);
+            assert!(
+                json.contains("https://ads.publisher.example:8443/first-party/proxy?tsurl="),
+                "{}",
+                json
+            );
             assert!(json.contains("tsexp"), "{}", json);
             assert!(
                 json.contains("\"base\":\"https://cdn.example/asset.js\""),
@@ -2626,6 +2635,89 @@ mod tests {
         });
     }
 
+    #[test]
+    fn proxy_rebuild_accepts_legacy_and_absolute_clicks_and_canonicalizes_output() {
+        futures::executor::block_on(async {
+            let mut settings = create_test_settings();
+            settings.publisher.public_origin =
+                Some("https://ads.publisher.example:8443".to_string());
+            let tsurl = "https://advertiser.example.com/landing";
+            let token = crate::http_util::compute_encrypted_sha256_token(&settings, tsurl);
+            let legacy = format!(
+                "/first-party/click?tsurl={}&tstoken={token}",
+                url::form_urlencoded::byte_serialize(tsurl.as_bytes()).collect::<String>()
+            );
+
+            for tsclick in [legacy.clone(), format!("https://alias.example{legacy}")] {
+                let body = serde_json::json!({ "tsclick": tsclick });
+                let req = HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("https://edge.example/first-party/proxy-rebuild")
+                    .body(EdgeBody::from(
+                        serde_json::to_string(&body).expect("should serialize test JSON"),
+                    ))
+                    .expect("should build rebuild request");
+                let response = handle_first_party_proxy_rebuild(&settings, &noop_services(), req)
+                    .await
+                    .expect("should rebuild a valid click");
+                let body: serde_json::Value = serde_json::from_str(&response_body_string(response))
+                    .expect("should return JSON");
+                assert!(
+                    body["href"]
+                        .as_str()
+                        .expect("should return href")
+                        .starts_with("https://ads.publisher.example:8443/first-party/click?"),
+                    "should canonicalize to public_origin"
+                );
+            }
+
+            let query = url::form_urlencoded::Serializer::new(String::new())
+                .append_pair("tsclick", &legacy)
+                .finish();
+            let req = build_http_request(
+                Method::GET,
+                format!("https://edge.example/first-party/proxy-rebuild?{query}"),
+            );
+            let response = handle_first_party_proxy_rebuild(&settings, &noop_services(), req)
+                .await
+                .expect("should rebuild legacy GET click");
+            assert_eq!(response.status(), StatusCode::FOUND);
+            assert!(
+                response_header(&response, header::LOCATION)
+                    .expect("should return a Location header")
+                    .starts_with("https://ads.publisher.example:8443/first-party/click?")
+            );
+        });
+    }
+
+    #[test]
+    fn proxy_rebuild_rejects_invalid_click_authorities_and_paths() {
+        futures::executor::block_on(async {
+            let settings = create_test_settings();
+            for tsclick in [
+                "//edge.example/first-party/click?tsurl=x",
+                "ftp://edge.example/first-party/click?tsurl=x",
+                "https://edge.example/first-party/click-extra?tsurl=x",
+                "not a URL",
+            ] {
+                let body = serde_json::json!({ "tsclick": tsclick });
+                let req = HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("https://edge.example/first-party/proxy-rebuild")
+                    .body(EdgeBody::from(
+                        serde_json::to_string(&body).expect("should serialize test JSON"),
+                    ))
+                    .expect("should build rebuild request");
+                assert!(
+                    handle_first_party_proxy_rebuild(&settings, &noop_services(), req)
+                        .await
+                        .is_err(),
+                    "should reject {tsclick:?}"
+                );
+            }
+        });
+    }
+
     // Build a signed `/first-party/click` URL carrying a future `tsexp` replay
     // bound, returning (tsclick, tsexp_value).
     fn signed_click_with_tsexp(settings: &crate::settings::Settings) -> (String, String) {
@@ -2729,14 +2821,10 @@ mod tests {
     fn reconstruct_valid_with_params_preserves_order() {
         let settings = create_test_settings();
         let clear = "https://cdn.example/asset.js?c=3&b=2&a=1";
-        // Simulate creative-generated first-party URL
+        // Simulate creative-generated first-party URL.
         let first_party = creative::build_proxy_url(&settings, clear);
-        // Reconstruct and validate (need absolute URL for parsing)
-        let st = reconstruct_and_validate_signed_target(
-            &settings,
-            &format!("https://edge.example{}", first_party),
-        )
-        .expect("reconstruct ok");
+        let st = reconstruct_and_validate_signed_target(&settings, &first_party)
+            .expect("reconstruct ok");
         assert_eq!(st.tsurl, "https://cdn.example/asset.js");
         assert!(st.had_params);
         assert_eq!(st.target_url, canonical_clear_url(clear));
@@ -2747,11 +2835,8 @@ mod tests {
         let settings = create_test_settings();
         let clear = "https://cdn.example/asset.js";
         let first_party = creative::build_proxy_url(&settings, clear);
-        let st = reconstruct_and_validate_signed_target(
-            &settings,
-            &format!("https://edge.example{}", first_party),
-        )
-        .expect("reconstruct ok");
+        let st = reconstruct_and_validate_signed_target(&settings, &first_party)
+            .expect("reconstruct ok");
         assert_eq!(st.tsurl, clear);
         assert!(!st.had_params);
         assert_eq!(st.target_url, clear);
@@ -2762,10 +2847,9 @@ mod tests {
         futures::executor::block_on(async {
             let settings = create_test_settings();
             let clear = "ftp://cdn.example/file.gif";
-            // Build a first-party proxy URL with a token for the unsupported scheme
+            // Build a first-party proxy URL with a token for the unsupported scheme.
             let first_party = creative::build_proxy_url(&settings, clear);
-            let req =
-                build_http_request(Method::GET, format!("https://edge.example{}", first_party));
+            let req = build_http_request(Method::GET, first_party);
             let err: Report<TrustedServerError> =
                 handle_first_party_proxy(&settings, &noop_services(), req)
                     .await
@@ -2803,8 +2887,7 @@ mod tests {
             let settings = create_test_settings();
             let clear = "https://cdn.example/landing.html?x=1";
             let first_party = creative::build_click_url(&settings, clear);
-            let req =
-                build_http_request(Method::GET, format!("https://edge.example{}", first_party));
+            let req = build_http_request(Method::GET, first_party);
             let resp = handle_first_party_click(&settings, &noop_services(), req)
                 .await
                 .expect("should redirect");

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -35,6 +35,13 @@ pub struct Publisher {
     pub cookie_domain: String,
     #[validate(custom(function = validate_no_trailing_slash))]
     pub origin_url: String,
+    /// Browser-facing Trusted Server origin for first-party creative URLs.
+    ///
+    /// When omitted, generated URLs fall back to `https://{domain}` for
+    /// compatibility with existing configurations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(custom(function = validate_public_origin))]
+    pub public_origin: Option<String>,
     /// Optional outbound Host header to send while connecting to `origin_url`.
     #[serde(default)]
     #[validate(custom(function = validate_host_header_override))]
@@ -83,6 +90,7 @@ impl Default for Publisher {
             domain: String::default(),
             cookie_domain: String::default(),
             origin_url: String::default(),
+            public_origin: None,
             origin_host_header_override: None,
             proxy_secret: Redacted::default(),
             max_buffered_body_bytes: default_max_buffered_body_bytes(),
@@ -125,6 +133,7 @@ impl Publisher {
     ///     domain: "example.com".to_string(),
     ///     cookie_domain: ".example.com".to_string(),
     ///     origin_url: "https://origin.example.com:8080".to_string(),
+    ///     public_origin: None,
     ///     origin_host_header_override: None,
     ///     proxy_secret: Redacted::new("proxy-secret".to_string()),
     ///     max_buffered_body_bytes: 16 * 1024 * 1024,
@@ -143,6 +152,14 @@ impl Publisher {
                 })
             })
             .unwrap_or_else(|| self.origin_url.clone())
+    }
+
+    /// Returns the effective browser-facing origin for generated first-party URLs.
+    #[must_use]
+    pub fn effective_public_origin(&self) -> String {
+        self.public_origin
+            .clone()
+            .unwrap_or_else(|| format!("https://{}", self.domain))
     }
 
     /// Returns the outbound Host header for proxied publisher-origin requests.
@@ -2339,6 +2356,52 @@ fn validate_no_trailing_slash(value: &str) -> Result<(), ValidationError> {
     Ok(())
 }
 
+fn validate_public_origin(value: &str) -> Result<(), ValidationError> {
+    if value.chars().any(char::is_whitespace) || value.chars().any(char::is_control) {
+        let mut err = ValidationError::new("public_origin_has_whitespace");
+        err.add_param("value".into(), &value);
+        err.message =
+            Some("public_origin must not contain whitespace or control characters".into());
+        return Err(err);
+    }
+
+    if value.ends_with('/') {
+        let mut err = ValidationError::new("public_origin_trailing_slash");
+        err.add_param("value".into(), &value);
+        err.message = Some("public_origin must not include a trailing slash".into());
+        return Err(err);
+    }
+
+    let parsed = Url::parse(value).map_err(|parse_error| {
+        let mut err = ValidationError::new("invalid_public_origin");
+        err.add_param("value".into(), &value);
+        err.add_param("message".into(), &parse_error.to_string());
+        err.message = Some("public_origin must be an absolute http or https origin".into());
+        err
+    })?;
+
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(ValidationError::new("invalid_public_origin_scheme"));
+    }
+    if parsed.host_str().is_none() {
+        return Err(ValidationError::new("missing_public_origin_host"));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(ValidationError::new("public_origin_has_userinfo"));
+    }
+    if !matches!(parsed.path(), "" | "/") {
+        return Err(ValidationError::new("public_origin_has_path"));
+    }
+    if parsed.query().is_some() {
+        return Err(ValidationError::new("public_origin_has_query"));
+    }
+    if parsed.fragment().is_some() {
+        return Err(ValidationError::new("public_origin_has_fragment"));
+    }
+
+    Ok(())
+}
+
 fn validate_host_header_override(value: &str) -> Result<(), ValidationError> {
     if let Err(reason) = validate_host_header_override_value(value) {
         let mut err = ValidationError::new("invalid_host_header_override");
@@ -2747,6 +2810,84 @@ mod tests {
         assert!(
             result.is_err(),
             "origin_url ending with '/' should fail validation"
+        );
+    }
+
+    #[test]
+    fn publisher_public_origin_validates_and_falls_back_to_domain() {
+        let fallback = Settings::from_toml(&crate_test_settings_str())
+            .expect("should parse settings without public origin");
+        assert_eq!(
+            fallback.publisher.effective_public_origin(),
+            "https://test-publisher.com",
+            "should use the publisher domain for the compatibility fallback"
+        );
+        let fallback_json = serde_json::to_value(&fallback).expect("should serialize settings");
+        assert!(
+            fallback_json["publisher"].get("public_origin").is_none(),
+            "should omit an unset public origin from serialized configs"
+        );
+
+        for origin in ["https://ads.example.com", "http://localhost:8080"] {
+            let settings = Settings::from_toml(&crate_test_settings_str().replace(
+                r#"origin_url = "https://origin.test-publisher.com""#,
+                &format!(
+                    "origin_url = \"https://origin.test-publisher.com\"\npublic_origin = \"{origin}\""
+                ),
+            ))
+            .expect("should accept an HTTP(S) origin without a trailing slash");
+            assert_eq!(settings.publisher.effective_public_origin(), origin);
+        }
+
+        for origin in [
+            "ftp://ads.example.com",
+            "https://user@ads.example.com",
+            "https://ads.example.com/path",
+            "https://ads.example.com?query=1",
+            "https://ads.example.com#fragment",
+            "https://ads.example.com/",
+            " https://ads.example.com",
+            "https://ads.example.com ",
+            "https://ads.exa\nmple.com",
+        ] {
+            let result = Settings::from_toml(&crate_test_settings_str().replace(
+                r#"origin_url = "https://origin.test-publisher.com""#,
+                &format!(
+                    "origin_url = \"https://origin.test-publisher.com\"\npublic_origin = \"{origin}\""
+                ),
+            ));
+            assert!(
+                result.is_err(),
+                "should reject invalid public origin {origin:?}"
+            );
+        }
+
+        for origin in [" https://ads.example.com", "https://ads.exa\nmple.com"] {
+            let mut json = serde_json::to_value(&fallback).expect("should serialize settings");
+            json["publisher"]["public_origin"] = serde_json::json!(origin);
+            assert!(
+                Settings::from_json_value(json).is_err(),
+                "should reject whitespace/control characters in public origin {origin:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn publisher_public_origin_round_trips_through_json() {
+        let settings = Settings::from_toml(&crate_test_settings_str().replace(
+            r#"origin_url = "https://origin.test-publisher.com""#,
+            "origin_url = \"https://origin.test-publisher.com\"\npublic_origin = \"https://ads.example.com:8443\"",
+        ))
+        .expect("should parse an explicit public origin");
+        let json = serde_json::to_value(&settings).expect("should serialize settings");
+        assert_eq!(
+            json["publisher"]["public_origin"],
+            serde_json::json!("https://ads.example.com:8443")
+        );
+        let reconstructed = Settings::from_json_value(json).expect("should deserialize settings");
+        assert_eq!(
+            reconstructed.publisher.effective_public_origin(),
+            "https://ads.example.com:8443"
         );
     }
 
@@ -3851,6 +3992,7 @@ origin_host_header_overide = "www.example.com""#,
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "https://origin.example.com:8080".to_string(),
+            public_origin: None,
             origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
             max_buffered_body_bytes: 16 * 1024 * 1024,
@@ -3862,6 +4004,7 @@ origin_host_header_overide = "www.example.com""#,
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "https://origin.example.com".to_string(),
+            public_origin: None,
             origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
             max_buffered_body_bytes: 16 * 1024 * 1024,
@@ -3873,6 +4016,7 @@ origin_host_header_overide = "www.example.com""#,
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://localhost:9090".to_string(),
+            public_origin: None,
             origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
             max_buffered_body_bytes: 16 * 1024 * 1024,
@@ -3884,6 +4028,7 @@ origin_host_header_overide = "www.example.com""#,
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "localhost:9090".to_string(),
+            public_origin: None,
             origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
             max_buffered_body_bytes: 16 * 1024 * 1024,
@@ -3895,6 +4040,7 @@ origin_host_header_overide = "www.example.com""#,
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://192.168.1.1:8080".to_string(),
+            public_origin: None,
             origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
             max_buffered_body_bytes: 16 * 1024 * 1024,
@@ -3906,6 +4052,7 @@ origin_host_header_overide = "www.example.com""#,
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "http://[::1]:8080".to_string(),
+            public_origin: None,
             origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
             max_buffered_body_bytes: 16 * 1024 * 1024,
@@ -3919,6 +4066,7 @@ origin_host_header_overide = "www.example.com""#,
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "https://origin.example.com:8443".to_string(),
+            public_origin: None,
             origin_host_header_override: None,
             proxy_secret: Redacted::new("test-secret".to_string()),
             max_buffered_body_bytes: 16 * 1024 * 1024,
@@ -3933,6 +4081,7 @@ origin_host_header_overide = "www.example.com""#,
             domain: "example.com".to_string(),
             cookie_domain: ".example.com".to_string(),
             origin_url: "https://origin.example.com".to_string(),
+            public_origin: None,
             origin_host_header_override: Some("www.example.com".to_string()),
             proxy_secret: Redacted::new("test-secret".to_string()),
             max_buffered_body_bytes: 16 * 1024 * 1024,

--- a/crates/trusted-server-integration-tests/tests/parity.rs
+++ b/crates/trusted-server-integration-tests/tests/parity.rs
@@ -432,6 +432,32 @@ async fn discovery_route_body_is_json_parity() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proxy_rebuild_get_route_parity() {
+    let (axum_status, _) = axum_get("/first-party/proxy-rebuild").await;
+    let (cf_status, _) = cf_get("/first-party/proxy-rebuild").await;
+    let (spin_status, _) = spin_get("/first-party/proxy-rebuild").await;
+
+    for (adapter, status) in [
+        ("Axum", axum_status),
+        ("Cloudflare", cf_status),
+        ("Spin", spin_status),
+    ] {
+        assert_ne!(
+            status, 404,
+            "{adapter} GET /first-party/proxy-rebuild must be routed"
+        );
+    }
+    assert_eq!(
+        axum_status, cf_status,
+        "GET rebuild status must match: axum={axum_status} cf={cf_status}"
+    );
+    assert_eq!(
+        cf_status, spin_status,
+        "GET rebuild status must match: cf={cf_status} spin={spin_status}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn verify_signature_route_parity() {
     // known divergence: without real signing-key configuration the handler may
     // return 5xx. The parity assertion is that both adapters agree on the status

--- a/crates/trusted-server-js/lib/src/integrations/creative/click.ts
+++ b/crates/trusted-server-js/lib/src/integrations/creative/click.ts
@@ -4,6 +4,8 @@ import { creativeGlobal } from '../../shared/globals';
 import { delay, queueTask } from '../../shared/async';
 import { createMutationScheduler } from '../../shared/scheduler';
 
+import { resolveFirstPartyPath } from './first_party';
+
 type AnchorLike = HTMLAnchorElement | HTMLAreaElement;
 type Canon = { base: string; params: Record<string, string> };
 type Diff = { add: Record<string, string>; del: string[] };
@@ -37,8 +39,7 @@ function parseQuery(qs: string): Record<string, string> {
 function canonFromFirstPartyClick(url: string): Canon | null {
   try {
     const u = new URL(url, location.href);
-    if (!(u.pathname === '/first-party/click' || u.pathname.startsWith('/first-party/click')))
-      return null;
+    if (u.pathname !== '/first-party/click') return null;
     const p = parseQuery(u.search);
     const tsurl = p['tsurl'];
     if (!tsurl) return null;
@@ -141,7 +142,7 @@ function buildProxyRebuildUrl(tsClickStr: string, diff: Diff): string {
   if (diff.del.length > 0) {
     params.set('del', JSON.stringify(diff.del));
   }
-  return `/first-party/proxy-rebuild?${params.toString()}`;
+  return resolveFirstPartyPath(`/first-party/proxy-rebuild?${params.toString()}`);
 }
 
 // Call the proxy-rebuild endpoint so the edge can re-sign mutated click params.
@@ -169,7 +170,7 @@ async function rebuildClick(a: AnchorLike, tsClickStr: string, diff: Diff): Prom
   if (delKeys.length > 0) payload.del = delKeys;
 
   try {
-    const resp = await fetch('/first-party/proxy-rebuild', {
+    const resp = await fetch(resolveFirstPartyPath('/first-party/proxy-rebuild'), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(payload),

--- a/crates/trusted-server-js/lib/src/integrations/creative/first_party.ts
+++ b/crates/trusted-server-js/lib/src/integrations/creative/first_party.ts
@@ -1,0 +1,41 @@
+// Immutable browser-facing first-party endpoint resolver for the creative IIFE.
+// Capture the injected classic script synchronously during module evaluation so
+// later DOM mutations cannot redirect dynamic sign or rebuild requests.
+let capturedOrigin: string | null = null;
+
+try {
+  const source = document.currentScript?.getAttribute('src') || document.currentScript?.src;
+  if (source) capturedOrigin = new URL(source, location.href).origin;
+} catch {
+  capturedOrigin = null;
+}
+
+export function firstPartyOrigin(): string | null {
+  if (capturedOrigin) return capturedOrigin;
+  try {
+    return new URL(location.href).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveFirstPartyPath(path: string): string {
+  const origin = firstPartyOrigin();
+  if (!origin || !path.startsWith('/')) return path;
+  try {
+    return new URL(path, origin).toString();
+  } catch {
+    return path;
+  }
+}
+
+export function isFirstPartyProxyUrl(value: string): boolean {
+  const origin = firstPartyOrigin();
+  if (!origin) return false;
+  try {
+    const url = new URL(value, origin);
+    return url.origin === origin && url.pathname === '/first-party/proxy';
+  } catch {
+    return false;
+  }
+}

--- a/crates/trusted-server-js/lib/src/integrations/creative/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/creative/index.ts
@@ -3,6 +3,8 @@ import { log } from '../../core/log';
 import type { TsCreativeConfig, CreativeWindow, TsCreativeApi } from '../../shared/globals';
 import { creativeGlobal, resolveWindow } from '../../shared/globals';
 
+import './first_party';
+
 import { installClickGuard } from './click';
 import { installDynamicImageProxy } from './image';
 import { installDynamicIframeProxy } from './iframe';

--- a/crates/trusted-server-js/lib/src/integrations/creative/proxy_sign.ts
+++ b/crates/trusted-server-js/lib/src/integrations/creative/proxy_sign.ts
@@ -1,18 +1,15 @@
 import { log } from '../../core/log';
 
-const PROXY_PREFIX = '/first-party/proxy';
+import { isFirstPartyProxyUrl, resolveFirstPartyPath } from './first_party';
 
 export function shouldProxyExternalUrl(raw: string): boolean {
   const value = String(raw || '').trim();
   if (!value) return false;
   if (/^(data:|javascript:|blob:|about:)/i.test(value)) return false;
-  if (value.startsWith(PROXY_PREFIX)) return false;
+  if (isFirstPartyProxyUrl(value)) return false;
   try {
     const url = new URL(value, location.href);
-    if (url.origin === location.origin) {
-      if (url.pathname.startsWith(PROXY_PREFIX)) return false;
-      return false;
-    }
+    if (url.origin === location.origin) return false;
     return url.protocol === 'http:' || url.protocol === 'https:';
   } catch {
     return false;
@@ -28,12 +25,7 @@ export async function signProxyUrl(raw: string): Promise<string | null> {
     return null;
   }
 
-  let endpoint = '/first-party/sign';
-  try {
-    endpoint = new URL('/first-party/sign', location.href).toString();
-  } catch {
-    /* fall back to relative path */
-  }
+  const endpoint = resolveFirstPartyPath('/first-party/sign');
 
   try {
     const resp = await fetch(endpoint, {

--- a/crates/trusted-server-js/lib/test/integrations/creative/click.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/creative/click.test.ts
@@ -32,9 +32,38 @@ describe('creative/click.ts', () => {
     await vi.runAllTimersAsync();
 
     const finalHref = anchor.getAttribute('href') ?? '';
-    expect(finalHref.startsWith('/first-party/proxy-rebuild?')).toBe(true);
+    expect(finalHref.startsWith('http://localhost:3000/first-party/proxy-rebuild?')).toBe(true);
     expect(finalHref).toContain('add=%7B%22bar%22%3A%222%22%7D');
     expect(finalHref).toContain('del=%5B%22foo%22%5D');
+  });
+
+  it('targets the captured script origin for rebuild requests and fallbacks', async () => {
+    vi.useFakeTimers();
+    const descriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
+    const script = Object.assign(document.createElement('script'), {
+      src: 'https://ads.example.com:8443/static/tsjs=tsjs-unified.min.js?v=hash',
+    });
+    Object.defineProperty(document, 'currentScript', { configurable: true, value: script });
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network'));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const anchor = document.createElement('a');
+      anchor.setAttribute('data-tsclick', FIRST_PARTY_CLICK);
+      anchor.setAttribute('href', FIRST_PARTY_CLICK);
+      document.body.appendChild(anchor);
+      await importCreativeModule();
+      anchor.setAttribute('href', MUTATED_CLICK);
+      await Promise.resolve();
+      await vi.runAllTimersAsync();
+
+      expect(fetchMock.mock.calls.map((call) => call[0])).toContain(
+        'https://ads.example.com:8443/first-party/proxy-rebuild'
+      );
+    } finally {
+      if (descriptor) Object.defineProperty(document, 'currentScript', descriptor);
+      else Reflect.deleteProperty(document, 'currentScript');
+    }
   });
 
   it('updates anchors using proxy rebuild response payload', async () => {
@@ -60,7 +89,7 @@ describe('creative/click.ts', () => {
 
     expect(fetchMock).toHaveBeenCalled();
     const call = fetchMock.mock.calls[0];
-    expect(call[0]).toBe('/first-party/proxy-rebuild');
+    expect(call[0]).toBe('http://localhost:3000/first-party/proxy-rebuild');
     const payload = JSON.parse(call[1]?.body as string);
     expect(payload).toEqual({
       tsclick: FIRST_PARTY_CLICK,

--- a/crates/trusted-server-js/lib/test/integrations/creative/click_capture.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/creative/click_capture.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FIRST_PARTY_CLICK, MUTATED_CLICK, importCreativeModule } from './helpers';
+
+const originalFetch = global.fetch;
+const currentScriptDescriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = '';
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.useRealTimers();
+  if (currentScriptDescriptor) {
+    Object.defineProperty(document, 'currentScript', currentScriptDescriptor);
+  } else {
+    Reflect.deleteProperty(document, 'currentScript');
+  }
+});
+
+describe('creative/click.ts captured first-party fallback', () => {
+  it('installs an absolute GET fallback when fetch is unavailable', async () => {
+    const script = Object.assign(document.createElement('script'), {
+      src: 'https://ads.example.com:8443/static/tsjs=tsjs-unified.min.js?v=hash',
+    });
+    Object.defineProperty(document, 'currentScript', { configurable: true, value: script });
+    global.fetch = undefined as unknown as typeof fetch;
+
+    const anchor = document.createElement('a');
+    anchor.setAttribute('data-tsclick', FIRST_PARTY_CLICK);
+    anchor.setAttribute('href', FIRST_PARTY_CLICK);
+    document.body.appendChild(anchor);
+
+    await importCreativeModule();
+    anchor.setAttribute('href', MUTATED_CLICK);
+    await Promise.resolve();
+    await vi.runAllTimersAsync();
+
+    const fallback = anchor.getAttribute('href') ?? '';
+    expect(fallback).toMatch(/^https:\/\/ads\.example\.com:8443\/first-party\/proxy-rebuild\?/);
+    expect(anchor.getAttribute('data-tsclick')).toBe(fallback);
+  });
+});

--- a/crates/trusted-server-js/lib/test/integrations/creative/first_party.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/creative/first_party.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const currentScriptDescriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
+
+function setCurrentScript(src?: string): void {
+  const script = src ? Object.assign(document.createElement('script'), { src }) : null;
+  Object.defineProperty(document, 'currentScript', {
+    configurable: true,
+    value: script,
+  });
+}
+
+afterEach(() => {
+  vi.resetModules();
+  if (currentScriptDescriptor) {
+    Object.defineProperty(document, 'currentScript', currentScriptDescriptor);
+  } else {
+    Reflect.deleteProperty(document, 'currentScript');
+  }
+});
+
+describe('creative/first_party.ts', () => {
+  it('captures the injected classic script origin and resolves endpoints against it', async () => {
+    setCurrentScript('https://ads.example.com:8443/static/tsjs=tsjs-unified.min.js?v=hash');
+    const { firstPartyOrigin, resolveFirstPartyPath, isFirstPartyProxyUrl } =
+      await import('../../../src/integrations/creative/first_party');
+
+    expect(firstPartyOrigin()).toBe('https://ads.example.com:8443');
+    expect(resolveFirstPartyPath('/first-party/sign')).toBe(
+      'https://ads.example.com:8443/first-party/sign'
+    );
+    expect(isFirstPartyProxyUrl('https://ads.example.com:8443/first-party/proxy?token=1')).toBe(
+      true
+    );
+    expect(isFirstPartyProxyUrl('https://ads.example.com:8443/first-party/proxy-extra')).toBe(
+      false
+    );
+    expect(isFirstPartyProxyUrl('https://foreign.example/first-party/proxy')).toBe(false);
+  });
+
+  it('falls back to the document origin when currentScript is unavailable', async () => {
+    setCurrentScript();
+    const { firstPartyOrigin, resolveFirstPartyPath } =
+      await import('../../../src/integrations/creative/first_party');
+
+    expect(firstPartyOrigin()).toBe(location.origin);
+    expect(resolveFirstPartyPath('/first-party/proxy-rebuild')).toBe(
+      new URL('/first-party/proxy-rebuild', location.href).toString()
+    );
+  });
+});

--- a/crates/trusted-server-js/lib/test/integrations/creative/iframe.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/creative/iframe.test.ts
@@ -16,7 +16,7 @@ describe('creative/iframe.ts', () => {
 
   it('proxies iframe src via signer endpoint', async () => {
     const signed =
-      '/first-party/proxy?tsurl=https%3A%2F%2Fframe.example%2Fwidget.html&tstoken=iframe&tsexp=1';
+      'https://ads.example.com/first-party/proxy?tsurl=https%3A%2F%2Fframe.example%2Fwidget.html&tstoken=iframe&tsexp=1';
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ href: signed }),
@@ -33,7 +33,7 @@ describe('creative/iframe.ts', () => {
         expect.stringContaining('/first-party/sign'),
         expect.objectContaining({ method: 'POST' })
       );
-      expect(iframe.src).toContain('/first-party/proxy?');
+      expect(iframe.src).toContain('https://ads.example.com/first-party/proxy?');
       expect(iframe.src).toContain('tsexp=');
     });
   });

--- a/crates/trusted-server-js/lib/test/integrations/creative/image.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/creative/image.test.ts
@@ -16,7 +16,7 @@ describe('creative/image.ts', () => {
 
   it('proxies image src via signer endpoint', async () => {
     const signed =
-      '/first-party/proxy?tsurl=https%3A%2F%2Fimg.example%2Fpixel.gif&tstoken=new&tsexp=1';
+      'https://ads.example.com/first-party/proxy?tsurl=https%3A%2F%2Fimg.example%2Fpixel.gif&tstoken=new&tsexp=1';
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ href: signed }),
@@ -33,7 +33,7 @@ describe('creative/image.ts', () => {
         expect.stringContaining('/first-party/sign'),
         expect.objectContaining({ method: 'POST' })
       );
-      expect(img.src).toContain('/first-party/proxy?');
+      expect(img.src).toContain('https://ads.example.com/first-party/proxy?');
       expect(img.src).toContain('tsexp=');
     });
   });

--- a/crates/trusted-server-js/lib/test/integrations/creative/proxy_sign.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/creative/proxy_sign.test.ts
@@ -17,16 +17,37 @@ describe('creative/proxy_sign.ts', () => {
     expect(shouldProxyExternalUrl('http://cdn.example/pixel.gif')).toBe(true);
   });
 
-  it('rejects data, javascript, and same-origin URLs', () => {
+  it('rejects data, javascript, same-origin URLs, and only the exact trusted proxy path', () => {
     expect(shouldProxyExternalUrl('data:image/png;base64,AAAA')).toBe(false);
     expect(shouldProxyExternalUrl('javascript:alert(1)')).toBe(false);
     expect(shouldProxyExternalUrl('/first-party/proxy?foo=1')).toBe(false);
     expect(shouldProxyExternalUrl(`${location.origin}/first-party/proxy?foo=1`)).toBe(false);
+    expect(shouldProxyExternalUrl('https://foreign.example/first-party/proxy?foo=1')).toBe(true);
+  });
+
+  it('trusts only the captured origin and exact proxy endpoint', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
+    const script = Object.assign(document.createElement('script'), {
+      src: 'https://ads.example.com/static/tsjs=tsjs-unified.min.js?v=hash',
+    });
+    Object.defineProperty(document, 'currentScript', { configurable: true, value: script });
+    vi.resetModules();
+
+    try {
+      const { shouldProxyExternalUrl: shouldProxy } =
+        await import('../../../src/integrations/creative/proxy_sign');
+      expect(shouldProxy('https://ads.example.com/first-party/proxy?token=1')).toBe(false);
+      expect(shouldProxy('https://ads.example.com/first-party/proxy-extra?token=1')).toBe(true);
+      expect(shouldProxy('https://foreign.example/first-party/proxy?token=1')).toBe(true);
+    } finally {
+      if (descriptor) Object.defineProperty(document, 'currentScript', descriptor);
+      else Reflect.deleteProperty(document, 'currentScript');
+    }
   });
 
   it('posts to /first-party/sign and returns signed href', async () => {
     const signed =
-      '/first-party/proxy?tsurl=https%3A%2F%2Fcdn.example%2Fasset.js&tstoken=tok&tsexp=1';
+      'https://ads.example.com/first-party/proxy?tsurl=https%3A%2F%2Fcdn.example%2Fasset.js&tstoken=tok&tsexp=1';
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ href: signed }),
@@ -36,7 +57,7 @@ describe('creative/proxy_sign.ts', () => {
     const result = await signProxyUrl('https://cdn.example/asset.js?cb=1');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/first-party/sign'),
+      new URL('/first-party/sign', location.href).toString(),
       expect.objectContaining({
         method: 'POST',
         headers: { 'content-type': 'application/json' },

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -342,7 +342,8 @@ curl -X POST https://edge.example.com/first-party/sign \
 
 ```json
 {
-  "signed_url": "https://edge.example.com/first-party/proxy?tsurl=https://external.com/pixel.gif&tstoken=abc123..."
+  "href": "https://ads.publisher.example/first-party/proxy?tsurl=https://external.com/pixel.gif&tsexp=123&tstoken=abc123...",
+  "base": "https://external.com/pixel.gif"
 }
 ```
 
@@ -354,7 +355,7 @@ curl -X POST https://edge.example.com/first-party/sign \
 
 ---
 
-### POST /first-party/proxy-rebuild
+### GET/POST /first-party/proxy-rebuild
 
 URL mutation recovery endpoint. Rebuilds signed proxy URL after creative JavaScript modifies query parameters.
 
@@ -374,7 +375,8 @@ URL mutation recovery endpoint. Rebuilds signed proxy URL after creative JavaScr
 
 ```json
 {
-  "url": "https://edge.example.com/first-party/click?tsurl=https://advertiser.com&campaign=123&utm_source=banner&tstoken=new..."
+  "href": "https://ads.publisher.example/first-party/click?tsurl=https://advertiser.com&campaign=123&utm_source=banner&tstoken=new...",
+  "base": "https://advertiser.com"
 }
 ```
 

--- a/docs/guide/auction-orchestration.md
+++ b/docs/guide/auction-orchestration.md
@@ -150,7 +150,7 @@ sequenceDiagram
     Orch->>Orch: Transform to OpenRTB response<br/>Generate iframe creatives<br/>Rewrite creative URLs<br/>Add orchestrator metadata
 
     Orch-->>TS: OpenRTB BidResponse
-    Note right of Orch: { "id": "auction-response",<br/>  "seatbid": [{ "seat": "amazon-aps",<br/>    "bid": [{ "price": 2.50,<br/>      "adm": "<iframe src=\"/first-party/proxy?tsurl=...\">",<br/>      "w": 728, "h": 90 }] }] }<br/>  "ext": { "orchestrator": {<br/>    "strategy": "parallel_mediation",<br/>    "bidders": 2, "time_ms": 150 } }
+    Note right of Orch: { "id": "auction-response",<br/>  "seatbid": [{ "seat": "amazon-aps",<br/>    "bid": [{ "price": 2.50,<br/>      "adm": "<iframe src=\"https://ads.publisher.example/first-party/proxy?tsurl=...\">",<br/>      "w": 728, "h": 90 }] }] }<br/>  "ext": { "orchestrator": {<br/>    "strategy": "parallel_mediation",<br/>    "bidders": 2, "time_ms": 150 } }
 
     TS-->>Client: 200 OpenRTB response<br/>with winning creative
     deactivate Orch
@@ -161,7 +161,7 @@ sequenceDiagram
   rect rgb(239,246,255)
     Note over Client,Mock: Creative Rendering
     Client->>Client: Inject winning creative<br/>Render iframe<br/>Load creative through proxy
-    Note right of Client: iframe src="/first-party/proxy?tsurl=...&tstoken=sig"<br/>Ensures first-party serving<br/>Maintains privacy & security
+    Note right of Client: iframe src="https://ads.publisher.example/first-party/proxy?tsurl=...&tstoken=sig"<br/>Ensures first-party serving<br/>Maintains privacy & security
     deactivate Client
   end
 ```
@@ -531,7 +531,7 @@ Auction results are returned in standard OpenRTB format with an `ext.orchestrato
           "id": "bid-1",
           "impid": "header-banner",
           "price": 2.5,
-          "adm": "<iframe src=\"/first-party/proxy?tsurl=...&tstoken=sig\">...</iframe>",
+          "adm": "<iframe src=\"https://ads.publisher.example/first-party/proxy?tsurl=...&tstoken=sig\">...</iframe>",
           "w": 728,
           "h": 90
         }
@@ -557,16 +557,16 @@ Winning creatives are processed through a streaming HTML rewriter (`lol_html`) b
 
 **Elements rewritten:**
 
-| Element                          | Attributes                  | Target                         |
-| -------------------------------- | --------------------------- | ------------------------------ |
-| `<img>`                          | `src`, `data-src`, `srcset` | `/first-party/proxy?tsurl=...` |
-| `<script>`                       | `src`                       | `/first-party/proxy?tsurl=...` |
-| `<link>`                         | `href`, `imagesrcset`       | `/first-party/proxy?tsurl=...` |
-| `<iframe>`                       | `src`                       | `/first-party/proxy?tsurl=...` |
-| `<video>`, `<audio>`, `<source>` | `src`                       | `/first-party/proxy?tsurl=...` |
-| `<a>`, `<area>`                  | `href`                      | `/first-party/click?tsurl=...` |
-| `<style>`, `[style]`             | `url()` references          | `/first-party/proxy?tsurl=...` |
-| SVG `<image>`, `<use>`           | `href`, `xlink:href`        | `/first-party/proxy?tsurl=...` |
+| Element                          | Attributes                  | Target                                                      |
+| -------------------------------- | --------------------------- | ----------------------------------------------------------- |
+| `<img>`                          | `src`, `data-src`, `srcset` | `https://ads.publisher.example/first-party/proxy?tsurl=...` |
+| `<script>`                       | `src`                       | `https://ads.publisher.example/first-party/proxy?tsurl=...` |
+| `<link>`                         | `href`, `imagesrcset`       | `https://ads.publisher.example/first-party/proxy?tsurl=...` |
+| `<iframe>`                       | `src`                       | `https://ads.publisher.example/first-party/proxy?tsurl=...` |
+| `<video>`, `<audio>`, `<source>` | `src`                       | `https://ads.publisher.example/first-party/proxy?tsurl=...` |
+| `<a>`, `<area>`                  | `href`                      | `/first-party/click?tsurl=...`                              |
+| `<style>`, `[style]`             | `url()` references          | `https://ads.publisher.example/first-party/proxy?tsurl=...` |
+| SVG `<image>`, `<use>`           | `href`, `xlink:href`        | `/first-party/proxy?tsurl=...`                              |
 
 URLs that are relative, or use `data:`, `javascript:`, `blob:`, or `mailto:` schemes are left unchanged. Domains in the `rewrite.exclude_domains` config list (supports wildcards like `*.cloudflare.com`) are also skipped.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -21,6 +21,7 @@ Create `trusted-server.toml` in your project root:
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
+public_origin = "https://ads.publisher.example"
 proxy_secret = "your-secure-secret-here"
 
 [ec]
@@ -166,6 +167,7 @@ Core publisher settings for domain, origin, and proxy configuration.
 | `domain`                      | String  | Yes      | Publisher's apex domain name                                                            |
 | `cookie_domain`               | String  | Yes      | Domain for non-EC cookies (typically with leading dot)                                  |
 | `origin_url`                  | String  | Yes      | Full URL of publisher origin server                                                     |
+| `public_origin`               | String  | No       | Browser-facing Trusted Server origin used in rewritten creative URLs                    |
 | `origin_host_header_override` | String  | No       | Outbound Host header to send while connecting to `origin_url`                           |
 | `proxy_secret`                | String  | Yes      | Secret key for encrypting/signing proxy URLs                                            |
 | `max_buffered_body_bytes`     | Integer | No       | Max bytes buffered when a publisher response is post-processed in full (default 16 MiB) |
@@ -180,6 +182,8 @@ Core publisher settings for domain, origin, and proxy configuration.
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
+# Browser-facing origin for rewritten creative proxy, click, and TSJS URLs.
+public_origin = "https://ads.publisher.example"
 # Optional: connect to origin_url but send this outbound Host header.
 # origin_host_header_override = "www.publisher.com"
 proxy_secret = "change-me-to-secure-random-value"
@@ -191,6 +195,7 @@ proxy_secret = "change-me-to-secure-random-value"
 TRUSTED_SERVER__PUBLISHER__DOMAIN=publisher.com
 TRUSTED_SERVER__PUBLISHER__COOKIE_DOMAIN=.publisher.com
 TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.com
+TRUSTED_SERVER__PUBLISHER__PUBLIC_ORIGIN=https://ads.publisher.example
 TRUSTED_SERVER__PUBLISHER__ORIGIN_HOST_HEADER_OVERRIDE=www.publisher.com
 TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
 TRUSTED_SERVER__PUBLISHER__MAX_BUFFERED_BODY_BYTES=16777216
@@ -248,6 +253,16 @@ TRUSTED_SERVER__PUBLISHER__MAX_BUFFERED_BODY_BYTES=16777216
 - ❌ `origin.publisher.com` (missing protocol)
 
 **Port Handling**: Includes port if non-standard (not 80/443).
+
+#### `public_origin`
+
+**Purpose**: Browser-facing Trusted Server origin used for first-party URLs emitted into rewritten creatives, including proxy, click, and injected TSJS URLs.
+
+This is distinct from `origin_url`, which is only the backend connection target. Do not derive it from request headers.
+
+**Format**: An `http` or `https` origin with a host and optional port, without userinfo, path, query, fragment, or a trailing slash. HTTPS is recommended for deployed publisher traffic; HTTP is supported for direct localhost development.
+
+**Default**: When omitted, Trusted Server uses `https://{publisher.domain}` to preserve existing configuration behavior.
 
 #### `origin_host_header_override`
 

--- a/docs/guide/creative-processing.md
+++ b/docs/guide/creative-processing.md
@@ -12,6 +12,10 @@ Creative processing transforms third-party ad creatives by rewriting URLs to go 
 - **Security** - Validated, signed URLs prevent tampering
 - **GDPR Compliance** - Controlled data sharing
 
+## Browser-facing first-party origin
+
+Set `[publisher].public_origin` to the browser-reachable Trusted Server origin, for example `https://ads.publisher.example`. Rewritten proxy, click, CSS, `srcset`, and injected creative TSJS URLs are absolute on that origin. When it is omitted, Trusted Server uses `https://{publisher.domain}` for compatibility. Relative creative source URLs and excluded third-party URLs remain unchanged.
+
 ## How It Works
 
 ```
@@ -33,9 +37,9 @@ Creative processing transforms third-party ad creatives by rewriting URLs to go 
                         ↓
 ┌──────────────────────────────────────────────────────┐
 │  Rewritten Creative HTML                             │
-│  <img src="/first-party/proxy?tsurl=...&tstoken=sig">│
-│  <iframe src="/first-party/proxy?tsurl=...&token=sig">│
-│  <style> .bg { background: url(/first-party/proxy...) }│
+│  <img src="https://ads.publisher.example/first-party/proxy?tsurl=...&tstoken=sig">│
+│  <iframe src="https://ads.publisher.example/first-party/proxy?tsurl=...&token=sig">│
+│  <style> .bg { background: url(https://ads.publisher.example/first-party/proxy...) }│
 └──────────────────────────────────────────────────────┘
 ```
 
@@ -78,10 +82,10 @@ When `with_streaming()` is enabled in `ProxyRequestConfig`, HTML/CSS processing 
 
 <!-- Rewritten -->
 <img
-  src="/first-party/proxy?tsurl=https://cdn.example.com/banner.jpg&tstoken=sig1"
+  src="https://ads.publisher.example/first-party/proxy?tsurl=https://cdn.example.com/banner.jpg&tstoken=sig1"
   srcset="
-    /first-party/proxy?tsurl=https://cdn.example.com/banner@1x.jpg&tstoken=sig2 1x,
-    /first-party/proxy?tsurl=https://cdn.example.com/banner@2x.jpg&tstoken=sig3 2x
+    https://ads.publisher.example/first-party/proxy?tsurl=https://cdn.example.com/banner@1x.jpg&tstoken=sig2 1x,
+    https://ads.publisher.example/first-party/proxy?tsurl=https://cdn.example.com/banner@2x.jpg&tstoken=sig3 2x
   "
 />
 ```

--- a/docs/guide/first-party-proxy.md
+++ b/docs/guide/first-party-proxy.md
@@ -12,12 +12,16 @@ The First-Party Proxy system rewrites third-party URLs in ad creatives to route 
 - **Click Tracking** - First-party click redirects
 - **Content Security** - Validated, signed URLs prevent tampering
 
+## Generated URL authority
+
+Routes remain path-based, but URLs emitted into rewritten creatives and `/first-party/sign` or `/first-party/proxy-rebuild` responses are absolute on `[publisher].public_origin`, for example `https://ads.publisher.example/first-party/proxy?...`. Existing root-relative signed proxy and click inputs remain accepted. Configure a browser-reachable HTTPS public origin for deployments; HTTP is supported for localhost development.
+
 ## How It Works
 
 ```mermaid
 flowchart TD
   original["`Creative (Original) &lt;img src='tracker.com/pixel.gif' /&gt;`"]
-  rewritten["Creative (Rewritten)<br/>&lt;img src='/first-party/proxy?<br/>tsurl=https://tracker.com/<br/>pixel.gif&amp;tstoken=abc123...' /&gt;"]
+  rewritten["Creative (Rewritten)<br/>&lt;img src='https://ads.publisher.example/first-party/proxy?<br/>tsurl=https://tracker.com/<br/>pixel.gif&amp;tstoken=abc123...' /&gt;"]
   server["Trusted Server<br/>1. Validate tstoken<br/>2. Append ts-ec<br/>3. Proxy to tracker.com<br/>4. Return response"]
 
   original -->|Rewrite| rewritten -->|Browser Request| server
@@ -73,7 +77,7 @@ https://tracker.com/pixel.gif?campaign=123&uid=abc
 Signed proxy URL:
 
 ```
-/first-party/proxy?
+https://ads.publisher.example/first-party/proxy?
   tsurl=https://tracker.com/pixel.gif&
   campaign=123&
   uid=abc&

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -2,6 +2,10 @@
 
 Learn how to test Trusted Server locally and in CI/CD.
 
+## Testing absolute creative rewrite URLs
+
+Creative rewrite tests should configure a distinct `publisher.public_origin` and assert the parsed URL origin, not only a `/first-party/...` path substring. Keep manual root-relative proxy and click fixtures for compatibility tests, because deployed creative output is absolute on the configured public origin.
+
 ## Test Infrastructure
 
 ### Viceroy

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -7,6 +7,8 @@ password = "replace-with-admin-password-32-bytes"
 domain = "example.com"
 cookie_domain = ".example.com"
 origin_url = "https://origin.example.com"
+# Browser-facing Trusted Server origin used in rewritten creative URLs. Use HTTPS in deployments.
+public_origin = "https://ads.example.com"
 # Optional: override outbound Host header while connecting to origin_url.
 # origin_host_header_override = "www.example.com"
 proxy_secret = "change-me-proxy-secret"


### PR DESCRIPTION
## Summary

- Add validated `publisher.public_origin` (with the legacy `https://{publisher.domain}` fallback) and emit absolute first-party URLs for creative proxy/click rewrites, creative TSJS, sign responses, rebuild responses, and auction `adm`.
- Anchor creative runtime sign/rebuild requests and first-party proxy detection to the injected classic script origin; preserve raw-resource and absolute GET fallback behavior when JSON requests fail.
- Register GET rebuild routing across all adapters and document the browser-facing-origin contract.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/settings.rs` | Add, validate, serialize, and test `publisher.public_origin`. |
| `crates/trusted-server-core/src/{creative,proxy}.rs` | Qualify generated creative endpoints and support absolute/legacy rebuild inputs. |
| `crates/trusted-server-js/lib/src/integrations/creative/` | Capture the injected script origin and resolve dynamic sign/rebuild endpoints from it. |
| Adapter app/routes and parity tests | Route GET `/first-party/proxy-rebuild` consistently. |
| `docs/`, example config, and changelog | Document the public-origin and absolute-output contract. |

`#907` remains independent: this change preserves the current TSJS module-set source/hash selection and qualifies only the selected creative script source. `#916` remains independent: this branch is based directly on `main` and does not change optional-rewrite behavior.

## Closes

Closes #915

## Test plan

- [x] `cargo test-fastly && cargo test-axum`
- [x] `cargo clippy-fastly && cargo clippy-axum`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/trusted-server-js/lib && npx vitest run`
- [x] JS format: `cd crates/trusted-server-js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [x] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: Cloudflare and Spin native/WASM clippy; Fastly/Axum/Cloudflare/Spin tests; full adapter parity; integration-test clippy; CLI/codegen checks and tests; JS build/lint; docs lint/build; Fastly and Spin release builds.

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [ ] Uses `tracing` macros (not `println!`) — no logging was added; this repository uses `log` macros.
- [x] New code has tests
- [x] No secrets or credentials committed
