### PR TITLE
Update edgezero to chunked-config GC rev and wire ts config gc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@
 .edgezero/
 /dist/prebid/
 
+# Fastly local config-push lock (a persistent advisory-lock sidecar next to
+# the manifest; serialises concurrent `config push --local` / `provision`).
+# The glob also covers a manifest named something other than `fastly.toml`.
+.*.edgezero-lock
+
 # env
 .env*
 trusted-server.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
 dependencies = [
  "toml",
 ]
@@ -1406,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
 dependencies = [
  "chrono",
  "clap",
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
 dependencies = [
  "log",
  "proc-macro2",
@@ -5920,7 +5920,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.4#9e661ae520a8130660f18fd10f42703d7f3e050b"
+source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
 dependencies = [
  "toml",
 ]
@@ -1406,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.4#9e661ae520a8130660f18fd10f42703d7f3e050b"
+source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.4#9e661ae520a8130660f18fd10f42703d7f3e050b"
+source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1449,7 +1449,7 @@ dependencies = [
  "log",
  "serde_json",
  "tempfile",
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
  "walkdir",
  "worker",
 ]
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.4#9e661ae520a8130660f18fd10f42703d7f3e050b"
+source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1479,14 +1479,14 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.4#9e661ae520a8130660f18fd10f42703d7f3e050b"
+source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1506,14 +1506,14 @@ dependencies = [
  "subtle",
  "thiserror 2.0.18",
  "toml",
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.4#9e661ae520a8130660f18fd10f42703d7f3e050b"
+source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
 dependencies = [
  "chrono",
  "clap",
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.4#9e661ae520a8130660f18fd10f42703d7f3e050b"
+source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1569,14 +1569,14 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.4#9e661ae520a8130660f18fd10f42703d7f3e050b"
+source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
 dependencies = [
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.118",
+ "syn 3.0.3",
  "toml",
  "validator",
 ]
@@ -3604,7 +3604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -3624,7 +3624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3637,7 +3637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4770,6 +4770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5075,6 +5086,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5340,7 +5364,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "toml",
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
  "trusted-server-core",
  "url",
  "webpki-roots",
@@ -5896,7 +5920,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
 dependencies = [
  "toml",
 ]
@@ -1406,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
 dependencies = [
  "chrono",
  "clap",
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=c2658795fb47b904f980dc73600f413f4d0e5bb8#c2658795fb47b904f980dc73600f413f4d0e5bb8"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#0873ec5a609f017c7ee3cbd08e99d070cfdb1b8f"
 dependencies = [
  "log",
  "proc-macro2",
@@ -5920,7 +5920,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
+source = "git+https://github.com/stackpop/edgezero?branch=main#40377bae0e6f20242c5d92d9f38479e508630643"
 dependencies = [
  "toml",
 ]
@@ -1406,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
+source = "git+https://github.com/stackpop/edgezero?branch=main#40377bae0e6f20242c5d92d9f38479e508630643"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
+source = "git+https://github.com/stackpop/edgezero?branch=main#40377bae0e6f20242c5d92d9f38479e508630643"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
+source = "git+https://github.com/stackpop/edgezero?branch=main#40377bae0e6f20242c5d92d9f38479e508630643"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
+source = "git+https://github.com/stackpop/edgezero?branch=main#40377bae0e6f20242c5d92d9f38479e508630643"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
+source = "git+https://github.com/stackpop/edgezero?branch=main#40377bae0e6f20242c5d92d9f38479e508630643"
 dependencies = [
  "chrono",
  "clap",
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
+source = "git+https://github.com/stackpop/edgezero?branch=main#40377bae0e6f20242c5d92d9f38479e508630643"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
+source = "git+https://github.com/stackpop/edgezero?branch=main#40377bae0e6f20242c5d92d9f38479e508630643"
 dependencies = [
  "log",
  "proc-macro2",
@@ -5920,7 +5920,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
 dependencies = [
  "toml",
 ]
@@ -1406,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
 dependencies = [
  "chrono",
  "clap",
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#9a0b1552b493563285ebd8d0f27b3ffc1c18a811"
+source = "git+https://github.com/stackpop/edgezero?branch=spec%2Ffastly-chunk-gc#43cec87e63f6b5f3d28029c954e2cf166d42e1ae"
 dependencies = [
  "log",
  "proc-macro2",
@@ -5920,7 +5920,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 derive_more = { version = "2.0", features = ["display", "error"] }
 directories = "5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
-edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.4", default-features = false }
-edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.4", default-features = false }
-edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.4", default-features = false }
-edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.4", default-features = false }
-edgezero-cli = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.4" }
-edgezero-core = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.4", default-features = false }
+edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
+edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
+edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
+edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
+edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8" }
+edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
 env_logger = "0.11"
 error-stack = "0.6"
 fastly = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 derive_more = { version = "2.0", features = ["display", "error"] }
 directories = "5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
-edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
-edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
-edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
-edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
-edgezero-cli = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc" }
-edgezero-core = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
+edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", branch = "main", default-features = false }
+edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", branch = "main", default-features = false }
+edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", branch = "main", default-features = false }
+edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", branch = "main", default-features = false }
+edgezero-cli = { git = "https://github.com/stackpop/edgezero", branch = "main" }
+edgezero-core = { git = "https://github.com/stackpop/edgezero", branch = "main", default-features = false }
 env_logger = "0.11"
 error-stack = "0.6"
 fastly = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 derive_more = { version = "2.0", features = ["display", "error"] }
 directories = "5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
-edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
-edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
-edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
-edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
-edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8" }
-edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "c2658795fb47b904f980dc73600f413f4d0e5bb8", default-features = false }
+edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
+edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
+edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
+edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
+edgezero-cli = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc" }
+edgezero-core = { git = "https://github.com/stackpop/edgezero", branch = "spec/fastly-chunk-gc", default-features = false }
 env_logger = "0.11"
 error-stack = "0.6"
 fastly = "0.12"

--- a/crates/trusted-server-cli/src/run.rs
+++ b/crates/trusted-server-cli/src/run.rs
@@ -2,8 +2,8 @@ use std::process;
 
 use clap::{Parser, Subcommand};
 use edgezero_cli::args::{
-    AuthArgs, BuildArgs, ConfigDiffArgs, ConfigPushArgs, ConfigValidateArgs, DeployArgs,
-    ProvisionArgs, ServeArgs,
+    AuthArgs, BuildArgs, ConfigDiffArgs, ConfigGcArgs, ConfigPushArgs, ConfigValidateArgs,
+    DeployArgs, ProvisionArgs, ServeArgs,
 };
 use trusted_server_core::config::TrustedServerAppConfig;
 
@@ -49,6 +49,12 @@ enum ConfigCommand {
     Init(ConfigInitArgs),
     /// Diff `trusted-server.toml` against the live `EdgeZero` config.
     Diff(ConfigDiffArgs),
+    /// Reclaim orphaned chunk entries the config store leaked from prior
+    /// oversized pushes. Store-derived and untyped (no `TrustedServerAppConfig`).
+    /// A dry-run by default; deletes only with `--yes` + an explicit
+    /// `--older-than` (YOUR assertion that nothing superseded within that
+    /// window is still being served, and no push is running).
+    Gc(ConfigGcArgs),
     /// Push `trusted-server.toml` as a blob envelope through `EdgeZero`.
     Push(ConfigPushArgs),
     /// Validate `edgezero.toml` and the typed Trusted Server config.
@@ -95,6 +101,9 @@ fn dispatch(args: Args) -> Result<(), String> {
                 Err(err) => Err(err),
             }
         }
+        // `gc` inspects the STORE, not the typed config, so it is not
+        // parameterised over `TrustedServerAppConfig`.
+        Command::Config(ConfigCommand::Gc(args)) => edgezero_cli::run_config_gc(&args),
         Command::Config(ConfigCommand::Push(args)) => {
             edgezero_cli::run_config_push_typed::<TrustedServerAppConfig>(&args)
         }
@@ -123,7 +132,9 @@ mod tests {
     use std::path::PathBuf;
 
     use clap::Parser as _;
-    use edgezero_cli::args::{AuthSub, ConfigDiffArgs, ConfigPushArgs, ConfigValidateArgs};
+    use edgezero_cli::args::{
+        AuthSub, ConfigDiffArgs, ConfigGcArgs, ConfigPushArgs, ConfigValidateArgs,
+    };
 
     use super::*;
 
@@ -268,6 +279,40 @@ mod tests {
         assert!(!diff.local);
         assert!(!diff.exit_code);
         assert!(!diff.no_env);
+    }
+
+    #[test]
+    fn config_gc_uses_edgezero_defaults() {
+        let args = parse(&["ts", "config", "gc", "--adapter", "fastly"]);
+        let Command::Config(ConfigCommand::Gc(gc)) = args.command else {
+            panic!("expected config gc command");
+        };
+        let default_gc = ConfigGcArgs::default();
+        assert_eq!(gc.adapter, "fastly");
+        assert_eq!(gc.manifest, default_gc.manifest);
+        assert_eq!(gc.store, default_gc.store);
+        assert_eq!(gc.older_than, None);
+        assert!(!gc.no_env);
+        assert!(!gc.yes);
+    }
+
+    #[test]
+    fn config_gc_accepts_destructive_flags() {
+        let args = parse(&[
+            "ts",
+            "config",
+            "gc",
+            "--adapter",
+            "fastly",
+            "--older-than",
+            "7d",
+            "--yes",
+        ]);
+        let Command::Config(ConfigCommand::Gc(gc)) = args.command else {
+            panic!("expected config gc command");
+        };
+        assert_eq!(gc.older_than.as_deref(), Some("7d"));
+        assert!(gc.yes);
     }
 
     #[test]

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -112,7 +112,9 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
     // app-config blob. Migrating app-level secrets to `EdgeZero` secret-store
     // references needs nested/array extraction support and operator migration
     // work tracked separately.
-    const SECRET_FIELDS: &'static [edgezero_core::app_config::SecretField] = &[];
+    fn secret_fields() -> Vec<edgezero_core::app_config::SecretField> {
+        Vec::new()
+    }
 }
 
 /// Runs Trusted Server deploy-time validation for pushed app config.


### PR DESCRIPTION
## Summary

Adopts the new commands from [stackpop/edgezero#314](https://github.com/stackpop/edgezero/pull/314) (Fastly chunked-config GC, merged 2026-08-14): the edgezero dependency pins move from tag `v0.0.4` to `branch = "main"`, and the `ts` CLI gains the new `config gc` subcommand.

> **Note:** no edgezero release tag includes #314 yet, so the pins track `main` (lockfile currently resolves to `40377bae`). Once a release is tagged, the pins should move to that tag.

## Changes

| File | Change |
| ---- | ------ |
| `Cargo.toml`, `Cargo.lock` | edgezero pins: `tag = "v0.0.4"` → `branch = "main"` |
| `crates/trusted-server-cli/src/run.rs` | Wire `ts config gc` (`ConfigGcArgs` → `edgezero_cli::run_config_gc`) following the updated upstream CLI template, plus parse tests |
| `crates/trusted-server-core/src/config.rs` | Adapt to the `AppConfigMeta` trait change: `SECRET_FIELDS` const replaced by a `secret_fields()` method (still empty for Trusted Server) |
| `.gitignore` | Ignore `.*.edgezero-lock`, the new local config-push advisory-lock sidecar written next to `fastly.toml` |

`config gc` is untyped (it inspects the store's physical entries, not the typed app config), dry-run by default, and deletes only with `--yes` plus an explicit `--older-than` window. `config push` now also garbage-collects the superseded chunk generation on re-push (cloud and `--local`), so re-pushing a changed `trusted-server.toml` no longer leaks the prior generation of chunk entries.

## Test plan

All run against edgezero main `40377bae`:

- [x] `./scripts/test-cli.sh` — all pass, including new `config gc` parse tests
- [x] `ts config gc --help` smoke test (parses and renders upstream arg docs)
- [x] `cargo check-fastly` / `check-axum` / `check-cloudflare` / `check-spin`
- [x] `cargo test-fastly` (2000+ tests) / `test-axum` / `test-cloudflare` / `test-spin`
- [x] `cargo clippy-fastly` / `-axum` / `-cloudflare` / `-cloudflare-wasm` / `-spin-native` / `-spin-wasm` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Parity integration tests — 13 passed