### PR TITLE
Multiple branches on rc/july (DO NOT MERGE)

### DIFF
--- a/crates/trusted-server-adapter-axum/src/app.rs
+++ b/crates/trusted-server-adapter-axum/src/app.rs
@@ -29,6 +29,7 @@ use trusted_server_core::settings::Settings;
 use trusted_server_core::settings_data::{
     default_config_key, default_config_store_name, get_settings_from_config_store,
 };
+use trusted_server_core::trace_cookie::handle_trace_mode;
 
 use trusted_server_core::platform::RuntimeServices;
 
@@ -255,6 +256,7 @@ enum NamedRouteHandler {
     /// Legacy `/admin/keys/*` aliases — denied locally with 404 so they never
     /// reach the publisher fallback (which would leak admin credentials).
     LegacyAdminDenied,
+    TraceMode,
     Auction,
     PageBids,
     FirstPartyProxy,
@@ -279,7 +281,7 @@ const LEGACY_ADMIN_DENY_METHODS: &[Method] = &[
     Method::DELETE,
 ];
 
-fn named_routes() -> [NamedRoute; 12] {
+fn named_routes() -> [NamedRoute; 13] {
     [
         NamedRoute {
             path: "/.well-known/trusted-server.json",
@@ -319,6 +321,11 @@ fn named_routes() -> [NamedRoute; 12] {
             path: "/admin/keys/deactivate",
             primary_methods: LEGACY_ADMIN_DENY_METHODS,
             handler: NamedRouteHandler::LegacyAdminDenied,
+        },
+        NamedRoute {
+            path: "/_ts/trace",
+            primary_methods: &[Method::GET],
+            handler: NamedRouteHandler::TraceMode,
         },
         NamedRoute {
             path: "/auction",
@@ -389,6 +396,9 @@ fn named_route_handler(
                         Ok(resp)
                     }
                     NamedRouteHandler::LegacyAdminDenied => Ok(legacy_admin_alias_denied()),
+                    NamedRouteHandler::TraceMode => {
+                        handle_trace_mode(&state.settings, req.uri().query())
+                    }
                     NamedRouteHandler::Auction => {
                         // Build the geo-aware EC context so the auction consent
                         // gate sees the caller's jurisdiction — `EcContext::default()`

--- a/crates/trusted-server-adapter-axum/src/app.rs
+++ b/crates/trusted-server-adapter-axum/src/app.rs
@@ -12,6 +12,8 @@ use error_stack::Report;
 use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 use trusted_server_core::ec::EcContext;
+use trusted_server_core::ec::admin::handle_admin_eids_lookup;
+use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::error::{IntoHttpResponse as _, TrustedServerError};
 use trusted_server_core::integrations::{IntegrationRegistry, ProxyDispatchInput};
 use trusted_server_core::proxy::{
@@ -253,6 +255,7 @@ enum NamedRouteHandler {
     VerifySignature,
     AdminNotSupported,
     AdminEcNotSupported,
+    AdminEidsLookup,
     /// Legacy `/admin/keys/*` aliases — denied locally with 404 so they never
     /// reach the publisher fallback (which would leak admin credentials).
     LegacyAdminDenied,
@@ -280,7 +283,7 @@ const LEGACY_ADMIN_DENY_METHODS: &[Method] = &[
     Method::DELETE,
 ];
 
-fn named_routes() -> [NamedRoute; 14] {
+fn named_routes() -> [NamedRoute; 15] {
     [
         NamedRoute {
             path: "/.well-known/trusted-server.json",
@@ -317,6 +320,13 @@ fn named_routes() -> [NamedRoute; 14] {
             path: "/_ts/admin/ec/{id}",
             primary_methods: &[Method::GET],
             handler: NamedRouteHandler::AdminEcNotSupported,
+        },
+        // Admin EIDs echo: pure request inspection (no KV), so the dev
+        // server serves the real handler.
+        NamedRoute {
+            path: "/_ts/admin/eids",
+            primary_methods: &[Method::GET],
+            handler: NamedRouteHandler::AdminEidsLookup,
         },
         // The legacy non-`/_ts` aliases (`/admin/keys/*`) are denied locally with
         // a 404, matching the Fastly and Cloudflare adapters: the production
@@ -416,6 +426,11 @@ fn named_route_handler(
                             HeaderValue::from_static("text/plain; charset=utf-8"),
                         );
                         Ok(resp)
+                    }
+                    NamedRouteHandler::AdminEidsLookup => {
+                        let partner_registry =
+                            PartnerRegistry::from_config(&state.settings.ec.partners)?;
+                        handle_admin_eids_lookup(&partner_registry, &req)
                     }
                     NamedRouteHandler::LegacyAdminDenied => Ok(legacy_admin_alias_denied()),
                     NamedRouteHandler::Auction => {

--- a/crates/trusted-server-adapter-axum/src/app.rs
+++ b/crates/trusted-server-adapter-axum/src/app.rs
@@ -252,6 +252,7 @@ enum NamedRouteHandler {
     TrustedServerDiscovery,
     VerifySignature,
     AdminNotSupported,
+    AdminEcNotSupported,
     /// Legacy `/admin/keys/*` aliases — denied locally with 404 so they never
     /// reach the publisher fallback (which would leak admin credentials).
     LegacyAdminDenied,
@@ -279,7 +280,7 @@ const LEGACY_ADMIN_DENY_METHODS: &[Method] = &[
     Method::DELETE,
 ];
 
-fn named_routes() -> [NamedRoute; 12] {
+fn named_routes() -> [NamedRoute; 14] {
     [
         NamedRoute {
             path: "/.well-known/trusted-server.json",
@@ -303,6 +304,19 @@ fn named_routes() -> [NamedRoute; 12] {
             path: "/_ts/admin/keys/deactivate",
             primary_methods: &[Method::POST],
             handler: NamedRouteHandler::AdminNotSupported,
+        },
+        // Admin EC lookup routes. Registered explicitly (like the key routes
+        // above) so they never fall through to the publisher fallback, and
+        // they match `Settings::ADMIN_ENDPOINTS` for auth coverage.
+        NamedRoute {
+            path: "/_ts/admin/ec",
+            primary_methods: &[Method::GET],
+            handler: NamedRouteHandler::AdminEcNotSupported,
+        },
+        NamedRoute {
+            path: "/_ts/admin/ec/{id}",
+            primary_methods: &[Method::GET],
+            handler: NamedRouteHandler::AdminEcNotSupported,
         },
         // The legacy non-`/_ts` aliases (`/admin/keys/*`) are denied locally with
         // a 404, matching the Fastly and Cloudflare adapters: the production
@@ -379,6 +393,21 @@ fn named_route_handler(
                         let body = edgezero_core::body::Body::from(
                             "Admin key management is not supported on the Axum dev server.\n\
                              Use the Fastly adapter (via Viceroy or deployed) to rotate or deactivate keys.\n",
+                        );
+                        let mut resp = Response::new(body);
+                        *resp.status_mut() = StatusCode::NOT_IMPLEMENTED;
+                        resp.headers_mut().insert(
+                            header::CONTENT_TYPE,
+                            HeaderValue::from_static("text/plain; charset=utf-8"),
+                        );
+                        Ok(resp)
+                    }
+                    NamedRouteHandler::AdminEcNotSupported => {
+                        // The EC identity graph is Fastly KV backed; the Axum
+                        // dev server has no store to read.
+                        let body = edgezero_core::body::Body::from(
+                            "Admin EC lookup is not supported on the Axum dev server.\n\
+                             Use the Fastly adapter (via Viceroy or deployed) to inspect EC entries.\n",
                         );
                         let mut resp = Response::new(body);
                         *resp.status_mut() = StatusCode::NOT_IMPLEMENTED;

--- a/crates/trusted-server-adapter-axum/tests/routes.rs
+++ b/crates/trusted-server-adapter-axum/tests/routes.rs
@@ -76,6 +76,7 @@ fn all_explicit_routes_are_registered() {
         ("POST", "/_ts/admin/keys/deactivate"),
         ("GET", "/_ts/admin/ec"),
         ("GET", "/_ts/admin/ec/{id}"),
+        ("GET", "/_ts/admin/eids"),
         ("POST", "/admin/keys/rotate"),
         ("POST", "/admin/keys/deactivate"),
         ("POST", "/auction"),
@@ -288,6 +289,31 @@ async fn authenticated_admin_ec_routes_return_501() {
             "{path} should report that Axum EC lookup is unsupported"
         );
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_admin_eids_route_returns_200() {
+    // The EIDs echo is pure request inspection (no KV), so the dev server
+    // serves the real handler.
+    let mut svc = make_service();
+    let req = Request::builder()
+        .method("GET")
+        .uri("/_ts/admin/eids")
+        .header("authorization", "Basic YWRtaW46YWRtaW4tcGFzcw==")
+        .body(AxumBody::empty())
+        .expect("should build request");
+    let resp = svc
+        .ready()
+        .await
+        .expect("should be ready")
+        .call(req)
+        .await
+        .expect("should respond");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "/_ts/admin/eids should serve the real EIDs echo handler"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/trusted-server-adapter-axum/tests/routes.rs
+++ b/crates/trusted-server-adapter-axum/tests/routes.rs
@@ -74,6 +74,8 @@ fn all_explicit_routes_are_registered() {
         ("POST", "/verify-signature"),
         ("POST", "/_ts/admin/keys/rotate"),
         ("POST", "/_ts/admin/keys/deactivate"),
+        ("GET", "/_ts/admin/ec"),
+        ("GET", "/_ts/admin/ec/{id}"),
         ("POST", "/admin/keys/rotate"),
         ("POST", "/admin/keys/deactivate"),
         ("POST", "/auction"),
@@ -254,6 +256,38 @@ async fn admin_route_without_credentials_returns_401() {
         401,
         "admin route must return 401 without credentials"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_admin_ec_routes_return_501() {
+    // The EC identity graph is Fastly KV backed, so the Axum dev server
+    // answers the admin EC lookup routes locally with 501 instead of letting
+    // them fall through to the publisher fallback.
+    let sample_ec_id = format!("{}.abc123", "a".repeat(64));
+    for path in [
+        "/_ts/admin/ec".to_owned(),
+        format!("/_ts/admin/ec/{sample_ec_id}"),
+    ] {
+        let mut svc = make_service();
+        let req = Request::builder()
+            .method("GET")
+            .uri(&path)
+            .header("authorization", "Basic YWRtaW46YWRtaW4tcGFzcw==")
+            .body(AxumBody::empty())
+            .expect("should build request");
+        let resp = svc
+            .ready()
+            .await
+            .expect("should be ready")
+            .call(req)
+            .await
+            .expect("should respond");
+        assert_eq!(
+            resp.status().as_u16(),
+            501,
+            "{path} should report that Axum EC lookup is unsupported"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/trusted-server-adapter-cloudflare/src/app.rs
+++ b/crates/trusted-server-adapter-cloudflare/src/app.rs
@@ -28,6 +28,7 @@ use trusted_server_core::request_signing::{
     handle_trusted_server_discovery, handle_verify_signature,
 };
 use trusted_server_core::settings::Settings;
+use trusted_server_core::trace_cookie::handle_trace_mode;
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware};
 use crate::platform::build_runtime_services;
@@ -461,6 +462,15 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             .post("/_ts/admin/keys/deactivate", |_ctx: RequestContext| async {
                 Ok::<Response, EdgeError>(admin_key_management_not_supported())
             })
+            // Render-trace toggle: arms/disarms the ts-trace cookie and
+            // redirects to `/`. Gated by [debug] trace_route_enabled (404 when
+            // off).
+            .get(
+                "/_ts/trace",
+                make_handler(Arc::clone(&state), |s, _services, req| async move {
+                    handle_trace_mode(&s.settings, req.uri().query())
+                }),
+            )
             .post(
                 "/auction",
                 make_handler(Arc::clone(&state), |s, services, req| async move {

--- a/crates/trusted-server-adapter-cloudflare/src/app.rs
+++ b/crates/trusted-server-adapter-cloudflare/src/app.rs
@@ -242,6 +242,20 @@ fn admin_key_management_not_supported() -> Response {
     response
 }
 
+fn admin_ec_lookup_not_supported() -> Response {
+    let body = edgezero_core::body::Body::from(
+        "Admin EC lookup is not supported on Cloudflare Workers.\n\
+         Use the Fastly adapter (via Viceroy or deployed) to inspect EC entries.\n",
+    );
+    let mut response = Response::new(body);
+    *response.status_mut() = StatusCode::NOT_IMPLEMENTED;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    response
+}
+
 /// Builds the local `404 Not Found` returned for legacy `/admin/keys/*`
 /// aliases on the Cloudflare adapter.
 ///
@@ -460,6 +474,17 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             })
             .post("/_ts/admin/keys/deactivate", |_ctx: RequestContext| async {
                 Ok::<Response, EdgeError>(admin_key_management_not_supported())
+            })
+            // Admin EC lookup routes. Registered explicitly (like the key
+            // routes above) so they never fall through to the publisher
+            // fallback, and they match `Settings::ADMIN_ENDPOINTS` for auth
+            // coverage. The EC identity graph is Fastly KV backed, so this
+            // adapter has no store to read.
+            .get("/_ts/admin/ec", |_ctx: RequestContext| async {
+                Ok::<Response, EdgeError>(admin_ec_lookup_not_supported())
+            })
+            .get("/_ts/admin/ec/{id}", |_ctx: RequestContext| async {
+                Ok::<Response, EdgeError>(admin_ec_lookup_not_supported())
             })
             .post(
                 "/auction",

--- a/crates/trusted-server-adapter-cloudflare/src/app.rs
+++ b/crates/trusted-server-adapter-cloudflare/src/app.rs
@@ -13,6 +13,8 @@ use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 #[cfg(target_arch = "wasm32")]
 use trusted_server_core::config_payload::settings_from_config_blob;
 use trusted_server_core::ec::EcContext;
+use trusted_server_core::ec::admin::handle_admin_eids_lookup;
+use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::error::{IntoHttpResponse as _, TrustedServerError};
 use trusted_server_core::integrations::{IntegrationRegistry, ProxyDispatchInput};
 use trusted_server_core::platform::RuntimeServices;
@@ -486,6 +488,15 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             .get("/_ts/admin/ec/{id}", |_ctx: RequestContext| async {
                 Ok::<Response, EdgeError>(admin_ec_lookup_not_supported())
             })
+            // Admin EIDs echo: pure request inspection (no KV), so this
+            // adapter serves the real handler.
+            .get(
+                "/_ts/admin/eids",
+                make_handler(Arc::clone(&state), |s, _services, req| async move {
+                    let partner_registry = PartnerRegistry::from_config(&s.settings.ec.partners)?;
+                    handle_admin_eids_lookup(&partner_registry, &req)
+                }),
+            )
             .post(
                 "/auction",
                 make_handler(Arc::clone(&state), |s, services, req| async move {

--- a/crates/trusted-server-adapter-cloudflare/tests/routes.rs
+++ b/crates/trusted-server-adapter-cloudflare/tests/routes.rs
@@ -217,6 +217,7 @@ fn all_explicit_routes_are_registered() {
         ("POST", "/_ts/admin/keys/deactivate"),
         ("GET", "/_ts/admin/ec"),
         ("GET", "/_ts/admin/ec/{id}"),
+        ("GET", "/_ts/admin/eids"),
         ("POST", "/auction"),
         ("GET", "/first-party/proxy"),
         ("GET", "/first-party/click"),
@@ -290,6 +291,25 @@ async fn authenticated_admin_ec_routes_return_501() {
             "{path} should report that Cloudflare EC lookup is unsupported"
         );
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_admin_eids_route_returns_200() {
+    // The EIDs echo is pure request inspection (no KV), so this adapter
+    // serves the real handler.
+    let req = request_builder()
+        .method("GET")
+        .uri("/_ts/admin/eids")
+        .header("authorization", "Basic YWRtaW46YWRtaW4tcGFzcw==")
+        .body(edgezero_core::body::Body::empty())
+        .expect("should build request");
+    let resp = route(test_router(), req).await;
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "/_ts/admin/eids should serve the real EIDs echo handler"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/trusted-server-adapter-cloudflare/tests/routes.rs
+++ b/crates/trusted-server-adapter-cloudflare/tests/routes.rs
@@ -215,6 +215,8 @@ fn all_explicit_routes_are_registered() {
         ("POST", "/verify-signature"),
         ("POST", "/_ts/admin/keys/rotate"),
         ("POST", "/_ts/admin/keys/deactivate"),
+        ("GET", "/_ts/admin/ec"),
+        ("GET", "/_ts/admin/ec/{id}"),
         ("POST", "/auction"),
         ("GET", "/first-party/proxy"),
         ("GET", "/first-party/click"),
@@ -260,6 +262,32 @@ async fn authenticated_admin_routes_return_501() {
             resp.status().as_u16(),
             501,
             "{path} should report that Cloudflare key management is unsupported"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_admin_ec_routes_return_501() {
+    // The EC identity graph is Fastly KV backed, so Cloudflare answers the
+    // admin EC lookup routes locally with 501 instead of letting them fall
+    // through to the publisher fallback.
+    let sample_ec_id = format!("{}.abc123", "a".repeat(64));
+    for path in [
+        "/_ts/admin/ec".to_owned(),
+        format!("/_ts/admin/ec/{sample_ec_id}"),
+    ] {
+        let req = request_builder()
+            .method("GET")
+            .uri(&path)
+            .header("authorization", "Basic YWRtaW46YWRtaW4tcGFzcw==")
+            .body(edgezero_core::body::Body::empty())
+            .expect("should build request");
+        let resp = route(test_router(), req).await;
+
+        assert_eq!(
+            resp.status().as_u16(),
+            501,
+            "{path} should report that Cloudflare EC lookup is unsupported"
         );
     }
 }

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -569,8 +569,12 @@ async fn run_named_route(
         NamedRouteHandler::RotateKey => handle_rotate_key(&state.settings, services, req),
         NamedRouteHandler::DeactivateKey => handle_deactivate_key(&state.settings, services, req),
         NamedRouteHandler::AdminEcLookup => {
+            // Deliberately NOT `ec.kv_graph`: that copy is bot-gated (None for
+            // non-browser clients), and operators hit this auth-gated endpoint
+            // with curl. Build the graph directly from settings instead.
+            let kv = crate::maybe_identity_graph(&state.settings);
             let partner_registry = PartnerRegistry::from_config(&state.settings.ec.partners)?;
-            handle_admin_ec_lookup(ec.kv_graph.as_ref(), &partner_registry, &req)
+            handle_admin_ec_lookup(kv.as_ref(), &partner_registry, &req)
         }
         NamedRouteHandler::LegacyAdminDenied => Ok(legacy_admin_alias_denied()),
         NamedRouteHandler::BatchSync => {

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -24,6 +24,7 @@
 //! | POST | `/_ts/admin/keys/deactivate` | [`handle_deactivate_key`] |
 //! | GET | `/_ts/admin/ec` | [`handle_admin_ec_lookup`] |
 //! | GET | `/_ts/admin/ec/{id}` | [`handle_admin_ec_lookup`] |
+//! | GET | `/_ts/admin/eids` | [`handle_admin_eids_lookup`] |
 //! | POST | `/_ts/api/v1/batch-sync` | [`handle_batch_sync`] |
 //! | GET | `/_ts/api/v1/identify` | [`handle_identify`] |
 //! | GET | `/_ts/set-tester` | [`handle_set_tester`] |
@@ -100,7 +101,7 @@ use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 use trusted_server_core::constants::{COOKIE_SHAREDID, COOKIE_TS_EIDS};
 use trusted_server_core::ec::EcContext;
-use trusted_server_core::ec::admin::handle_admin_ec_lookup;
+use trusted_server_core::ec::admin::{handle_admin_ec_lookup, handle_admin_eids_lookup};
 use trusted_server_core::ec::batch_sync::handle_batch_sync;
 use trusted_server_core::ec::consent::ec_consent_withdrawn;
 use trusted_server_core::ec::device::DeviceSignals;
@@ -576,6 +577,10 @@ async fn run_named_route(
             let partner_registry = PartnerRegistry::from_config(&state.settings.ec.partners)?;
             handle_admin_ec_lookup(kv.as_ref(), &partner_registry, &req)
         }
+        NamedRouteHandler::AdminEidsLookup => {
+            let partner_registry = PartnerRegistry::from_config(&state.settings.ec.partners)?;
+            handle_admin_eids_lookup(&partner_registry, &req)
+        }
         NamedRouteHandler::LegacyAdminDenied => Ok(legacy_admin_alias_denied()),
         NamedRouteHandler::BatchSync => {
             // Dispatched by execute_named before EC state is built.
@@ -999,6 +1004,7 @@ enum NamedRouteHandler {
     RotateKey,
     DeactivateKey,
     AdminEcLookup,
+    AdminEidsLookup,
     /// Legacy `/admin/keys/*` aliases — denied locally with 404 so they never
     /// reach the publisher fallback (which would leak admin credentials).
     LegacyAdminDenied,
@@ -1062,6 +1068,13 @@ const NAMED_ROUTES: &[NamedRoute] = &[
         path: "/_ts/admin/ec/{id}",
         primary_methods: &[Method::GET],
         handler: NamedRouteHandler::AdminEcLookup,
+    },
+    // Admin EIDs echo: decodes the request's ts-eids/sharedId cookies with
+    // an ingestion preview. Pure request inspection — no KV access.
+    NamedRoute {
+        path: "/_ts/admin/eids",
+        primary_methods: &[Method::GET],
+        handler: NamedRouteHandler::AdminEidsLookup,
     },
     // The legacy non-`/_ts` aliases (`/admin/keys/*`) are denied locally with a
     // 404 instead of executing key operations: the production basic-auth handler
@@ -1670,6 +1683,20 @@ mod tests {
                 "{path} must have GET as its only primary method"
             );
         }
+
+        let eids_route = NAMED_ROUTES
+            .iter()
+            .find(|route| route.path == "/_ts/admin/eids")
+            .expect("should register /_ts/admin/eids as a named route");
+        assert!(
+            matches!(eids_route.handler, NamedRouteHandler::AdminEidsLookup),
+            "/_ts/admin/eids must map to the admin EIDs lookup handler"
+        );
+        assert_eq!(
+            eids_route.primary_methods,
+            &[Method::GET],
+            "/_ts/admin/eids must have GET as its only primary method"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -22,6 +22,8 @@
 //! | POST | `/verify-signature` | [`handle_verify_signature`] |
 //! | POST | `/_ts/admin/keys/rotate` | [`handle_rotate_key`] |
 //! | POST | `/_ts/admin/keys/deactivate` | [`handle_deactivate_key`] |
+//! | GET | `/_ts/admin/ec` | [`handle_admin_ec_lookup`] |
+//! | GET | `/_ts/admin/ec/{id}` | [`handle_admin_ec_lookup`] |
 //! | POST | `/_ts/api/v1/batch-sync` | [`handle_batch_sync`] |
 //! | GET | `/_ts/api/v1/identify` | [`handle_identify`] |
 //! | GET | `/_ts/set-tester` | [`handle_set_tester`] |
@@ -98,6 +100,7 @@ use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 use trusted_server_core::constants::{COOKIE_SHAREDID, COOKIE_TS_EIDS};
 use trusted_server_core::ec::EcContext;
+use trusted_server_core::ec::admin::handle_admin_ec_lookup;
 use trusted_server_core::ec::batch_sync::handle_batch_sync;
 use trusted_server_core::ec::consent::ec_consent_withdrawn;
 use trusted_server_core::ec::device::DeviceSignals;
@@ -565,6 +568,10 @@ async fn run_named_route(
         }
         NamedRouteHandler::RotateKey => handle_rotate_key(&state.settings, services, req),
         NamedRouteHandler::DeactivateKey => handle_deactivate_key(&state.settings, services, req),
+        NamedRouteHandler::AdminEcLookup => {
+            let partner_registry = PartnerRegistry::from_config(&state.settings.ec.partners)?;
+            handle_admin_ec_lookup(ec.kv_graph.as_ref(), &partner_registry, &req)
+        }
         NamedRouteHandler::LegacyAdminDenied => Ok(legacy_admin_alias_denied()),
         NamedRouteHandler::BatchSync => {
             // Dispatched by execute_named before EC state is built.
@@ -987,6 +994,7 @@ enum NamedRouteHandler {
     VerifySignature,
     RotateKey,
     DeactivateKey,
+    AdminEcLookup,
     /// Legacy `/admin/keys/*` aliases — denied locally with 404 so they never
     /// reach the publisher fallback (which would leak admin credentials).
     LegacyAdminDenied,
@@ -1038,6 +1046,18 @@ const NAMED_ROUTES: &[NamedRoute] = &[
         path: "/_ts/admin/keys/deactivate",
         primary_methods: &[Method::POST],
         handler: NamedRouteHandler::DeactivateKey,
+    },
+    // Admin EC lookup: the bare route reads the EC ID from the caller's
+    // `ts-ec` cookie; the parameterized route takes an explicit EC ID.
+    NamedRoute {
+        path: "/_ts/admin/ec",
+        primary_methods: &[Method::GET],
+        handler: NamedRouteHandler::AdminEcLookup,
+    },
+    NamedRoute {
+        path: "/_ts/admin/ec/{id}",
+        primary_methods: &[Method::GET],
+        handler: NamedRouteHandler::AdminEcLookup,
     },
     // The legacy non-`/_ts` aliases (`/admin/keys/*`) are denied locally with a
     // 404 instead of executing key operations: the production basic-auth handler
@@ -1621,6 +1641,30 @@ mod tests {
                     "legacy {method} {path} must route to the local deny handler, not publisher fallback"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn admin_ec_lookup_routes_are_registered() {
+        // Both lookup shapes must be explicitly routed to the admin EC
+        // handler: the bare cookie-based route and the parameterized route.
+        // Leaving either unrouted would fall through to the publisher
+        // fallback, forwarding the caller's `Authorization` header to the
+        // origin.
+        for path in ["/_ts/admin/ec", "/_ts/admin/ec/{id}"] {
+            let route = NAMED_ROUTES
+                .iter()
+                .find(|route| route.path == path)
+                .unwrap_or_else(|| panic!("{path} must be a named route"));
+            assert!(
+                matches!(route.handler, NamedRouteHandler::AdminEcLookup),
+                "{path} must map to the admin EC lookup handler"
+            );
+            assert_eq!(
+                route.primary_methods,
+                &[Method::GET],
+                "{path} must have GET as its only primary method"
+            );
         }
     }
 

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -26,6 +26,7 @@
 //! | GET | `/_ts/api/v1/identify` | [`handle_identify`] |
 //! | GET | `/_ts/set-tester` | [`handle_set_tester`] |
 //! | GET | `/_ts/clear-tester` | [`handle_clear_tester`] |
+//! | GET | `/_ts/trace` | [`handle_trace_mode`] |
 //! | OPTIONS | `/_ts/api/v1/identify` | [`cors_preflight_identify`] |
 //! | POST | `/auction` | [`handle_auction`] |
 //! | GET | `/first-party/proxy` | [`handle_first_party_proxy`] |
@@ -128,6 +129,7 @@ use trusted_server_core::settings_data::{
     default_config_key, default_config_store_name, get_settings_from_config_store,
 };
 use trusted_server_core::tester_cookie::{handle_clear_tester, handle_set_tester};
+use trusted_server_core::trace_cookie::handle_trace_mode;
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware};
 use crate::platform::{
@@ -587,6 +589,7 @@ async fn run_named_route(
         }
         NamedRouteHandler::SetTester => handle_set_tester(&state.settings),
         NamedRouteHandler::ClearTester => handle_clear_tester(&state.settings),
+        NamedRouteHandler::TraceMode => handle_trace_mode(&state.settings, req.uri().query()),
         NamedRouteHandler::Auction => {
             // The auction reads consent data, so the consent KV store must be
             // available — fail closed with 503 when it is configured but
@@ -994,6 +997,7 @@ enum NamedRouteHandler {
     Identify,
     SetTester,
     ClearTester,
+    TraceMode,
     Auction,
     PageBids,
     FirstPartyProxy,
@@ -1074,6 +1078,11 @@ const NAMED_ROUTES: &[NamedRoute] = &[
         path: "/_ts/clear-tester",
         primary_methods: &[Method::GET],
         handler: NamedRouteHandler::ClearTester,
+    },
+    NamedRoute {
+        path: "/_ts/trace",
+        primary_methods: &[Method::GET],
+        handler: NamedRouteHandler::TraceMode,
     },
     NamedRoute {
         path: "/auction",
@@ -1743,6 +1752,55 @@ mod tests {
         assert!(
             response.headers().get(header::SET_COOKIE).is_none(),
             "disabled tester-cookie route should not set a cookie"
+        );
+    }
+
+    #[test]
+    fn dispatch_trace_route_is_disabled_by_default() {
+        let router = test_router();
+        let response = route(&router, empty_request(Method::GET, "/_ts/trace"));
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "disabled trace route should return 404"
+        );
+        assert!(
+            response.headers().get(header::SET_COOKIE).is_none(),
+            "disabled trace route should not set a cookie"
+        );
+    }
+
+    #[test]
+    fn dispatch_trace_route_arms_cookie_and_redirects() {
+        let mut settings = test_settings();
+        settings.debug.trace_route_enabled = true;
+        let state = app_state_for_settings(settings);
+        let router = TrustedServerApp::routes_for_state(&state);
+        let response = route(&router, empty_request(Method::GET, "/_ts/trace"));
+
+        assert_eq!(
+            response.status(),
+            StatusCode::FOUND,
+            "enabled trace route should redirect to root"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("/"),
+            "trace route should redirect to /"
+        );
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("should set trace cookie")
+            .to_str()
+            .expect("should render set-cookie as utf-8");
+        assert!(
+            set_cookie.starts_with("ts-trace=1;"),
+            "trace route should arm the ts-trace cookie"
         );
     }
 

--- a/crates/trusted-server-adapter-spin/src/app.rs
+++ b/crates/trusted-server-adapter-spin/src/app.rs
@@ -141,12 +141,14 @@ const LEGACY_ADMIN_DENY_METHODS: &[Method] = &[
     Method::DELETE,
 ];
 
-fn named_fallback_paths() -> [(&'static str, &'static [Method]); 12] {
+fn named_fallback_paths() -> [(&'static str, &'static [Method]); 14] {
     [
         ("/.well-known/trusted-server.json", &[Method::GET]),
         ("/verify-signature", &[Method::POST]),
         ("/_ts/admin/keys/rotate", &[Method::POST]),
         ("/_ts/admin/keys/deactivate", &[Method::POST]),
+        ("/_ts/admin/ec", &[Method::GET]),
+        ("/_ts/admin/ec/{id}", &[Method::GET]),
         ("/admin/keys/rotate", LEGACY_ADMIN_DENY_METHODS),
         ("/admin/keys/deactivate", LEGACY_ADMIN_DENY_METHODS),
         ("/auction", &[Method::POST]),
@@ -359,6 +361,20 @@ fn admin_key_management_not_supported() -> Response {
     response
 }
 
+fn admin_ec_lookup_not_supported() -> Response {
+    let body = edgezero_core::body::Body::from(
+        "Admin EC lookup is not supported on Fermyon Spin.\n\
+         Use the Fastly adapter (via Viceroy or deployed) to inspect EC entries.\n",
+    );
+    let mut response = Response::new(body);
+    *response.status_mut() = StatusCode::NOT_IMPLEMENTED;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    response
+}
+
 // ---------------------------------------------------------------------------
 // Error helper
 // ---------------------------------------------------------------------------
@@ -509,6 +525,10 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
 
         let admin_not_supported_handler = |_ctx: RequestContext| async {
             Ok::<Response, EdgeError>(admin_key_management_not_supported())
+        };
+
+        let admin_ec_not_supported_handler = |_ctx: RequestContext| async {
+            Ok::<Response, EdgeError>(admin_ec_lookup_not_supported())
         };
 
         // /auction
@@ -730,6 +750,13 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             // credentials and key-management payloads to the origin.
             .post("/_ts/admin/keys/rotate", admin_not_supported_handler)
             .post("/_ts/admin/keys/deactivate", admin_not_supported_handler)
+            // Admin EC lookup routes. Registered explicitly (like the key
+            // routes above) so they never fall through to the publisher
+            // fallback, and they match `Settings::ADMIN_ENDPOINTS` for auth
+            // coverage. The EC identity graph is Fastly KV backed, so this
+            // adapter has no store to read.
+            .get("/_ts/admin/ec", admin_ec_not_supported_handler)
+            .get("/_ts/admin/ec/{id}", admin_ec_not_supported_handler)
             .post("/auction", auction_handler)
             .get("/__ts/page-bids", page_bids_handler)
             .route(

--- a/crates/trusted-server-adapter-spin/src/app.rs
+++ b/crates/trusted-server-adapter-spin/src/app.rs
@@ -27,6 +27,7 @@ use trusted_server_core::request_signing::{
     handle_trusted_server_discovery, handle_verify_signature,
 };
 use trusted_server_core::settings::Settings;
+use trusted_server_core::trace_cookie::handle_trace_mode;
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware, NormalizeMiddleware};
 use crate::platform::build_runtime_services;
@@ -141,7 +142,7 @@ const LEGACY_ADMIN_DENY_METHODS: &[Method] = &[
     Method::DELETE,
 ];
 
-fn named_fallback_paths() -> [(&'static str, &'static [Method]); 12] {
+fn named_fallback_paths() -> [(&'static str, &'static [Method]); 13] {
     [
         ("/.well-known/trusted-server.json", &[Method::GET]),
         ("/verify-signature", &[Method::POST]),
@@ -149,6 +150,7 @@ fn named_fallback_paths() -> [(&'static str, &'static [Method]); 12] {
         ("/_ts/admin/keys/deactivate", &[Method::POST]),
         ("/admin/keys/rotate", LEGACY_ADMIN_DENY_METHODS),
         ("/admin/keys/deactivate", LEGACY_ADMIN_DENY_METHODS),
+        ("/_ts/trace", &[Method::GET]),
         ("/auction", &[Method::POST]),
         ("/__ts/page-bids", &[Method::GET, Method::OPTIONS]),
         ("/first-party/proxy", &[Method::GET]),
@@ -541,6 +543,21 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             }
         };
 
+        // GET /_ts/trace — render-trace toggle: arms/disarms the ts-trace
+        // cookie and redirects to `/`. Gated by [debug] trace_route_enabled
+        // (404 when off).
+        let s = Arc::clone(&state);
+        let trace_mode_handler = move |ctx: RequestContext| {
+            let s = Arc::clone(&s);
+            async move {
+                let req = ctx.into_request();
+                Ok::<Response, EdgeError>(
+                    handle_trace_mode(&s.settings, req.uri().query())
+                        .unwrap_or_else(|e| http_error(&e)),
+                )
+            }
+        };
+
         // GET /__ts/page-bids — SPA re-auction endpoint.
         let s = Arc::clone(&state);
         let page_bids_handler = move |ctx: RequestContext| {
@@ -730,6 +747,7 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             // credentials and key-management payloads to the origin.
             .post("/_ts/admin/keys/rotate", admin_not_supported_handler)
             .post("/_ts/admin/keys/deactivate", admin_not_supported_handler)
+            .get("/_ts/trace", trace_mode_handler)
             .post("/auction", auction_handler)
             .get("/__ts/page-bids", page_bids_handler)
             .route(

--- a/crates/trusted-server-adapter-spin/src/app.rs
+++ b/crates/trusted-server-adapter-spin/src/app.rs
@@ -11,6 +11,8 @@ use error_stack::Report;
 use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 use trusted_server_core::ec::EcContext;
+use trusted_server_core::ec::admin::handle_admin_eids_lookup;
+use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::error::{IntoHttpResponse as _, TrustedServerError};
 use trusted_server_core::http_util::sanitize_forwarded_headers;
 use trusted_server_core::integrations::{IntegrationRegistry, ProxyDispatchInput};
@@ -141,7 +143,7 @@ const LEGACY_ADMIN_DENY_METHODS: &[Method] = &[
     Method::DELETE,
 ];
 
-fn named_fallback_paths() -> [(&'static str, &'static [Method]); 14] {
+fn named_fallback_paths() -> [(&'static str, &'static [Method]); 15] {
     [
         ("/.well-known/trusted-server.json", &[Method::GET]),
         ("/verify-signature", &[Method::POST]),
@@ -149,6 +151,7 @@ fn named_fallback_paths() -> [(&'static str, &'static [Method]); 14] {
         ("/_ts/admin/keys/deactivate", &[Method::POST]),
         ("/_ts/admin/ec", &[Method::GET]),
         ("/_ts/admin/ec/{id}", &[Method::GET]),
+        ("/_ts/admin/eids", &[Method::GET]),
         ("/admin/keys/rotate", LEGACY_ADMIN_DENY_METHODS),
         ("/admin/keys/deactivate", LEGACY_ADMIN_DENY_METHODS),
         ("/auction", &[Method::POST]),
@@ -531,6 +534,19 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             Ok::<Response, EdgeError>(admin_ec_lookup_not_supported())
         };
 
+        // Admin EIDs echo: pure request inspection (no KV), so this adapter
+        // serves the real handler.
+        let s = Arc::clone(&state);
+        let admin_eids_handler = move |ctx: RequestContext| {
+            let s = Arc::clone(&s);
+            async move {
+                let req = ctx.into_request();
+                let result = PartnerRegistry::from_config(&s.settings.ec.partners)
+                    .and_then(|registry| handle_admin_eids_lookup(&registry, &req));
+                Ok::<Response, EdgeError>(result.unwrap_or_else(|e| http_error(&e)))
+            }
+        };
+
         // /auction
         let s = Arc::clone(&state);
         let auction_handler = move |ctx: RequestContext| {
@@ -757,6 +773,7 @@ fn build_router(state: &Arc<AppState>) -> RouterService {
             // adapter has no store to read.
             .get("/_ts/admin/ec", admin_ec_not_supported_handler)
             .get("/_ts/admin/ec/{id}", admin_ec_not_supported_handler)
+            .get("/_ts/admin/eids", admin_eids_handler)
             .post("/auction", auction_handler)
             .get("/__ts/page-bids", page_bids_handler)
             .route(

--- a/crates/trusted-server-adapter-spin/tests/routes.rs
+++ b/crates/trusted-server-adapter-spin/tests/routes.rs
@@ -140,6 +140,25 @@ async fn authenticated_admin_ec_routes_return_501() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_admin_eids_route_returns_200() {
+    // The EIDs echo is pure request inspection (no KV), so this adapter
+    // serves the real handler.
+    let req = request_builder()
+        .method("GET")
+        .uri("/_ts/admin/eids")
+        .header("authorization", "Basic YWRtaW46YWRtaW4tcGFzcw==")
+        .body(edgezero_core::body::Body::empty())
+        .expect("should build request");
+    let resp = route(test_router(), req).await;
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "/_ts/admin/eids should serve the real EIDs echo handler"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn health_route_returns_ok() {
     // Parity with the Fastly/Axum adapters: GET /health is a cheap liveness probe
     // answering 200 "ok", not routed through publisher handling.

--- a/crates/trusted-server-adapter-spin/tests/routes.rs
+++ b/crates/trusted-server-adapter-spin/tests/routes.rs
@@ -114,6 +114,32 @@ async fn authenticated_admin_routes_return_501() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_admin_ec_routes_return_501() {
+    // The EC identity graph is Fastly KV backed, so Spin answers the admin
+    // EC lookup routes locally with 501 instead of letting them fall through
+    // to the publisher fallback.
+    let sample_ec_id = format!("{}.abc123", "a".repeat(64));
+    for path in [
+        "/_ts/admin/ec".to_owned(),
+        format!("/_ts/admin/ec/{sample_ec_id}"),
+    ] {
+        let req = request_builder()
+            .method("GET")
+            .uri(&path)
+            .header("authorization", "Basic YWRtaW46YWRtaW4tcGFzcw==")
+            .body(edgezero_core::body::Body::empty())
+            .expect("should build request");
+        let resp = route(test_router(), req).await;
+
+        assert_eq!(
+            resp.status().as_u16(),
+            501,
+            "{path} should report that Spin EC lookup is unsupported"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn health_route_returns_ok() {
     // Parity with the Fastly/Axum adapters: GET /health is a cheap liveness probe
     // answering 200 "ok", not routed through publisher handling.

--- a/crates/trusted-server-core/src/auction/types.rs
+++ b/crates/trusted-server-core/src/auction/types.rs
@@ -249,7 +249,11 @@ pub struct Bid {
     pub nurl: Option<String>,
     /// Billing notification URL
     pub burl: Option<String>,
-    /// `OpenRTB` bid identifier.
+    /// `OpenRTB` bid identifier (`seatbid.bid.id`).
+    ///
+    /// Unique per bid instance, not a creative identifier — always present per
+    /// spec. Used as the last-resort `hb_adid` fallback in `build_bid_map` for
+    /// bidders that return neither a Prebid Cache UUID nor `adid`.
     pub bid_id: Option<String>,
     /// Ad ID from the bidder.
     pub ad_id: Option<String>,

--- a/crates/trusted-server-core/src/constants.rs
+++ b/crates/trusted-server-core/src/constants.rs
@@ -5,6 +5,7 @@ pub const COOKIE_TS_EC: &str = "ts-ec";
 /// JSON array of Extended User IDs (`[{ source, uids }]`) from identity providers.
 pub const COOKIE_TS_EIDS: &str = "ts-eids";
 pub const COOKIE_TS_TESTER: &str = "ts-tester";
+pub const COOKIE_TS_TRACE: &str = "ts-trace";
 pub const COOKIE_SHAREDID: &str = "sharedId";
 
 pub const HEADER_X_PUB_USER_ID: HeaderName = HeaderName::from_static("x-pub-user-id");

--- a/crates/trusted-server-core/src/ec/admin.rs
+++ b/crates/trusted-server-core/src/ec/admin.rs
@@ -55,7 +55,9 @@ struct AdminEcLookupResponse {
     /// (`consent.ok = false`). Absent when the body failed to parse.
     #[serde(skip_serializing_if = "Option::is_none")]
     tombstone: Option<bool>,
-    /// The stored entry, re-serialized verbatim. Absent when the body
+    /// The stored entry, re-serialized verbatim except for derived
+    /// `created_iso` / `updated_iso` companions added next to the stored
+    /// unix-seconds timestamps for readability. Absent when the body
     /// failed to deserialize (see `entry_error` / `raw_body`).
     #[serde(skip_serializing_if = "Option::is_none")]
     entry: Option<JsonValue>,
@@ -226,7 +228,7 @@ fn build_lookup_response(
                     ));
                 }
             }
-            payload.entry = Some(serde_json::to_value(&entry).expect("should serialize KvEntry"));
+            payload.entry = Some(entry_json_with_iso_timestamps(&entry));
         }
         Err(error) => {
             payload.entry_error = Some(format!("failed to deserialize entry: {error}"));
@@ -251,6 +253,37 @@ fn build_lookup_response(
     }
 
     payload
+}
+
+/// Serializes an entry, adding derived ISO 8601 companions next to the
+/// stored unix-seconds timestamps (`created_iso`, `consent.updated_iso`).
+///
+/// The stored numeric values stay untouched so the echo remains faithful to
+/// what is in KV; the ISO fields exist purely for operator readability.
+fn entry_json_with_iso_timestamps(entry: &KvEntry) -> JsonValue {
+    let mut entry_json = serde_json::to_value(entry).expect("should serialize KvEntry");
+
+    if let Some(object) = entry_json.as_object_mut() {
+        if let Some(iso) = iso_timestamp(entry.created) {
+            object.insert("created_iso".to_owned(), JsonValue::String(iso));
+        }
+        if let Some(consent) = object.get_mut("consent").and_then(JsonValue::as_object_mut)
+            && let Some(iso) = iso_timestamp(entry.consent.updated)
+        {
+            consent.insert("updated_iso".to_owned(), JsonValue::String(iso));
+        }
+    }
+
+    entry_json
+}
+
+/// Formats a unix-seconds timestamp as ISO 8601 (`yyyy-MM-ddTHH:mm:ss.SSSZ`).
+///
+/// Returns `None` for values outside the representable date range.
+fn iso_timestamp(unix_seconds: u64) -> Option<String> {
+    let unix_seconds = i64::try_from(unix_seconds).ok()?;
+    chrono::DateTime::from_timestamp(unix_seconds, 0)
+        .map(|datetime| datetime.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
 }
 
 /// Derives the auction EID view for a valid entry, mirroring the filters in
@@ -558,6 +591,18 @@ mod tests {
         assert_eq!(
             json["entry"]["ids"]["bidstream.example"]["uid"], "uid-live",
             "should echo the stored entry verbatim"
+        );
+        assert_eq!(
+            json["entry"]["created"], 1_741_824_000_u64,
+            "should keep the stored unix-seconds timestamp"
+        );
+        assert_eq!(
+            json["entry"]["created_iso"], "2025-03-13T00:00:00.000Z",
+            "should add an ISO 8601 companion for created"
+        );
+        assert_eq!(
+            json["entry"]["consent"]["updated_iso"], "2025-03-13T00:00:00.000Z",
+            "should add an ISO 8601 companion for consent.updated"
         );
 
         let eids = json["auction"]["eids"]

--- a/crates/trusted-server-core/src/ec/admin.rs
+++ b/crates/trusted-server-core/src/ec/admin.rs
@@ -164,7 +164,8 @@ fn requested_ec_id(req: &Request<EdgeBody>) -> Result<String, Box<Response<EdgeB
             None => {
                 return Err(Box::new(json_error(
                     StatusCode::NOT_FOUND,
-                    "no EC ID in path and no ts-ec cookie on the request",
+                    "no EC ID in path and no ts-ec cookie on the request — pass \
+                     an explicit id: /_ts/admin/ec/{id}",
                 )));
             }
         }

--- a/crates/trusted-server-core/src/ec/admin.rs
+++ b/crates/trusted-server-core/src/ec/admin.rs
@@ -1,0 +1,626 @@
+//! Admin endpoint for inspecting EC identity graph entries.
+//!
+//! Serves `GET /_ts/admin/ec` (EC ID taken from the request's `ts-ec`
+//! cookie) and `GET /_ts/admin/ec/{id}` (explicit EC ID). Returns the raw
+//! stored [`KvEntry`] plus a derived view of the EIDs the auction would
+//! attach, so operators can debug KV-to-auction propagation without KV
+//! console access.
+//!
+//! Authentication is enforced by the `^/_ts/admin` basic-auth handler
+//! configuration; startup validation rejects configs that leave these paths
+//! uncovered (see `Settings::ADMIN_ENDPOINTS`). Because the endpoint is
+//! auth-gated and operator-facing, responses intentionally include full
+//! internal detail (raw consent strings, partner UIDs, parse errors).
+
+use http::{Request, Response, StatusCode, header};
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+use edgezero_core::body::Body as EdgeBody;
+use error_stack::{Report, ResultExt as _};
+
+use crate::constants::COOKIE_TS_EC;
+use crate::error::TrustedServerError;
+use crate::openrtb::Eid;
+
+use super::eids::{resolve_partner_ids, to_eids};
+use super::generation::is_valid_ec_id;
+use super::kv::KvIdentityGraph;
+use super::kv_backend::EcKvLookup;
+use super::kv_types::{KvEntry, KvMetadata};
+use super::log_id;
+use super::registry::PartnerRegistry;
+
+/// Route prefix shared by the cookie-based and explicit-ID lookup routes.
+const ADMIN_EC_PATH: &str = "/_ts/admin/ec";
+
+/// Successful admin EC lookup payload.
+#[derive(Debug, Serialize)]
+struct AdminEcLookupResponse {
+    /// The EC ID that was looked up.
+    ec_id: String,
+    /// Platform KV store name the entry was read from.
+    store: String,
+    /// Store generation marker for the entry.
+    generation: u64,
+    /// `true` when the entry is a consent-withdrawal tombstone
+    /// (`consent.ok = false`). Absent when the body failed to parse.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tombstone: Option<bool>,
+    /// The stored entry, re-serialized verbatim. Absent when the body
+    /// failed to deserialize (see `entry_error` / `raw_body`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entry: Option<JsonValue>,
+    /// Deserialization or validation failure detail for the entry body.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entry_error: Option<String>,
+    /// Raw entry body (lossy UTF-8) when it could not be deserialized.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    raw_body: Option<String>,
+    /// The stored KV metadata mirror, when present and parseable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<JsonValue>,
+    /// Deserialization failure detail for the metadata, including its raw
+    /// value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata_error: Option<String>,
+    /// Derived auction view. Present only when the entry deserializes and
+    /// validates — the same precondition the auction read path applies, so
+    /// its absence means the auction would attach no KV-derived EIDs.
+    /// Live requests additionally gate on per-request consent, which is not
+    /// reproducible here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auction: Option<AuctionEidsView>,
+}
+
+/// What the auction EID decoration would produce for this entry.
+#[derive(Debug, Serialize)]
+struct AuctionEidsView {
+    /// EIDs the auction would attach to `user.eids`, exactly as produced by
+    /// the auction resolution path.
+    eids: Vec<Eid>,
+    /// Stored partner IDs that the auction resolution filters out, with the
+    /// reason each was skipped.
+    skipped: Vec<SkippedPartnerId>,
+}
+
+/// A stored partner ID excluded from auction EIDs.
+#[derive(Debug, Serialize)]
+struct SkippedPartnerId {
+    /// Partner namespace key in the entry's `ids` map.
+    source_domain: String,
+    /// Why the auction resolution skips it: `empty_uid`, `not_in_registry`,
+    /// or `bidstream_disabled`.
+    reason: &'static str,
+}
+
+/// Handles `GET /_ts/admin/ec` and `GET /_ts/admin/ec/{id}`.
+///
+/// Resolves the EC ID from the path when present, falling back to the
+/// request's `ts-ec` cookie for the bare route. Responds:
+///
+/// - `200 OK` with an [`AdminEcLookupResponse`] JSON body when the key
+///   exists (including corrupt entries, which are reported with
+///   `entry_error` and `raw_body` instead of failing closed);
+/// - `400 Bad Request` when the resolved ID is not a valid EC ID;
+/// - `404 Not Found` when the key does not exist, or the bare route was
+///   called without a `ts-ec` cookie;
+/// - `501 Not Implemented` when no EC identity graph is configured.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError::KvStore`] when the store open or read
+/// fails.
+pub fn handle_admin_ec_lookup(
+    kv: Option<&KvIdentityGraph>,
+    registry: &PartnerRegistry,
+    req: &Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    let Some(kv) = kv else {
+        return Ok(json_error(
+            StatusCode::NOT_IMPLEMENTED,
+            "EC identity graph is not configured on this deployment",
+        ));
+    };
+
+    let ec_id = match requested_ec_id(req) {
+        Ok(ec_id) => ec_id,
+        Err(response) => return Ok(*response),
+    };
+
+    let Some(lookup) = kv.lookup_raw(&ec_id)? else {
+        log::info!("Admin EC lookup: no entry for '{}'", log_id(&ec_id));
+        return Ok(json_error(
+            StatusCode::NOT_FOUND,
+            "EC entry not found (KV reads are eventually consistent; a very \
+             recent entry may not be visible yet)",
+        ));
+    };
+
+    log::info!("Admin EC lookup: returning entry for '{}'", log_id(&ec_id));
+    let payload = build_lookup_response(registry, kv.store_name(), ec_id, &lookup);
+    let body =
+        serde_json::to_string(&payload).change_context(TrustedServerError::Configuration {
+            message: "failed to serialize admin EC lookup response".to_owned(),
+        })?;
+    Ok(json_response(StatusCode::OK, body))
+}
+
+/// Resolves the EC ID to look up from the path or the `ts-ec` cookie.
+///
+/// Returns the (boxed) error response to send directly when no valid ID is
+/// available.
+fn requested_ec_id(req: &Request<EdgeBody>) -> Result<String, Box<Response<EdgeBody>>> {
+    let remainder = req
+        .uri()
+        .path()
+        .strip_prefix(ADMIN_EC_PATH)
+        .unwrap_or("")
+        .trim_matches('/');
+
+    let ec_id = if remainder.is_empty() {
+        match extract_cookie_value(req, COOKIE_TS_EC) {
+            Some(cookie_ec_id) => cookie_ec_id,
+            None => {
+                return Err(Box::new(json_error(
+                    StatusCode::NOT_FOUND,
+                    "no EC ID in path and no ts-ec cookie on the request",
+                )));
+            }
+        }
+    } else {
+        remainder.to_owned()
+    };
+
+    if !is_valid_ec_id(&ec_id) {
+        return Err(Box::new(json_error(
+            StatusCode::BAD_REQUEST,
+            "invalid EC ID format (expected {64hex}.{6alnum})",
+        )));
+    }
+
+    Ok(ec_id)
+}
+
+/// Builds the success payload from a raw KV lookup.
+///
+/// Parse failures are reported in the payload rather than propagated, so
+/// corrupt entries remain inspectable.
+fn build_lookup_response(
+    registry: &PartnerRegistry,
+    store_name: &str,
+    ec_id: String,
+    lookup: &EcKvLookup,
+) -> AdminEcLookupResponse {
+    let mut payload = AdminEcLookupResponse {
+        ec_id,
+        store: store_name.to_owned(),
+        generation: lookup.generation,
+        tombstone: None,
+        entry: None,
+        entry_error: None,
+        raw_body: None,
+        metadata: None,
+        metadata_error: None,
+        auction: None,
+    };
+
+    match serde_json::from_slice::<KvEntry>(&lookup.body) {
+        Ok(entry) => {
+            payload.tombstone = Some(!entry.consent.ok);
+            match entry.validate() {
+                Ok(()) => payload.auction = Some(build_auction_view(registry, &entry)),
+                Err(message) => {
+                    payload.entry_error = Some(format!(
+                        "entry failed validation (auction reads fail closed \
+                         and attach no EIDs): {message}"
+                    ));
+                }
+            }
+            payload.entry = Some(serde_json::to_value(&entry).expect("should serialize KvEntry"));
+        }
+        Err(error) => {
+            payload.entry_error = Some(format!("failed to deserialize entry: {error}"));
+            payload.raw_body = Some(String::from_utf8_lossy(&lookup.body).into_owned());
+        }
+    }
+
+    match &lookup.metadata {
+        None => {}
+        Some(bytes) => match serde_json::from_slice::<KvMetadata>(bytes) {
+            Ok(metadata) => {
+                payload.metadata =
+                    Some(serde_json::to_value(&metadata).expect("should serialize KvMetadata"));
+            }
+            Err(error) => {
+                payload.metadata_error = Some(format!(
+                    "failed to deserialize metadata: {error} (raw: {})",
+                    String::from_utf8_lossy(bytes)
+                ));
+            }
+        },
+    }
+
+    payload
+}
+
+/// Derives the auction EID view for a valid entry, mirroring the filters in
+/// [`resolve_partner_ids`] and reporting why each stored ID was skipped.
+fn build_auction_view(registry: &PartnerRegistry, entry: &KvEntry) -> AuctionEidsView {
+    let resolved = resolve_partner_ids(registry, entry);
+    let eids = to_eids(&resolved);
+
+    let mut skipped = Vec::new();
+    for (source_domain, partner_uid) in &entry.ids {
+        let reason = if partner_uid.uid.is_empty() {
+            "empty_uid"
+        } else {
+            match registry.get(source_domain) {
+                None => "not_in_registry",
+                Some(partner) if !partner.bidstream_enabled => "bidstream_disabled",
+                Some(_) => continue,
+            }
+        };
+        skipped.push(SkippedPartnerId {
+            source_domain: source_domain.clone(),
+            reason,
+        });
+    }
+
+    AuctionEidsView { eids, skipped }
+}
+
+fn extract_cookie_value(req: &Request<EdgeBody>, name: &str) -> Option<String> {
+    let cookie_header = req
+        .headers()
+        .get(header::COOKIE)
+        .and_then(|value| value.to_str().ok())?;
+    for pair in cookie_header.split(';') {
+        let pair = pair.trim();
+        if let Some((key, value)) = pair.split_once('=')
+            && key.trim() == name
+        {
+            return Some(value.trim().to_owned());
+        }
+    }
+    None
+}
+
+fn json_error(status: StatusCode, message: &str) -> Response<EdgeBody> {
+    let body = serde_json::json!({ "error": message });
+    json_response(status, body.to_string())
+}
+
+fn json_response(status: StatusCode, body: String) -> Response<EdgeBody> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(EdgeBody::from(body.into_bytes()))
+        .expect("should build admin EC lookup response")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::ec::kv_backend::test_support::InMemoryEcKv;
+    use crate::ec::kv_backend::{EcKvStore as _, EcKvWrite, EcKvWriteMode};
+    use crate::ec::kv_types::KvPartnerId;
+    use crate::redacted::Redacted;
+    use crate::settings::EcPartner;
+
+    fn test_ec_id() -> String {
+        format!("{}.abc123", "a".repeat(64))
+    }
+
+    fn make_test_partner(source_domain: &str, bidstream_enabled: bool) -> EcPartner {
+        EcPartner {
+            name: format!("Partner {source_domain}"),
+            source_domain: source_domain.to_owned(),
+            openrtb_atype: EcPartner::default_openrtb_atype(),
+            bidstream_enabled,
+            api_token: Redacted::new(format!("test-token-{source_domain:-<32}")),
+            batch_rate_limit: EcPartner::default_batch_rate_limit(),
+            pull_sync_enabled: false,
+            pull_sync_url: None,
+            pull_sync_allowed_domains: vec![],
+            pull_sync_ttl_sec: EcPartner::default_pull_sync_ttl_sec(),
+            pull_sync_rate_limit: EcPartner::default_pull_sync_rate_limit(),
+            ts_pull_token: None,
+        }
+    }
+
+    fn test_registry() -> PartnerRegistry {
+        PartnerRegistry::from_config(&[
+            make_test_partner("bidstream.example", true),
+            make_test_partner("disabled.example", false),
+        ])
+        .expect("should build test partner registry")
+    }
+
+    fn get_request(path: &str) -> Request<EdgeBody> {
+        Request::builder()
+            .method("GET")
+            .uri(format!("https://edge.example.com{path}"))
+            .body(EdgeBody::empty())
+            .expect("should build test request")
+    }
+
+    fn get_request_with_cookie(path: &str, cookie: &str) -> Request<EdgeBody> {
+        Request::builder()
+            .method("GET")
+            .uri(format!("https://edge.example.com{path}"))
+            .header(header::COOKIE, cookie)
+            .body(EdgeBody::empty())
+            .expect("should build test request")
+    }
+
+    fn kv_with_entry(ec_id: &str, entry: &KvEntry) -> KvIdentityGraph {
+        let kv = KvIdentityGraph::in_memory("test-store");
+        kv.create(ec_id, entry).expect("should seed KV entry");
+        kv
+    }
+
+    fn kv_with_raw_body(ec_id: &str, body: &str) -> KvIdentityGraph {
+        let metadata = serde_json::json!({ "ok": true, "country": "US", "v": 1 }).to_string();
+        let store = InMemoryEcKv::new("test-store");
+        store
+            .insert(
+                ec_id,
+                EcKvWrite {
+                    body,
+                    metadata: &metadata,
+                    ttl: Duration::from_secs(60),
+                    mode: EcKvWriteMode::Add,
+                },
+            )
+            .expect("should seed raw KV body");
+        KvIdentityGraph::new(store)
+    }
+
+    fn response_json(response: Response<EdgeBody>) -> JsonValue {
+        serde_json::from_slice(&response.into_body().into_bytes().unwrap_or_default())
+            .expect("should parse response body as JSON")
+    }
+
+    fn sample_entry() -> KvEntry {
+        let mut entry = KvEntry::minimal("bidstream.example", "uid-live", 1_741_824_000);
+        entry.ids.insert(
+            "disabled.example".to_owned(),
+            KvPartnerId {
+                uid: "uid-disabled".to_owned(),
+            },
+        );
+        entry.ids.insert(
+            "unknown.example".to_owned(),
+            KvPartnerId {
+                uid: "uid-unknown".to_owned(),
+            },
+        );
+        entry
+    }
+
+    #[test]
+    fn returns_entry_with_auction_view() {
+        let ec_id = test_ec_id();
+        let kv = kv_with_entry(&ec_id, &sample_entry());
+        let req = get_request(&format!("/_ts/admin/ec/{ec_id}"));
+
+        let response = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req)
+            .expect("should handle lookup");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok()),
+            Some("no-store"),
+            "should send no-store on admin responses"
+        );
+
+        let json = response_json(response);
+        assert_eq!(json["ec_id"], ec_id.as_str());
+        assert_eq!(json["store"], "test-store");
+        assert_eq!(json["tombstone"], false);
+        assert_eq!(
+            json["entry"]["ids"]["bidstream.example"]["uid"], "uid-live",
+            "should echo the stored entry verbatim"
+        );
+
+        let eids = json["auction"]["eids"]
+            .as_array()
+            .expect("should have auction eids");
+        assert_eq!(eids.len(), 1, "should resolve only the bidstream partner");
+        assert_eq!(eids[0]["source"], "bidstream.example");
+        assert_eq!(eids[0]["uids"][0]["id"], "uid-live");
+
+        let skipped = json["auction"]["skipped"]
+            .as_array()
+            .expect("should have skipped list");
+        assert_eq!(skipped.len(), 2, "should report both filtered partners");
+        assert!(
+            skipped
+                .iter()
+                .any(|s| s["source_domain"] == "disabled.example"
+                    && s["reason"] == "bidstream_disabled"),
+            "should report the bidstream-disabled partner"
+        );
+        assert!(
+            skipped.iter().any(
+                |s| s["source_domain"] == "unknown.example" && s["reason"] == "not_in_registry"
+            ),
+            "should report the unregistered partner"
+        );
+    }
+
+    #[test]
+    fn reports_tombstone_entries() {
+        let ec_id = test_ec_id();
+        let kv = KvIdentityGraph::in_memory("test-store");
+        kv.write_withdrawal_tombstone(&ec_id)
+            .expect("should write tombstone");
+        let req = get_request(&format!("/_ts/admin/ec/{ec_id}"));
+
+        let response = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req)
+            .expect("should handle lookup");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response);
+        assert_eq!(json["tombstone"], true, "should flag tombstone entries");
+        assert!(
+            json["auction"]["eids"]
+                .as_array()
+                .expect("should have auction eids")
+                .is_empty(),
+            "tombstone should resolve no EIDs"
+        );
+    }
+
+    #[test]
+    fn missing_entry_returns_404() {
+        let kv = KvIdentityGraph::in_memory("test-store");
+        let req = get_request(&format!("/_ts/admin/ec/{}", test_ec_id()));
+
+        let response = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req)
+            .expect("should handle lookup");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn invalid_id_returns_400() {
+        let kv = KvIdentityGraph::in_memory("test-store");
+        let req = get_request("/_ts/admin/ec/not-a-valid-id");
+
+        let response = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req)
+            .expect("should handle lookup");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn corrupt_entry_returns_parse_error_and_raw_body() {
+        let ec_id = test_ec_id();
+        let kv = kv_with_raw_body(&ec_id, "not json at all");
+        let req = get_request(&format!("/_ts/admin/ec/{ec_id}"));
+
+        let response = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req)
+            .expect("should handle lookup");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "corrupt entries should be inspectable, not opaque errors"
+        );
+        let json = response_json(response);
+        assert!(
+            json["entry_error"]
+                .as_str()
+                .expect("should have entry_error")
+                .contains("failed to deserialize"),
+            "should describe the parse failure"
+        );
+        assert_eq!(json["raw_body"], "not json at all");
+        assert!(json.get("entry").is_none(), "should omit unparsed entry");
+        assert!(
+            json.get("auction").is_none(),
+            "should omit auction view for unparseable entries"
+        );
+        assert_eq!(
+            json["metadata"]["country"], "US",
+            "should still parse the stored metadata"
+        );
+    }
+
+    #[test]
+    fn invalid_schema_version_reports_validation_error() {
+        let ec_id = test_ec_id();
+        let body = serde_json::json!({
+            "v": 99,
+            "created": 1000,
+            "consent": { "ok": true, "updated": 1000 },
+            "geo": { "country": "US" }
+        })
+        .to_string();
+        let kv = kv_with_raw_body(&ec_id, &body);
+        let req = get_request(&format!("/_ts/admin/ec/{ec_id}"));
+
+        let response = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req)
+            .expect("should handle lookup");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response);
+        assert!(
+            json["entry_error"]
+                .as_str()
+                .expect("should have entry_error")
+                .contains("failed validation"),
+            "should describe the validation failure"
+        );
+        assert_eq!(json["entry"]["v"], 99, "should still show the parsed entry");
+        assert!(
+            json.get("auction").is_none(),
+            "should omit auction view when the auction read would fail closed"
+        );
+    }
+
+    #[test]
+    fn bare_route_uses_ts_ec_cookie() {
+        let ec_id = test_ec_id();
+        let kv = kv_with_entry(&ec_id, &sample_entry());
+        let req = get_request_with_cookie("/_ts/admin/ec", &format!("other=1; ts-ec={ec_id}; x=2"));
+
+        let response = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req)
+            .expect("should handle lookup");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response);
+        assert_eq!(
+            json["ec_id"],
+            ec_id.as_str(),
+            "should resolve the EC ID from the ts-ec cookie"
+        );
+    }
+
+    #[test]
+    fn bare_route_without_cookie_returns_404() {
+        let kv = KvIdentityGraph::in_memory("test-store");
+        let req = get_request("/_ts/admin/ec");
+
+        let response = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req)
+            .expect("should handle lookup");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let json = response_json(response);
+        assert!(
+            json["error"]
+                .as_str()
+                .expect("should have error message")
+                .contains("ts-ec cookie"),
+            "should explain the missing cookie"
+        );
+    }
+
+    #[test]
+    fn missing_identity_graph_returns_501() {
+        let req = get_request(&format!("/_ts/admin/ec/{}", test_ec_id()));
+
+        let response =
+            handle_admin_ec_lookup(None, &test_registry(), &req).expect("should handle lookup");
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[test]
+    fn kv_read_failure_propagates() {
+        let kv = KvIdentityGraph::failing("broken-store");
+        let req = get_request(&format!("/_ts/admin/ec/{}", test_ec_id()));
+
+        let result = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req);
+
+        assert!(result.is_err(), "should propagate KV read failures");
+    }
+}

--- a/crates/trusted-server-core/src/ec/admin.rs
+++ b/crates/trusted-server-core/src/ec/admin.rs
@@ -1,4 +1,4 @@
-//! Admin endpoint for inspecting EC identity graph entries.
+//! Admin endpoints for inspecting EC identity state.
 //!
 //! Serves `GET /_ts/admin/ec` (EC ID taken from the request's `ts-ec`
 //! cookie) and `GET /_ts/admin/ec/{id}` (explicit EC ID). Returns the raw
@@ -6,9 +6,13 @@
 //! attach, so operators can debug KV-to-auction propagation without KV
 //! console access.
 //!
+//! Also serves `GET /_ts/admin/eids`, which echoes the request's `ts-eids`
+//! and `sharedId` cookies with an ingestion preview — the client-side half
+//! of EID propagation that is never stored server-side.
+//!
 //! Authentication is enforced by the `^/_ts/admin` basic-auth handler
 //! configuration; startup validation rejects configs that leave these paths
-//! uncovered (see `Settings::ADMIN_ENDPOINTS`). Because the endpoint is
+//! uncovered (see `Settings::ADMIN_ENDPOINTS`). Because the endpoints are
 //! auth-gated and operator-facing, responses intentionally include full
 //! internal detail (raw consent strings, partner UIDs, parse errors).
 
@@ -19,7 +23,7 @@ use serde_json::Value as JsonValue;
 use edgezero_core::body::Body as EdgeBody;
 use error_stack::{Report, ResultExt as _};
 
-use crate::constants::COOKIE_TS_EC;
+use crate::constants::{COOKIE_SHAREDID, COOKIE_TS_EC, COOKIE_TS_EIDS};
 use crate::error::TrustedServerError;
 use crate::openrtb::Eid;
 
@@ -29,6 +33,10 @@ use super::kv::KvIdentityGraph;
 use super::kv_backend::EcKvLookup;
 use super::kv_types::{KvEntry, KvMetadata};
 use super::log_id;
+use super::prebid_eids::{
+    collect_prebid_eid_updates, collect_sharedid_update, dedupe_partner_updates,
+    parse_prebid_eids_cookie,
+};
 use super::registry::PartnerRegistry;
 
 /// Route prefix shared by the cookie-based and explicit-ID lookup routes.
@@ -271,6 +279,125 @@ fn build_auction_view(registry: &PartnerRegistry, entry: &KvEntry) -> AuctionEid
     AuctionEidsView { eids, skipped }
 }
 
+/// Admin EIDs echo payload.
+#[derive(Debug, Serialize)]
+struct AdminEidsResponse {
+    /// Whether a `ts-eids` cookie was present on the request.
+    cookie_present: bool,
+    /// EIDs parsed from the `ts-eids` cookie. Absent when the cookie is
+    /// missing or failed to parse.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    eids: Option<Vec<Eid>>,
+    /// Parse failure detail when the `ts-eids` cookie could not be decoded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parse_error: Option<String>,
+    /// Whether a `sharedId` cookie was present on the request.
+    sharedid_present: bool,
+    /// Number of partners configured in the registry.
+    partners_configured: usize,
+    /// Preview of what cookie ingestion would write into the EC entry's
+    /// `ids` map on a navigation carrying these cookies.
+    ingest: IngestPreview,
+}
+
+/// What cookie ingestion would store, and what it would drop.
+#[derive(Debug, Serialize)]
+struct IngestPreview {
+    /// Cookie sources matched to a configured partner, with the UID that
+    /// would be stored (deduplicated exactly like the ingestion path).
+    matched: Vec<MatchedPartnerId>,
+    /// `ts-eids` sources with no configured partner; dropped on ingestion.
+    unmatched: Vec<String>,
+}
+
+/// A cookie-derived partner UID that ingestion would store.
+#[derive(Debug, Serialize)]
+struct MatchedPartnerId {
+    /// Partner namespace key in the EC entry's `ids` map.
+    source_domain: String,
+    /// The UID that would be stored.
+    uid: String,
+}
+
+/// Handles `GET /_ts/admin/eids`.
+///
+/// Echoes the request's `ts-eids` and `sharedId` cookies: the parsed EID
+/// list plus a preview of what cookie ingestion would write into the EC
+/// entry's `ids` map given the configured partner registry. Pure request
+/// inspection — no KV access — so it works on every adapter.
+///
+/// Always responds `200 OK`; missing or malformed cookies are reported in
+/// the payload instead of as errors.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError::Configuration`] only when the response
+/// payload fails JSON serialization.
+pub fn handle_admin_eids_lookup(
+    registry: &PartnerRegistry,
+    req: &Request<EdgeBody>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    let eids_cookie = extract_cookie_value(req, COOKIE_TS_EIDS);
+    let sharedid_cookie = extract_cookie_value(req, COOKIE_SHAREDID);
+
+    let (eids, parse_error) = match &eids_cookie {
+        None => (None, None),
+        Some(value) => match parse_prebid_eids_cookie(value) {
+            Ok(parsed) => (Some(parsed), None),
+            Err(error) => (
+                None,
+                Some(format!("failed to parse ts-eids cookie: {error}")),
+            ),
+        },
+    };
+
+    // Mirror the ingestion path (`ingest_eid_cookies`): collect matches from
+    // both cookies, then dedupe the same way so the preview reports exactly
+    // what a navigation would store.
+    let mut updates = Vec::new();
+    if let Some(value) = &eids_cookie {
+        updates.extend(collect_prebid_eid_updates(value, registry));
+    }
+    if let Some(value) = &sharedid_cookie
+        && let Some(update) = collect_sharedid_update(value, registry)
+    {
+        updates.push(update);
+    }
+    let matched = dedupe_partner_updates(updates)
+        .into_iter()
+        .map(|update| MatchedPartnerId {
+            source_domain: update.partner_id,
+            uid: update.uid,
+        })
+        .collect();
+
+    let unmatched = eids
+        .as_ref()
+        .map(|parsed| {
+            parsed
+                .iter()
+                .filter(|eid| registry.find_by_source_domain(&eid.source).is_none())
+                .map(|eid| eid.source.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let payload = AdminEidsResponse {
+        cookie_present: eids_cookie.is_some(),
+        eids,
+        parse_error,
+        sharedid_present: sharedid_cookie.is_some(),
+        partners_configured: registry.len(),
+        ingest: IngestPreview { matched, unmatched },
+    };
+
+    let body =
+        serde_json::to_string(&payload).change_context(TrustedServerError::Configuration {
+            message: "failed to serialize admin EIDs response".to_owned(),
+        })?;
+    Ok(json_response(StatusCode::OK, body))
+}
+
 fn extract_cookie_value(req: &Request<EdgeBody>, name: &str) -> Option<String> {
     let cookie_header = req
         .headers()
@@ -304,6 +431,8 @@ fn json_response(status: StatusCode, body: String) -> Response<EdgeBody> {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
+
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
     use super::*;
     use crate::ec::kv_backend::test_support::InMemoryEcKv;
@@ -623,5 +752,129 @@ mod tests {
         let result = handle_admin_ec_lookup(Some(&kv), &test_registry(), &req);
 
         assert!(result.is_err(), "should propagate KV read failures");
+    }
+
+    fn eids_cookie_for(entries: &serde_json::Value) -> String {
+        BASE64.encode(entries.to_string())
+    }
+
+    #[test]
+    fn eids_lookup_without_cookies_returns_empty_payload() {
+        let req = get_request("/_ts/admin/eids");
+
+        let response =
+            handle_admin_eids_lookup(&test_registry(), &req).expect("should handle eids lookup");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response);
+        assert_eq!(json["cookie_present"], false);
+        assert_eq!(json["sharedid_present"], false);
+        assert_eq!(json["partners_configured"], 2);
+        assert!(
+            json["ingest"]["matched"]
+                .as_array()
+                .expect("should have matched list")
+                .is_empty(),
+            "should preview no matches without cookies"
+        );
+    }
+
+    #[test]
+    fn eids_lookup_parses_cookie_and_previews_ingestion() {
+        let cookie = eids_cookie_for(&serde_json::json!([
+            {
+                "source": "bidstream.example",
+                "uids": [{ "id": "uid-configured", "atype": 1 }]
+            },
+            {
+                "source": "unknown.example",
+                "uids": [{ "id": "uid-unknown", "atype": 1 }]
+            }
+        ]));
+        let req = get_request_with_cookie("/_ts/admin/eids", &format!("ts-eids={cookie}"));
+
+        let response =
+            handle_admin_eids_lookup(&test_registry(), &req).expect("should handle eids lookup");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response);
+        assert_eq!(json["cookie_present"], true);
+        assert_eq!(
+            json["eids"]
+                .as_array()
+                .expect("should have parsed eids")
+                .len(),
+            2,
+            "should echo both parsed EID sources"
+        );
+
+        let matched = json["ingest"]["matched"]
+            .as_array()
+            .expect("should have matched list");
+        assert_eq!(matched.len(), 1, "should match only the configured partner");
+        assert_eq!(matched[0]["source_domain"], "bidstream.example");
+        assert_eq!(matched[0]["uid"], "uid-configured");
+
+        let unmatched = json["ingest"]["unmatched"]
+            .as_array()
+            .expect("should have unmatched list");
+        assert_eq!(unmatched.len(), 1, "should report the unregistered source");
+        assert_eq!(unmatched[0], "unknown.example");
+    }
+
+    #[test]
+    fn eids_lookup_reports_parse_error() {
+        let req = get_request_with_cookie("/_ts/admin/eids", "ts-eids=!!!not-base64!!!");
+
+        let response =
+            handle_admin_eids_lookup(&test_registry(), &req).expect("should handle eids lookup");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "malformed cookies should be reported, not errored"
+        );
+        let json = response_json(response);
+        assert_eq!(json["cookie_present"], true);
+        assert!(
+            json["parse_error"]
+                .as_str()
+                .expect("should have parse_error")
+                .contains("ts-eids"),
+            "should describe the parse failure"
+        );
+        assert!(json.get("eids").is_none(), "should omit unparsed eids");
+        assert!(
+            json["ingest"]["matched"]
+                .as_array()
+                .expect("should have matched list")
+                .is_empty(),
+            "unparseable cookie should preview no matches"
+        );
+    }
+
+    #[test]
+    fn eids_lookup_includes_sharedid_match() {
+        let registry = PartnerRegistry::from_config(&[
+            make_test_partner("bidstream.example", true),
+            make_test_partner("sharedid.org", true),
+        ])
+        .expect("should build sharedid test registry");
+        let req = get_request_with_cookie("/_ts/admin/eids", "sharedId=shared-uid-123");
+
+        let response =
+            handle_admin_eids_lookup(&registry, &req).expect("should handle eids lookup");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response);
+        assert_eq!(json["cookie_present"], false);
+        assert_eq!(json["sharedid_present"], true);
+
+        let matched = json["ingest"]["matched"]
+            .as_array()
+            .expect("should have matched list");
+        assert_eq!(matched.len(), 1, "should match the sharedid partner");
+        assert_eq!(matched[0]["source_domain"], "sharedid.org");
+        assert_eq!(matched[0]["uid"], "shared-uid-123");
     }
 }

--- a/crates/trusted-server-core/src/ec/kv.rs
+++ b/crates/trusted-server-core/src/ec/kv.rs
@@ -21,7 +21,7 @@ use crate::error::TrustedServerError;
 
 use super::current_timestamp;
 use super::generation::ec_hash;
-use super::kv_backend::{EcKvStore, EcKvWrite, EcKvWriteMode, EcKvWriteOutcome};
+use super::kv_backend::{EcKvLookup, EcKvStore, EcKvWrite, EcKvWriteMode, EcKvWriteOutcome};
 use super::kv_types::{KvEntry, KvMetadata, KvNetwork};
 use super::log_id;
 
@@ -168,6 +168,25 @@ impl KvIdentityGraph {
                 message: "Failed to serialize KV entry metadata".to_owned(),
             })?;
         Ok((body, meta_str))
+    }
+
+    /// Reads the raw stored body, metadata, and generation for an EC ID key.
+    ///
+    /// Unlike [`Self::get`], the entry body is returned without
+    /// deserialization or validation, so corrupt or legacy-schema records can
+    /// still be inspected instead of failing closed. Used by the admin EC
+    /// lookup endpoint.
+    ///
+    /// Returns `Ok(None)` when the key does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrustedServerError::KvStore`] on store open or read failure.
+    pub fn lookup_raw(
+        &self,
+        ec_id: &str,
+    ) -> Result<Option<EcKvLookup>, Report<TrustedServerError>> {
+        self.store.lookup(ec_id)
     }
 
     /// Reads the full entry and its generation marker for CAS writes.

--- a/crates/trusted-server-core/src/ec/mod.rs
+++ b/crates/trusted-server-core/src/ec/mod.rs
@@ -31,6 +31,7 @@
 
 mod auth;
 
+pub mod admin;
 pub mod batch_sync;
 pub mod consent;
 pub mod cookies;

--- a/crates/trusted-server-core/src/ec/prebid_eids.rs
+++ b/crates/trusted-server-core/src/ec/prebid_eids.rs
@@ -179,7 +179,7 @@ fn ingest_eid_cookies_with_writer(
     }
 }
 
-fn collect_prebid_eid_updates(
+pub(crate) fn collect_prebid_eid_updates(
     cookie_value: &str,
     registry: &PartnerRegistry,
 ) -> Vec<PartnerIdUpdate> {
@@ -213,7 +213,7 @@ fn collect_prebid_eid_updates(
     updates
 }
 
-fn dedupe_partner_updates(updates: Vec<PartnerIdUpdate>) -> Vec<PartnerIdUpdate> {
+pub(crate) fn dedupe_partner_updates(updates: Vec<PartnerIdUpdate>) -> Vec<PartnerIdUpdate> {
     let mut latest = std::collections::BTreeMap::new();
     for update in updates {
         latest.insert(update.partner_id, update.uid);
@@ -250,7 +250,7 @@ pub fn ingest_sharedid_cookie(
     ingest_eid_cookies(None, Some(cookie_value), ec_id, kv, registry);
 }
 
-fn collect_sharedid_update(
+pub(crate) fn collect_sharedid_update(
     cookie_value: &str,
     registry: &PartnerRegistry,
 ) -> Option<PartnerIdUpdate> {

--- a/crates/trusted-server-core/src/integrations/prebid.rs
+++ b/crates/trusted-server-core/src/integrations/prebid.rs
@@ -2247,8 +2247,17 @@ impl AuctionProvider for PrebidAuctionProvider {
     ) -> Result<PlatformPendingRequest, Report<TrustedServerError>> {
         log::info!("Prebid: requesting bids for {} slots", request.slots.len());
 
-        let request_info =
-            RequestInfo::from_request(context.request, context.services.client_info());
+        // `ext.trusted_server.request_host` must be the publisher's own domain
+        // (matching `site.domain`/`publisher.domain` below), not the raw edge
+        // `Host` header of the incoming `/auction` request. On the SSAT proxy
+        // path the browser calls `/auction` against the trusted-server edge
+        // domain (e.g. `ts.example.com`), which is not what PBS's
+        // `trusted_server` verification module expects — see the "Host header
+        // value expected by the receiving service" doc on `SigningParams`.
+        let request_info = RequestInfo {
+            host: request.publisher.domain.clone(),
+            scheme: "https".to_owned(),
+        };
 
         // Create signer and compute signature if request signing is enabled
         let signer_with_signature =
@@ -2676,6 +2685,50 @@ mod tests {
             stub.recorded_backend_names().len(),
             1,
             "should launch one upstream request through PlatformHttpClient"
+        );
+    }
+
+    #[test]
+    fn request_bids_sets_trusted_server_request_host_to_publisher_domain_not_edge_host() {
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response(200, br#"{"seatbid":[]}"#.to_vec());
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let settings = make_settings();
+        let provider = PrebidAuctionProvider::new(base_config());
+        let auction_request = create_test_auction_request();
+        // The incoming `/auction` call arrives on the trusted-server edge
+        // domain (SSAT proxy pattern), which must NOT leak into
+        // `ext.trusted_server.request_host` — that field must track the
+        // publisher's own domain instead.
+        let http_req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://ts.pub.example/auction")
+            .header(header::HOST, "ts.pub.example")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+        let context = AuctionContext {
+            settings: &settings,
+            request: &http_req,
+            timeout_ms: 500,
+            provider_responses: None,
+            services: &services,
+        };
+
+        futures::executor::block_on(provider.request_bids(&auction_request, &context))
+            .expect("should start request");
+
+        let bodies = stub.recorded_request_bodies();
+        assert_eq!(bodies.len(), 1, "should send one upstream PBS request");
+        let sent: Json =
+            serde_json::from_slice(&bodies[0]).expect("should parse sent OpenRTB request body");
+        let request_host = sent["ext"]["trusted_server"]["request_host"]
+            .as_str()
+            .expect("should set ext.trusted_server.request_host");
+        assert_eq!(
+            request_host, auction_request.publisher.domain,
+            "request_host should be the publisher domain, not the edge Host header"
         );
     }
 

--- a/crates/trusted-server-core/src/lib.rs
+++ b/crates/trusted-server-core/src/lib.rs
@@ -70,6 +70,7 @@ pub mod streaming_processor;
 pub mod streaming_replacer;
 pub mod test_support;
 pub mod tester_cookie;
+pub mod trace_cookie;
 pub mod tsjs;
 
 #[cfg(test)]

--- a/crates/trusted-server-core/src/platform/test_support.rs
+++ b/crates/trusted-server-core/src/platform/test_support.rs
@@ -488,6 +488,21 @@ impl PlatformHttpClient for StubHttpClient {
             .expect("should lock request_headers")
             .push(headers);
 
+        // Capture the outgoing request body, mirroring `send()`, so tests
+        // exercising the async fan-out path (`request_bids` providers) can
+        // assert on it via `recorded_request_bodies()` too.
+        let (_, body) = request.request.into_parts();
+        let body_bytes = body
+            .into_bytes_bounded(MAX_RECORDED_BODY_BYTES)
+            .await
+            .change_context(PlatformError::HttpClient)
+            .attach("failed to capture StubHttpClient request body")?
+            .to_vec();
+        self.request_bodies
+            .lock()
+            .expect("should lock request bodies")
+            .push(body_bytes);
+
         let response = self
             .responses
             .lock()

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -3040,11 +3040,18 @@ pub(crate) fn build_bid_map(
                     .renderer
                     .as_ref()
                     .map(|renderer| renderer.aps().bid_id.as_str());
+                // `bid_id` (the OpenRTB bid's own `id`) is the last resort: it is
+                // always present per spec but only unique per bid instance, not a
+                // creative identifier. It still satisfies what hb_adid needs here —
+                // a stable value GAM's Universal Creative echoes back verbatim so
+                // the render bridge can find this exact winning bid — for bidders
+                // (e.g. Kargo) that return neither a cache UUID nor `adid`.
                 let hb_adid = bid
                     .cache_id
                     .as_deref()
                     .or(renderer_bid_id)
-                    .or(bid.ad_id.as_deref());
+                    .or(bid.ad_id.as_deref())
+                    .or(bid.bid_id.as_deref());
                 if let Some(id) = hb_adid {
                     obj.insert(
                         "hb_adid".to_string(),
@@ -6809,7 +6816,9 @@ mod tests {
                     height: 250,
                     nurl: None,
                     burl: None,
-                    bid_id: None,
+                    // Present alongside cache_id/ad_id to prove cache_id still wins
+                    // — bid_id is the last resort, not a co-equal fallback.
+                    bid_id: Some("should-be-ignored-bid-id".to_string()),
                     ad_id: Some("bid-impression-id".to_string()),
                     creative_id: None,
                     renderer: None,
@@ -6828,7 +6837,7 @@ mod tests {
             assert_eq!(
                 obj.get("hb_adid").and_then(|v| v.as_str()),
                 Some("f47447a0-b759-4f2f-9887-af458b79b570"),
-                "should use cache_id for hb_adid, not ad_id"
+                "should use cache_id for hb_adid, not ad_id or bid_id"
             );
             assert_eq!(
                 obj.get("hb_cache_host").and_then(|v| v.as_str()),
@@ -6858,7 +6867,9 @@ mod tests {
                     height: 250,
                     nurl: None,
                     burl: None,
-                    bid_id: None,
+                    // Present alongside ad_id to prove ad_id still wins — bid_id
+                    // is the last resort, not a co-equal fallback.
+                    bid_id: Some("should-be-ignored-bid-id".to_string()),
                     ad_id: Some("ordinary-ad-id".to_string()),
                     creative_id: None,
                     renderer: None,
@@ -6877,7 +6888,7 @@ mod tests {
             assert_eq!(
                 obj.get("hb_adid").and_then(|v| v.as_str()),
                 Some("ordinary-ad-id"),
-                "should fall back to ad_id when cache_id absent"
+                "should fall back to ad_id when cache_id absent, ignoring bid_id"
             );
             assert!(
                 obj.get("hb_cache_host").is_none(),
@@ -6890,7 +6901,49 @@ mod tests {
         }
 
         #[test]
-        fn bid_map_omits_hb_adid_when_both_cache_id_and_ad_id_absent() {
+        fn bid_map_falls_back_to_bid_id_when_cache_id_and_ad_id_absent() {
+            // Real shape for bidders like Kargo: no Prebid Cache UUID, no `adid`
+            // in the OpenRTB response, but `id` (the bid's own identifier) is
+            // always present per spec.
+            let mut winning_bids = HashMap::new();
+            winning_bids.insert(
+                "atf_sidebar_ad".to_string(),
+                Bid {
+                    slot_id: "atf_sidebar_ad".to_string(),
+                    price: Some(1.00),
+                    currency: "USD".to_string(),
+                    creative: None,
+                    adomain: None,
+                    bidder: "kargo".to_string(),
+                    width: 300,
+                    height: 250,
+                    nurl: None,
+                    burl: None,
+                    bid_id: Some("019f7e2a-b45b-70b0-a2d1-b651c430700b".to_string()),
+                    ad_id: None,
+                    creative_id: None,
+                    renderer: None,
+                    cache_id: None,
+                    cache_host: None,
+                    cache_path: None,
+                    metadata: Default::default(),
+                },
+            );
+            let map = build_bid_map(&winning_bids, PriceGranularity::Dense, false, None);
+            let obj = map
+                .get("atf_sidebar_ad")
+                .expect("should have bid entry")
+                .as_object()
+                .expect("should be object");
+            assert_eq!(
+                obj.get("hb_adid").and_then(|v| v.as_str()),
+                Some("019f7e2a-b45b-70b0-a2d1-b651c430700b"),
+                "should fall back to bid_id when cache_id and ad_id are both absent"
+            );
+        }
+
+        #[test]
+        fn bid_map_omits_hb_adid_when_cache_id_ad_id_and_bid_id_all_absent() {
             let mut winning_bids = HashMap::new();
             winning_bids.insert(
                 "atf_sidebar_ad".to_string(),
@@ -6923,7 +6976,7 @@ mod tests {
                 .expect("should be object");
             assert!(
                 obj.get("hb_adid").is_none(),
-                "should omit hb_adid when no cache_id and no ad_id"
+                "should omit hb_adid when no cache_id, ad_id, or bid_id"
             );
         }
 

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -2200,9 +2200,18 @@ impl Settings {
     /// where any of these paths lack a matching handler, ensuring admin
     /// endpoints are always protected by authentication.
     /// Update [`ADMIN_ENDPOINTS`](Self::ADMIN_ENDPOINTS) when adding new
-    /// admin routes to `crates/trusted-server-adapter-fastly/src/main.rs`.
-    pub(crate) const ADMIN_ENDPOINTS: &[&str] =
-        &["/_ts/admin/keys/rotate", "/_ts/admin/keys/deactivate"];
+    /// admin routes to `crates/trusted-server-adapter-fastly/src/app.rs`.
+    ///
+    /// The `/_ts/admin/ec/{id}` entry is the literal router pattern; handler
+    /// path regexes are matched against it verbatim, so prefix-style admin
+    /// regexes (e.g. `^/_ts/admin`) cover it while regexes too narrow to
+    /// cover the parameterized route are rejected fail-closed.
+    pub(crate) const ADMIN_ENDPOINTS: &[&str] = &[
+        "/_ts/admin/keys/rotate",
+        "/_ts/admin/keys/deactivate",
+        "/_ts/admin/ec",
+        "/_ts/admin/ec/{id}",
+    ];
 
     /// Returns admin endpoint paths that no configured handler covers.
     ///
@@ -5249,7 +5258,12 @@ origin_host_header_overide = "www.example.com""#,
             .expect("should check admin coverage");
         assert_eq!(
             uncovered,
-            vec!["/_ts/admin/keys/rotate", "/_ts/admin/keys/deactivate"],
+            vec![
+                "/_ts/admin/keys/rotate",
+                "/_ts/admin/keys/deactivate",
+                "/_ts/admin/ec",
+                "/_ts/admin/ec/{id}",
+            ],
             "should report every admin endpoint as uncovered"
         );
     }
@@ -5283,7 +5297,11 @@ origin_host_header_overide = "www.example.com""#,
             .expect("should check admin coverage");
         assert_eq!(
             uncovered,
-            vec!["/_ts/admin/keys/deactivate"],
+            vec![
+                "/_ts/admin/keys/deactivate",
+                "/_ts/admin/ec",
+                "/_ts/admin/ec/{id}",
+            ],
             "should detect the admin endpoints not covered by the narrow handler"
         );
     }

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -2211,6 +2211,7 @@ impl Settings {
         "/_ts/admin/keys/deactivate",
         "/_ts/admin/ec",
         "/_ts/admin/ec/{id}",
+        "/_ts/admin/eids",
     ];
 
     /// Returns admin endpoint paths that no configured handler covers.
@@ -5263,6 +5264,7 @@ origin_host_header_overide = "www.example.com""#,
                 "/_ts/admin/keys/deactivate",
                 "/_ts/admin/ec",
                 "/_ts/admin/ec/{id}",
+                "/_ts/admin/eids",
             ],
             "should report every admin endpoint as uncovered"
         );
@@ -5301,6 +5303,7 @@ origin_host_header_overide = "www.example.com""#,
                 "/_ts/admin/keys/deactivate",
                 "/_ts/admin/ec",
                 "/_ts/admin/ec/{id}",
+                "/_ts/admin/eids",
             ],
             "should detect the admin endpoints not covered by the narrow handler"
         );

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -1916,6 +1916,18 @@ pub struct DebugConfig {
     /// production — injects raw HTML from SSPs.
     #[serde(default)]
     pub inject_adm_for_testing: bool,
+
+    /// Expose `GET /_ts/trace`, which toggles the `ts-trace` cookie and
+    /// redirects to `/`.
+    ///
+    /// The cookie makes the TSJS render-trace overlay draw a floating panel
+    /// summarising every traced slot (render path, bidder, GAM/injected/visible
+    /// state) plus a confirmation badge on each genuinely-rendered creative.
+    /// The overlay only surfaces data already exposed on `window.tsjs`, so
+    /// enabling this leaks nothing new — it is off by default to avoid shipping
+    /// a live toggle route on deployments that never asked for it.
+    #[serde(default)]
+    pub trace_route_enabled: bool,
 }
 
 /// Tester-cookie endpoint configuration.

--- a/crates/trusted-server-core/src/trace_cookie.rs
+++ b/crates/trusted-server-core/src/trace_cookie.rs
@@ -1,0 +1,218 @@
+//! Render-trace toggle endpoint helpers.
+//!
+//! `GET /_ts/trace` arms (or with `?enabled=false` disarms) the first-party
+//! `ts-trace` cookie and redirects to `/`. While the cookie is present, the
+//! TSJS render-trace layer draws a visible badge on every traced creative so
+//! an operator can see on the page itself that a creative was delivered by
+//! Trusted Server — and via which render path (SSAT/GAM or `/auction`).
+//!
+//! The route is gated behind `[debug] trace_route_enabled` and returns
+//! `404 Not Found` while disabled, mirroring the tester-cookie endpoints. The
+//! badge only surfaces data already exposed on `window.tsjs`, so the cookie
+//! gates visibility, not access.
+
+use edgezero_core::body::Body as EdgeBody;
+use error_stack::{Report, ResultExt};
+use http::{HeaderValue, Response, StatusCode, header};
+
+use crate::constants::COOKIE_TS_TRACE;
+use crate::error::TrustedServerError;
+use crate::settings::Settings;
+
+/// How long an armed trace cookie lives, in seconds.
+///
+/// One hour: long enough for a debugging session across reloads and SPA
+/// navigations, short enough that a forgotten toggle expires on its own.
+const TRACE_COOKIE_MAX_AGE_SECS: u32 = 3600;
+
+/// Formats the trace cookie `Set-Cookie` header value.
+///
+/// Deliberately host-only (no `Domain` attribute): a `Domain` scoped to
+/// `publisher.cookie_domain` would be rejected by the browser during local
+/// development against `127.0.0.1`/`localhost`, and the overlay only needs to
+/// work on the exact host being debugged. Also neither `HttpOnly` (the TSJS
+/// overlay must read it from `document.cookie`) nor `Secure` (the badge is a
+/// debug aid that must work through plain-HTTP local dev proxies, and the
+/// cookie carries no data worth protecting).
+fn format_trace_cookie() -> String {
+    format!(
+        "{}=1; Path=/; SameSite=Lax; Max-Age={}",
+        COOKIE_TS_TRACE, TRACE_COOKIE_MAX_AGE_SECS,
+    )
+}
+
+/// Formats the trace cookie clearing `Set-Cookie` header value.
+fn format_clear_trace_cookie() -> String {
+    format!("{}=; Path=/; SameSite=Lax; Max-Age=0", COOKIE_TS_TRACE)
+}
+
+/// Whether the request's query string asks to disarm the trace cookie.
+///
+/// Only an explicit `enabled=false` (or `enabled=0`) disarms; any other query
+/// — including none at all — arms it, so `GET /_ts/trace` alone switches the
+/// overlay on.
+fn query_disables(query: Option<&str>) -> bool {
+    query.is_some_and(|q| {
+        q.split('&')
+            .any(|pair| pair == "enabled=false" || pair == "enabled=0")
+    })
+}
+
+/// Handles `GET /_ts/trace`.
+///
+/// Returns `404 Not Found` while `[debug] trace_route_enabled` is false. When
+/// enabled, sets (or with `?enabled=false` clears) the `ts-trace` cookie
+/// scoped to `publisher.cookie_domain` and returns `302 Found` redirecting to
+/// `/` — landing back on the homepage confirms the toggle round-trip worked.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError::InvalidHeaderValue`] if the configured cookie
+/// domain cannot be rendered as an HTTP header value.
+pub fn handle_trace_mode(
+    settings: &Settings,
+    query: Option<&str>,
+) -> Result<Response<EdgeBody>, Report<TrustedServerError>> {
+    if !settings.debug.trace_route_enabled {
+        let mut response = Response::new(EdgeBody::empty());
+        *response.status_mut() = StatusCode::NOT_FOUND;
+        return Ok(response);
+    }
+
+    let cookie_value = if query_disables(query) {
+        format_clear_trace_cookie()
+    } else {
+        format_trace_cookie()
+    };
+    let set_cookie = HeaderValue::from_str(&cookie_value).change_context(
+        TrustedServerError::InvalidHeaderValue {
+            message: "trace cookie contains invalid header value".to_string(),
+        },
+    )?;
+
+    let mut response = Response::new(EdgeBody::empty());
+    *response.status_mut() = StatusCode::FOUND;
+    response
+        .headers_mut()
+        .insert(header::LOCATION, HeaderValue::from_static("/"));
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, private"),
+    );
+    response
+        .headers_mut()
+        .insert(header::SET_COOKIE, set_cookie);
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::tests::create_test_settings;
+
+    fn trace_enabled_settings() -> Settings {
+        let mut settings = create_test_settings();
+        settings.debug.trace_route_enabled = true;
+        settings
+    }
+
+    #[test]
+    fn trace_route_arms_cookie_and_redirects_to_root() {
+        let settings = trace_enabled_settings();
+
+        let response = handle_trace_mode(&settings, None).expect("should build trace response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::FOUND,
+            "enabled trace route should redirect"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("/"),
+            "should redirect to the site root"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok()),
+            Some("no-store, private"),
+            "trace route should not be cacheable"
+        );
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("should set trace cookie")
+            .to_str()
+            .expect("should render set-cookie as utf-8");
+        assert_eq!(
+            set_cookie, "ts-trace=1; Path=/; SameSite=Lax; Max-Age=3600",
+            "trace cookie should be host-only with a bounded lifetime"
+        );
+    }
+
+    #[test]
+    fn trace_route_clears_cookie_when_disabled_by_query() {
+        let settings = trace_enabled_settings();
+
+        let response = handle_trace_mode(&settings, Some("enabled=false"))
+            .expect("should build trace clear response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::FOUND,
+            "clearing should still redirect"
+        );
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("should clear trace cookie")
+            .to_str()
+            .expect("should render set-cookie as utf-8");
+        assert_eq!(
+            set_cookie, "ts-trace=; Path=/; SameSite=Lax; Max-Age=0",
+            "trace cookie clear should expire the cookie"
+        );
+    }
+
+    #[test]
+    fn trace_route_arms_cookie_for_unrelated_query() {
+        let settings = trace_enabled_settings();
+
+        let response = handle_trace_mode(&settings, Some("enabled=true&foo=bar"))
+            .expect("should build trace response");
+
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("should set trace cookie")
+            .to_str()
+            .expect("should render set-cookie as utf-8");
+        assert!(
+            set_cookie.starts_with("ts-trace=1;"),
+            "non-disabling query should arm the cookie"
+        );
+    }
+
+    #[test]
+    fn trace_route_is_disabled_by_default() {
+        let settings = create_test_settings();
+
+        let response =
+            handle_trace_mode(&settings, None).expect("should build disabled trace response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "disabled trace route should return not found"
+        );
+        assert!(
+            response.headers().get(header::SET_COOKIE).is_none(),
+            "disabled trace route should not set a cookie"
+        );
+    }
+}

--- a/crates/trusted-server-js/lib/src/core/request.ts
+++ b/crates/trusted-server-js/lib/src/core/request.ts
@@ -4,7 +4,7 @@ import { collectContext } from './context';
 import { getAllUnits, firstSize } from './registry';
 import { createAdIframe, findSlot, buildCreativeDocument, sanitizeCreativeHtml } from './render';
 import { buildAdRequest, sendAuction } from './auction';
-import { recordRender, stampCreativeTrace } from './trace';
+import { recordRender, stampCreativeTrace, isEffectivelyVisible } from './trace';
 
 export type RequestAdsCallback = () => void;
 export interface RequestAdsOptions {
@@ -107,7 +107,7 @@ function renderCreativeInline({
   const container = findSlot(slotId) as HTMLElement | null;
   if (!container) {
     log.warn('renderCreativeInline: slot not found; skipping render', { slotId, seat, creativeId });
-    recordRender({ ...trace, rendered: false });
+    recordRender({ ...trace, rendered: false, injected: false, visible: false });
     return;
   }
 
@@ -126,6 +126,8 @@ function renderCreativeInline({
       const rejectedRecord = recordRender({
         ...trace,
         rendered: false,
+        injected: false,
+        visible: false,
         elementId: container.id || undefined,
       });
       stampCreativeTrace(container, rejectedRecord);
@@ -162,9 +164,13 @@ function renderCreativeInline({
 
     // Trace: registry entry + DOM markers joining this creative back to the
     // server-side auction (matches the `auction delivered creative:` log line).
+    // The /auction path writes the srcdoc itself, so this is a confirmed TS
+    // placement (injected: true).
     const record = recordRender({
       ...trace,
       rendered: true,
+      injected: true,
+      visible: isEffectivelyVisible(container),
       elementId: container.id || undefined,
     });
     stampCreativeTrace(container, record);

--- a/crates/trusted-server-js/lib/src/core/trace.ts
+++ b/crates/trusted-server-js/lib/src/core/trace.ts
@@ -148,11 +148,11 @@ function attachTraceBadge(el: HTMLElement, record: RenderRecord): void {
   badge.title = [
     `render: #${record.seq}`,
     `slot: ${record.slotId}`,
-    `auction: ${record.auctionId ?? '?'}`,
-    `bidder: ${record.bidder ?? '?'}`,
-    `creative: ${record.creativeId ?? '?'}`,
-    `adm_hash: ${record.admHash ?? '?'}`,
-    `served: ${record.servedFrom ?? '?'}`,
+    `auction: ${record.auctionId ?? '—'}`,
+    `bidder: ${record.bidder ?? '—'}`,
+    `creative: ${record.creativeId ?? '—'}`,
+    `adm_hash: ${record.admHash ?? '—'}`,
+    `served: ${record.servedFrom ?? '—'}`,
   ].join('\n');
   const s = badge.style;
   s.setProperty('position', 'absolute');
@@ -276,13 +276,13 @@ function buildPanelRow(record: RenderRecord): HTMLElement {
     `gam_empty: ${record.gamEmpty ?? '—'}`,
     `injected (ts placed): ${record.injected ?? '—'}`,
     `visible: ${record.visible ?? '—'}`,
-    `auction: ${record.auctionId ?? '?'}`,
-    `bidder: ${record.bidder ?? '?'}`,
-    `creative: ${record.creativeId ?? '?'}`,
-    `ad_id: ${record.adId ?? '?'}`,
-    `adm_hash: ${record.admHash ?? '?'}`,
-    `served: ${record.servedFrom ?? '?'}`,
-    `element: ${record.elementId ?? '?'}`,
+    `auction: ${record.auctionId ?? '—'}`,
+    `bidder: ${record.bidder ?? '—'}`,
+    `creative: ${record.creativeId ?? '—'}`,
+    `ad_id: ${record.adId ?? '—'}`,
+    `adm_hash: ${record.admHash ?? '—'}`,
+    `served: ${record.servedFrom ?? '—'}`,
+    `element: ${record.elementId ?? '—'}`,
     `renders: ${record.count}`,
   ].join('\n');
 

--- a/crates/trusted-server-js/lib/src/core/trace.ts
+++ b/crates/trusted-server-js/lib/src/core/trace.ts
@@ -30,6 +30,13 @@ export const TRACE_PANEL_ID = 'ts-render-trace-panel';
  */
 const MAX_RENDER_LOG_ENTRIES = 200;
 
+/**
+ * Page-global render counter backing [`RenderRecord.seq`]. Module-scoped
+ * rather than stored on `window.tsjs` so a re-executed bundle cannot resume
+ * mid-sequence and hand two different renders the same number.
+ */
+let renderSeq = 0;
+
 /** CSS class of the per-slot confirmation badge (only on honestly-ok slots). */
 export const TRACE_BADGE_CLASS = 'ts-render-badge';
 
@@ -133,8 +140,13 @@ function attachTraceBadge(el: HTMLElement, record: RenderRecord): void {
 
   const badge = document.createElement('div');
   badge.className = TRACE_BADGE_CLASS;
-  badge.textContent = `TS ${style.mark} ${record.bidder ?? '?'}${style.label === 'ok' ? '' : ` · ${style.label}`}`;
+  // Lead with the sequence number: it is what ties this badge to a panel row.
+  badge.textContent =
+    `TS ${style.mark} #${record.seq}` +
+    `${record.bidder ? ` · ${record.bidder}` : ''}` +
+    `${style.label === 'ok' ? '' : ` · ${style.label}`}`;
   badge.title = [
+    `render: #${record.seq}`,
     `slot: ${record.slotId}`,
     `auction: ${record.auctionId ?? '?'}`,
     `bidder: ${record.bidder ?? '?'}`,
@@ -197,10 +209,26 @@ function ensureTracePanel(): HTMLElement | null {
   return panel;
 }
 
+/**
+ * Whether this record is still the live render for its slot — i.e. the entry
+ * `window.tsjs.renders` currently holds. Every other row in the log has been
+ * superseded by a later render of the same slot.
+ */
+function isCurrentRender(record: RenderRecord): boolean {
+  try {
+    return window.tsjs?.renders?.[record.slotId]?.seq === record.seq;
+  } catch {
+    return false;
+  }
+}
+
 /** GAM/injection state summary for the panel's detail line. */
 function stateSummary(record: RenderRecord): string {
   const parts: string[] = [];
-  if (record.path === 'ssat') {
+  // GAM's own fill signal, on every render path that has one. Gating this on
+  // `ssat` would hide it for `gam-refresh`, where "did GAM fill it this time"
+  // is the whole question.
+  if (record.gamEmpty !== undefined) {
     parts.push(`gam:${record.gamEmpty ? 'empty' : 'filled'}`);
   }
   if (record.injected !== undefined) {
@@ -240,6 +268,7 @@ function buildPanelRow(record: RenderRecord): HTMLElement {
   // Click a row to copy its full record (untruncated IDs/hash) + log it.
   row.addEventListener('click', () => copyRecord(record));
   row.title = [
+    `render: #${record.seq}`,
     `slot: ${record.slotId}`,
     `status: ${style.label}`,
     `path: ${record.path}`,
@@ -259,17 +288,30 @@ function buildPanelRow(record: RenderRecord): HTMLElement {
 
   const line1 = document.createElement('div');
   const clock = new Date(record.at).toLocaleTimeString('en-GB', { hour12: false });
-  line1.textContent = `${clock} ${style.mark} ${record.slotId} · ${style.label}`;
+  // `current` marks the row still on screen for its slot — the one whose badge,
+  // if any, is the badge you are looking at. Older rows are history.
+  const current = isCurrentRender(record) ? ' ◂ current' : '';
+  line1.textContent = `#${record.seq} ${clock} ${style.mark} ${record.slotId} · ${style.label}${current}`;
   line1.style.setProperty('font-weight', '600');
   line1.style.setProperty('color', style.color);
 
   const line2 = document.createElement('div');
   line2.style.setProperty('color', '#bbb');
-  line2.textContent = `${record.path}${mechanismSuffix(record)} · ${record.bidder ?? '?'} · ${short(record.admHash)}`;
+  // An unattributed render (a GAM refresh TS ran no auction for) carries no
+  // bidder or hash by design. Say that, rather than rendering `? · ?` as if a
+  // lookup had failed.
+  const attribution =
+    record.bidder || record.admHash
+      ? `${record.bidder ?? '?'} · ${short(record.admHash)}`
+      : 'no TS attribution';
+  line2.textContent = `${record.path}${mechanismSuffix(record)} · ${attribution}`;
 
   const line3 = document.createElement('div');
   line3.style.setProperty('color', '#777');
-  line3.textContent = `${stateSummary(record)} · auction ${short(record.auctionId)} · #${record.count}`;
+  const auction = record.auctionId ? ` · auction ${short(record.auctionId)}` : '';
+  // `×N` is this slot's own render count — distinct from the page-global `#seq`
+  // on line 1, which is what the on-creative badge shows.
+  line3.textContent = `${stateSummary(record)}${auction} · ×${record.count}`;
 
   row.append(line1, line2, line3);
   return row;
@@ -361,8 +403,8 @@ export function renderTracePanel(): void {
  * When the trace overlay is armed, the floating panel is refreshed here — the
  * single choke point every render passes through.
  */
-export function recordRender(record: Omit<RenderRecord, 'count' | 'at'>): RenderRecord {
-  const full: RenderRecord = { ...record, count: 1, at: Date.now() };
+export function recordRender(record: Omit<RenderRecord, 'count' | 'at' | 'seq'>): RenderRecord {
+  const full: RenderRecord = { ...record, count: 1, seq: ++renderSeq, at: Date.now() };
   try {
     const ts = (window.tsjs ??= {} as TsjsApi);
     const renders = (ts.renders ??= {});

--- a/crates/trusted-server-js/lib/src/core/trace.ts
+++ b/crates/trusted-server-js/lib/src/core/trace.ts
@@ -1,8 +1,12 @@
-// Render-trace registry and DOM markers: joins a creative rendered on the
-// page back to the winning server-side auction bid. Every render writes a
-// RenderRecord to window.tsjs.renders (keyed by slot ID), stamps the slot
-// element with data-ts-* attributes carrying the same trace tuple, and fires
-// a 'tsjs:adRendered' CustomEvent so tests and tooling can await renders.
+// Render-trace registry, DOM markers, and a floating debug panel: joins a
+// creative rendered on the page back to the winning server-side auction bid.
+// Every render writes a RenderRecord to window.tsjs.renders (keyed by slot ID),
+// stamps the slot element with data-ts-* attributes carrying the same trace
+// tuple, and fires a 'tsjs:adRendered' CustomEvent. When the ts-trace cookie is
+// armed (via GET /_ts/trace), a Google-Publisher-Console-style overlay panel
+// summarises every traced slot so an operator can confirm on the page itself
+// that creatives came through Trusted Server — on both the SSAT/GAM and
+// /auction render paths.
 import { log } from './log';
 import type { RenderRecord, TsjsApi } from './types';
 
@@ -10,11 +14,337 @@ import type { RenderRecord, TsjsApi } from './types';
 export const RENDER_EVENT_NAME = 'tsjs:adRendered';
 
 /**
+ * Cookie armed by `GET /_ts/trace` (server-side, `ts-trace=1`). While present,
+ * the floating trace panel is shown so an operator can see on the page itself
+ * that creatives were delivered by Trusted Server.
+ */
+const TRACE_COOKIE_NAME = 'ts-trace';
+
+/** DOM id of the floating trace panel (body-level overlay). */
+export const TRACE_PANEL_ID = 'ts-render-trace-panel';
+
+/** CSS class of the per-slot confirmation badge (only on honestly-ok slots). */
+export const TRACE_BADGE_CLASS = 'ts-render-badge';
+
+/**
+ * Whether the visible trace overlay is armed (`ts-trace=1` cookie present —
+ * set via `GET /_ts/trace`, cleared via `GET /_ts/trace?enabled=false`).
+ */
+export function traceOverlayEnabled(): boolean {
+  try {
+    return new RegExp(`(?:^|;\\s*)${TRACE_COOKIE_NAME}=1(?:;|$)`).test(document.cookie);
+  } catch {
+    return false;
+  }
+}
+
+/** Short-form mechanism suffix — only the bridge mechanisms add information. */
+function mechanismSuffix(record: RenderRecord): string {
+  return record.servedFrom === 'debug-adm' || record.servedFrom === 'pbs-cache'
+    ? ` (${record.servedFrom})`
+    : '';
+}
+
+/**
+ * Whether an element is effectively visible: connected, non-zero box, and no
+ * ancestor hiding it via `display:none`, `visibility:hidden`, or `opacity:0`.
+ *
+ * The ancestor walk is what catches a slot the publisher holds at `opacity:0`
+ * on a wrapper until its own ad code reveals it — the slot's own computed
+ * opacity is `1`, so only walking up exposes the gate.
+ */
+export function isEffectivelyVisible(el: Element | null): boolean {
+  try {
+    if (!el || !(el instanceof HTMLElement) || !el.isConnected) return false;
+    const rect = el.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return false;
+    let node: HTMLElement | null = el;
+    while (node) {
+      const cs = getComputedStyle(node);
+      if (
+        cs.display === 'none' ||
+        cs.visibility === 'hidden' ||
+        parseFloat(cs.opacity || '1') === 0
+      ) {
+        return false;
+      }
+      node = node.parentElement;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Honest per-slot status for the panel, derived from the separate signals:
+ * - `empty`   — GAM reported the slot empty, or nothing was placed.
+ * - `hidden`  — a creative rendered but the slot is not visible (reveal gate).
+ * - `gam-only`— GAM rendered something, but TS did not place it (can't confirm
+ *               it is the TS creative — cross-origin).
+ * - `ok`      — TS placed a creative and the slot is visible.
+ */
+type PanelStatus = 'ok' | 'hidden' | 'gam-only' | 'empty';
+
+function panelStatus(record: RenderRecord): PanelStatus {
+  if (!record.rendered || record.gamEmpty === true) return 'empty';
+  if (record.visible === false) return 'hidden';
+  // injected===false means TS applied targeting only; the creative is GAM's and
+  // unreadable, so we must not claim it as a confirmed TS render.
+  if (record.injected === false) return 'gam-only';
+  return 'ok';
+}
+
+const STATUS_STYLE: Record<PanelStatus, { color: string; mark: string; label: string }> = {
+  ok: { color: '#3fb950', mark: '✓', label: 'ok' },
+  hidden: { color: '#d29922', mark: '⚠', label: 'hidden' },
+  'gam-only': { color: '#58a6ff', mark: '◐', label: 'gam-only' },
+  empty: { color: '#f85149', mark: '✗', label: 'empty' },
+};
+
+/**
+ * Attach (or replace) the per-slot confirmation badge on a slot element.
+ *
+ * Only called for `ok` slots — a TS creative that actually placed and is
+ * visible — so the green badge on a physical banner is a truthful "this banner
+ * is the render in the trace panel" marker, not the overclaiming badge the
+ * first cut shipped. Hidden / gam-only / empty slots deliberately get none.
+ *
+ * `pointer-events: none` keeps the badge from intercepting clicks on the ad.
+ */
+function attachTraceBadge(el: HTMLElement, record: RenderRecord): void {
+  el.querySelectorAll(`:scope > .${TRACE_BADGE_CLASS}`).forEach((n) => n.remove());
+
+  const position = getComputedStyle(el).position;
+  if (position === 'static' || position === '') {
+    el.style.position = 'relative';
+  }
+
+  const badge = document.createElement('div');
+  badge.className = TRACE_BADGE_CLASS;
+  badge.textContent = `TS ✓ ${record.bidder ?? '?'}`;
+  badge.title = [
+    `slot: ${record.slotId}`,
+    `auction: ${record.auctionId ?? '?'}`,
+    `bidder: ${record.bidder ?? '?'}`,
+    `creative: ${record.creativeId ?? '?'}`,
+    `adm_hash: ${record.admHash ?? '?'}`,
+    `served: ${record.servedFrom ?? '?'}`,
+  ].join('\n');
+  const s = badge.style;
+  s.setProperty('position', 'absolute');
+  s.setProperty('top', '4px');
+  s.setProperty('left', '4px');
+  s.setProperty('z-index', '2147483646');
+  s.setProperty('pointer-events', 'none');
+  s.setProperty('font', '10px/1.5 ui-monospace, Menlo, Consolas, monospace');
+  s.setProperty('padding', '1px 5px');
+  s.setProperty('color', '#fff');
+  s.setProperty('background', 'rgba(0,128,0,0.9)');
+  s.setProperty('border-radius', '3px');
+  el.appendChild(badge);
+}
+
+/** Truncate a long id for the compact panel row while keeping the tail. */
+function short(value: string | undefined, keep = 10): string {
+  if (!value) return '?';
+  return value.length > keep ? `…${value.slice(-keep)}` : value;
+}
+
+/**
+ * Create (or return) the floating trace panel appended to `document.body`.
+ *
+ * A body-level fixed overlay is used deliberately instead of per-slot badges:
+ * it survives GAM/APS clearing a slot's `innerHTML`, publisher reveal gates
+ * that hold a slot wrapper at `opacity: 0`, and cross-origin creative iframes —
+ * none of which a child-of-slot badge can survive.
+ */
+function ensureTracePanel(): HTMLElement | null {
+  if (typeof document === 'undefined' || !document.body) return null;
+
+  const existing = document.getElementById(TRACE_PANEL_ID);
+  if (existing) return existing;
+
+  const panel = document.createElement('div');
+  panel.id = TRACE_PANEL_ID;
+  const s = panel.style;
+  s.setProperty('position', 'fixed');
+  s.setProperty('bottom', '12px');
+  s.setProperty('right', '12px');
+  s.setProperty('z-index', '2147483647');
+  s.setProperty('max-width', '360px');
+  s.setProperty('max-height', '45vh');
+  s.setProperty('overflow', 'auto');
+  s.setProperty('background', 'rgba(17,17,17,0.94)');
+  s.setProperty('color', '#eee');
+  s.setProperty('font', '11px/1.5 ui-monospace, Menlo, Consolas, monospace');
+  s.setProperty('border', '1px solid #333');
+  s.setProperty('border-radius', '6px');
+  s.setProperty('box-shadow', '0 4px 16px rgba(0,0,0,0.4)');
+  s.setProperty('padding', '0');
+  document.body.appendChild(panel);
+  return panel;
+}
+
+/** GAM/injection state summary for the panel's detail line. */
+function stateSummary(record: RenderRecord): string {
+  const parts: string[] = [];
+  if (record.path === 'ssat') {
+    parts.push(`gam:${record.gamEmpty ? 'empty' : 'filled'}`);
+  }
+  if (record.injected !== undefined) {
+    parts.push(`inj:${record.injected ? 'y' : 'n'}`);
+  }
+  parts.push(`vis:${record.visible === false ? 'n' : record.visible ? 'y' : '?'}`);
+  return parts.join(' · ');
+}
+
+/**
+ * Copy a record's full JSON to the clipboard and log it — used by the panel's
+ * click-to-copy so full (untruncated) auction IDs and hashes are debuggable
+ * without hovering the title or digging in `window.tsjs.renders`.
+ */
+function copyRecord(record: RenderRecord): void {
+  const json = JSON.stringify(record, null, 2);
+  log.info('trace: render record', record);
+  try {
+    void navigator.clipboard?.writeText(json);
+  } catch {
+    // Clipboard unavailable (insecure context / permissions) — the console
+    // log above is the fallback.
+  }
+}
+
+/** Build one slot row for the panel. */
+function buildPanelRow(record: RenderRecord): HTMLElement {
+  const status = panelStatus(record);
+  const style = STATUS_STYLE[status];
+
+  const row = document.createElement('div');
+  const rs = row.style;
+  rs.setProperty('padding', '6px 10px');
+  rs.setProperty('border-top', '1px solid #2a2a2a');
+  rs.setProperty('border-left', `3px solid ${style.color}`);
+  rs.setProperty('cursor', 'pointer');
+  // Click a row to copy its full record (untruncated IDs/hash) + log it.
+  row.addEventListener('click', () => copyRecord(record));
+  row.title = [
+    `slot: ${record.slotId}`,
+    `status: ${style.label}`,
+    `path: ${record.path}`,
+    `rendered (gam non-empty): ${record.rendered}`,
+    `gam_empty: ${record.gamEmpty ?? '—'}`,
+    `injected (ts placed): ${record.injected ?? '—'}`,
+    `visible: ${record.visible ?? '—'}`,
+    `auction: ${record.auctionId ?? '?'}`,
+    `bidder: ${record.bidder ?? '?'}`,
+    `creative: ${record.creativeId ?? '?'}`,
+    `ad_id: ${record.adId ?? '?'}`,
+    `adm_hash: ${record.admHash ?? '?'}`,
+    `served: ${record.servedFrom ?? '?'}`,
+    `element: ${record.elementId ?? '?'}`,
+    `renders: ${record.count}`,
+  ].join('\n');
+
+  const line1 = document.createElement('div');
+  line1.textContent = `${style.mark} ${record.slotId} · ${style.label}`;
+  line1.style.setProperty('font-weight', '600');
+  line1.style.setProperty('color', style.color);
+
+  const line2 = document.createElement('div');
+  line2.style.setProperty('color', '#bbb');
+  line2.textContent = `${record.path}${mechanismSuffix(record)} · ${record.bidder ?? '?'} · ${short(record.admHash)}`;
+
+  const line3 = document.createElement('div');
+  line3.style.setProperty('color', '#777');
+  line3.textContent = `${stateSummary(record)} · auction ${short(record.auctionId)}${record.count > 1 ? ` · ×${record.count}` : ''}`;
+
+  row.append(line1, line2, line3);
+  return row;
+}
+
+/**
+ * Rebuild the floating trace panel from `window.tsjs.renders`.
+ *
+ * Reads the whole registry each call so the panel always reflects the current
+ * state; safe to call on every render event.
+ */
+export function renderTracePanel(): void {
+  try {
+    if (!traceOverlayEnabled()) return;
+    const panel = ensureTracePanel();
+    if (!panel) return;
+
+    const renders = window.tsjs?.renders ?? {};
+    const records = Object.values(renders).sort((a, b) => a.slotId.localeCompare(b.slotId));
+    // Count only slots that are honestly OK (TS creative placed and visible),
+    // not merely "GAM said something rendered" — the whole point of the fix.
+    const ok = records.filter((r) => panelStatus(r) === 'ok').length;
+
+    panel.replaceChildren();
+
+    const header = document.createElement('div');
+    const hs = header.style;
+    hs.setProperty('display', 'flex');
+    hs.setProperty('justify-content', 'space-between');
+    hs.setProperty('align-items', 'center');
+    hs.setProperty('gap', '8px');
+    hs.setProperty('padding', '6px 10px');
+    hs.setProperty('position', 'sticky');
+    hs.setProperty('top', '0');
+    hs.setProperty('background', '#000');
+    hs.setProperty('font-weight', '700');
+
+    const title = document.createElement('span');
+    title.textContent = `TS Render Trace · ${ok}/${records.length} ok`;
+
+    const close = document.createElement('button');
+    close.textContent = '×';
+    close.setAttribute('aria-label', 'Close trace panel');
+    const cs = close.style;
+    cs.setProperty('background', 'transparent');
+    cs.setProperty('color', '#eee');
+    cs.setProperty('border', '0');
+    cs.setProperty('font-size', '14px');
+    cs.setProperty('cursor', 'pointer');
+    cs.setProperty('line-height', '1');
+    close.addEventListener('click', () => panel.remove());
+
+    header.append(title, close);
+    panel.appendChild(header);
+
+    const hint = document.createElement('div');
+    hint.style.setProperty('padding', '2px 10px 4px');
+    hint.style.setProperty('color', '#777');
+    hint.style.setProperty('font-size', '9px');
+    hint.textContent = 'click a row to copy its full record · hover for detail';
+    panel.appendChild(hint);
+
+    if (records.length === 0) {
+      const empty = document.createElement('div');
+      empty.style.setProperty('padding', '6px 10px');
+      empty.style.setProperty('color', '#bbb');
+      empty.textContent = 'No creatives traced yet.';
+      panel.appendChild(empty);
+      return;
+    }
+
+    for (const record of records) {
+      panel.appendChild(buildPanelRow(record));
+    }
+  } catch (err) {
+    log.warn('trace: failed to render panel', err);
+  }
+}
+
+/**
  * Write a render record into `window.tsjs.renders` and fire the render event.
  *
  * Repeated records for the same slot (SPA navigation, GPT refresh) overwrite
  * the previous entry and increment `count`, so the registry always reflects
  * the latest render while preserving how many renders the slot has seen.
+ * When the trace overlay is armed, the floating panel is refreshed here — the
+ * single choke point every render passes through.
  */
 export function recordRender(record: Omit<RenderRecord, 'count' | 'at'>): RenderRecord {
   const full: RenderRecord = { ...record, count: 1, at: Date.now() };
@@ -33,6 +363,7 @@ export function recordRender(record: Omit<RenderRecord, 'count' | 'at'>): Render
     // CustomEvent unavailable — registry entry above is still written.
     log.debug('trace: failed to dispatch render event', { slotId: record.slotId, err });
   }
+  renderTracePanel();
   return full;
 }
 
@@ -43,7 +374,9 @@ export function recordRender(record: Omit<RenderRecord, 'count' | 'at'>): Render
  *
  * Attributes whose record field is absent are removed, so a re-render of the
  * same element (SPA navigation, GPT refresh) never leaves stale values from a
- * previous auction next to the new ones.
+ * previous auction next to the new ones. These attributes live on the element
+ * itself, so they survive a later `innerHTML = ''` that clears the slot's
+ * children (e.g. the GAM adm interceptor) — unlike a child badge would.
  */
 export function stampCreativeTrace(el: Element, record: RenderRecord): void {
   const attrs: Array<[string, string | undefined]> = [
@@ -56,6 +389,9 @@ export function stampCreativeTrace(el: Element, record: RenderRecord): void {
     ['data-ts-creative-id', record.creativeId],
     ['data-ts-adm-hash', record.admHash],
     ['data-ts-served-from', record.servedFrom],
+    ['data-ts-gam-empty', record.gamEmpty === undefined ? undefined : String(record.gamEmpty)],
+    ['data-ts-injected', record.injected === undefined ? undefined : String(record.injected)],
+    ['data-ts-visible', record.visible === undefined ? undefined : String(record.visible)],
   ];
   try {
     for (const [name, value] of attrs) {
@@ -64,6 +400,17 @@ export function stampCreativeTrace(el: Element, record: RenderRecord): void {
       } else {
         el.removeAttribute(name);
       }
+    }
+    // Confirmation badge only on an honestly-ok slot (TS creative placed and
+    // visible), never on the iframe itself — ties a physical banner to its
+    // panel row. Hidden / gam-only / empty slots stay unbadged on purpose.
+    if (
+      el instanceof HTMLElement &&
+      el.tagName !== 'IFRAME' &&
+      traceOverlayEnabled() &&
+      panelStatus(record) === 'ok'
+    ) {
+      attachTraceBadge(el, record);
     }
   } catch (err) {
     log.warn('trace: failed to stamp element', { slotId: record.slotId, err });

--- a/crates/trusted-server-js/lib/src/core/trace.ts
+++ b/crates/trusted-server-js/lib/src/core/trace.ts
@@ -89,9 +89,12 @@ type PanelStatus = 'ok' | 'hidden' | 'gam-only' | 'empty';
 function panelStatus(record: RenderRecord): PanelStatus {
   if (!record.rendered || record.gamEmpty === true) return 'empty';
   if (record.visible === false) return 'hidden';
-  // injected===false means TS applied targeting only; the creative is GAM's and
-  // unreadable, so we must not claim it as a confirmed TS render.
-  if (record.injected === false) return 'gam-only';
+  // `ok` requires a *confirmed* TS placement. Anything else — TS applied
+  // targeting only (injected false, creative is GAM's and cross-origin
+  // unreadable), or a path that never reported placement (undefined) — must not
+  // be claimed as a TS render. Defaulting to gam-only keeps the panel honest
+  // even if a future render path forgets to set `injected`.
+  if (record.injected !== true) return 'gam-only';
   return 'ok';
 }
 

--- a/crates/trusted-server-js/lib/src/core/trace.ts
+++ b/crates/trusted-server-js/lib/src/core/trace.ts
@@ -23,6 +23,13 @@ const TRACE_COOKIE_NAME = 'ts-trace';
 /** DOM id of the floating trace panel (body-level overlay). */
 export const TRACE_PANEL_ID = 'ts-render-trace-panel';
 
+/**
+ * Upper bound on `window.tsjs.renderLog`. A publisher page that refreshes its
+ * slots on every render can produce hundreds of entries in a session, so the
+ * history is trimmed from the front rather than growing without limit.
+ */
+const MAX_RENDER_LOG_ENTRIES = 200;
+
 /** CSS class of the per-slot confirmation badge (only on honestly-ok slots). */
 export const TRACE_BADGE_CLASS = 'ts-render-badge';
 
@@ -116,6 +123,7 @@ const STATUS_STYLE: Record<PanelStatus, { color: string; mark: string; label: st
  * `pointer-events: none` keeps the badge from intercepting clicks on the ad.
  */
 function attachTraceBadge(el: HTMLElement, record: RenderRecord): void {
+  const style = STATUS_STYLE[panelStatus(record)];
   el.querySelectorAll(`:scope > .${TRACE_BADGE_CLASS}`).forEach((n) => n.remove());
 
   const position = getComputedStyle(el).position;
@@ -125,7 +133,7 @@ function attachTraceBadge(el: HTMLElement, record: RenderRecord): void {
 
   const badge = document.createElement('div');
   badge.className = TRACE_BADGE_CLASS;
-  badge.textContent = `TS ✓ ${record.bidder ?? '?'}`;
+  badge.textContent = `TS ${style.mark} ${record.bidder ?? '?'}${style.label === 'ok' ? '' : ` · ${style.label}`}`;
   badge.title = [
     `slot: ${record.slotId}`,
     `auction: ${record.auctionId ?? '?'}`,
@@ -143,7 +151,7 @@ function attachTraceBadge(el: HTMLElement, record: RenderRecord): void {
   s.setProperty('font', '10px/1.5 ui-monospace, Menlo, Consolas, monospace');
   s.setProperty('padding', '1px 5px');
   s.setProperty('color', '#fff');
-  s.setProperty('background', 'rgba(0,128,0,0.9)');
+  s.setProperty('background', style.color);
   s.setProperty('border-radius', '3px');
   el.appendChild(badge);
 }
@@ -250,7 +258,8 @@ function buildPanelRow(record: RenderRecord): HTMLElement {
   ].join('\n');
 
   const line1 = document.createElement('div');
-  line1.textContent = `${style.mark} ${record.slotId} · ${style.label}`;
+  const clock = new Date(record.at).toLocaleTimeString('en-GB', { hour12: false });
+  line1.textContent = `${clock} ${style.mark} ${record.slotId} · ${style.label}`;
   line1.style.setProperty('font-weight', '600');
   line1.style.setProperty('color', style.color);
 
@@ -260,7 +269,7 @@ function buildPanelRow(record: RenderRecord): HTMLElement {
 
   const line3 = document.createElement('div');
   line3.style.setProperty('color', '#777');
-  line3.textContent = `${stateSummary(record)} · auction ${short(record.auctionId)}${record.count > 1 ? ` · ×${record.count}` : ''}`;
+  line3.textContent = `${stateSummary(record)} · auction ${short(record.auctionId)} · #${record.count}`;
 
   row.append(line1, line2, line3);
   return row;
@@ -279,10 +288,13 @@ export function renderTracePanel(): void {
     if (!panel) return;
 
     const renders = window.tsjs?.renders ?? {};
-    const records = Object.values(renders).sort((a, b) => a.slotId.localeCompare(b.slotId));
+    const slots = Object.values(renders);
     // Count only slots that are honestly OK (TS creative placed and visible),
     // not merely "GAM said something rendered" — the whole point of the fix.
-    const ok = records.filter((r) => panelStatus(r) === 'ok').length;
+    const ok = slots.filter((r) => panelStatus(r) === 'ok').length;
+    // Newest render first: on a page that refreshes its slots this reads as a
+    // timeline rather than a set of counters.
+    const history = [...(window.tsjs?.renderLog ?? [])].reverse();
 
     panel.replaceChildren();
 
@@ -299,7 +311,7 @@ export function renderTracePanel(): void {
     hs.setProperty('font-weight', '700');
 
     const title = document.createElement('span');
-    title.textContent = `TS Render Trace · ${ok}/${records.length} ok`;
+    title.textContent = `TS Render Trace · ${ok}/${slots.length} slots ok · ${history.length} renders`;
 
     const close = document.createElement('button');
     close.textContent = '×';
@@ -320,10 +332,10 @@ export function renderTracePanel(): void {
     hint.style.setProperty('padding', '2px 10px 4px');
     hint.style.setProperty('color', '#777');
     hint.style.setProperty('font-size', '9px');
-    hint.textContent = 'click a row to copy its full record · hover for detail';
+    hint.textContent = 'newest first · click a row to copy its full record · hover for detail';
     panel.appendChild(hint);
 
-    if (records.length === 0) {
+    if (history.length === 0) {
       const empty = document.createElement('div');
       empty.style.setProperty('padding', '6px 10px');
       empty.style.setProperty('color', '#bbb');
@@ -332,7 +344,7 @@ export function renderTracePanel(): void {
       return;
     }
 
-    for (const record of records) {
+    for (const record of history) {
       panel.appendChild(buildPanelRow(record));
     }
   } catch (err) {
@@ -357,6 +369,13 @@ export function recordRender(record: Omit<RenderRecord, 'count' | 'at'>): Render
     const prev = renders[record.slotId];
     if (prev) full.count = prev.count + 1;
     renders[record.slotId] = full;
+
+    // Keep each render as its own history entry, trimmed from the front.
+    const history = (ts.renderLog ??= []);
+    history.push(full);
+    if (history.length > MAX_RENDER_LOG_ENTRIES) {
+      history.splice(0, history.length - MAX_RENDER_LOG_ENTRIES);
+    }
   } catch (err) {
     log.warn('trace: failed to write render record', { slotId: record.slotId, err });
   }
@@ -404,14 +423,17 @@ export function stampCreativeTrace(el: Element, record: RenderRecord): void {
         el.removeAttribute(name);
       }
     }
-    // Confirmation badge only on an honestly-ok slot (TS creative placed and
-    // visible), never on the iframe itself — ties a physical banner to its
-    // panel row. Hidden / gam-only / empty slots stay unbadged on purpose.
+    // Badge any slot that actually shows something, carrying its honest status
+    // colour: green ✓ for a confirmed TS render, blue ◐ for `gam-only` (GAM
+    // rendered, TS cannot confirm it as its own). Slots with nothing on screen
+    // (`empty`) or nothing visible (`hidden`) stay unbadged — there is no
+    // creative there to label. Never badge the iframe itself.
+    const status = panelStatus(record);
     if (
       el instanceof HTMLElement &&
       el.tagName !== 'IFRAME' &&
       traceOverlayEnabled() &&
-      panelStatus(record) === 'ok'
+      (status === 'ok' || status === 'gam-only')
     ) {
       attachTraceBadge(el, record);
     }

--- a/crates/trusted-server-js/lib/src/core/types.ts
+++ b/crates/trusted-server-js/lib/src/core/types.ts
@@ -100,6 +100,29 @@ export interface RenderRecord {
   admHash?: string;
   /** Mechanism that delivered the creative. */
   servedFrom?: RenderServedFrom;
+  /**
+   * GAM's own `slotRenderEnded.isEmpty` (SSAT/GAM path only). `true` means GAM
+   * itself reported the slot empty. Undefined on the `/auction` path, which
+   * never involves GAM.
+   */
+  gamEmpty?: boolean;
+  /**
+   * Whether Trusted Server actually placed the creative markup itself:
+   * `true` for the `/auction` iframe render and for a synchronous
+   * `injectAdmIntoSlot` placement; `false` when TS only applied GAM targeting
+   * (prod GAM path — the creative, if any, is GAM's and lives in a cross-origin
+   * iframe TS cannot read); `undefined` when placement was deferred/unknown.
+   *
+   * This is the honest "is it TS's creative" signal — distinct from `rendered`
+   * (GAM said something rendered) and `visible` (the slot box is on-screen).
+   */
+  injected?: boolean;
+  /**
+   * Whether the slot element was effectively visible at record time — non-zero
+   * box and no ancestor `display:none` / `visibility:hidden` / `opacity:0`.
+   * Catches slots that "rendered" but are hidden behind a publisher reveal gate.
+   */
+  visible?: boolean;
   /** How many renders this slot has seen (SPA navigations, refreshes). */
   count: number;
   /** Epoch ms when the record was written. */

--- a/crates/trusted-server-js/lib/src/core/types.ts
+++ b/crates/trusted-server-js/lib/src/core/types.ts
@@ -166,6 +166,12 @@ export interface RenderRecord {
   visible?: boolean;
   /** How many renders this slot has seen (SPA navigations, refreshes). */
   count: number;
+  /**
+   * Page-global render sequence, starting at 1 and shared by the trace panel
+   * row and the on-creative badge. Unlike `count` (per-slot) this is unique
+   * across the page, so a badge reading `#12` identifies exactly one row.
+   */
+  seq: number;
   /** Epoch ms when the record was written. */
   at: number;
 }

--- a/crates/trusted-server-js/lib/src/core/types.ts
+++ b/crates/trusted-server-js/lib/src/core/types.ts
@@ -197,6 +197,13 @@ export interface TsjsApi {
   adInit?: () => void;
   /** Render-trace registry: latest render per slot (see [`RenderRecord`]). */
   renders?: Record<string, RenderRecord>;
+  /**
+   * Append-only history of every render, oldest first, bounded to the most
+   * recent entries. `renders` collapses to one row per slot (useful for
+   * "did this slot ever render" checks); this keeps each individual render so
+   * a refreshing page shows a timeline instead of a climbing counter.
+   */
+  renderLog?: RenderRecord[];
   /** GPT slot objects TS defined — used to destroy stale slots on SPA navigation. */
   prevGptSlots?: unknown[];
   /** Guards one-time-per-page enableSingleRequest/enableServices calls. */

--- a/crates/trusted-server-js/lib/src/core/types.ts
+++ b/crates/trusted-server-js/lib/src/core/types.ts
@@ -114,8 +114,17 @@ export type RenderServedFrom = 'inline' | 'gam' | 'debug-adm' | 'pbs-cache' | 'p
 export interface RenderRecord {
   /** Slot the creative was rendered for. */
   slotId: string;
-  /** Which render path produced this record. */
-  path: 'auction' | 'ssat';
+  /**
+   * Which render path produced this record.
+   *
+   * `ssat` is claimed only for the render that consumes the server-side
+   * targeting TS just applied — the server-side auction runs once per
+   * navigation, so a later GAM refresh of the same slot is NOT an SSAT render
+   * even though `window.tsjs.bids` still holds that auction's data.
+   * `gam-refresh` is that later render: GAM re-requested the slot and TS cannot
+   * attribute the returned creative to any TS auction.
+   */
+  path: 'auction' | 'ssat' | 'gam-refresh';
   /** Whether a creative actually rendered (false for empty/rejected). */
   rendered: boolean;
   /** Actual DOM element ID the slot resolved to (div_id may be a prefix). */
@@ -210,6 +219,14 @@ export interface TsjsApi {
   servicesEnabled?: boolean;
   /** Maps actualDivId → slotId for slotRenderEnded billing lookup. */
   divToSlotId?: Record<string, string>;
+  /**
+   * Per-slot flag: TS applied server-side bid targeting and no GAM render has
+   * consumed it yet. Set by `adInit()`, cleared by the first `slotRenderEnded`
+   * for that slot, so only that render is attributed to the SSAT auction (see
+   * [`RenderRecord.path`]). Publisher-driven refreshes afterwards find it false
+   * and are recorded as `gam-refresh` without the stale auction tuple.
+   */
+  ssatTargetingFresh?: Record<string, boolean>;
   /**
    * Win/billing beacons already fired, keyed by `slotId|bidIdentity|kind|url`.
    * Used by the GPT render bridge so a bid's nurl/burl fire at most once even

--- a/crates/trusted-server-js/lib/src/core/types.ts
+++ b/crates/trusted-server-js/lib/src/core/types.ts
@@ -72,7 +72,7 @@ export interface AuctionBidData {
 }
 
 /** How a creative reached the page for a [`RenderRecord`]. */
-export type RenderServedFrom = 'inline' | 'gam' | 'debug-adm' | 'pbs-cache';
+export type RenderServedFrom = 'inline' | 'gam' | 'debug-adm' | 'pbs-cache' | 'prebid';
 
 /**
  * One entry in `window.tsjs.renders` — the client-side half of the render

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -1,5 +1,5 @@
 import { log } from '../../core/log';
-import { recordRender, stampCreativeTrace } from '../../core/trace';
+import { recordRender, stampCreativeTrace, isEffectivelyVisible } from '../../core/trace';
 import type { AuctionSlot, AuctionBidData, RenderServedFrom, TsjsApi } from '../../core/types';
 
 import { installGptGuard } from './script_guard';
@@ -290,13 +290,19 @@ export function safeAdmIframeSrc(src: string): string | undefined {
  * 2. Otherwise replace the slot element's content with a sandboxed srcdoc
  *    iframe (no `allow-same-origin` — see [ADM_IFRAME_SANDBOX]).
  */
-function injectAdmIntoSlot(divId: string, adm: string): void {
+/**
+ * Returns whether the TS creative was placed **synchronously**. The
+ * animation-frame retry branch resolves after this returns, so it reports
+ * `false` (placement deferred/unconfirmed) — the render trace must not claim a
+ * placement that has not happened yet.
+ */
+function injectAdmIntoSlot(divId: string, adm: string): boolean {
   try {
     // divId may be the container div (used by GPT slot) or the inner div.
     // Resolve it the same way the rest of adInit does (exact then prefix) so
     // a config div_id prefix with a render-time suffix still finds the element.
     const slotEl = findSlotElementByDivId(divId);
-    if (!slotEl) return;
+    if (!slotEl) return false;
 
     // Extract the first iframe src from the adm (e.g. mocktioneer creative
     // wraps a first-party proxy iframe in a div). Reject non-http(s) schemes.
@@ -308,6 +314,7 @@ function injectAdmIntoSlot(divId: string, adm: string): void {
       // Set the GAM iframe src — works even cross-origin (no document access needed).
       gamIframe.src = innerSrc;
       log.debug(`[tsjs-gpt] gam-intercept: set iframe src for '${divId}'`);
+      return true;
     } else if (innerSrc) {
       // GAM iframe not yet in DOM (APS renders async after slotRenderEnded).
       // Retry on next animation frame so APS has a tick to insert its iframe;
@@ -324,11 +331,14 @@ function injectAdmIntoSlot(divId: string, adm: string): void {
           f.width = String(slotEl!.offsetWidth || 728);
           f.height = String(slotEl!.offsetHeight || 90);
           f.setAttribute('sandbox', ADM_IFRAME_SANDBOX);
+          f.setAttribute('data-ts-injected-adm', 'true');
           f.src = innerSrc;
           slotEl!.appendChild(f);
           log.debug(`[tsjs-gpt] gam-intercept: inserted src iframe for '${divId}'`);
         }
       });
+      // Placement deferred to the animation frame — not confirmed yet.
+      return false;
     } else {
       // No extractable safe src — replace slot content with a sandboxed srcdoc iframe.
       slotEl.innerHTML = '';
@@ -341,9 +351,11 @@ function injectAdmIntoSlot(divId: string, adm: string): void {
       f.srcdoc = adm;
       slotEl.appendChild(f);
       log.debug(`[tsjs-gpt] gam-intercept: replaced slot content for '${divId}'`);
+      return true;
     }
   } catch (err) {
     log.warn('[tsjs-gpt] gam-intercept: error injecting adm', err);
+    return false;
   }
 }
 
@@ -595,12 +607,25 @@ export function installTsAdInit(): void {
           // Read ts.bids live (not the snapshot above) so post-navigation bid data is used.
           const bid = (ts.bids ?? {})[slotId] ?? {};
 
-          // Trace: registry entry + DOM markers joining the GAM-rendered
-          // creative back to the server-side auction bid for this slot.
+          // GAM interceptor (testing): when adm is present, replace the GAM creative.
+          // Adapted from PR #241 — uses window.tsjs.bids[slotId].adm instead of pbjs.
+          // Only active when inject_adm_for_testing injects adm into bids server-side.
+          // Run before recording so the trace reflects the post-injection state.
+          const injected = bid.adm ? injectAdmIntoSlot(divId, bid.adm) : undefined;
+
+          // Trace: registry entry + DOM markers joining the GAM render to the
+          // server-side auction bid. `rendered` is GAM's own non-empty signal;
+          // `injected`/`visible` carry the honest "is the TS creative actually
+          // on screen" state so the panel does not overclaim (a non-empty GAM
+          // slot is not proof the TS creative rendered).
+          const slotEl = document.getElementById(divId);
           const record = recordRender({
             slotId,
             path: 'ssat',
             rendered: !event.isEmpty,
+            gamEmpty: event.isEmpty,
+            injected,
+            visible: isEffectivelyVisible(slotEl),
             elementId: divId,
             auctionId: bid.hb_auction_id,
             bidder: bid.hb_bidder,
@@ -609,15 +634,7 @@ export function installTsAdInit(): void {
             admHash: bid.hb_adm_hash,
             servedFrom: 'gam',
           });
-          const slotEl = document.getElementById(divId);
           if (slotEl) stampCreativeTrace(slotEl, record);
-
-          // GAM interceptor (testing): when adm is present, replace the GAM creative.
-          // Adapted from PR #241 — uses window.tsjs.bids[slotId].adm instead of pbjs.
-          // Only active when inject_adm_for_testing injects adm into bids server-side.
-          if (bid.adm) {
-            injectAdmIntoSlot(divId, bid.adm);
-          }
         });
       }
 
@@ -873,10 +890,14 @@ function recordBridgeRender(
   servedFrom: RenderServedFrom,
   el: HTMLElement | null
 ): void {
+  // The bridge serves TS's own markup into the Prebid Universal Creative, so
+  // this is a confirmed TS placement (injected: true).
   const record = recordRender({
     slotId,
     path: 'ssat',
     rendered: true,
+    injected: true,
+    visible: isEffectivelyVisible(el),
     elementId: el?.id,
     auctionId: bid.hb_auction_id,
     bidder: bid.hb_bidder,

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -663,6 +663,13 @@ export function installTsAdInit(): void {
           if (bid[key]) gptSlot.setTargeting(key, String(bid[key]!));
         });
         gptSlot.setTargeting(TS_INITIAL_TARGETING_KEY, '1');
+        // Arm SSAT attribution for the next render of this slot only. Without
+        // this, every later publisher refresh would still read the page-load
+        // bid out of ts.bids and claim the (long finished) server-side auction
+        // rendered it.
+        (ts.ssatTargetingFresh ??= {})[slot.id] = TS_BID_TARGETING_KEYS.some((key) =>
+          Boolean(bid[key])
+        );
         // Map both inner div and container div → slot ID so slotRenderEnded
         // (which reports the GPT slot's div, i.e. slotDivId/container) can look up
         // the slot, while adm injection (which targets the inner div) also works.
@@ -729,20 +736,32 @@ export function installTsAdInit(): void {
           // on screen" state so the panel does not overclaim (a non-empty GAM
           // slot is not proof the TS creative rendered).
           const slotEl = document.getElementById(divId);
+          // The server-side auction runs once per navigation. Only the render
+          // that consumes the targeting adInit just applied may be attributed
+          // to it; a later publisher refresh re-requests GAM on its own and the
+          // creative it returns has no traceable link to any TS auction, so the
+          // stale bid tuple is dropped rather than re-stamped.
+          const fresh = (ts.ssatTargetingFresh ??= {})[slotId] === true;
+          ts.ssatTargetingFresh[slotId] = false;
+          const attributed = fresh
+            ? {
+                path: 'ssat' as const,
+                auctionId: bid.hb_auction_id,
+                bidder: bid.hb_bidder,
+                adId: bid.hb_adid,
+                creativeId: bid.hb_crid,
+                admHash: bid.hb_adm_hash,
+              }
+            : { path: 'gam-refresh' as const };
           const record = recordRender({
             slotId,
-            path: 'ssat',
             rendered: !event.isEmpty,
             gamEmpty: event.isEmpty,
             injected,
             visible: isEffectivelyVisible(slotEl),
             elementId: divId,
-            auctionId: bid.hb_auction_id,
-            bidder: bid.hb_bidder,
-            adId: bid.hb_adid,
-            creativeId: bid.hb_crid,
-            admHash: bid.hb_adm_hash,
             servedFrom: 'gam',
+            ...attributed,
           });
           if (slotEl) stampCreativeTrace(slotEl, record);
         });

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -1226,6 +1226,7 @@ export function installTsRenderBridge(): void {
         })
       );
       fireWinBillingBeacons(slotId, matchedBid);
+      recordBridgeRender(slotId, matchedBid, 'inline', slotEl);
       log.debug(`[tsjs-gpt] pbRender bridge served '${slotId}' from inline adm`);
       return;
     }

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -611,7 +611,10 @@ export function installTsAdInit(): void {
           // Adapted from PR #241 — uses window.tsjs.bids[slotId].adm instead of pbjs.
           // Only active when inject_adm_for_testing injects adm into bids server-side.
           // Run before recording so the trace reflects the post-injection state.
-          const injected = bid.adm ? injectAdmIntoSlot(divId, bid.adm) : undefined;
+          // No adm to inject means TS only applied GAM targeting: whatever GAM
+          // rendered lives in a cross-origin iframe TS cannot read, so this is
+          // explicitly *not* a confirmed TS placement (status: gam-only).
+          const injected = bid.adm ? injectAdmIntoSlot(divId, bid.adm) : false;
 
           // Trace: registry entry + DOM markers joining the GAM render to the
           // server-side auction bid. `rendered` is GAM's own non-empty signal;

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -43,6 +43,24 @@ const TS_BID_TARGETING_KEYS = [
 ] as const;
 const TS_BASE_TARGETING_KEYS = [...TS_BID_TARGETING_KEYS, TS_INITIAL_TARGETING_KEY] as const;
 
+// ---- Orphaned-slot recovery (client re-render / hydration race) ------------
+// A client framework can replace the ad divs *after* GPT slots were bound to
+// them: server-rendered React ids (`…-_R_abc_`) are swapped for client ids
+// (`…-_r_1_`) during hydration, leaving GPT holding slots whose element no
+// longer exists ("defineSlot was called without a corresponding DIV"). GAM
+// still fetches a creative for those slots, but it has nowhere to render, so
+// the bid is silently wasted. These bound the recovery re-bind.
+/** Quiet period after DOM mutations before checking for orphaned slots. */
+const ORPHAN_RECONCILE_DEBOUNCE_MS = 250;
+/** How long after an adInit() to keep watching for a re-render. */
+const ORPHAN_RECONCILE_WINDOW_MS = 5000;
+/**
+ * Maximum re-binds per page load. Each re-bind re-requests the affected slots,
+ * so this is deliberately small: it recovers a hydration swap without letting a
+ * continuously-mutating page loop on ad requests.
+ */
+const MAX_ORPHAN_RECONCILE_ATTEMPTS = 2;
+
 // ------------------------------------------------------------------
 // googletag type stubs (minimal surface needed by the shim)
 // ------------------------------------------------------------------
@@ -482,6 +500,73 @@ function installInitialLoadDetector(ts: TsjsApi): void {
   });
 }
 
+// Orphan-watch state. Module-scoped so a re-bind cannot stack observers, and
+// so the attempt budget is shared across the page load rather than reset by the
+// adInit() the watcher itself triggers.
+let orphanObserver: MutationObserver | null = null;
+let orphanDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+let orphanWindowTimer: ReturnType<typeof setTimeout> | undefined;
+let orphanReconcileAttempts = 0;
+
+function stopOrphanWatch(): void {
+  orphanObserver?.disconnect();
+  orphanObserver = null;
+  clearTimeout(orphanDebounceTimer);
+  clearTimeout(orphanWindowTimer);
+}
+
+/**
+ * TS-defined GPT slots whose bound element is no longer in the document.
+ *
+ * Exported for testing.
+ */
+export function orphanedTsSlots(ts: TsjsApi): GoogleTagSlot[] {
+  return ((ts.prevGptSlots ?? []) as GoogleTagSlot[]).filter((slot) => {
+    const elementId = slot?.getSlotElementId?.();
+    return !!elementId && !document.getElementById(elementId);
+  });
+}
+
+/**
+ * Watch for a client re-render that orphans TS's GPT slots and re-bind once it
+ * happens.
+ *
+ * Waiting for the divs to merely *exist* (as the SPA hook does) cannot help
+ * here: at `adInit()` time the server-rendered divs are present — they are
+ * later *replaced*. So instead of delaying the initial ad request, this detects
+ * the swap after the fact and re-runs `adInit()`, which destroys the orphaned
+ * slots and re-binds against the live DOM (reusing the publisher's own slot for
+ * that div when they have since defined one).
+ *
+ * Bounded by {@link MAX_ORPHAN_RECONCILE_ATTEMPTS} and
+ * {@link ORPHAN_RECONCILE_WINDOW_MS} so a page whose DOM never settles cannot
+ * spin on ad requests.
+ */
+function watchForOrphanedSlots(ts: TsjsApi): void {
+  if (typeof MutationObserver === 'undefined' || typeof document === 'undefined') return;
+  // Re-arm: a previous window may still be open from an earlier adInit().
+  stopOrphanWatch();
+  if (orphanReconcileAttempts >= MAX_ORPHAN_RECONCILE_ATTEMPTS) return;
+
+  orphanObserver = new MutationObserver(() => {
+    clearTimeout(orphanDebounceTimer);
+    orphanDebounceTimer = setTimeout(() => {
+      const orphans = orphanedTsSlots(ts);
+      if (orphans.length === 0) return;
+      orphanReconcileAttempts += 1;
+      log.warn(
+        `[tsjs-gpt] ${orphans.length} TS slot(s) orphaned by a DOM re-render; re-binding`,
+        orphans.map((slot) => slot.getSlotElementId?.())
+      );
+      // Stop before re-running: adInit() re-arms the watch itself.
+      stopOrphanWatch();
+      ts.adInit?.();
+    }, ORPHAN_RECONCILE_DEBOUNCE_MS);
+  });
+  orphanObserver.observe(document.documentElement, { childList: true, subtree: true });
+  orphanWindowTimer = setTimeout(stopOrphanWatch, ORPHAN_RECONCILE_WINDOW_MS);
+}
+
 export function installTsAdInit(): void {
   const ts = (window.tsjs ??= {} as TsjsApi);
   installInitialLoadDetector(ts);
@@ -695,6 +780,12 @@ export function installTsAdInit(): void {
         } finally {
           ts.adInitRefreshInProgress = false;
         }
+      }
+
+      // Only TS-defined slots can be orphaned by a re-render — publisher-owned
+      // slots are theirs to manage, and TS never destroys them.
+      if (newSlots.length > 0) {
+        watchForOrphanedSlots(ts);
       }
     });
   };

--- a/crates/trusted-server-js/lib/src/integrations/prebid/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/prebid/index.ts
@@ -30,7 +30,8 @@ import './_user_ids.generated';
 import { log } from '../../core/log';
 import { buildAdRequest, parseAuctionResponse } from '../../core/auction';
 import type { AuctionBid, AuctionEid } from '../../core/auction';
-import type { AuctionSlot } from '../../core/types';
+import type { AuctionSlot, RenderRecord } from '../../core/types';
+import { recordRender, stampCreativeTrace, isEffectivelyVisible } from '../../core/trace';
 
 import { DEFAULT_PREBID_USER_ID_MODULES, PREBID_USER_ID_MODULE_REGISTRY } from './user_id_modules';
 
@@ -209,6 +210,11 @@ export function auctionBidsToPrebidBids(auctionBids: AuctionBid[], bidRequests: 
       bidderCode: bid.seat,
       meta: {
         advertiserDomains: bid.adomain,
+        // Carry the server-side trace tuple through Prebid so the bidWon
+        // render-trace hook can attribute the render to its /auction (see
+        // installPrebidRenderTrace). Prebid passes `meta` through unchanged.
+        tsAuctionId: bid.auctionId,
+        tsAdmHash: bid.admHash,
       },
     };
   });
@@ -921,10 +927,97 @@ function syncPrebidEidsCookie(): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Render trace (client-side /auction path)
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of the bid object Prebid.js passes to a `bidWon` handler. */
+interface PrebidWonBid {
+  adUnitCode?: string;
+  bidderCode?: string;
+  bidder?: string;
+  creativeId?: string;
+  meta?: { tsAuctionId?: unknown; tsAdmHash?: unknown; [key: string]: unknown };
+}
+
+/**
+ * Resolve the on-page element for a `bidWon` ad-unit code. Prebid renders into
+ * the ad unit's own div; fall back to the `-container` wrapper used by the GPT
+ * integration when the inner div is not directly addressable.
+ */
+function findAuctionSlotElement(adUnitCode: string): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  return (document.getElementById(adUnitCode) ??
+    document.getElementById(`${adUnitCode}-container`)) as HTMLElement | null;
+}
+
+/**
+ * Record a render-trace entry for a Prebid `bidWon` — the authoritative signal
+ * that the client-side `/auction` creative actually rendered, distinct from the
+ * SSAT/GAM path. Only server-side (`trustedServer`) bids carry `meta.tsAuctionId`
+ * (set in {@link auctionBidsToPrebidBids}); client-side bidders lack it and are
+ * skipped so the panel never attributes a non-TS render to Trusted Server.
+ *
+ * Exported for unit testing; the render path itself is unaffected (this only
+ * observes and stamps the DOM).
+ */
+export function recordPrebidBidWon(bid: PrebidWonBid | undefined): RenderRecord | undefined {
+  if (!bid || typeof bid.adUnitCode !== 'string' || bid.adUnitCode === '') return undefined;
+  const meta = bid.meta ?? {};
+  // Only trace our server-side bids: the trustedServer adapter is the only
+  // source of meta.tsAuctionId.
+  if (typeof meta.tsAuctionId !== 'string') return undefined;
+
+  const el = findAuctionSlotElement(bid.adUnitCode);
+  const record = recordRender({
+    slotId: bid.adUnitCode,
+    path: 'auction',
+    rendered: true,
+    // Prebid rendered the `ad` markup our adapter returned — a confirmed TS
+    // placement for this path.
+    injected: true,
+    visible: isEffectivelyVisible(el),
+    elementId: el?.id,
+    auctionId: meta.tsAuctionId,
+    admHash: typeof meta.tsAdmHash === 'string' ? meta.tsAdmHash : undefined,
+    bidder: bid.bidderCode ?? bid.bidder,
+    creativeId: bid.creativeId,
+    servedFrom: 'prebid',
+  });
+  if (el) stampCreativeTrace(el, record);
+  return record;
+}
+
+/**
+ * Install the Prebid `bidWon` render-trace hook (idempotent).
+ *
+ * `bidWon` is the render-confirmation event for the client-side `/auction`
+ * path; without this hook only the one-time SSAT auction is traced and the
+ * ongoing Prebid renders are invisible to the panel. Read-only: the listener
+ * records and stamps but never alters Prebid's rendering.
+ */
+export function installPrebidRenderTrace(): void {
+  if (typeof window === 'undefined') return;
+  const p = pbjs as unknown as {
+    onEvent?: (event: string, handler: (bid: PrebidWonBid) => void) => void;
+    __tsRenderTraceInstalled?: boolean;
+  };
+  if (typeof p.onEvent !== 'function' || p.__tsRenderTraceInstalled) return;
+  p.__tsRenderTraceInstalled = true;
+  p.onEvent('bidWon', (bid) => {
+    try {
+      recordPrebidBidWon(bid);
+    } catch (err) {
+      log.warn('[tsjs-prebid] render-trace bidWon failed', err);
+    }
+  });
+}
+
 // Self-initialize when loaded in a browser (same pattern as other integrations).
 if (typeof window !== 'undefined') {
   installPrebidNpm();
   installRefreshHandler();
+  installPrebidRenderTrace();
   // The slim-Prebid lazy loader appends this bundle from a window.load
   // handler, so `load` may already have fired by the time this code runs —
   // waiting for it again would skip user ID setup entirely on that path.

--- a/crates/trusted-server-js/lib/test/core/trace.test.ts
+++ b/crates/trusted-server-js/lib/test/core/trace.test.ts
@@ -181,7 +181,7 @@ describe('trace/floating panel', () => {
     const panel = document.getElementById(TRACE_PANEL_ID);
     expect(panel).toBeTruthy();
     // Only slot-1 is honestly ok; slot-2 rendered nothing.
-    expect(panel!.textContent).toContain('TS Render Trace · 1/2 ok');
+    expect(panel!.textContent).toContain('TS Render Trace · 1/2 slots ok');
     expect(panel!.textContent).toContain('✓ slot-1 · ok');
     expect(panel!.textContent).toContain('✗ slot-2 · empty');
     expect(panel!.textContent).toContain('ssat · kargo');
@@ -194,7 +194,7 @@ describe('trace/floating panel', () => {
     recordRender({ ...record, visible: false });
 
     const panel = document.getElementById(TRACE_PANEL_ID);
-    expect(panel!.textContent).toContain('0/1 ok');
+    expect(panel!.textContent).toContain('0/1 slots ok');
     expect(panel!.textContent).toContain('⚠ slot-1 · hidden');
   });
 
@@ -204,7 +204,7 @@ describe('trace/floating panel', () => {
     recordRender({ ...record, injected: false, gamEmpty: false, visible: true });
 
     const panel = document.getElementById(TRACE_PANEL_ID);
-    expect(panel!.textContent).toContain('0/1 ok');
+    expect(panel!.textContent).toContain('0/1 slots ok');
     expect(panel!.textContent).toContain('◐ slot-1 · gam-only');
   });
 
@@ -216,7 +216,7 @@ describe('trace/floating panel', () => {
     recordRender({ ...withoutInjected, gamEmpty: false, visible: true });
 
     const panel = document.getElementById(TRACE_PANEL_ID);
-    expect(panel!.textContent).toContain('0/1 ok');
+    expect(panel!.textContent).toContain('0/1 slots ok');
     expect(panel!.textContent).toContain('◐ slot-1 · gam-only');
   });
 
@@ -227,9 +227,9 @@ describe('trace/floating panel', () => {
 
     const panels = document.querySelectorAll(`#${TRACE_PANEL_ID}`);
     expect(panels).toHaveLength(1);
-    // Second render of the same slot bumps the count, still one row.
-    expect(panels[0].textContent).toContain('TS Render Trace · 1/1 ok');
-    expect(panels[0].textContent).toContain('×2');
+    // Second render of the same slot bumps the count and appends a history row.
+    expect(panels[0].textContent).toContain('TS Render Trace · 1/1 slots ok');
+    expect(panels[0].textContent).toContain('#2');
   });
 
   it('close button removes the panel', () => {

--- a/crates/trusted-server-js/lib/test/core/trace.test.ts
+++ b/crates/trusted-server-js/lib/test/core/trace.test.ts
@@ -208,6 +208,18 @@ describe('trace/floating panel', () => {
     expect(panel!.textContent).toContain('◐ slot-1 · gam-only');
   });
 
+  it('never claims ok when a render path did not report placement', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    // Regression: an unset `injected` must not fall through to ok — that would
+    // claim a confirmed TS render for a slot TS only targeted.
+    const { injected: _omitted, ...withoutInjected } = record;
+    recordRender({ ...withoutInjected, gamEmpty: false, visible: true });
+
+    const panel = document.getElementById(TRACE_PANEL_ID);
+    expect(panel!.textContent).toContain('0/1 ok');
+    expect(panel!.textContent).toContain('◐ slot-1 · gam-only');
+  });
+
   it('reuses a single panel across renders and reflects the latest count', () => {
     document.cookie = 'ts-trace=1; Path=/';
     recordRender(record);

--- a/crates/trusted-server-js/lib/test/core/trace.test.ts
+++ b/crates/trusted-server-js/lib/test/core/trace.test.ts
@@ -1,10 +1,28 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { recordRender, stampCreativeTrace, RENDER_EVENT_NAME } from '../../src/core/trace';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  recordRender,
+  stampCreativeTrace,
+  traceOverlayEnabled,
+  renderTracePanel,
+  RENDER_EVENT_NAME,
+  TRACE_PANEL_ID,
+  TRACE_BADGE_CLASS,
+} from '../../src/core/trace';
 import type { RenderRecord, TsjsApi } from '../../src/core/types';
+
+function clearTraceCookie(): void {
+  document.cookie = 'ts-trace=; Max-Age=0; Path=/';
+}
+
+function removePanel(): void {
+  document.getElementById(TRACE_PANEL_ID)?.remove();
+}
 
 describe('trace/recordRender', () => {
   beforeEach(() => {
     delete (window as { tsjs?: TsjsApi }).tsjs;
+    clearTraceCookie();
+    removePanel();
   });
 
   it('writes a render record into window.tsjs.renders', () => {
@@ -110,5 +128,190 @@ describe('trace/stampCreativeTrace', () => {
     // The previous auction's hash and mechanism must not survive the re-stamp.
     expect(el.hasAttribute('data-ts-adm-hash')).toBe(false);
     expect(el.hasAttribute('data-ts-served-from')).toBe(false);
+  });
+});
+
+describe('trace/floating panel', () => {
+  const record: Omit<RenderRecord, 'count' | 'at'> = {
+    slotId: 'slot-1',
+    path: 'ssat',
+    rendered: true,
+    injected: true,
+    visible: true,
+    gamEmpty: false,
+    auctionId: 'ts-req-abcdef123456',
+    bidder: 'kargo',
+    admHash: 'a1b2c3d4e5f60718',
+    servedFrom: 'gam',
+  };
+
+  beforeEach(() => {
+    delete (window as { tsjs?: TsjsApi }).tsjs;
+    clearTraceCookie();
+    removePanel();
+  });
+
+  afterEach(() => {
+    clearTraceCookie();
+    removePanel();
+  });
+
+  it('reports the overlay disabled without the ts-trace cookie', () => {
+    expect(traceOverlayEnabled()).toBe(false);
+  });
+
+  it('does not create a panel when the overlay is disarmed', () => {
+    recordRender(record);
+    expect(document.getElementById(TRACE_PANEL_ID)).toBeNull();
+  });
+
+  it('renders a panel row per traced slot with honest status', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    // slot-1: TS placed + visible → ok. slot-2: nothing rendered → empty.
+    recordRender(record);
+    recordRender({
+      slotId: 'slot-2',
+      path: 'auction',
+      rendered: false,
+      injected: false,
+      visible: false,
+      bidder: 'appnexus',
+    });
+
+    const panel = document.getElementById(TRACE_PANEL_ID);
+    expect(panel).toBeTruthy();
+    // Only slot-1 is honestly ok; slot-2 rendered nothing.
+    expect(panel!.textContent).toContain('TS Render Trace · 1/2 ok');
+    expect(panel!.textContent).toContain('✓ slot-1 · ok');
+    expect(panel!.textContent).toContain('✗ slot-2 · empty');
+    expect(panel!.textContent).toContain('ssat · kargo');
+    expect(panel!.textContent).toContain('auction · appnexus');
+  });
+
+  it('marks a rendered-but-hidden slot as hidden, not ok', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    // GAM rendered non-empty, TS injected, but a reveal gate keeps it hidden.
+    recordRender({ ...record, visible: false });
+
+    const panel = document.getElementById(TRACE_PANEL_ID);
+    expect(panel!.textContent).toContain('0/1 ok');
+    expect(panel!.textContent).toContain('⚠ slot-1 · hidden');
+  });
+
+  it('marks a targeting-only GAM slot as gam-only, not a confirmed TS render', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    // GAM rendered something, but TS never placed it (prod targeting path).
+    recordRender({ ...record, injected: false, gamEmpty: false, visible: true });
+
+    const panel = document.getElementById(TRACE_PANEL_ID);
+    expect(panel!.textContent).toContain('0/1 ok');
+    expect(panel!.textContent).toContain('◐ slot-1 · gam-only');
+  });
+
+  it('reuses a single panel across renders and reflects the latest count', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    recordRender(record);
+    recordRender(record);
+
+    const panels = document.querySelectorAll(`#${TRACE_PANEL_ID}`);
+    expect(panels).toHaveLength(1);
+    // Second render of the same slot bumps the count, still one row.
+    expect(panels[0].textContent).toContain('TS Render Trace · 1/1 ok');
+    expect(panels[0].textContent).toContain('×2');
+  });
+
+  it('close button removes the panel', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    recordRender(record);
+    const panel = document.getElementById(TRACE_PANEL_ID)!;
+    const close = panel.querySelector('button') as HTMLButtonElement;
+    close.click();
+    expect(document.getElementById(TRACE_PANEL_ID)).toBeNull();
+  });
+
+  it('renderTracePanel is a no-op while disarmed even if renders exist', () => {
+    (window as { tsjs?: TsjsApi }).tsjs = {
+      renders: { 'slot-1': { ...record, count: 1, at: 1 } },
+    } as unknown as TsjsApi;
+    renderTracePanel();
+    expect(document.getElementById(TRACE_PANEL_ID)).toBeNull();
+  });
+
+  it('clicking a row logs the full record', async () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    const { log } = await import('../../src/core/log');
+    const infoSpy = vi.spyOn(log, 'info').mockImplementation(() => undefined);
+
+    recordRender(record);
+    const row = document.getElementById(TRACE_PANEL_ID)!.querySelector('div[style*="cursor"]');
+    (row as HTMLElement).click();
+
+    const call = infoSpy.mock.calls.find(([m]) => m === 'trace: render record');
+    expect(call?.[1]).toEqual(
+      expect.objectContaining({ slotId: 'slot-1', auctionId: record.auctionId })
+    );
+    infoSpy.mockRestore();
+  });
+});
+
+describe('trace/confirmation badge', () => {
+  beforeEach(() => {
+    delete (window as { tsjs?: TsjsApi }).tsjs;
+    clearTraceCookie();
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    clearTraceCookie();
+    document.body.innerHTML = '';
+  });
+
+  const okRecord: RenderRecord = {
+    slotId: 'slot-1',
+    path: 'ssat',
+    rendered: true,
+    injected: true,
+    visible: true,
+    gamEmpty: false,
+    bidder: 'mocktioneer',
+    admHash: 'a1b2c3d4e5f60718',
+    servedFrom: 'gam',
+    count: 1,
+    at: 1,
+  };
+
+  it('badges an ok slot when armed', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    stampCreativeTrace(el, okRecord);
+    const badge = el.querySelector(`.${TRACE_BADGE_CLASS}`) as HTMLElement;
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toBe('TS ✓ mocktioneer');
+  });
+
+  it('does not badge a hidden slot', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    stampCreativeTrace(el, { ...okRecord, visible: false });
+    expect(el.querySelector(`.${TRACE_BADGE_CLASS}`)).toBeNull();
+  });
+
+  it('does not badge when the overlay is disarmed', () => {
+    clearTraceCookie();
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    stampCreativeTrace(el, okRecord);
+    expect(el.querySelector(`.${TRACE_BADGE_CLASS}`)).toBeNull();
+  });
+
+  it('never badges an iframe element', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    stampCreativeTrace(iframe, okRecord);
+    expect(iframe.querySelector(`.${TRACE_BADGE_CLASS}`)).toBeNull();
+    // Attributes still stamped on the iframe though.
+    expect(iframe.getAttribute('data-ts-slot-id')).toBe('slot-1');
   });
 });

--- a/crates/trusted-server-js/lib/test/core/trace.test.ts
+++ b/crates/trusted-server-js/lib/test/core/trace.test.ts
@@ -84,6 +84,7 @@ describe('trace/stampCreativeTrace', () => {
       adId: 'cache-uuid-1',
       admHash: 'a1b2c3d4e5f60718',
       count: 1,
+      seq: 1,
       at: 1,
     };
 
@@ -110,6 +111,7 @@ describe('trace/stampCreativeTrace', () => {
       admHash: 'a1b2c3d4e5f60718',
       servedFrom: 'gam',
       count: 1,
+      seq: 1,
       at: 1,
     };
     stampCreativeTrace(el, first);
@@ -120,6 +122,7 @@ describe('trace/stampCreativeTrace', () => {
       rendered: true,
       auctionId: 'auction-new',
       count: 2,
+      seq: 2,
       at: 2,
     };
     stampCreativeTrace(el, second);
@@ -132,7 +135,7 @@ describe('trace/stampCreativeTrace', () => {
 });
 
 describe('trace/floating panel', () => {
-  const record: Omit<RenderRecord, 'count' | 'at'> = {
+  const record: Omit<RenderRecord, 'count' | 'at' | 'seq'> = {
     slotId: 'slot-1',
     path: 'ssat',
     rendered: true,
@@ -229,7 +232,79 @@ describe('trace/floating panel', () => {
     expect(panels).toHaveLength(1);
     // Second render of the same slot bumps the count and appends a history row.
     expect(panels[0].textContent).toContain('TS Render Trace · 1/1 slots ok');
-    expect(panels[0].textContent).toContain('#2');
+    expect(panels[0].textContent).toContain('×2');
+  });
+
+  it("keeps GAM's fill signal and drops ? placeholders on an unattributed refresh", () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    // A publisher-driven GAM refresh: TS ran no auction for it, so there is no
+    // bidder/hash/auction id — but GAM still reported whether it filled, and
+    // that is the most useful field on the row.
+    recordRender({
+      slotId: 'slot-1',
+      path: 'gam-refresh',
+      rendered: true,
+      gamEmpty: false,
+      injected: false,
+      visible: true,
+      servedFrom: 'gam',
+    });
+
+    const panel = document.getElementById(TRACE_PANEL_ID)!;
+    expect(panel.textContent).toContain('gam:filled');
+    expect(panel.textContent).toContain('no TS attribution');
+    // Absent attribution must not render as a failed lookup, and an auction
+    // segment must not appear at all when there is no auction to name.
+    expect(panel.textContent).not.toContain('· ? ·');
+    expect(panel.textContent).not.toContain('auction ?');
+  });
+
+  it('still reports gam:empty for a refresh GAM declined to fill', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    recordRender({
+      slotId: 'slot-1',
+      path: 'gam-refresh',
+      rendered: false,
+      gamEmpty: true,
+      injected: false,
+      visible: true,
+    });
+
+    const panel = document.getElementById(TRACE_PANEL_ID)!;
+    expect(panel.textContent).toContain('gam:empty');
+    expect(panel.textContent).toContain('✗ slot-1 · empty');
+  });
+
+  it('gives each render a page-global seq the badge and its panel row share', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    const el = document.createElement('div');
+    el.id = 'slot-el';
+    document.body.appendChild(el);
+
+    // Two slots interleaved: seq must be unique page-wide, not per-slot, so a
+    // badge reading #N identifies exactly one row.
+    const first = recordRender(record);
+    const other = recordRender({ ...record, slotId: 'slot-2' });
+    expect(other.seq).toBe(first.seq + 1);
+
+    stampCreativeTrace(el, other);
+    const badge = el.querySelector(`.${TRACE_BADGE_CLASS}`) as HTMLElement;
+    expect(badge.textContent).toContain(`#${other.seq}`);
+    // The same number appears on that render's row in the panel.
+    expect(document.getElementById(TRACE_PANEL_ID)!.textContent).toContain(`#${other.seq}`);
+
+    el.remove();
+  });
+
+  it('marks only the live render for a slot as current', () => {
+    document.cookie = 'ts-trace=1; Path=/';
+    recordRender(record);
+    const latest = recordRender(record);
+
+    const panel = document.getElementById(TRACE_PANEL_ID)!;
+    // Both renders are in the log, but only the newest is still on screen.
+    expect(panel.textContent).toContain(`#${latest.seq}`);
+    expect(panel.textContent!.match(/◂ current/g)).toHaveLength(1);
   });
 
   it('close button removes the panel', () => {
@@ -243,7 +318,7 @@ describe('trace/floating panel', () => {
 
   it('renderTracePanel is a no-op while disarmed even if renders exist', () => {
     (window as { tsjs?: TsjsApi }).tsjs = {
-      renders: { 'slot-1': { ...record, count: 1, at: 1 } },
+      renders: { 'slot-1': { ...record, count: 1, seq: 1, at: 1 } },
     } as unknown as TsjsApi;
     renderTracePanel();
     expect(document.getElementById(TRACE_PANEL_ID)).toBeNull();
@@ -288,6 +363,7 @@ describe('trace/confirmation badge', () => {
     admHash: 'a1b2c3d4e5f60718',
     servedFrom: 'gam',
     count: 1,
+    seq: 1,
     at: 1,
   };
 
@@ -298,7 +374,7 @@ describe('trace/confirmation badge', () => {
     stampCreativeTrace(el, okRecord);
     const badge = el.querySelector(`.${TRACE_BADGE_CLASS}`) as HTMLElement;
     expect(badge).toBeTruthy();
-    expect(badge.textContent).toBe('TS ✓ mocktioneer');
+    expect(badge.textContent).toBe('TS ✓ #1 · mocktioneer');
   });
 
   it('does not badge a hidden slot', () => {

--- a/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
@@ -1761,3 +1761,106 @@ describe('installTsRenderBridge', () => {
     expect(fetchStub).not.toHaveBeenCalled();
   });
 });
+
+describe('orphaned TS slot recovery', () => {
+  type TestWin = Window & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tsjs?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    googletag?: any;
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    const tw = window as TestWin;
+    delete tw.tsjs;
+    delete tw.googletag;
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function slotStub(elementId: string) {
+    return {
+      addService: vi.fn().mockReturnThis(),
+      setTargeting: vi.fn().mockReturnThis(),
+      clearTargeting: vi.fn().mockReturnThis(),
+      getSlotElementId: vi.fn().mockReturnValue(elementId),
+      getTargeting: vi.fn().mockReturnValue([]),
+    };
+  }
+
+  it('reports slots whose bound element left the document', async () => {
+    const { orphanedTsSlots } = await import('../../../src/integrations/gpt/index');
+    document.body.innerHTML = '<div id="live-div"></div>';
+
+    const live = slotStub('live-div');
+    const orphan = slotStub('ad-header-0-_R_ssr_');
+    const ts = { prevGptSlots: [live, orphan] };
+
+    const orphans = orphanedTsSlots(ts as never);
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].getSlotElementId()).toBe('ad-header-0-_R_ssr_');
+  });
+
+  it('returns nothing when every TS slot still has its element', async () => {
+    const { orphanedTsSlots } = await import('../../../src/integrations/gpt/index');
+    document.body.innerHTML = '<div id="a"></div><div id="b"></div>';
+    const ts = { prevGptSlots: [slotStub('a'), slotStub('b')] };
+    expect(orphanedTsSlots(ts as never)).toHaveLength(0);
+  });
+
+  it('re-runs adInit after a re-render swaps the ad div', async () => {
+    // SSR div that hydration will replace.
+    document.body.innerHTML = '<div id="ad-header-0-_R_ssr_"></div>';
+
+    const definedSlots: string[] = [];
+    const mockPubads = {
+      enableSingleRequest: vi.fn(),
+      getSlots: vi.fn().mockReturnValue([]),
+      refresh: vi.fn(),
+      addEventListener: vi.fn(),
+    };
+    const tw = window as TestWin;
+    tw.googletag = {
+      cmd: { push: vi.fn((fn: () => void) => fn()) },
+      defineSlot: vi.fn((_path: string, _sizes: unknown, divId: string) => {
+        definedSlots.push(divId);
+        return slotStub(divId);
+      }),
+      pubads: vi.fn().mockReturnValue(mockPubads),
+      enableServices: vi.fn(),
+      display: vi.fn(),
+      destroySlots: vi.fn(),
+    };
+    tw.tsjs = {
+      adSlots: [
+        {
+          id: 'ad-header-0',
+          gam_unit_path: '/123/header',
+          div_id: 'ad-header-0',
+          formats: [[728, 90]],
+          targeting: {},
+        },
+      ],
+      bids: {},
+    };
+
+    const { installTsAdInit } = await import('../../../src/integrations/gpt/index');
+    installTsAdInit();
+    tw.tsjs.adInit();
+
+    expect(definedSlots).toEqual(['ad-header-0-_R_ssr_']);
+
+    // Hydration: React replaces the SSR div with a client-id div.
+    document.body.innerHTML = '<div id="ad-header-0-_r_1_"></div>';
+
+    // The MutationObserver is debounced; give it room to fire.
+    await new Promise<void>((r) => setTimeout(r, 600));
+
+    // adInit re-ran and bound to the live div instead of the dead one.
+    expect(definedSlots).toContain('ad-header-0-_r_1_');
+  });
+});

--- a/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
@@ -1500,6 +1500,20 @@ describe('installTsRenderBridge', () => {
     expect(beaconSpy).toHaveBeenCalledWith('https://ssp.example/bill');
     expect(beaconSpy).toHaveBeenCalledTimes(2);
 
+    // The PBS Cache branch must trace the same as the inline-adm branch —
+    // regression coverage for the two recordBridgeRender call sites staying
+    // in sync (this branch's stamp only lands after the async fetch settles).
+    const record = (window as TestWindow).tsjs!.renders?.['homepage_header'];
+    expect(record).toEqual(
+      expect.objectContaining({
+        slotId: 'homepage_header',
+        path: 'ssat',
+        rendered: true,
+        injected: true,
+        servedFrom: 'pbs-cache',
+      })
+    );
+
     bridgeListener!(
       Object.assign(new Event('message'), {
         data: JSON.stringify({ message: 'Prebid Request', adId: 'test-cache-uuid' }),
@@ -1641,6 +1655,21 @@ describe('installTsRenderBridge', () => {
     expect(beaconSpy).toHaveBeenCalledWith('https://debug.example/bill');
     expect(beaconSpy).toHaveBeenCalledTimes(2);
     beaconSpy.mockRestore();
+
+    // Serving inline adm through the Universal Creative bridge is a confirmed
+    // TS placement — same as the PBS Cache branch — and must not be silently
+    // untraced just because no cache fetch was involved.
+    const record = (window as TestWindow).tsjs!.renders?.['homepage_header'];
+    expect(record).toEqual(
+      expect.objectContaining({
+        slotId: 'homepage_header',
+        path: 'ssat',
+        rendered: true,
+        injected: true,
+        bidder: 'mocktioneer',
+        servedFrom: 'inline',
+      })
+    );
   });
 
   it('falls back to keepalive fetch when sendBeacon is unavailable', async () => {

--- a/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
@@ -665,6 +665,77 @@ describe('installTsAdInit', () => {
     expect(el.getAttribute('data-ts-rendered')).toBe('false');
   });
 
+  it('does not attribute a later GAM refresh to the finished server-side auction', async () => {
+    let capturedListener: ((e: SlotRenderEvent) => void) | undefined;
+
+    const mockSlot = {
+      addService: vi.fn().mockReturnThis(),
+      setTargeting: vi.fn().mockReturnThis(),
+      getSlotElementId: vi.fn().mockReturnValue('div-atf-sidebar'),
+      getTargeting: vi.fn().mockReturnValue([]),
+    };
+    const mockPubads = {
+      enableSingleRequest: vi.fn(),
+      getSlots: vi.fn().mockReturnValue([mockSlot]),
+      refresh: vi.fn(),
+      addEventListener: vi.fn((event: string, fn: (e: SlotRenderEvent) => void) => {
+        if (event === 'slotRenderEnded') capturedListener = fn;
+      }),
+    };
+    (window as TestWindow).googletag = {
+      cmd: { push: vi.fn((fn: () => void) => fn()) },
+      defineSlot: vi.fn().mockReturnValue(mockSlot),
+      pubads: vi.fn().mockReturnValue(mockPubads),
+      enableServices: vi.fn(),
+    };
+    (window as TestWindow).tsjs = {
+      adSlots: [
+        {
+          id: 'atf_sidebar_ad',
+          gam_unit_path: '/123/atf',
+          div_id: 'div-atf-sidebar',
+          formats: [[300, 250]],
+          targeting: {},
+        },
+      ],
+      bids: {
+        atf_sidebar_ad: {
+          hb_bidder: 'kargo',
+          hb_adid: 'cache-uuid-9',
+          hb_auction_id: 'ts-req-trace9',
+          hb_adm_hash: 'a1b2c3d4e5f60718',
+        },
+      },
+    };
+
+    const { installTsAdInit } = await import('../../../src/integrations/gpt/index');
+    installTsAdInit();
+    (window as TestWindow).tsjs!.adInit!();
+
+    // First render consumes the targeting adInit applied → attributable.
+    capturedListener!({ isEmpty: false, slot: mockSlot });
+    expect((window as TestWindow).tsjs!.renders?.['atf_sidebar_ad']?.path).toBe('ssat');
+
+    // A publisher-driven refresh fills the slot again, but the server-side
+    // auction ran once and is long finished. ts.bids still holds its data —
+    // re-stamping it would claim a render that auction never produced.
+    capturedListener!({ isEmpty: false, slot: mockSlot });
+
+    const refreshed = (window as TestWindow).tsjs!.renders?.['atf_sidebar_ad'];
+    expect(refreshed?.path).toBe('gam-refresh');
+    expect(refreshed?.rendered).toBe(true);
+    expect(refreshed?.count).toBe(2);
+    expect(refreshed?.auctionId).toBeUndefined();
+    expect(refreshed?.bidder).toBeUndefined();
+    expect(refreshed?.admHash).toBeUndefined();
+
+    // Stale attribution must not survive on the DOM either.
+    const el = document.getElementById('div-atf-sidebar')!;
+    expect(el.getAttribute('data-ts-render-path')).toBe('gam-refresh');
+    expect(el.hasAttribute('data-ts-auction-id')).toBe(false);
+    expect(el.hasAttribute('data-ts-adm-hash')).toBe(false);
+  });
+
   it('does not fire beacons for an APS-style bid that carries no hb_adid', async () => {
     const beaconSpy = vi.spyOn(navigator, 'sendBeacon').mockReturnValue(true);
     let capturedListener: ((e: SlotRenderEvent) => void) | undefined;

--- a/crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts
@@ -63,8 +63,10 @@ import {
   auctionBidsToPrebidBids,
   installPrebidNpm,
   installRefreshHandler,
+  recordPrebidBidWon,
 } from '../../../src/integrations/prebid/index';
 import type { AuctionBid } from '../../../src/core/auction';
+import type { TsjsApi } from '../../../src/core/types';
 
 describe('prebid/collectBidders', () => {
   it('returns empty array for empty ad units', () => {
@@ -196,6 +198,82 @@ describe('prebid/auctionBidsToPrebidBids', () => {
     expect(result).toHaveLength(2);
     expect(result[0].requestId).toBe('req-a');
     expect(result[1].requestId).toBe('req-b');
+  });
+
+  it('forwards the server-side trace tuple into Prebid meta', () => {
+    const auctionBids: AuctionBid[] = [
+      {
+        impid: 'div-gpt-1',
+        adm: '<div>Ad</div>',
+        price: 1.0,
+        width: 300,
+        height: 250,
+        seat: 'kargo',
+        creativeId: 'KM-CREA-1',
+        adomain: ['kargo.com'],
+        auctionId: 'ts-auction-xyz',
+        admHash: 'a1b2c3d4e5f60718',
+      },
+    ];
+
+    const result = auctionBidsToPrebidBids(auctionBids, []);
+
+    expect(result[0].meta.tsAuctionId).toBe('ts-auction-xyz');
+    expect(result[0].meta.tsAdmHash).toBe('a1b2c3d4e5f60718');
+  });
+});
+
+describe('prebid/recordPrebidBidWon', () => {
+  beforeEach(() => {
+    delete (window as { tsjs?: TsjsApi }).tsjs;
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    delete (window as { tsjs?: TsjsApi }).tsjs;
+    document.body.innerHTML = '';
+  });
+
+  it('records an auction-path render for a server-side bid', () => {
+    document.body.innerHTML = '<div id="ad-header-0-_R_x_"></div>';
+    const record = recordPrebidBidWon({
+      adUnitCode: 'ad-header-0-_R_x_',
+      bidderCode: 'kargo',
+      creativeId: 'KM-CREA-1',
+      meta: { tsAuctionId: '265dcedd-aa0a', tsAdmHash: 'f68044ca9f68c88c' },
+    });
+
+    expect(record).toBeDefined();
+    expect(record).toEqual(
+      expect.objectContaining({
+        slotId: 'ad-header-0-_R_x_',
+        path: 'auction',
+        rendered: true,
+        injected: true,
+        auctionId: '265dcedd-aa0a',
+        admHash: 'f68044ca9f68c88c',
+        bidder: 'kargo',
+        creativeId: 'KM-CREA-1',
+        servedFrom: 'prebid',
+        elementId: 'ad-header-0-_R_x_',
+      })
+    );
+    // Written into the shared registry the panel reads.
+    expect((window as { tsjs?: TsjsApi }).tsjs?.renders?.['ad-header-0-_R_x_']).toBeDefined();
+  });
+
+  it('skips a bid without the server-side trace tuple (client-side bidder)', () => {
+    const record = recordPrebidBidWon({
+      adUnitCode: 'ad-header-0',
+      bidderCode: 'appnexus',
+      meta: { advertiserDomains: ['x.com'] },
+    });
+    expect(record).toBeUndefined();
+    expect((window as { tsjs?: TsjsApi }).tsjs?.renders).toBeUndefined();
+  });
+
+  it('skips a bid with no adUnitCode', () => {
+    expect(recordPrebidBidWon({ meta: { tsAuctionId: 'x' } })).toBeUndefined();
+    expect(recordPrebidBidWon(undefined)).toBeUndefined();
   });
 });
 

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -137,6 +137,15 @@ example_segments = "segments"
 [debug]
 ja4_endpoint_enabled = false
 
+# Expose GET /_ts/trace, which toggles the `ts-trace` cookie and redirects to /.
+# While the cookie is set, the TSJS overlay draws a floating panel summarising
+# every traced ad slot (render path, bidder, and GAM/injected/visible state)
+# plus a confirmation badge on each genuinely-rendered creative. It only
+# surfaces data already present on window.tsjs, so it leaks nothing new — but
+# it is off by default so the toggle route is not live on deployments that
+# never asked for it. Enable only for render-verification debugging.
+# trace_route_enabled = false
+
 [creative_opportunities]
 gam_network_id = "123456789"
 # FCP is not affected by this value — body content above </body> has already


### PR DESCRIPTION
## Summary

- **Admin EC inspection.** Operators had no way to see what an EC identity actually holds in KV, or which EID cookies a given request is carrying. Adds two authenticated `/_ts/admin` endpoints — an EC lookup by id (returning the KV graph, with ISO 8601 companions alongside epoch timestamps) and a request EID cookie echo — so identity issues can be diagnosed without shell access to the store.
- **On-page render confirmation.** The server-side auction already logged an `auction_id` + `adm_hash` per winning bid (landed in `rc/july`), but nothing confirmed those creatives reached the page. This adds the client half: a `window.tsjs.renders` / `renderLog` registry fed by both render paths, `data-ts-*` markers on the slot element, and a `/_ts/trace` route that arms a floating overlay showing each render as a timeline entry. A winning bid can now be followed from the server log to the pixels.
- **Correctness fixes surfaced by that verification.** Building the overlay exposed three real defects it would otherwise have hidden — a hydration race orphaning GPT slots, a status that claimed success for slots GAM had only targeted, and refreshes re-claiming a finished auction. Each is fixed and covered by tests; details below.

## Changes

| File | Change |
| ---- | ------ |
| `core/src/ec/admin.rs` | New. EC lookup-by-id and request-EID-echo admin handlers, with ISO 8601 companions for epoch timestamps. |
| `core/src/ec/kv.rs`, `ec/mod.rs`, `ec/prebid_eids.rs` | Expose the KV graph shape the lookup endpoint returns. |
| `core/src/trace_cookie.rs` | New. `GET /_ts/trace` arms/disarms the overlay via a host-only cookie, then 302s back to `/`. Gated on `debug.trace_route_enabled`. |
| `core/src/settings.rs` | Adds `debug.trace_route_enabled` (defaults off) and admin endpoint config. |
| `core/src/constants.rs`, `core/src/lib.rs` | Trace cookie name; module wiring. |
| `adapter-{fastly,cloudflare,axum,spin}/src/app.rs` | Register the admin and trace routes on all four adapters. |
| `adapter-{axum,cloudflare,spin}/tests/routes.rs` | Route coverage, including that the admin paths stay behind auth. |
| `js/lib/src/core/trace.ts` | Render registry, bounded append-only `renderLog`, floating overlay panel, on-creative badge, `isEffectivelyVisible` ancestor walk. |
| `js/lib/src/core/types.ts` | `RenderRecord` (incl. `gamEmpty` / `injected` / `visible`), `path` union, `TsjsApi` additions. |
| `js/lib/src/core/request.ts` | Records `/auction` iframe renders. |
| `js/lib/src/integrations/gpt/index.ts` | `slotRenderEnded` tracing; orphaned-slot recovery; scopes SSAT attribution to a single render. |
| `js/lib/src/integrations/prebid/index.ts` | `bidWon` / `adRenderSucceeded` trace hook; forwards `tsAuctionId` / `tsAdmHash` through bid meta. |
| `js/lib/test/**` | Coverage for the above — trace registry and panel states, orphan recovery, Prebid trace hook. |
| `trusted-server.example.toml` | Documents `trace_route_enabled`, off by default. |

## Notes for review

Three behaviours worth a careful look, since all three are about *not overclaiming*:

1. **Honest status.** The panel reports `ok` / `hidden` / `gam-only` / `empty` rather than a single success mark. `rendered` (GAM said non-empty), `injected` (TS actually placed the markup) and `visible` (the box is on screen) are tracked separately — a non-empty GAM slot is not proof the TS creative rendered, and the earlier version claimed it was.
2. **Single-shot SSAT attribution.** `window.tsjs.bids` is frozen page-load data, so reading it on every `slotRenderEnded` made each publisher-driven refresh re-stamp a long-finished auction. Only the render consuming the targeting `adInit` applied is labelled `ssat`; later ones are `gam-refresh` with the stale tuple dropped.
3. **Overlay is opt-in and off by default.** `trace_route_enabled` defaults to `false`, the cookie is host-only, and the badge only renders for statuses that are actually confirmed.

## Test plan

- [x] `cargo test-fastly && cargo test-axum`
- [x] `cargo clippy-fastly && cargo clippy-axum`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/trusted-server-js/lib && npx vitest run` (505 passing)
- [x] JS format: `cd crates/trusted-server-js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [x] Manual testing via `fastly compute serve` + `ts dev proxy`
- [x] Other: deployed to a staging Fastly service and verified against a live publisher page — the overlay reports real renders, and the orphaned-slot recovery was observed firing on a production load (`2 TS slot(s) orphaned by a DOM re-render; re-binding`).

Not yet verifiable in production: the `/auction` render rows. That hook compiles into the external Prebid bundle, which is served from R2 and does not ship with a deploy, so it needs a separate bundle rebuild + upload before those rows appear.

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
