### PR TITLE
Load the decoupled prebid shim in the APS renderer browser test

### DIFF
--- a/crates/trusted-server-integration-tests/browser/tests/shared/aps-renderer.spec.ts
+++ b/crates/trusted-server-integration-tests/browser/tests/shared/aps-renderer.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { runtimeUrl } from "../../helpers/state.js";
 
 const RUNNER_URL = "https://client.aps.amazon-adsystem.com/prebid-creative.js";
@@ -21,6 +21,31 @@ function clientAuctionBundlePaths() {
         prebid: resolve(TSJS_CRATE, "dist/prebid", manifest.filename),
         prebidShim: resolve(TSJS_CRATE, "dist/tsjs-prebid.js"),
     };
+}
+
+/**
+ * Load the client auction scripts in the order the server serves them.
+ *
+ * A coupled external bundle ships Prebid.js with the tsjs shim (and the
+ * trustedServer adapter) already installed. A decoupled external bundle is
+ * pure Prebid.js and stamps its manifest on `window.__tsjs_prebid_bundle`;
+ * the shim then arrives as the separately served deferred tsjs module, so
+ * this helper loads it whenever the stamp is present.
+ */
+async function loadClientAuctionBundles(page: Page): Promise<void> {
+    const bundles = clientAuctionBundlePaths();
+    await page.addScriptTag({ path: bundles.core });
+    await page.addScriptTag({ path: bundles.gpt });
+    await page.addScriptTag({ path: bundles.prebid });
+    const decoupledBundle = await page.evaluate(() =>
+        Boolean(
+            (window as unknown as { __tsjs_prebid_bundle?: unknown })
+                .__tsjs_prebid_bundle,
+        ),
+    );
+    if (decoupledBundle) {
+        await page.addScriptTag({ path: bundles.prebidShim });
+    }
 }
 
 function descriptor(
@@ -212,11 +237,7 @@ test.describe("APS opaque renderer", () => {
         });
 
         await page.goto(runtimeUrl("/aps-prebid-adapter-test"));
-        const bundles = clientAuctionBundlePaths();
-        await page.addScriptTag({ path: bundles.core });
-        await page.addScriptTag({ path: bundles.gpt });
-        await page.addScriptTag({ path: bundles.prebid });
-        await page.addScriptTag({ path: bundles.prebidShim });
+        await loadClientAuctionBundles(page);
 
         const result = await page.evaluate(async () => {
             type PrebidBid = {


### PR DESCRIPTION
Fixes #989. Stacked on #963. Fixes the browser integration failure that appears wherever #963's APS renderer spec meets #967's prebid decoupling (currently `rc/july`).

## Problem

`aps-renderer.spec.ts` ("renders a trustedServer adapter bid using Prebid's generated GAM ad ID") loads the external Prebid bundle and relies on it carrying the tsjs shim — which is what registers the `trustedServer` bid adapter. After #967 the external bundle is pure Prebid.js and the shim ships as the separately served `tsjs-prebid.js` deferred module. With no adapter registered the in-page auction never completes and the test times out at 30s. On `rc/july` the "Integration Tests" workflow has been red since the #967 merge (`78632fe33`); this spec doesn't exist on #967's branch, so its own CI never caught it.

## Fix

Detect which world the built bundle is from via the `window.__tsjs_prebid_bundle` manifest stamp (only the decoupled bundle stamps it) and load `dist/tsjs-prebid.js` after the external bundle — the same script order the server serves. 

- On this branch (coupled bundle): stamp absent, shim not loaded, spec behaves exactly as today.
- On `rc/july`/anything containing #967 (decoupled bundle): shim loads, adapter registers, test passes.

Test-only change; no runtime code touched.
