### PR TITLE
Detect GPT initial load configured through setConfig

### DIFF
--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -1247,9 +1247,10 @@ mod tests {
 
     #[test]
     fn head_inserts_bootstrap_refreshes_ts_slots_when_initial_load_disabled() {
-        // Mirrors the bundle: when the publisher calls disableInitialLoad(),
-        // display() only registers a TS-defined slot, so the bootstrap must also
-        // refresh those slots or they render blank.
+        // Mirrors the bundle: when the publisher disables initial load through
+        // setConfig() or the legacy disableInitialLoad() method, display() only
+        // registers a TS-defined slot, so the bootstrap must also refresh those
+        // slots or they render blank.
         let config = test_config();
         let integration = GptIntegration::new(config);
         let doc_state = IntegrationDocumentState::default();
@@ -1261,8 +1262,12 @@ mod tests {
         };
         let combined = integration.head_inserts(&ctx).join("");
         assert!(
-            combined.contains("disableInitialLoad"),
-            "bootstrap should wrap disableInitialLoad() to detect the disabled state"
+            combined.contains("gpt.setConfig"),
+            "bootstrap should wrap googletag.setConfig() to detect the disabled state"
+        );
+        assert!(
+            combined.contains("pubads.disableInitialLoad"),
+            "bootstrap should wrap legacy disableInitialLoad() calls"
         );
         assert!(
             combined.contains("gptInitialLoadDisabled"),

--- a/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
+++ b/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
@@ -20,13 +20,29 @@
   if (ts.adInit) return;
 
   // Track whether the publisher disabled GPT initial load. GPT exposes no
-  // getter for this, so wrap pubads().disableInitialLoad() to record it. With
-  // initial load disabled, display() only registers a slot and the ad request
-  // must come from a later refresh(); adInit() reads this to refresh its own
-  // freshly defined slots so they are not left blank. Pushed onto the command
-  // queue so it runs before the publisher's own disableInitialLoad() call.
+  // getter for this, so wrap both googletag.setConfig() and the legacy
+  // pubads().disableInitialLoad() method to record it. With initial load
+  // disabled, display() only registers a slot and the ad request must come from
+  // a later refresh(); adInit() reads this to refresh its own freshly defined
+  // slots so they are not left blank. Pushed onto the command queue so it runs
+  // before the publisher's own GPT configuration.
   (window.googletag = window.googletag || { cmd: [] }).cmd.push(function () {
-    var pubads = googletag.pubads && googletag.pubads();
+    var gpt = window.googletag;
+    if (
+      typeof gpt.setConfig === "function" &&
+      !gpt.__tsInitialLoadConfigHooked
+    ) {
+      var originalSetConfig = gpt.setConfig.bind(gpt);
+      gpt.setConfig = function (config) {
+        if (config && config.disableInitialLoad === true) {
+          ts.gptInitialLoadDisabled = true;
+        }
+        return originalSetConfig(config);
+      };
+      gpt.__tsInitialLoadConfigHooked = true;
+    }
+
+    var pubads = gpt.pubads && gpt.pubads();
     if (
       !pubads ||
       typeof pubads.disableInitialLoad !== "function" ||
@@ -34,10 +50,10 @@
     ) {
       return;
     }
-    var original = pubads.disableInitialLoad.bind(pubads);
+    var originalDisableInitialLoad = pubads.disableInitialLoad.bind(pubads);
     pubads.disableInitialLoad = function () {
       ts.gptInitialLoadDisabled = true;
-      return original();
+      return originalDisableInitialLoad();
     };
     pubads.__tsInitialLoadHooked = true;
   });

--- a/crates/trusted-server-js/lib/src/core/types.ts
+++ b/crates/trusted-server-js/lib/src/core/types.ts
@@ -114,11 +114,12 @@ export interface TsjsApi {
    */
   adInitRefreshInProgress?: boolean;
   /**
-   * True once the publisher has called `googletag.pubads().disableInitialLoad()`.
-   * GPT exposes no getter for this state, so it is tracked by wrapping the
-   * setter. When set, `display()` only registers a slot and the ad request must
-   * come from a `refresh()`; adInit() uses this to refresh its own freshly
-   * defined slots so they are not left blank.
+   * True once the publisher has disabled GPT initial load through
+   * `googletag.setConfig()` or `googletag.pubads().disableInitialLoad()`.
+   * GPT exposes no getter for this state, so TS tracks both configuration APIs.
+   * When set, `display()` only registers a slot and the ad request must come
+   * from a `refresh()`; adInit() uses this to refresh its own freshly defined
+   * slots so they are not left blank.
    */
   gptInitialLoadDisabled?: boolean;
   /** Guards SPA pushState hook installation. */

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -109,6 +109,10 @@ interface GoogleTagPubAdsService {
   disableInitialLoad?(): void;
 }
 
+interface GoogleTagConfig extends Record<string, unknown> {
+  disableInitialLoad?: boolean;
+}
+
 interface GoogleTag {
   cmd: Array<() => void>;
   pubads(): GoogleTagPubAdsService;
@@ -120,6 +124,7 @@ interface GoogleTag {
   destroySlots(slots?: GoogleTagSlot[]): boolean;
   enableServices(): void;
   display(elementId: string): void;
+  setConfig(config: GoogleTagConfig): void;
   _loaded_?: boolean;
 }
 
@@ -409,15 +414,16 @@ function queueWinBillingBeacon(url: string): boolean {
 /**
  * Track whether the publisher disabled GPT initial load.
  *
- * GPT exposes no getter for the initial-load-disabled flag, so wrap
- * `pubads().disableInitialLoad()` to record it on `window.tsjs`. With initial
- * load disabled, `display()` only registers a slot — the ad request must come
- * from a later `refresh()`. adInit() reads this to refresh its own freshly
- * defined slots so they are not left blank.
+ * GPT exposes no getter for the initial-load-disabled flag, so wrap both the
+ * modern `googletag.setConfig({ disableInitialLoad: true })` API and the legacy
+ * `pubads().disableInitialLoad()` method to record it on `window.tsjs`. With
+ * initial load disabled, `display()` only registers a slot — the ad request
+ * must come from a later `refresh()`. adInit() reads this to refresh its own
+ * freshly defined slots so they are not left blank.
  *
- * Installed via the command queue so it runs before the publisher's own
- * `disableInitialLoad()` call (the TS core script is injected ahead of the
- * publisher's GPT setup). Idempotent per pubads service.
+ * Installed via the command queue so it runs before the publisher's own GPT
+ * configuration (the TS core script is injected ahead of the publisher's GPT
+ * setup). Idempotent per googletag object and pubads service.
  *
  * Only hooks an existing `googletag` stub — it never creates one. A plain module
  * import that does not activate the GPT integration must not touch
@@ -430,16 +436,32 @@ function installInitialLoadDetector(ts: TsjsApi): void {
   const cmd = win.googletag?.cmd;
   if (!cmd) return;
   cmd.push(() => {
-    const pubads = win.googletag?.pubads?.();
+    const gpt = win.googletag as
+      | (Partial<GoogleTag> & { __tsInitialLoadConfigHooked?: boolean })
+      | undefined;
+    if (!gpt) return;
+
+    if (typeof gpt.setConfig === 'function' && !gpt.__tsInitialLoadConfigHooked) {
+      const originalSetConfig = gpt.setConfig.bind(gpt);
+      gpt.setConfig = function (config: GoogleTagConfig) {
+        if (config?.disableInitialLoad === true) {
+          ts.gptInitialLoadDisabled = true;
+        }
+        return originalSetConfig(config);
+      };
+      gpt.__tsInitialLoadConfigHooked = true;
+    }
+
+    const pubads = gpt.pubads?.();
     if (!pubads) return;
     const service = pubads as GoogleTagPubAdsService & { __tsInitialLoadHooked?: boolean };
     if (typeof service.disableInitialLoad !== 'function' || service.__tsInitialLoadHooked) {
       return;
     }
-    const original = service.disableInitialLoad.bind(service);
+    const originalDisableInitialLoad = service.disableInitialLoad.bind(service);
     service.disableInitialLoad = function () {
       ts.gptInitialLoadDisabled = true;
-      return original();
+      return originalDisableInitialLoad();
     };
     service.__tsInitialLoadHooked = true;
   });
@@ -612,9 +634,9 @@ export function installTsAdInit(): void {
       // Slots needing an explicit ad request via refresh(). Reused
       // publisher-owned slots always need one to pick up the just-applied
       // server-side targeting. TS-defined slots are normally fetched by the
-      // display() above — but when the publisher called
-      // pubads().disableInitialLoad(), display() only registers the slot and the
-      // ad request must come from refresh(). Without this, a TS-owned
+      // display() above — but when the publisher disabled initial load through
+      // setConfig() or the legacy pubads() method, display() only registers the
+      // slot and the ad request must come from refresh(). Without this, a TS-owned
       // first-impression slot renders blank on initial-load-disabled pages. Only
       // add them in that case; otherwise display() + refresh() would
       // double-request the impression.

--- a/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
@@ -243,6 +243,62 @@ describe('installTsAdInit', () => {
     expect(mockPubads.refresh).toHaveBeenCalledWith([mockSlot]);
   });
 
+  it('refreshes TS-defined slots when setConfig disables GPT initial load', async () => {
+    // Modern GPT configuration uses googletag.setConfig() rather than the
+    // legacy pubads().disableInitialLoad() method. TS must detect both forms.
+    const mockSlot = {
+      addService: vi.fn().mockReturnThis(),
+      setTargeting: vi.fn().mockReturnThis(),
+      getSlotElementId: vi.fn().mockReturnValue('div-atf-sidebar'),
+      getTargeting: vi.fn().mockReturnValue([]),
+    };
+    const mockPubads = {
+      enableSingleRequest: vi.fn(),
+      // Publisher has not defined this slot, so TS defines (owns) it.
+      getSlots: vi.fn().mockReturnValue([]),
+      addEventListener: vi.fn(),
+      refresh: vi.fn(),
+    };
+    const displayMock = vi.fn();
+    const setConfigMock = vi.fn();
+    (window as TestWindow).googletag = {
+      cmd: { push: vi.fn((fn: () => void) => fn()) },
+      defineSlot: vi.fn().mockReturnValue(mockSlot),
+      display: displayMock,
+      pubads: vi.fn().mockReturnValue(mockPubads),
+      enableServices: vi.fn(),
+      setConfig: setConfigMock,
+    };
+    (window as TestWindow).tsjs = {
+      adSlots: [
+        {
+          id: 'atf_sidebar_ad',
+          gam_unit_path: '/123/atf',
+          div_id: 'div-atf-sidebar',
+          formats: [[300, 250]],
+          targeting: {},
+        },
+      ],
+      bids: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const { installTsAdInit } = await import('../../../src/integrations/gpt/index');
+    installTsAdInit();
+
+    const config = { disableInitialLoad: true, singleRequest: true };
+    ((window as TestWindow).googletag as { setConfig(value: typeof config): void }).setConfig(
+      config
+    );
+    expect(setConfigMock).toHaveBeenCalledWith(config);
+    expect((window as TestWindow).tsjs!.gptInitialLoadDisabled).toBe(true);
+
+    (window as TestWindow).tsjs!.adInit!();
+
+    expect(displayMock).toHaveBeenCalledWith('div-atf-sidebar');
+    expect(mockPubads.refresh).toHaveBeenCalledWith([mockSlot]);
+  });
+
   it('sets adInitRefreshInProgress only for the duration of the internal refresh', async () => {
     const mockSlot = {
       addService: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary

- Detect GPT initial-load disabling through the modern `googletag.setConfig({ disableInitialLoad: true })` API as well as the legacy pubads method.
- Ensure TS-owned slots receive the required `refresh()` after `display()`, preventing GPT slots from stopping at fetch count zero.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/integrations/gpt_bootstrap.js` | Wrap both GPT initial-load configuration APIs in the early page bootstrap. |
| `crates/trusted-server-js/lib/src/integrations/gpt/index.ts` | Add equivalent detection to the bundled GPT integration and preserve the existing refresh behavior. |
| `crates/trusted-server-js/lib/src/core/types.ts` | Document both supported initial-load configuration paths. |
| `crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts` | Add regression coverage for `googletag.setConfig()`. |
| `crates/trusted-server-core/src/integrations/gpt.rs` | Assert that the injected bootstrap includes both detectors. |

## Closes

Closes #946

## Test plan

- [x] `cargo test-fastly && cargo test-axum`
- [x] `cargo clippy-fastly && cargo clippy-axum`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/trusted-server-js/lib && npx vitest run`
- [x] JS format: `cd crates/trusted-server-js/lib && npm run format`
- [ ] Docs format: `cd docs && npm run format`
- [ ] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [ ] Manual testing via `fastly compute serve`
- [x] Other: Cloudflare and Spin tests/clippy passed; Playwright confirmed the current publisher `setConfig()` call now sets `gptInitialLoadDisabled`.

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — use `expect("should ...")`
- [x] Uses `tracing` macros (not `println!`)
- [x] New code has tests
- [x] No secrets or credentials committed
