### PR TITLE
Name the Ad Manager decision in the auction trace console

### DIFF
--- a/crates/trusted-server-integration-tests/browser/tests/ad-trace/auction-trace.spec.ts
+++ b/crates/trusted-server-integration-tests/browser/tests/ad-trace/auction-trace.spec.ts
@@ -614,7 +614,7 @@ test.describe("tester-only auction trace contract", () => {
             });
     });
 
-    test("actual generated Prebid selects the traced TS bid before an unattributed GAM render", async ({
+    test("actual generated Prebid selects the traced TS bid before GAM delivers other demand", async ({
         page,
     }) => {
         await openTesterPage(page);
@@ -645,34 +645,40 @@ test.describe("tester-only auction trace contract", () => {
             win.adTraceFixture.setSuppressCreative(true);
             win.googletag.pubads().refresh([win.adTraceFixture.latestSlot()]);
         });
+        // The suppressed creative never requests markup, so the bounded
+        // attribution window resolves the render as other Ad Manager demand
+        // instead of leaving it a permanent Trusted Server candidate.
         await expect
-            .poll(async () => {
-                const result = await exported(page);
-                const slot = result.slots.find(
-                    (item) => item.slotId === "ad-trace-slot",
-                ) as
-                    | {
-                          stages?: Record<
-                              string,
-                              { outcome?: string; confidence?: string }
-                          >;
-                      }
-                    | undefined;
-                return {
-                    prebid: slot?.stages?.prebid,
-                    gam: slot?.stages?.gam,
-                };
-            })
+            .poll(
+                async () => {
+                    const result = await exported(page);
+                    const slot = result.slots.find(
+                        (item) => item.slotId === "ad-trace-slot",
+                    ) as
+                        | {
+                              stages?: Record<
+                                  string,
+                                  { outcome?: string; confidence?: string }
+                              >;
+                          }
+                        | undefined;
+                    return {
+                        prebid: slot?.stages?.prebid,
+                        gam: slot?.stages?.gam,
+                    };
+                },
+                { timeout: 15_000 },
+            )
             .toMatchObject({
                 prebid: { outcome: "won", confidence: "definitive" },
                 gam: {
-                    outcome: "trusted_server_candidate",
-                    confidence: "probable",
+                    outcome: "other_gam_demand",
+                    confidence: "strong",
                 },
             });
     });
 
-    test("client selection, backfill, direct-or-unattributed, and retained generations stay independent", async ({
+    test("client selection, backfill, named reservation, and retained generations stay independent", async ({
         page,
     }) => {
         await openTesterPage(page);
@@ -744,6 +750,7 @@ test.describe("tester-only auction trace contract", () => {
             const win = window as Window & {
                 adTraceFixture: {
                     latestSlot(): { clearTargeting(): void };
+                    setNextRender(flags: Record<string, boolean>): void;
                     requestCurrent(): void;
                 };
                 tsjs: {
@@ -753,19 +760,35 @@ test.describe("tester-only auction trace contract", () => {
             const slot = win.adTraceFixture.latestSlot();
             slot.clearTargeting();
             win.tsjs.captureAdTraceRequest(slot, "fixture_direct");
+            win.adTraceFixture.setNextRender({ isReservation: true });
             win.adTraceFixture.requestCurrent();
         });
+        // Ad Manager reported its own reservation line item for a slot carrying
+        // no Trusted Server targeting, so the render is named rather than
+        // reported as unattributed.
         await expect
             .poll(async () => {
                 const result = await exported(page);
                 const slot = result.slots.find(
                     (item) => item.slotId === "ad-trace-slot",
                 ) as
-                    | { stages?: Record<string, { outcome?: string }> }
+                    | {
+                          stages?: Record<string, { outcome?: string }>;
+                          generations?: Array<{
+                              diagnostics?: {
+                                  gamIdentity?: { lineItemId?: number };
+                              };
+                          }>;
+                      }
                     | undefined;
-                return slot?.stages?.gam?.outcome;
+                return {
+                    gam: slot?.stages?.gam?.outcome,
+                    lineItemId:
+                        slot?.generations?.[slot.generations.length - 1]
+                            ?.diagnostics?.gamIdentity?.lineItemId,
+                };
             })
-            .toBe("direct_or_unattributed");
+            .toEqual({ gam: "other_reservation", lineItemId: 101 });
 
         const generations = await page.evaluate(() => {
             const win = window as Window & {

--- a/crates/trusted-server-js/lib/src/core/ad_trace.ts
+++ b/crates/trusted-server-js/lib/src/core/ad_trace.ts
@@ -7,6 +7,7 @@ import type {
   AdTraceEvent,
   AdTraceEventKind,
   AdTraceExport,
+  AdTraceGamIdentity,
   AdTraceObservation,
   AdTraceStage,
   AdTraceStageName,
@@ -43,6 +44,7 @@ const EVENT_KINDS = new Set<AdTraceEventKind>([
   'gpt_slot_requested',
   'gpt_slot_response_received',
   'gpt_slot_render_ended',
+  'gpt_render_unclaimed',
   'gpt_slot_onload',
   'gpt_impression_viewable',
   'gpt_slot_visibility_changed',
@@ -214,9 +216,11 @@ function updateStage(target: Record<AdTraceStageName, AdTraceStage>, event: AdTr
       }
       break;
     case 'gpt_slot_render_ended':
-      // Cooperative acknowledgement is stronger than later GPT callbacks and
+      // Cooperative creative evidence is stronger than later GPT callbacks and
       // must never be downgraded to a probable candidate.
-      if (target.gam.confidence === 'definitive') break;
+      if (target.gam.confidence === 'definitive' || target.gam.outcome === 'trusted_server_won') {
+        break;
+      }
       if (explicit?.outcome === 'unresolved') target.gam = explicit;
       else if (event.isEmpty)
         target.gam = { outcome: 'empty', confidence: 'definitive', reason: 'gpt_empty' };
@@ -237,12 +241,58 @@ function updateStage(target: Record<AdTraceStageName, AdTraceStage>, event: AdTr
           confidence: 'probable',
           reason: 'client_bid_won_and_gpt_rendered',
         };
+      // Ad Manager reported a reservation line item it chose on its own. No
+      // Trusted Server targeting was live on the slot, so the delivered ad came
+      // from other Ad Manager demand — direct-sold or house.
+      else if (event.responseClass === 'reservation')
+        target.gam = {
+          outcome: 'other_reservation',
+          confidence: 'strong',
+          reason: 'reservation_reported_without_trusted_server_targeting',
+        };
+      // Non-empty with no reservation or backfill identifiers: Ad Manager's own
+      // default or backup image, or a render by a service other than PubAds.
+      else if (event.responseClass === 'unclassified_non_empty')
+        target.gam = {
+          outcome: 'gam_default_or_unclassified',
+          confidence: 'probable',
+          reason: 'non_empty_without_ad_manager_identifiers',
+        };
       else
         target.gam = {
           outcome: 'direct_or_unattributed',
           confidence: 'probable',
           reason: 'non_empty_unattributed',
         };
+      break;
+    case 'gpt_render_unclaimed':
+      // Ad Manager rendered while Trusted Server targeting was live, but the
+      // rendered creative never asked Trusted Server for markup. Ad Manager
+      // delivered other demand — house, direct-sold, or its own default.
+      if (
+        target.gam.confidence !== 'definitive' &&
+        target.gam.outcome !== 'trusted_server_won' &&
+        target.gam.outcome !== 'empty' &&
+        target.gam.outcome !== 'backfill'
+      ) {
+        target.gam = {
+          outcome: 'other_gam_demand',
+          confidence: 'strong',
+          reason: event.reason ?? 'creative_markup_never_requested',
+        };
+      }
+      break;
+    case 'pb_render_requested':
+      // The Prebid Universal Creative only executes when Ad Manager selected the
+      // header-bidding line item, and it asked for this generation's own ad ID.
+      // That settles the Ad Manager decision even if the creative never loads.
+      if (target.gam.confidence !== 'definitive') {
+        target.gam = {
+          outcome: 'trusted_server_won',
+          confidence: 'strong',
+          reason: 'creative_requested_markup',
+        };
+      }
       break;
     case 'aps_display_bids_set':
       // APS setting display bids is a handoff only. GAM attribution remains
@@ -271,6 +321,15 @@ function updateStage(target: Record<AdTraceStageName, AdTraceStage>, event: AdTr
           outcome: 'renderer_served',
           confidence: 'strong',
           reason: event.reason ?? 'pb_render_response',
+        };
+      }
+      // Serving markup to the creative Ad Manager rendered is the same Ad
+      // Manager decision evidence as the request that preceded it.
+      if (target.gam.confidence !== 'definitive') {
+        target.gam = {
+          outcome: 'trusted_server_won',
+          confidence: 'strong',
+          reason: 'creative_markup_served',
         };
       }
       break;
@@ -378,6 +437,37 @@ function emptyCoverage(): Record<AdTraceCoverageCategory, AdTraceCoverageCounter
   ) as Record<AdTraceCoverageCategory, AdTraceCoverageCounter>;
 }
 
+const GAM_IDENTITY_ID_KEYS = [
+  'lineItemId',
+  'creativeId',
+  'campaignId',
+  'advertiserId',
+  'sourceAgnosticLineItemId',
+  'sourceAgnosticCreativeId',
+] as const;
+const GAM_IDENTITY_LIST_KEYS = ['yieldGroupIds', 'companyIds'] as const;
+const GAM_IDENTITY_MAX_LIST = 8;
+
+function sanitizeGamIdentity(value: unknown): AdTraceGamIdentity | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const source = value as Record<string, unknown>;
+  const identity: Record<string, number | readonly number[]> = {};
+  for (const key of GAM_IDENTITY_ID_KEYS) {
+    const id = boundedInteger(source[key], 1, Number.MAX_SAFE_INTEGER);
+    if (id !== undefined) identity[key] = id;
+  }
+  for (const key of GAM_IDENTITY_LIST_KEYS) {
+    const raw = source[key];
+    if (!Array.isArray(raw)) continue;
+    const ids = raw
+      .map((item) => boundedInteger(item, 1, Number.MAX_SAFE_INTEGER))
+      .filter((item): item is number => item !== undefined)
+      .slice(0, GAM_IDENTITY_MAX_LIST);
+    if (ids.length > 0) identity[key] = ids;
+  }
+  return Object.keys(identity).length > 0 ? (identity as AdTraceGamIdentity) : undefined;
+}
+
 function boundedInteger(value: unknown, minimum: number, maximum: number): number | undefined {
   return typeof value === 'number' &&
     Number.isInteger(value) &&
@@ -428,6 +518,7 @@ function updateGenerationDiagnostics(
       timestamps.renderedAt ??= event.timestamp;
       diagnostics.terminalState = event.isEmpty ? 'empty' : 'rendered';
       if (event.responseClass) diagnostics.responseClass = event.responseClass;
+      if (event.gamIdentity) diagnostics.gamIdentity = event.gamIdentity;
       if (event.renderedWidth !== undefined && event.renderedHeight !== undefined) {
         diagnostics.renderedSize = [event.renderedWidth, event.renderedHeight];
       }
@@ -704,6 +795,9 @@ export function createAdTraceStore(
           : {}),
         ...(boundedInteger(observation.prebidAuctionDurationMs, 0, 300_000) !== undefined
           ? { prebidAuctionDurationMs: observation.prebidAuctionDurationMs }
+          : {}),
+        ...(sanitizeGamIdentity(observation.gamIdentity)
+          ? { gamIdentity: sanitizeGamIdentity(observation.gamIdentity) }
           : {}),
       };
       if (event.kind !== 'gpt_slot_visibility_changed') {

--- a/crates/trusted-server-js/lib/src/core/types.ts
+++ b/crates/trusted-server-js/lib/src/core/types.ts
@@ -115,6 +115,7 @@ export type AdTraceEventKind =
   | 'gpt_slot_requested'
   | 'gpt_slot_response_received'
   | 'gpt_slot_render_ended'
+  | 'gpt_render_unclaimed'
   | 'gpt_slot_onload'
   | 'gpt_impression_viewable'
   | 'gpt_slot_visibility_changed'
@@ -152,6 +153,7 @@ export interface AdTraceObservation {
   sizeMatchesConfigured?: boolean;
   inViewPercentage?: number;
   prebidAuctionDurationMs?: number;
+  gamIdentity?: AdTraceGamIdentity;
 }
 
 export interface AdTraceEvent extends AdTraceObservation {
@@ -160,6 +162,25 @@ export interface AdTraceEvent extends AdTraceObservation {
 }
 
 export type AdTraceResponseClass = 'empty' | 'backfill' | 'reservation' | 'unclassified_non_empty';
+
+/**
+ * Ad Manager's own account of what it served, as reported by `slotRenderEnded`.
+ *
+ * These are the publisher's own Ad Manager identifiers for the delivered ad —
+ * the same values Google's `?google_console=1` shows for the page. They are the
+ * only authoritative statement of which line item beat the Trusted Server
+ * candidate, so a render that Trusted Server cannot claim can still be named.
+ */
+export interface AdTraceGamIdentity {
+  lineItemId?: number;
+  creativeId?: number;
+  campaignId?: number;
+  advertiserId?: number;
+  sourceAgnosticLineItemId?: number;
+  sourceAgnosticCreativeId?: number;
+  yieldGroupIds?: readonly number[];
+  companyIds?: readonly number[];
+}
 export type AdTraceAcknowledgementState =
   | 'confirmed'
   | 'timed_out'
@@ -179,6 +200,7 @@ export interface GenerationTraceDiagnostics {
   requestNumber: number;
   terminalState: AdTraceGenerationTerminalState;
   responseClass?: AdTraceResponseClass;
+  gamIdentity?: AdTraceGamIdentity;
   renderedSize?: readonly [number, number];
   slotContentChanged?: boolean;
   sizeMatchesConfigured?: boolean;

--- a/crates/trusted-server-js/lib/src/integrations/ad_trace/presentation.ts
+++ b/crates/trusted-server-js/lib/src/integrations/ad_trace/presentation.ts
@@ -1,4 +1,5 @@
 import type {
+  AdTraceGamIdentity,
   AdTraceStage,
   AdTraceStageName,
   GenerationTraceDiagnostics,
@@ -23,6 +24,13 @@ export interface TraceOverlayPresentation {
 type TraceStages = Record<AdTraceStageName, AdTraceStage>;
 
 const STAGE_ORDER: readonly AdTraceStageName[] = ['trustedServer', 'prebid', 'gam', 'creative'];
+const UNATTRIBUTED_RENDER_STATUS = 'GAM rendered an ad — source not attributed';
+const NAMED_GAM_OUTCOMES = new Set([
+  'trusted_server_won',
+  'other_gam_demand',
+  'other_reservation',
+  'gam_default_or_unclassified',
+]);
 
 function stageFacts(name: AdTraceStageName, stage: AdTraceStage): readonly string[] {
   if (stage.outcome === 'not_observed' || stage.outcome === 'not_run') return [];
@@ -62,6 +70,12 @@ function stageFacts(name: AdTraceStageName, stage: AdTraceStage): readonly strin
           return ['GAM returned backfill'];
         case 'trusted_server_won':
           return ['GAM selected the Trusted Server creative'];
+        case 'other_gam_demand':
+          return ['GAM delivered other demand — the Trusted Server creative never ran'];
+        case 'other_reservation':
+          return ['GAM delivered another reservation line item'];
+        case 'gam_default_or_unclassified':
+          return ['GAM delivered its own default or backup ad'];
         case 'trusted_server_candidate':
         case 'client_prebid_candidate':
         case 'direct_or_unattributed':
@@ -134,6 +148,30 @@ function renderStatus(render?: RenderTraceSnapshot): string | undefined {
   }
 }
 
+/**
+ * Name the delivered ad using Ad Manager's own report of what it served.
+ *
+ * These identifiers are the operator's own Ad Manager data — the same values
+ * `?google_console=1` shows — and are the only way to tell a house ad from a
+ * direct-sold line item when Trusted Server did not win the Ad Manager decision.
+ */
+function gamIdentityFact(identity: AdTraceGamIdentity | undefined): string | undefined {
+  if (!identity) return undefined;
+
+  const parts: string[] = [];
+  const lineItem = identity.lineItemId ?? identity.sourceAgnosticLineItemId;
+  const creative = identity.creativeId ?? identity.sourceAgnosticCreativeId;
+  if (lineItem) parts.push(`line item ${lineItem}`);
+  if (identity.campaignId) parts.push(`order ${identity.campaignId}`);
+  if (identity.advertiserId) parts.push(`advertiser ${identity.advertiserId}`);
+  if (creative) parts.push(`creative ${creative}`);
+  if (identity.yieldGroupIds?.length) {
+    parts.push(`yield group ${identity.yieldGroupIds.join(', ')}`);
+  }
+  if (identity.companyIds?.length) parts.push(`company ${identity.companyIds.join(', ')}`);
+  return parts.length > 0 ? `GAM reported ${parts.join(' · ')}` : undefined;
+}
+
 function visibilityFact(visibility: RenderTraceVisibility | undefined): string | undefined {
   if (visibility === 'visible') return 'Slot element currently visible';
   if (visibility === 'hidden') return 'Slot element currently hidden';
@@ -175,6 +213,15 @@ function compactBadgeStatus(
     response = 'GAM backfill';
   } else if (stages.gam.outcome === 'empty' || diagnostics?.responseClass === 'empty') {
     response = 'GAM empty';
+  } else if (stages.gam.outcome === 'gam_default_or_unclassified') {
+    response = 'GAM default ad';
+  } else if (
+    stages.gam.outcome === 'other_gam_demand' ||
+    stages.gam.outcome === 'other_reservation'
+  ) {
+    const lineItem =
+      diagnostics?.gamIdentity?.lineItemId ?? diagnostics?.gamIdentity?.sourceAgnosticLineItemId;
+    response = lineItem ? `GAM line item ${lineItem}` : 'GAM other demand';
   } else if (
     stages.gam.outcome === 'trusted_server_candidate' ||
     stages.gam.outcome === 'client_prebid_candidate' ||
@@ -206,8 +253,20 @@ export function presentTraceOverlay(
   for (const name of STAGE_ORDER) {
     for (const fact of stageFacts(name, stages[name])) facts.add(fact);
   }
-  const status = renderStatus(render);
+  // A named GAM decision outranks the generic render-timeline wording, which
+  // cannot distinguish other Ad Manager demand from an unresolved Trusted
+  // Server render.
+  const namedGamStatus = NAMED_GAM_OUTCOMES.has(stages.gam.outcome)
+    ? stageFacts('gam', stages.gam)[0]
+    : undefined;
+  const timelineStatus = renderStatus(render);
+  const status =
+    namedGamStatus && timelineStatus === UNATTRIBUTED_RENDER_STATUS
+      ? namedGamStatus
+      : timelineStatus;
   if (status) facts.add(status);
+  const identity = gamIdentityFact(diagnostics?.gamIdentity);
+  if (identity) facts.add(identity);
   const visibility = visibilityFact(render?.visibility);
   if (visibility) facts.add(visibility);
   if (render?.viewability === 'viewable') facts.add('Viewable impression observed');

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -7,6 +7,7 @@ import { log } from '../../core/log';
 import type {
   AdTraceCorrelationResolution,
   AdTraceCoverageCategory,
+  AdTraceGamIdentity,
   AdTraceResponseClass,
   AuctionSlot,
   AuctionBidData,
@@ -75,6 +76,12 @@ interface SlotRenderEndedEvent {
   slotContentChanged?: boolean;
   lineItemId?: number | null;
   creativeId?: number | null;
+  campaignId?: number | null;
+  advertiserId?: number | null;
+  sourceAgnosticLineItemId?: number | null;
+  sourceAgnosticCreativeId?: number | null;
+  yieldGroupIds?: readonly number[] | null;
+  companyIds?: readonly number[] | null;
 }
 
 interface GptSlotEvent extends SlotRenderEndedEvent {
@@ -101,6 +108,10 @@ interface RenderCandidate {
   lateEventsAllowed: boolean;
   consumed: boolean;
   superseded: boolean;
+  /** The rendered creative asked Trusted Server for this generation's markup. */
+  creativeRequestObserved: boolean;
+  /** Bounded wait for that request before the render is called unclaimed. */
+  attributionTimer?: ReturnType<typeof setTimeout>;
 }
 
 interface ExpectedRender {
@@ -312,6 +323,79 @@ function responseClass(event: GptSlotEvent): AdTraceResponseClass {
   if (event.isBackfill === true) return 'backfill';
   if (event.lineItemId != null || event.creativeId != null) return 'reservation';
   return 'unclassified_non_empty';
+}
+
+const MAX_GAM_ID_LIST = 8;
+
+function gamId(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+function gamIdList(value: unknown): readonly number[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const ids = value
+    .map(gamId)
+    .filter((id): id is number => id !== undefined)
+    .slice(0, MAX_GAM_ID_LIST);
+  return ids.length > 0 ? ids : undefined;
+}
+
+/**
+ * Ad Manager's own identifiers for the ad it just delivered into the slot.
+ *
+ * Only Ad Manager can say which line item beat the Trusted Server candidate, so
+ * an unclaimed render is nameable — house, direct-sold, or backfill — instead of
+ * collapsing into a single unattributed bucket.
+ */
+function gamIdentity(event: GptSlotEvent): AdTraceGamIdentity | undefined {
+  const identity: AdTraceGamIdentity = {
+    ...(gamId(event.lineItemId) !== undefined ? { lineItemId: event.lineItemId as number } : {}),
+    ...(gamId(event.creativeId) !== undefined ? { creativeId: event.creativeId as number } : {}),
+    ...(gamId(event.campaignId) !== undefined ? { campaignId: event.campaignId as number } : {}),
+    ...(gamId(event.advertiserId) !== undefined
+      ? { advertiserId: event.advertiserId as number }
+      : {}),
+    ...(gamId(event.sourceAgnosticLineItemId) !== undefined
+      ? { sourceAgnosticLineItemId: event.sourceAgnosticLineItemId as number }
+      : {}),
+    ...(gamId(event.sourceAgnosticCreativeId) !== undefined
+      ? { sourceAgnosticCreativeId: event.sourceAgnosticCreativeId as number }
+      : {}),
+    ...(gamIdList(event.yieldGroupIds) ? { yieldGroupIds: gamIdList(event.yieldGroupIds) } : {}),
+    ...(gamIdList(event.companyIds) ? { companyIds: gamIdList(event.companyIds) } : {}),
+  };
+  return Object.keys(identity).length > 0 ? identity : undefined;
+}
+
+/**
+ * How long a Trusted Server candidate waits for its creative to ask for markup.
+ *
+ * The Universal Creative requests markup as soon as Ad Manager writes it into
+ * the slot. When nothing arrives within this window, Ad Manager delivered other
+ * demand instead, and the render is reported as unclaimed rather than pending
+ * forever. A late request still upgrades the generation afterwards.
+ */
+const GAM_ATTRIBUTION_WINDOW_MS = 5_000;
+
+function settleGamAttribution(candidate: RenderCandidate): void {
+  candidate.creativeRequestObserved = true;
+  if (candidate.attributionTimer) clearTimeout(candidate.attributionTimer);
+  candidate.attributionTimer = undefined;
+}
+
+function armGamAttributionWindow(candidate: RenderCandidate): void {
+  if (candidate.creativeRequestObserved || candidate.attributionTimer) return;
+  candidate.attributionTimer = setTimeout(() => {
+    candidate.attributionTimer = undefined;
+    if (candidate.creativeRequestObserved || candidate.superseded) return;
+    window.tsjs?.recordAdTrace?.({
+      kind: 'gpt_render_unclaimed',
+      slotId: candidate.slotId,
+      generation: candidate.generation,
+      bidTraceId: candidate.traceToken,
+      reason: 'creative_markup_never_requested',
+    });
+  }, GAM_ATTRIBUTION_WINDOW_MS);
 }
 
 function findSlotElementByDivId(divId: string): HTMLElement | null {
@@ -876,6 +960,8 @@ function supersedeCandidate(candidate: RenderCandidate, reason: string): void {
   if (candidate.superseded) return;
   settleSupersededExpectedRenders(candidate);
   candidate.superseded = true;
+  if (candidate.attributionTimer) clearTimeout(candidate.attributionTimer);
+  candidate.attributionTimer = undefined;
   // GPT late callbacks carry only a slot object, never a generation. Once a
   // request is replaced, attributing any later callback to the old generation
   // would be a guess, so replacement always closes late-event ownership.
@@ -1082,6 +1168,7 @@ export function captureAdTraceRequest(
     lateEventsAllowed: true,
     consumed: false,
     superseded: false,
+    creativeRequestObserved: false,
   };
   retainCandidate(candidate);
 
@@ -1253,6 +1340,7 @@ function candidateForGptRequest(slot: GoogleTagSlot): RenderCandidate | undefine
     lateEventsAllowed: true,
     consumed: false,
     superseded: false,
+    creativeRequestObserved: false,
   };
 
   retainCandidate(candidate);
@@ -1561,11 +1649,23 @@ function installGptEvidenceListeners(service: GoogleTagPubAdsService): void {
       isEmpty: event.isEmpty,
       isBackfill: event.isBackfill,
       responseClass: responseClass(event),
+      gamIdentity: gamIdentity(event),
       renderedWidth: size?.[0],
       renderedHeight: size?.[1],
       slotContentChanged: event.slotContentChanged,
       sizeMatchesConfigured,
     });
+    // Only a generation that had a Trusted Server bid to render has something
+    // for Ad Manager to have passed over.
+    if (
+      !event.isEmpty &&
+      !event.isBackfill &&
+      !candidate.ambiguousRequest &&
+      !candidate.superseded &&
+      (candidate.traceToken || candidate.bid)
+    ) {
+      armGamAttributionWindow(candidate);
+    }
   });
 }
 
@@ -2201,6 +2301,9 @@ export function installTsRenderBridge(): void {
         monotonicNow() - candidate.createdAt <= 30_000
     );
     const exactCandidate = candidates.length === 1 ? candidates[0] : undefined;
+    // The creative Ad Manager rendered asked for this generation's markup, so
+    // Ad Manager's line item decision is settled regardless of what follows.
+    if (exactCandidate) settleGamAttribution(exactCandidate);
     window.tsjs?.recordAdTrace?.({
       kind: candidates.length === 1 ? 'pb_render_requested' : 'pb_render_rejected',
       slotId: sourceSlotId,

--- a/crates/trusted-server-js/lib/test/core/ad_trace.test.ts
+++ b/crates/trusted-server-js/lib/test/core/ad_trace.test.ts
@@ -590,6 +590,155 @@ describe('ad trace reducer', () => {
     expect(store.getEvents()).toHaveLength(0);
   });
 
+  it('names Ad Manager demand that outranked the Trusted Server candidate', () => {
+    const store = createAdTraceStore(() => 10);
+    const generation = store.nextGeneration('slot-a');
+    store.record({
+      kind: 'gpt_slot_render_ended',
+      slotId: 'slot-a',
+      generation,
+      isEmpty: false,
+      responseClass: 'reservation',
+      gamIdentity: {
+        lineItemId: 6543210987,
+        creativeId: 1234567890,
+        campaignId: 2345678901,
+        advertiserId: 3456789012,
+        yieldGroupIds: [11, 12],
+      },
+    });
+
+    expect(store.getSlot('slot-a')?.stages.gam, 'should report a named reservation').toMatchObject({
+      outcome: 'other_reservation',
+      confidence: 'strong',
+    });
+    expect(
+      store.getSlot('slot-a')?.generations[0].diagnostics.gamIdentity,
+      'should retain the Ad Manager identifiers for the operator'
+    ).toEqual({
+      lineItemId: 6543210987,
+      creativeId: 1234567890,
+      campaignId: 2345678901,
+      advertiserId: 3456789012,
+      yieldGroupIds: [11, 12],
+    });
+  });
+
+  it('separates an Ad Manager default render from an attributed one', () => {
+    const store = createAdTraceStore(() => 10);
+    const generation = store.nextGeneration('slot-a');
+    store.record({
+      kind: 'gpt_slot_render_ended',
+      slotId: 'slot-a',
+      generation,
+      isEmpty: false,
+      responseClass: 'unclassified_non_empty',
+    });
+
+    expect(store.getSlot('slot-a')?.stages.gam.outcome).toBe('gam_default_or_unclassified');
+    expect(store.getSlot('slot-a')?.generations[0].diagnostics.gamIdentity).toBeUndefined();
+  });
+
+  it('settles the Ad Manager decision when the rendered creative requests markup', () => {
+    const store = createAdTraceStore(() => 10);
+    const generation = store.nextGeneration('slot-a');
+    store.record({
+      kind: 'gpt_slot_render_ended',
+      slotId: 'slot-a',
+      generation,
+      bidTraceId: BID_TRACE_ID,
+      isEmpty: false,
+      responseClass: 'reservation',
+    });
+    store.record({
+      kind: 'pb_render_requested',
+      slotId: 'slot-a',
+      generation,
+      bidTraceId: BID_TRACE_ID,
+      reason: 'exact_generation',
+    });
+
+    expect(store.getSlot('slot-a')?.stages.gam, 'should credit the render to TS').toMatchObject({
+      outcome: 'trusted_server_won',
+      confidence: 'strong',
+      reason: 'creative_requested_markup',
+    });
+    // The creative may still never load; the Ad Manager decision stands anyway.
+    store.record({ kind: 'creative_ack_timed_out', slotId: 'slot-a', generation });
+    expect(store.getSlot('slot-a')?.stages.gam.outcome).toBe('trusted_server_won');
+    expect(store.getSlot('slot-a')?.stages.creative.outcome).toBe('ack_timed_out');
+  });
+
+  it('resolves an unclaimed render without downgrading settled outcomes', () => {
+    const store = createAdTraceStore(() => 10);
+    const unclaimed = store.nextGeneration('slot-a');
+    store.record({
+      kind: 'gpt_slot_render_ended',
+      slotId: 'slot-a',
+      generation: unclaimed,
+      bidTraceId: BID_TRACE_ID,
+      isEmpty: false,
+      responseClass: 'reservation',
+      gamIdentity: { lineItemId: 6543210987 },
+    });
+    expect(store.getSlot('slot-a')?.stages.gam.outcome).toBe('trusted_server_candidate');
+
+    store.record({
+      kind: 'gpt_render_unclaimed',
+      slotId: 'slot-a',
+      generation: unclaimed,
+      bidTraceId: BID_TRACE_ID,
+      reason: 'creative_markup_never_requested',
+    });
+    expect(store.getSlot('slot-a')?.stages.gam, 'should name other demand').toMatchObject({
+      outcome: 'other_gam_demand',
+      confidence: 'strong',
+      reason: 'creative_markup_never_requested',
+    });
+
+    const claimed = store.nextGeneration('slot-b');
+    store.record({
+      kind: 'pb_render_requested',
+      slotId: 'slot-b',
+      generation: claimed,
+      bidTraceId: BID_TRACE_ID,
+      reason: 'exact_generation',
+    });
+    store.record({
+      kind: 'gpt_render_unclaimed',
+      slotId: 'slot-b',
+      generation: claimed,
+      bidTraceId: BID_TRACE_ID,
+    });
+    expect(
+      store.getSlot('slot-b')?.stages.gam.outcome,
+      'should never contradict observed creative evidence'
+    ).toBe('trusted_server_won');
+  });
+
+  it('drops malformed Ad Manager identifiers', () => {
+    const store = createAdTraceStore(() => 10);
+    const generation = store.nextGeneration('slot-a');
+    store.record({
+      kind: 'gpt_slot_render_ended',
+      slotId: 'slot-a',
+      generation,
+      isEmpty: false,
+      responseClass: 'reservation',
+      gamIdentity: {
+        lineItemId: 0,
+        creativeId: '1234567890',
+        campaignId: 2345678901,
+        yieldGroupIds: ['a', -1],
+        adUnitPath: '/1234/private',
+      },
+    } as never);
+
+    expect(store.getSlot('slot-a')?.generations[0].diagnostics.gamIdentity).toEqual({
+      campaignId: 2345678901,
+    });
+  });
+
   it('exports an immutable sanitized clone', () => {
     const store = createAdTraceStore(() => 1);
     store.record({

--- a/crates/trusted-server-js/lib/test/integrations/ad_trace/presentation.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/ad_trace/presentation.test.ts
@@ -285,6 +285,64 @@ describe('presentTraceOverlay', () => {
     expect(presentation.primaryStatus).toBe('GAM returned backfill');
   });
 
+  it('names other Ad Manager demand instead of the generic unattributed row', () => {
+    const presentation = presentTraceOverlay(
+      stages({ trustedServer: stage('won'), gam: stage('other_gam_demand', 'creative_never_ran') }),
+      render('gam_only'),
+      {
+        requestNumber: 1,
+        terminalState: 'rendered',
+        responseClass: 'reservation',
+        gamIdentity: { lineItemId: 6543210987, campaignId: 2345678901, advertiserId: 3456789012 },
+        durations: {},
+      }
+    );
+
+    expect(presentation.primaryStatus).toBe(
+      'GAM delivered other demand — the Trusted Server creative never ran'
+    );
+    expect(presentation.facts).toContain(
+      'GAM reported line item 6543210987 · order 2345678901 · advertiser 3456789012'
+    );
+    expect(presentation.facts).not.toContain('GAM rendered an ad — source not attributed');
+    expect(presentation.badgeStatus).toBe('GAM line item 6543210987');
+  });
+
+  it('names an Ad Manager default render', () => {
+    const presentation = presentTraceOverlay(
+      stages({ gam: stage('gam_default_or_unclassified') }),
+      render('gam_only'),
+      {
+        requestNumber: 1,
+        terminalState: 'rendered',
+        responseClass: 'unclassified_non_empty',
+        durations: {},
+      }
+    );
+
+    expect(presentation.primaryStatus).toBe('GAM delivered its own default or backup ad');
+    expect(presentation.badgeStatus).toBe('GAM default ad');
+  });
+
+  it('keeps a Trusted Server win visible when its creative never confirmed', () => {
+    const presentation = presentTraceOverlay(
+      stages({
+        gam: stage('trusted_server_won', 'creative_requested_markup'),
+        creative: stage('ack_timed_out'),
+      }),
+      render('timed_out'),
+      {
+        requestNumber: 1,
+        terminalState: 'rendered',
+        acknowledgement: 'timed_out',
+        durations: {},
+      }
+    );
+
+    expect(presentation.facts).toContain('GAM selected the Trusted Server creative');
+    expect(presentation.badgeStatus).toBe('TS creative · confirmation timed out');
+  });
+
   it('falls back to the strongest observed stage fact for a primary row', () => {
     const presentation = presentTraceOverlay(
       stages({ creative: stage('render_failed') }),

--- a/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
@@ -1471,6 +1471,198 @@ describe('installTsAdInit', () => {
     expect(() => (window as TestWindow).tsjs!.adInit!()).not.toThrow();
     expect(mockPubads.refresh).toHaveBeenCalledWith([dynamicSlot]);
   });
+
+  describe('Ad Manager render attribution', () => {
+    const TRACE_ID = '550e8400-e29b-41d4-a716-446655440000';
+    const AUCTION_ID = '750e8400-e29b-41d4-a716-446655440000';
+
+    interface AttributionHarness {
+      recordAdTrace: ReturnType<typeof vi.fn>;
+      renderEnded: (event: Record<string, unknown>) => void;
+      slotElement: HTMLElement;
+    }
+
+    async function setupAttributionSlot(): Promise<AttributionHarness> {
+      const slotElement = document.createElement('div');
+      slotElement.id = 'div-attribution';
+      document.body.appendChild(slotElement);
+
+      const listeners: Record<string, Array<(event: Record<string, unknown>) => void>> = {};
+      // GPT echoes applied targeting back through getTargeting; the trace token
+      // reaches the request boundary that way.
+      const targeting: Record<string, string> = { hb_adid: 'ts-ad-id' };
+      const mockSlot = {
+        addService: vi.fn().mockReturnThis(),
+        setTargeting: vi.fn(function (this: unknown, key: string, value: string) {
+          targeting[key] = value;
+          return this;
+        }),
+        clearTargeting: vi.fn(function (this: unknown, key?: string) {
+          if (key) delete targeting[key];
+          return this;
+        }),
+        getSlotElementId: vi.fn().mockReturnValue('div-attribution'),
+        getTargeting: vi.fn((key: string) => (targeting[key] ? [targeting[key]] : [])),
+        getSizes: vi.fn().mockReturnValue([[300, 250]]),
+      };
+      const mockPubads = {
+        enableSingleRequest: vi.fn(),
+        getSlots: vi.fn().mockReturnValue([mockSlot]),
+        addEventListener: vi.fn((event: string, fn: (value: Record<string, unknown>) => void) => {
+          (listeners[event] ??= []).push(fn);
+        }),
+        refresh: vi.fn(),
+      };
+      (window as TestWindow).googletag = {
+        cmd: { push: vi.fn((fn: () => void) => fn()) },
+        defineSlot: vi.fn().mockReturnValue(mockSlot),
+        pubads: vi.fn().mockReturnValue(mockPubads),
+        enableServices: vi.fn(),
+      };
+      const recordAdTrace = vi.fn();
+      (window as TestWindow).tsjs = {
+        adSlots: [
+          {
+            id: 'slot-a',
+            gam_unit_path: '/123/example',
+            div_id: 'div-attribution',
+            formats: [[300, 250]],
+            targeting: {},
+          },
+        ],
+        bids: {
+          'slot-a': {
+            hb_adid: 'ts-ad-id',
+            adm: '<div>Trusted Server creative</div>',
+            trace: {
+              version: 1,
+              auctionTraceId: AUCTION_ID,
+              bidTraceId: TRACE_ID,
+              source: 'initial_navigation',
+              slotId: 'slot-a',
+              provider: 'prebid',
+              bidder: 'example-bidder',
+            },
+          },
+        },
+        recordAdTrace,
+        nextAdTraceGeneration: vi.fn().mockReturnValue(1),
+      };
+
+      const { installTsAdInit } = await import('../../../src/integrations/gpt/index');
+      installTsAdInit();
+      (window as TestWindow).tsjs!.adInit!();
+
+      return {
+        recordAdTrace,
+        renderEnded: (event) =>
+          listeners.slotRenderEnded?.forEach((listener) => listener({ ...event, slot: mockSlot })),
+        slotElement,
+      };
+    }
+
+    afterEach(() => {
+      document.getElementById('div-attribution')?.remove();
+      vi.useRealTimers();
+    });
+
+    it("forwards Ad Manager's own identifiers for the delivered ad", async () => {
+      const { recordAdTrace, renderEnded } = await setupAttributionSlot();
+
+      renderEnded({
+        isEmpty: false,
+        isBackfill: false,
+        size: [300, 250],
+        lineItemId: 6543210987,
+        creativeId: 1234567890,
+        campaignId: 2345678901,
+        advertiserId: 3456789012,
+        yieldGroupIds: [11, 12],
+      });
+
+      expect(recordAdTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'gpt_slot_render_ended',
+          responseClass: 'reservation',
+          gamIdentity: {
+            lineItemId: 6543210987,
+            creativeId: 1234567890,
+            campaignId: 2345678901,
+            advertiserId: 3456789012,
+            yieldGroupIds: [11, 12],
+          },
+        })
+      );
+    });
+
+    it('reports an unclaimed render when the creative never requests markup', async () => {
+      vi.useFakeTimers();
+      const { recordAdTrace, renderEnded } = await setupAttributionSlot();
+
+      renderEnded({ isEmpty: false, isBackfill: false, lineItemId: 6543210987 });
+      expect(recordAdTrace).not.toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'gpt_render_unclaimed' })
+      );
+
+      vi.advanceTimersByTime(5_000);
+      expect(recordAdTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'gpt_render_unclaimed',
+          slotId: 'slot-a',
+          generation: 1,
+          bidTraceId: TRACE_ID,
+          reason: 'creative_markup_never_requested',
+        })
+      );
+    });
+
+    it('leaves an empty or backfill render to its own definitive classification', async () => {
+      vi.useFakeTimers();
+      const { recordAdTrace, renderEnded } = await setupAttributionSlot();
+
+      renderEnded({ isEmpty: true });
+      vi.advanceTimersByTime(5_000);
+
+      expect(recordAdTrace).not.toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'gpt_render_unclaimed' })
+      );
+    });
+
+    it('cancels the unclaimed report once the creative requests markup', async () => {
+      vi.useFakeTimers();
+      const { recordAdTrace, renderEnded, slotElement } = await setupAttributionSlot();
+      const iframe = document.createElement('iframe');
+      slotElement.appendChild(iframe);
+
+      const { installTsRenderBridge } = await import('../../../src/integrations/gpt/index');
+      const handlers: EventListener[] = [];
+      const spy = vi.spyOn(window, 'addEventListener').mockImplementation((type, listener) => {
+        if (type === 'message') handlers.push(listener as EventListener);
+      });
+      installTsRenderBridge();
+      spy.mockRestore();
+      // eslint-disable-next-line no-console
+
+      renderEnded({ isEmpty: false, isBackfill: false, lineItemId: 6543210987 });
+      handlers.forEach((handler) =>
+        handler({
+          data: { message: 'Prebid Request', adId: 'ts-ad-id' },
+          source: document.getElementById('div-attribution')!.querySelector('iframe')!
+            .contentWindow,
+          ports: [{ postMessage: vi.fn() }],
+          stopImmediatePropagation: vi.fn(),
+        } as unknown as Event)
+      );
+      vi.advanceTimersByTime(5_000);
+
+      expect(recordAdTrace).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'pb_render_requested', reason: 'exact_generation' })
+      );
+      expect(recordAdTrace).not.toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'gpt_render_unclaimed' })
+      );
+    });
+  });
 });
 
 describe('installTsRenderBridge', () => {

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1002,13 +1002,15 @@ apply when the integration section exists in `trusted-server.toml`.
 
 **Section**: `[integrations.ad_trace]`
 
-| Field     | Type    | Default | Description                                      |
-| --------- | ------- | ------- | ------------------------------------------------ |
+| Field     | Type    | Default | Description                                       |
+| --------- | ------- | ------- | ------------------------------------------------- |
 | `enabled` | Boolean | `false` | Include tester-only auction trace browser support |
 
 Browser-visible auction IDs, bid IDs, targeting, API state, and the console require this setting plus an activated browser session. Visit a publisher page with the exact query `?ts_console=true` or `?ts_console=1`; Trusted Server enables the first response and sets a host-only session cookie automatically. Use `?ts_console=false` or `?ts_console=0` to clear the session. The reserved query is removed from downstream requests and cleaned from eligible HTML URLs. Active trace responses are private and non-storeable.
 
 The integration is disabled by default. The query is a self-service diagnostic toggle, not authorization, and does nothing without the explicit configuration gate. The console never exposes the internal auction request ID, identity data, consent strings, page URLs, partner notification URLs, cache coordinates, raw targeting, or creative markup. A creative marked `confirmed` means its exact Trusted Server renderer iframe load was acknowledged; it does not claim viewability or arbitrary advertiser JavaScript completion.
+
+For a render Trusted Server cannot claim, the console reports the Ad Manager identifiers `slotRenderEnded` supplies for the delivered ad — line item, order, advertiser, creative, and backfill yield group or company. These are the publisher's own Ad Manager data, the same values `?google_console=1` shows, and they stay in the browser: they are never sent to auction telemetry. A render is credited to Trusted Server only when the rendered creative requests markup from Trusted Server or acknowledges its load; when neither happens within a bounded window, the render is reported as other Ad Manager demand.
 
 ```toml
 [integrations.ad_trace]


### PR DESCRIPTION
## Summary

Stacked on #961 — base branch is `feature/auction-creative-trace-overlay`, so review this diff on its own and let GitHub retarget the base to `main` once #961 lands.

The trace console could not answer the question it exists to answer: after the GAM call, did the line item Trusted Server won render, or did a house ad, a direct-sold line item, or the Ad Manager default render instead? Every non-empty, non-backfill render read as `direct_or_unattributed` — "GAM rendered an ad — source not attributed".

Three causes, all in the GAM stage:

1. `slotRenderEnded` identifiers were read as booleans and discarded. `lineItemId` and `creativeId` were only tested for presence; `advertiserId`, `campaignId`, `sourceAgnosticLineItemId`, `sourceAgnosticCreativeId`, `yieldGroupIds`, and `companyIds` were not read at all. Ad Manager's own report is the only authoritative statement of which line item won.
2. The computed response class never reached a stage outcome, so `reservation` and `unclassified_non_empty` both fell into the single unattributed bucket.
3. Attribution required the creative's cooperative acknowledgement. A markup request from the rendered creative — which only happens when Ad Manager selected the header-bidding line item — did not settle the GAM stage, so a suppressed, sandboxed, or slow creative was indistinguishable from losing the Ad Manager decision, and a slot with live Trusted Server targeting stayed a `trusted_server_candidate` indefinitely.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-js/lib/src/integrations/gpt/index.ts` | Read the full `slotRenderEnded` identifier set with bounded validation; arm a 5s attribution window for a render on a generation that had a Trusted Server bid; settle it when the rendered creative requests markup. |
| `crates/trusted-server-js/lib/src/core/ad_trace.ts` | Re-sanitize the identifiers into generation diagnostics; add `other_reservation`, `gam_default_or_unclassified`, and `other_gam_demand` outcomes; credit `trusted_server_won` at `strong` confidence on a markup request or served markup; stop later GPT callbacks from downgrading a settled win. |
| `crates/trusted-server-js/lib/src/core/types.ts` | Add `AdTraceGamIdentity` and the `gpt_render_unclaimed` event kind. |
| `crates/trusted-server-js/lib/src/integrations/ad_trace/presentation.ts` | Name each Ad Manager outcome, surface the reported identifiers as an operator fact, and prefer a named decision over the generic unattributed row. |
| `crates/trusted-server-integration-tests/browser/tests/ad-trace/auction-trace.spec.ts` | Update the two expectations that encoded the old ambiguity: a suppressed creative now resolves to `other_gam_demand`, and the cleared-targeting render asserts `other_reservation` plus the reported line item ID. |
| `docs/guide/configuration.md` | Document what the console reports for a render Trusted Server cannot claim, and that the identifiers stay in the browser. |

## Behavior

The console now reports one of: Trusted Server creative selected (confirmed, or selected with the confirmation still outstanding), another reservation line item plus its Ad Manager identifiers, an Ad Manager default or backup ad, other Ad Manager demand where the Trusted Server creative never ran, backfill, or empty.

Ad Manager identifiers are the publisher's own data — the same values `?google_console=1` shows — and are gated behind the existing console session. They are not added to auction telemetry.

Distinguishing a house line item from a direct-sold one still requires looking the ID up in Ad Manager. Auto-labeling that needs a configured allowlist of header-bidding and house order IDs, deliberately left as a follow-up rather than guessed at here.

## Test plan

- [x] JS tests: `cd crates/trusted-server-js/lib && npx vitest run` (531 passed, 12 new)
- [x] JS format: `cd crates/trusted-server-js/lib && npm run format`
- [x] JS build: `cd crates/trusted-server-js/lib && node build-all.mjs`
- [x] Docs format: `cd docs && npm run format`
- [ ] Playwright ad-trace suite — needs the docker fixture and viceroy; the two updated expectations are unverified locally and need a CI run
- [ ] Manual verification on the test site with `?ts_console=true`, checking a slot where GAM delivers a house ad against one where the Trusted Server creative renders

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No secrets, real domains, or real operator configuration values
- [x] New code has tests
