### PR TITLE
Add GAM cohort attribution for Trusted Server traffic

### DIFF
--- a/crates/trusted-server-cli/tests/config_env_overlay.rs
+++ b/crates/trusted-server-cli/tests/config_env_overlay.rs
@@ -29,6 +29,7 @@ ids = ["trusted_server_secrets"]
 "#;
 const REWRITE_ENV: &str = "TRUSTED_SERVER__AUCTION__REWRITE_CREATIVES";
 const SANITIZE_ENV: &str = "TRUSTED_SERVER__AUCTION__SANITIZE_CREATIVES";
+const GAM_ATTRIBUTION_ENV: &str = "TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED";
 
 struct MigratedProject {
     directory: TempDir,
@@ -109,6 +110,49 @@ fn migrated_legacy_config_applies_rewrite_creatives_environment_override() {
         envelope["data"]["auction"]["rewrite_creatives"],
         serde_json::Value::Bool(false),
         "pushed config should contain the environment override"
+    );
+}
+
+#[test]
+fn migrated_legacy_config_applies_gam_attribution_environment_override() {
+    let project = migrated_legacy_project();
+    let output = Command::new(env!("CARGO_BIN_EXE_ts"))
+        .args(["config", "push", "--adapter", "axum", "--manifest"])
+        .arg(&project.manifest_path)
+        .arg("--app-config")
+        .arg(&project.config_path)
+        .args(["--yes", "--no-diff"])
+        .current_dir(project.directory.path())
+        .env(GAM_ATTRIBUTION_ENV, "true")
+        .output()
+        .expect("should run ts config push");
+
+    assert!(
+        output.status.success(),
+        "valid boolean overlay should push successfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let local_store_path = project
+        .directory
+        .path()
+        .join(".edgezero/local-config-trusted_server_config.json");
+    let local_store: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(local_store_path).expect("should read pushed local config"),
+    )
+    .expect("should parse local config store");
+    let envelope_json = local_store
+        .as_object()
+        .and_then(|entries| entries.values().next())
+        .and_then(serde_json::Value::as_str)
+        .expect("should contain a blob envelope");
+    let envelope: serde_json::Value =
+        serde_json::from_str(envelope_json).expect("should parse blob envelope");
+
+    assert_eq!(
+        envelope["data"]["integrations"]["gpt"]["gam_attribution_enabled"],
+        serde_json::Value::Bool(true),
+        "pushed config should contain the GAM attribution environment override"
     );
 }
 

--- a/crates/trusted-server-core/benches/html_processor_bench.rs
+++ b/crates/trusted-server-core/benches/html_processor_bench.rs
@@ -13,6 +13,7 @@ fn make_config() -> HtmlProcessorConfig {
         ad_bids_state: std::sync::Arc::new(std::sync::Mutex::new(None)),
         max_buffered_body_bytes: 16 * 1024 * 1024,
         gpt_diagnostics: None,
+        suppress_datadome_client_side_tag: false,
     }
 }
 

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -155,7 +155,9 @@ fn validate_enabled_integrations(
     validate_integration::<SourcepointConfig>(settings, "sourcepoint")?;
     validate_integration::<OsanoConfig>(settings, "osano")?;
     validate_integration::<GoogleTagManagerConfig>(settings, "google_tag_manager")?;
-    validate_integration::<DataDomeConfig>(settings, "datadome")?;
+    if let Some(config) = settings.integration_config::<DataDomeConfig>("datadome")? {
+        crate::integrations::datadome::DataDomeIntegration::validate_config_for_startup(config)?;
+    }
     validate_integration::<GptConfig>(settings, "gpt")?;
     validate_integration::<GptDiagnosticsConfig>(settings, "gpt_diagnostics")?;
 
@@ -402,6 +404,44 @@ password = "production-admin-password-32-bytes"
             error_text.contains("osano") || error_text.contains("typo"),
             "error should mention Osano or the invalid field: {err:?}"
         );
+    }
+
+    #[test]
+    fn deploy_validation_rejects_invalid_datadome_test_bypass() {
+        for (enable_protection, store, name, expected_message) in [
+            (
+                false,
+                "ts_secrets",
+                "datadome_test_bypass",
+                "requires enable_protection",
+            ),
+            (true, "", "datadome_test_bypass", "credential_secret_store"),
+            (true, "ts_secrets", "", "credential_secret_name"),
+        ] {
+            let mut settings = valid_settings();
+            settings
+                .integrations
+                .insert_config(
+                    "datadome",
+                    &serde_json::json!({
+                        "enabled": true,
+                        "enable_protection": enable_protection,
+                        "protection_test_bypass": {
+                            "enabled": true,
+                            "credential_secret_store": store,
+                            "credential_secret_name": name,
+                        },
+                    }),
+                )
+                .expect("should insert DataDome config");
+
+            let err = validate_settings_for_deploy(&settings)
+                .expect_err("should reject invalid DataDome test bypass");
+            assert!(
+                format!("{err:?}").contains(expected_message),
+                "error should mention the invalid bypass setting: {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/trusted-server-core/src/creative_opportunities.rs
+++ b/crates/trusted-server-core/src/creative_opportunities.rs
@@ -1711,11 +1711,18 @@ mod tests {
 
     #[test]
     fn to_ad_slot_sets_floor_price_and_formats() {
-        let slot = make_slot("atf", vec!["/"]);
+        let mut slot = make_slot("atf", vec!["/"]);
+        slot.targeting
+            .insert("ts".to_string(), "operator-value".to_string());
         let ad_slot = slot.to_ad_slot();
         assert_eq!(ad_slot.id, "atf");
         assert_eq!(ad_slot.floor_price, Some(0.50));
         assert_eq!(ad_slot.formats.len(), 1);
+        assert_eq!(
+            ad_slot.targeting.get("ts"),
+            Some(&serde_json::Value::String("operator-value".to_owned())),
+            "should preserve operator-provided ts targeting verbatim"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -13,6 +13,7 @@ use lol_html::{
     text,
 };
 
+use crate::integrations::datadome::{DATADOME_INTEGRATION_ID, DataDomeClientTagSuppressed};
 use crate::integrations::gpt_diagnostics::GptDiagnosticsRequestDecision;
 use crate::integrations::{
     AttributeRewriteOutcome, IntegrationAttributeContext, IntegrationDocumentState,
@@ -175,6 +176,8 @@ pub struct HtmlProcessorConfig {
     pub max_buffered_body_bytes: usize,
     /// Request-scoped conditional diagnostics delivery decision.
     pub gpt_diagnostics: Option<GptDiagnosticsRequestDecision>,
+    /// Whether to omit Trusted Server's automatic `DataDome` client-side tag.
+    pub suppress_datadome_client_side_tag: bool,
 }
 
 impl HtmlProcessorConfig {
@@ -196,6 +199,7 @@ impl HtmlProcessorConfig {
             ad_bids_state: std::sync::Arc::new(std::sync::Mutex::new(None)),
             max_buffered_body_bytes: settings.publisher.max_buffered_body_bytes,
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         }
     }
 
@@ -223,6 +227,13 @@ impl HtmlProcessorConfig {
         self.gpt_diagnostics = decision;
         self
     }
+
+    /// Attach the request-scoped `DataDome` client-tag suppression decision.
+    #[must_use]
+    pub fn with_datadome_client_tag_suppression(mut self, suppress: bool) -> Self {
+        self.suppress_datadome_client_side_tag = suppress;
+        self
+    }
 }
 
 /// Create an HTML processor with URL replacement and integration hooks.
@@ -235,6 +246,9 @@ impl HtmlProcessorConfig {
 pub fn create_html_processor(config: HtmlProcessorConfig) -> impl StreamProcessor {
     let post_processors = config.integrations.html_post_processors();
     let document_state = IntegrationDocumentState::default();
+    if config.suppress_datadome_client_side_tag {
+        document_state.get_or_insert_with(DATADOME_INTEGRATION_ID, || DataDomeClientTagSuppressed);
+    }
 
     // Simplified URL patterns structure - stores only core data and generates variants on-demand
     struct UrlPatterns {
@@ -692,6 +706,7 @@ mod tests {
             ad_bids_state: std::sync::Arc::new(std::sync::Mutex::new(None)),
             max_buffered_body_bytes: 16 * 1024 * 1024,
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         }
     }
 
@@ -948,6 +963,62 @@ mod tests {
         assert_eq!(config.origin_host, "origin.test-publisher.com");
         assert_eq!(config.request_host, "proxy.example.com");
         assert_eq!(config.request_scheme, "https");
+    }
+
+    #[test]
+    fn suppressed_datadome_tag_preserves_and_rewrites_publisher_tag() {
+        let mut settings = create_test_settings();
+        settings
+            .integrations
+            .insert_config(
+                "datadome",
+                &json!({
+                    "enabled": true,
+                    "client_side_key": "test-client-key",
+                }),
+            )
+            .expect("should configure DataDome integration");
+        let registry = IntegrationRegistry::new(&settings)
+            .expect("should create integration registry with DataDome");
+        let config = HtmlProcessorConfig::from_settings(
+            &settings,
+            &registry,
+            "origin.example.com",
+            "test.example.com",
+            "https",
+        )
+        .with_datadome_client_tag_suppression(true);
+        let mut processor = create_html_processor(config);
+
+        let output = processor
+            .process_chunk(
+                br#"<html><head><script id="publisher-datadome" src="https://js.datadome.co/tags.js"></script></head><body>content</body></html>"#,
+                true,
+            )
+            .expect("should process HTML");
+        let html = String::from_utf8(output).expect("should produce UTF-8 HTML");
+
+        assert!(
+            !html.contains("window.ddjskey"),
+            "should omit the DataDome client configuration"
+        );
+        assert!(
+            html.contains("id=\"publisher-datadome\""),
+            "should preserve the publisher-originated DataDome tag"
+        );
+        assert!(
+            html.contains("src=\"/integrations/datadome/tags.js\""),
+            "should rewrite the publisher-originated DataDome tag"
+        );
+        assert!(
+            !html.contains("https://js.datadome.co/tags.js"),
+            "should remove the original third-party DataDome URL"
+        );
+        assert_eq!(
+            html.matches("/integrations/datadome/tags.js").count(),
+            1,
+            "should leave exactly one publisher-originated DataDome tag"
+        );
     }
 
     #[test]
@@ -1539,6 +1610,7 @@ mod tests {
             ad_bids_state: std::sync::Arc::new(std::sync::Mutex::new(None)),
             max_buffered_body_bytes: 16 * 1024 * 1024,
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let mut processor = create_html_processor(config);
         let output = processor
@@ -1613,6 +1685,7 @@ mod tests {
             ad_bids_state: state,
             max_buffered_body_bytes: 16 * 1024 * 1024,
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let mut processor = create_html_processor(config);
         let output = processor
@@ -1649,6 +1722,7 @@ mod tests {
             ad_bids_state: state,
             max_buffered_body_bytes: 16 * 1024 * 1024,
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let mut processor = create_html_processor(config);
         // Malformed HTML with two <body> elements (common in CMS template pages)
@@ -1684,6 +1758,7 @@ mod tests {
             ad_bids_state: std::sync::Arc::new(std::sync::Mutex::new(None)),
             max_buffered_body_bytes: 16 * 1024 * 1024,
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let mut processor = create_html_processor(config);
         let output = processor
@@ -1737,6 +1812,7 @@ mod tests {
             ad_bids_state: state,
             max_buffered_body_bytes: 16 * 1024 * 1024,
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let mut processor = create_html_processor(config);
         let output = processor
@@ -1764,6 +1840,7 @@ mod tests {
             ad_bids_state: state,
             max_buffered_body_bytes: 16 * 1024 * 1024,
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let mut processor = create_html_processor(config);
         let output = processor

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -356,7 +356,11 @@ pub fn create_html_processor(config: HtmlProcessorConfig) -> impl StreamProcesso
                     }
                     // Main bundle: core + non-deferred integrations (synchronous).
                     let immediate_ids = integrations.js_module_ids_immediate();
-                    snippet.push_str(&tsjs::tsjs_script_tag(&immediate_ids));
+                    let script_attributes = integrations.tsjs_script_tag_attributes();
+                    snippet.push_str(&tsjs::tsjs_script_tag_with_attributes(
+                        &immediate_ids,
+                        &script_attributes,
+                    ));
                     // Active diagnostics loads synchronously after core so its
                     // GPT listeners precede publisher scripts in the origin head.
                     if let Some(module_tag) = gpt_diagnostics
@@ -832,6 +836,71 @@ mod tests {
         assert!(
             tsjs_index < title_index,
             "should prepend all injected content before existing head content"
+        );
+    }
+
+    #[test]
+    fn integration_head_injector_marks_only_attribution_enabled_gpt_bundle() {
+        fn process(gam_attribution_enabled: Option<bool>) -> String {
+            let integrations = if let Some(gam_attribution_enabled) = gam_attribution_enabled {
+                let mut settings = create_test_settings();
+                settings
+                    .integrations
+                    .insert_config(
+                        "gpt",
+                        &json!({
+                            "enabled": true,
+                            "gam_attribution_enabled": gam_attribution_enabled
+                        }),
+                    )
+                    .expect("should insert GPT config");
+                IntegrationRegistry::new(&settings).expect("should build GPT registry")
+            } else {
+                IntegrationRegistry::empty_for_tests()
+            };
+            let mut config = create_test_config();
+            config.integrations = integrations;
+            let mut processor = create_html_processor(config);
+            let output = processor
+                .process_chunk(b"<html><head></head><body></body></html>", true)
+                .expect("should process HTML");
+
+            String::from_utf8(output).expect("should produce valid UTF-8")
+        }
+
+        let attributed = process(Some(true));
+        let unattributed = process(Some(false));
+        let without_gpt = process(None);
+
+        for html in [&attributed, &unattributed, &without_gpt] {
+            assert_eq!(
+                html.matches("id=\"trustedserver-js\"").count(),
+                1,
+                "should emit exactly one publisher bundle tag: {html}"
+            );
+        }
+        assert!(
+            attributed.contains("data-ts-gam-attribution=\"true\""),
+            "should mark only an attribution-enabled GPT publisher bundle"
+        );
+        assert!(
+            !unattributed.contains("data-ts-gam-attribution"),
+            "should leave an attribution-disabled GPT publisher bundle unmarked"
+        );
+        assert!(
+            !without_gpt.contains("data-ts-gam-attribution"),
+            "should leave a non-GPT publisher bundle unmarked"
+        );
+
+        let head_insert_index = attributed
+            .find("window.__tsjs_installGptShim")
+            .expect("should include the GPT head insert");
+        let publisher_bundle_index = attributed
+            .find("id=\"trustedserver-js\"")
+            .expect("should include the publisher bundle");
+        assert!(
+            head_insert_index < publisher_bundle_index,
+            "should keep integration head inserts before the publisher bundle"
         );
     }
 

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -841,15 +841,15 @@ mod tests {
 
     #[test]
     fn integration_head_injector_marks_only_attribution_enabled_gpt_bundle() {
-        fn process(gam_attribution_enabled: Option<bool>) -> String {
-            let integrations = if let Some(gam_attribution_enabled) = gam_attribution_enabled {
+        fn process(gpt_config: Option<(bool, bool)>) -> String {
+            let integrations = if let Some((enabled, gam_attribution_enabled)) = gpt_config {
                 let mut settings = create_test_settings();
                 settings
                     .integrations
                     .insert_config(
                         "gpt",
                         &json!({
-                            "enabled": true,
+                            "enabled": enabled,
                             "gam_attribution_enabled": gam_attribution_enabled
                         }),
                     )
@@ -868,11 +868,12 @@ mod tests {
             String::from_utf8(output).expect("should produce valid UTF-8")
         }
 
-        let attributed = process(Some(true));
-        let unattributed = process(Some(false));
+        let attributed = process(Some((true, true)));
+        let unattributed = process(Some((true, false)));
+        let disabled_gpt = process(Some((false, true)));
         let without_gpt = process(None);
 
-        for html in [&attributed, &unattributed, &without_gpt] {
+        for html in [&attributed, &unattributed, &disabled_gpt, &without_gpt] {
             assert_eq!(
                 html.matches("id=\"trustedserver-js\"").count(),
                 1,
@@ -886,6 +887,10 @@ mod tests {
         assert!(
             !unattributed.contains("data-ts-gam-attribution"),
             "should leave an attribution-disabled GPT publisher bundle unmarked"
+        );
+        assert!(
+            !disabled_gpt.contains("data-ts-gam-attribution"),
+            "should let the GPT master switch suppress attribution metadata"
         );
         assert!(
             !without_gpt.contains("data-ts-gam-attribution"),

--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -68,6 +68,7 @@ use serde_json::Value as JsonValue;
 use url::Url;
 use validator::Validate;
 
+use crate::constants::ENV_FASTLY_IS_STAGING;
 use crate::error::TrustedServerError;
 use crate::integrations::{
     AttributeRewriteAction, INTEGRATION_MAX_BODY_BYTES, IntegrationAttributeContext,
@@ -88,7 +89,14 @@ pub use protection_scope::{
 
 use protection_scope::ProtectionScope;
 
-pub(super) const DATADOME_INTEGRATION_ID: &str = "datadome";
+pub(crate) const DATADOME_INTEGRATION_ID: &str = "datadome";
+/// Fixed request header used by the staging-only protection test bypass.
+pub(crate) const HEADER_DATADOME_TEST_BYPASS: &str = "x-ts-datadome-bypass";
+
+/// Request marker indicating that Trusted Server should omit its automatic
+/// `DataDome` client-side tag for the current response.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DataDomeClientTagSuppressed;
 
 /// Regex pattern for matching and rewriting `DataDome` URLs in script content.
 ///
@@ -111,6 +119,28 @@ static DATADOME_URL_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(['"])(https?:)?(//)?(api-)?js\.datadome\.co(/[^'"]*)?(['"])"#)
         .expect("DataDome URL rewrite regex should compile")
 });
+
+/// Temporary static-header bypass for server-side `DataDome` protection.
+///
+/// This is intended only for an access-controlled staging environment. A
+/// matching `x-ts-datadome-bypass` header bypasses the server-side Protection
+/// API and is removed before the publisher origin receives the request. The
+/// credential itself is loaded from the Secret Store at runtime.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProtectionTestBypassConfig {
+    /// Enables the bypass. Defaults to disabled when the section is present.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Secret Store containing the temporary bypass credential.
+    #[serde(default = "default_protection_test_bypass_secret_store")]
+    pub credential_secret_store: String,
+
+    /// Secret name containing at least 32 bytes of high-entropy bypass material.
+    #[serde(default = "default_protection_test_bypass_secret_name")]
+    pub credential_secret_name: String,
+}
 
 /// Configuration for `DataDome` integration.
 #[derive(Debug, Clone, Deserialize, Validate)]
@@ -194,6 +224,10 @@ pub struct DataDomeConfig {
     )]
     pub protection_exclusion_rules: Vec<ProtectionExclusionRuleConfig>,
 
+    /// Temporary static-header bypass for access-controlled staging tests.
+    #[serde(default)]
+    pub protection_test_bypass: Option<ProtectionTestBypassConfig>,
+
     /// Reserved flag for future GraphQL payload extraction.
     #[serde(default)]
     pub enable_graphql_support: bool,
@@ -245,6 +279,14 @@ fn default_server_side_key_secret_store() -> String {
 
 fn default_server_side_key_secret_name() -> String {
     "datadome_server_side_key".to_string()
+}
+
+fn default_protection_test_bypass_secret_store() -> String {
+    "ts_secrets".to_string()
+}
+
+fn default_protection_test_bypass_secret_name() -> String {
+    "datadome_test_bypass".to_string()
 }
 
 fn default_timeout_ms() -> u32 {
@@ -324,6 +366,7 @@ impl Default for DataDomeConfig {
             protection_excluded_ip_cidr_sources: Vec::new(),
             protection_ip_list_cache_ttl_seconds: default_protection_ip_list_cache_ttl_seconds(),
             protection_exclusion_rules: default_protection_exclusion_rules(),
+            protection_test_bypass: None,
             enable_graphql_support: false,
             client_side_key: String::new(),
             inject_client_side_tag: default_inject_client_side_tag(),
@@ -357,6 +400,10 @@ impl DataDomeIntegration {
         config.server_side_key_secret_name = config.server_side_key_secret_name.trim().to_string();
         config.protection_api_origin = config.protection_api_origin.trim().to_string();
         config.client_side_tag_url = config.client_side_tag_url.trim().to_string();
+        if let Some(bypass) = &mut config.protection_test_bypass {
+            bypass.credential_secret_store = bypass.credential_secret_store.trim().to_string();
+            bypass.credential_secret_name = bypass.credential_secret_name.trim().to_string();
+        }
 
         if config.enable_protection {
             if config.server_side_key_secret_store.is_empty()
@@ -368,6 +415,7 @@ impl DataDomeIntegration {
             }
             Self::validate_protection_api_origin(&config.protection_api_origin)?;
         }
+        Self::validate_protection_test_bypass(&config)?;
 
         if config.inject_client_side_tag {
             Self::validate_client_side_tag_url(&config.client_side_tag_url)?;
@@ -411,6 +459,54 @@ impl DataDomeIntegration {
         {
             return Err(Report::new(Self::error(
                 "protection_api_origin must be an origin URL without path, query, or fragment",
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Validates `DataDome` configuration before runtime registration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when protection, bypass, or client-tag configuration is
+    /// invalid.
+    pub(crate) fn validate_config_for_startup(
+        config: DataDomeConfig,
+    ) -> Result<(), Report<TrustedServerError>> {
+        Self::try_new(config).map(|_| ())
+    }
+
+    fn active_protection_test_bypass(&self) -> Option<&ProtectionTestBypassConfig> {
+        if std::env::var(ENV_FASTLY_IS_STAGING).as_deref() != Ok("1") {
+            return None;
+        }
+
+        self.config
+            .protection_test_bypass
+            .as_ref()
+            .filter(|bypass| bypass.enabled)
+    }
+
+    fn validate_protection_test_bypass(
+        config: &DataDomeConfig,
+    ) -> Result<(), Report<TrustedServerError>> {
+        let Some(bypass) = config
+            .protection_test_bypass
+            .as_ref()
+            .filter(|bypass| bypass.enabled)
+        else {
+            return Ok(());
+        };
+
+        if !config.enable_protection {
+            return Err(Report::new(Self::error(
+                "protection_test_bypass requires enable_protection to be true",
+            )));
+        }
+        if bypass.credential_secret_store.is_empty() || bypass.credential_secret_name.is_empty() {
+            return Err(Report::new(Self::error(
+                "protection_test_bypass credential_secret_store and credential_secret_name must not be empty when enabled",
             )));
         }
 
@@ -765,7 +861,15 @@ impl IntegrationHeadInjector for DataDomeIntegration {
         DATADOME_INTEGRATION_ID
     }
 
-    fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+    fn head_inserts(&self, ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+        if ctx
+            .document_state
+            .get::<DataDomeClientTagSuppressed>(DATADOME_INTEGRATION_ID)
+            .is_some()
+        {
+            return Vec::new();
+        }
+
         if !self.config.inject_client_side_tag || self.config.client_side_key.trim().is_empty() {
             return Vec::new();
         }
@@ -840,13 +944,33 @@ fn build(
         return Ok(None);
     };
 
+    let integration = DataDomeIntegration::try_new(config)?;
+    let protection_test_bypass_configured = integration
+        .config
+        .protection_test_bypass
+        .as_ref()
+        .is_some_and(|bypass| bypass.enabled);
+    let protection_test_bypass_active = integration.active_protection_test_bypass().is_some();
+    if protection_test_bypass_configured && !protection_test_bypass_active {
+        log::warn!(
+            "[datadome] DataDome test bypass is configured but inactive because FASTLY_IS_STAGING is not 1"
+        );
+    }
     log::info!(
-        "[datadome] Registering integration (sdk_origin: {}, rewrite_sdk: {})",
-        config.sdk_origin,
-        config.rewrite_sdk
+        "[datadome] Registering integration (sdk_origin: {}, rewrite_sdk: {}, enable_protection: {}, protection_test_bypass: {})",
+        integration.config.sdk_origin,
+        integration.config.rewrite_sdk,
+        integration.config.enable_protection,
+        if protection_test_bypass_active {
+            "active"
+        } else if protection_test_bypass_configured {
+            "configured-inactive"
+        } else {
+            "disabled"
+        },
     );
 
-    Ok(Some(DataDomeIntegration::try_new(config)?))
+    Ok(Some(integration))
 }
 
 /// Register the `DataDome` integration with Trusted Server.
@@ -1084,6 +1208,70 @@ mod tests {
             config.server_side_key_secret_name,
             "datadome_server_side_key"
         );
+        assert!(
+            config.protection_test_bypass.is_none(),
+            "the temporary test bypass should be disabled by default"
+        );
+    }
+
+    #[test]
+    fn protection_test_bypass_deserializes_nested_configuration() {
+        let config: DataDomeConfig = toml::from_str(
+            r#"
+            enabled = true
+            enable_protection = true
+
+            [protection_test_bypass]
+            enabled = true
+            credential_secret_store = "ts_secrets"
+            credential_secret_name = "datadome_test_bypass"
+            "#,
+        )
+        .expect("should deserialize DataDome test bypass configuration");
+        let bypass = config
+            .protection_test_bypass
+            .expect("should deserialize the nested test bypass configuration");
+
+        assert!(bypass.enabled, "should retain the enabled flag");
+        assert_eq!(
+            bypass.credential_secret_store, "ts_secrets",
+            "should retain the configured credential Secret Store"
+        );
+        assert_eq!(
+            bypass.credential_secret_name, "datadome_test_bypass",
+            "should retain the configured credential secret name"
+        );
+    }
+
+    #[test]
+    fn protection_test_bypass_requires_protection_and_secret_references() {
+        for (enable_protection, store, name, expected_message) in [
+            (
+                false,
+                "ts_secrets",
+                "datadome_test_bypass",
+                "requires enable_protection",
+            ),
+            (true, "", "datadome_test_bypass", "credential_secret_store"),
+            (true, "ts_secrets", "", "credential_secret_name"),
+        ] {
+            let mut config = test_config();
+            config.enable_protection = enable_protection;
+            config.protection_test_bypass = Some(ProtectionTestBypassConfig {
+                enabled: true,
+                credential_secret_store: store.to_string(),
+                credential_secret_name: name.to_string(),
+            });
+
+            let err = match DataDomeIntegration::try_new(config) {
+                Ok(_) => panic!("should reject invalid protection test bypass configuration"),
+                Err(err) => err,
+            };
+            assert!(
+                format!("{err:?}").contains(expected_message),
+                "should explain the invalid protection test bypass configuration"
+            );
+        }
     }
 
     #[test]
@@ -1248,6 +1436,20 @@ mod tests {
 
     #[test]
     fn head_injector_omits_client_side_tag_when_disabled_or_blank() {
+        let mut suppressed = test_config();
+        suppressed.client_side_key = "test-client-key".to_string();
+        let suppressed_integration = DataDomeIntegration::new(suppressed);
+        let suppressed_state = crate::integrations::IntegrationDocumentState::default();
+        suppressed_state
+            .get_or_insert_with(DATADOME_INTEGRATION_ID, || DataDomeClientTagSuppressed);
+        let suppressed_ctx = html_context_for_tests(&suppressed_state);
+        assert!(
+            suppressed_integration
+                .head_inserts(&suppressed_ctx)
+                .is_empty(),
+            "should omit the tag when the request is IP-excluded"
+        );
+
         let mut blank_key = test_config();
         blank_key.client_side_key = " ".to_string();
         let integration = DataDomeIntegration::new(blank_key);

--- a/crates/trusted-server-core/src/integrations/datadome/protection.rs
+++ b/crates/trusted-server-core/src/integrations/datadome/protection.rs
@@ -4,9 +4,12 @@ use edgezero_core::body::Body as EdgeBody;
 use edgezero_core::http::{HeaderMap, HeaderName, request_builder};
 use error_stack::{Report, ResultExt};
 use http::{Method, Request, Response, StatusCode, header};
+use sha2::{Digest as _, Sha256};
+use subtle::ConstantTimeEq as _;
 use url::Url;
 
 use crate::error::TrustedServerError;
+use crate::http_util::is_navigation_request;
 use crate::integrations::{
     HeaderMutation, RequestFilterDecision, RequestFilterEffects, RequestFilterInput,
 };
@@ -14,7 +17,11 @@ use crate::platform::{PlatformBackendSpec, PlatformHttpRequest, RuntimeServices,
 use crate::redacted::Redacted;
 
 use super::DataDomeIntegration;
-use super::protection_scope::{ProtectionRequestFacts, ProtectionScopeDecision};
+use super::protection_scope::{
+    ProtectionRequestFacts, ProtectionScopeDecision, ProtectionSkipReason,
+};
+
+const MIN_TEST_BYPASS_CREDENTIAL_BYTES: usize = 32;
 
 const VALIDATE_REQUEST_PATH: &str = "/validate-request";
 const REQUEST_MODULE_NAME: &str = "Trusted-Server-Rust";
@@ -34,20 +41,38 @@ enum ProtectionRequestError {
 impl DataDomeIntegration {
     pub(super) async fn filter_protection_request(
         &self,
-        input: RequestFilterInput<'_>,
+        mut input: RequestFilterInput<'_>,
     ) -> RequestFilterDecision {
-        if !self.config.enable_protection || !self.is_request_protected(&input) {
+        let test_bypass_matched =
+            self.take_protection_test_bypass_header(input.request, input.services);
+        if test_bypass_matched {
+            input
+                .request
+                .extensions_mut()
+                .insert(super::DataDomeClientTagSuppressed);
+            log_protection_test_bypass(&input);
             return RequestFilterDecision::Continue(RequestFilterEffects::default());
         }
 
+        if !self.config.enable_protection || !self.is_request_protected(&mut input) {
+            return RequestFilterDecision::Continue(RequestFilterEffects::default());
+        }
+
+        let request_method = input.request.method().clone();
         match self.filter_protection_request_inner(input).await {
             Ok(decision) => decision,
             Err(ProtectionRequestError::Setup(err)) => {
-                log::error!("[datadome] Protection setup failed open: {err:?}");
+                log::error!(
+                    "[datadome] protection decision=failed_open api_status=none datadome_status=unavailable method={} route=continue failure=setup error={err:?}",
+                    request_method,
+                );
                 RequestFilterDecision::Continue(RequestFilterEffects::default())
             }
             Err(ProtectionRequestError::Runtime(err)) => {
-                log::warn!("[datadome] Protection API failed open: {err:?}");
+                log::warn!(
+                    "[datadome] protection decision=failed_open api_status=none datadome_status=unavailable method={} route=continue failure=runtime error={err:?}",
+                    request_method,
+                );
                 RequestFilterDecision::Continue(RequestFilterEffects::default())
             }
         }
@@ -98,11 +123,17 @@ impl DataDomeIntegration {
             .change_context(Self::error("Failed to call DataDome Protection API"))
             .map_err(ProtectionRequestError::Runtime)?;
 
-        Ok(self.classify_protection_response(platform_response.response, input.request.method()))
+        let status = platform_response.response.status();
+        let datadome_status = datadome_response_status(platform_response.response.headers());
+        let decision =
+            self.classify_protection_response(platform_response.response, input.request.method());
+        log_protection_result(&input, status, datadome_status, &decision);
+
+        Ok(decision)
     }
 
-    fn is_request_protected(&self, input: &RequestFilterInput<'_>) -> bool {
-        let req = input.request;
+    fn is_request_protected(&self, input: &mut RequestFilterInput<'_>) -> bool {
+        let req = &*input.request;
         if req.method() == Method::OPTIONS {
             return false;
         }
@@ -125,13 +156,73 @@ impl DataDomeIntegration {
         };
         match self.protection_scope.evaluate(&facts, input.services) {
             ProtectionScopeDecision::Protect => {}
-            ProtectionScopeDecision::Skip { rule_id, reason } => {
-                log::debug!("[datadome] Skipping Protection API for rule {rule_id} ({reason})");
+            ProtectionScopeDecision::Skip {
+                rule_id,
+                reason,
+                suppress_client_tag,
+            } => {
+                if suppress_client_tag {
+                    input
+                        .request
+                        .extensions_mut()
+                        .insert(super::DataDomeClientTagSuppressed);
+                }
+                log_protection_skip(input, &rule_id, reason, suppress_client_tag);
                 return false;
             }
         }
 
         true
+    }
+
+    fn take_protection_test_bypass_header(
+        &self,
+        req: &mut Request<EdgeBody>,
+        services: &RuntimeServices,
+    ) -> bool {
+        let supplied_values = req
+            .headers()
+            .get_all(super::HEADER_DATADOME_TEST_BYPASS)
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        req.headers_mut().remove(super::HEADER_DATADOME_TEST_BYPASS);
+        if supplied_values.is_empty() {
+            return false;
+        }
+        let Some(bypass) = self.active_protection_test_bypass() else {
+            return false;
+        };
+        if supplied_values.len() != 1 {
+            log::warn!(
+                "[datadome] Multiple DataDome test bypass headers supplied; ignoring bypass"
+            );
+            return false;
+        }
+
+        let store_name = StoreName::from(bypass.credential_secret_store.as_str());
+        let credential = match services
+            .secret_store()
+            .get_string(&store_name, &bypass.credential_secret_name)
+        {
+            Ok(credential) if credential.len() >= MIN_TEST_BYPASS_CREDENTIAL_BYTES => credential,
+            Ok(_) => {
+                log::warn!(
+                    "[datadome] DataDome test bypass credential does not meet security requirements; ignoring bypass header"
+                );
+                return false;
+            }
+            Err(err) => {
+                log::warn!(
+                    "[datadome] Failed to load DataDome test bypass credential; ignoring bypass header: {err:?}"
+                );
+                return false;
+            }
+        };
+
+        let actual = Sha256::digest(supplied_values[0].as_bytes());
+        let expected = Sha256::digest(credential.as_bytes());
+        bool::from(actual.ct_eq(&expected))
     }
 
     fn protection_validate_url(&self) -> String {
@@ -194,7 +285,7 @@ impl DataDomeIntegration {
         input: &RequestFilterInput<'_>,
         server_side_key: &Redacted<String>,
     ) -> ProtectionPayload {
-        let req = input.request;
+        let req = &*input.request;
         let client_info = input.services.client_info();
         let mut fields = Vec::new();
         let header_client_id = header_value(req, HEADER_DATADOME_CLIENT_ID);
@@ -357,13 +448,16 @@ impl DataDomeIntegration {
         let (parts, body) = response.into_parts();
         let status = parts.status;
         let Some(datadome_status) = datadome_response_status(&parts.headers) else {
-            log::warn!("[datadome] Protection API response missing X-DataDomeResponse");
+            log::warn!(
+                "[datadome] Protection API response has missing or non-numeric verdict: api_status={} datadome_status=missing_or_invalid",
+                status.as_u16()
+            );
             return RequestFilterDecision::Continue(RequestFilterEffects::default());
         };
 
         if datadome_status != status.as_u16() {
             log::warn!(
-                "[datadome] Protection API status/header mismatch: status={} header={}",
+                "[datadome] Protection API status/verdict mismatch: api_status={} datadome_status={}",
                 status.as_u16(),
                 datadome_status
             );
@@ -406,10 +500,106 @@ impl DataDomeIntegration {
         }
 
         log::warn!(
-            "[datadome] Protection API returned fail-open status {}",
-            status.as_u16()
+            "[datadome] Protection API returned unexpected fail-open status: api_status={} datadome_status={}",
+            status.as_u16(),
+            datadome_status
         );
         RequestFilterDecision::Continue(RequestFilterEffects::default())
+    }
+}
+
+fn log_protection_test_bypass(input: &RequestFilterInput<'_>) {
+    log::info!(
+        "[datadome] protection decision=skipped rule=protection-test-bypass reason=test_bypass client_tag=omitted method={}",
+        input.request.method(),
+    );
+}
+
+fn suppression_skip_log_level(suppress_client_tag: bool, is_navigation: bool) -> log::Level {
+    if suppress_client_tag && is_navigation {
+        log::Level::Info
+    } else {
+        log::Level::Debug
+    }
+}
+
+fn log_protection_skip(
+    input: &RequestFilterInput<'_>,
+    rule_id: &str,
+    reason: ProtectionSkipReason,
+    suppress_client_tag: bool,
+) {
+    let level =
+        suppression_skip_log_level(suppress_client_tag, is_navigation_request(input.request));
+    let client_tag = if suppress_client_tag {
+        " client_tag=omitted"
+    } else {
+        ""
+    };
+    log::log!(
+        level,
+        "[datadome] protection decision=skipped rule={} reason={}{} method={}",
+        rule_id,
+        reason.as_str(),
+        client_tag,
+        input.request.method(),
+    );
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ProtectionResultKind {
+    Allowed,
+    Blocked,
+    FailedOpen,
+}
+
+fn classify_logged_protection_result(
+    status: StatusCode,
+    datadome_status: Option<u16>,
+    decision: &RequestFilterDecision,
+) -> ProtectionResultKind {
+    match decision {
+        RequestFilterDecision::Respond { .. } => ProtectionResultKind::Blocked,
+        RequestFilterDecision::Continue(_)
+            if status == StatusCode::OK && datadome_status == Some(status.as_u16()) =>
+        {
+            ProtectionResultKind::Allowed
+        }
+        RequestFilterDecision::Continue(_) => ProtectionResultKind::FailedOpen,
+    }
+}
+
+fn log_protection_result(
+    input: &RequestFilterInput<'_>,
+    status: StatusCode,
+    datadome_status: Option<u16>,
+    decision: &RequestFilterDecision,
+) {
+    let method = input.request.method();
+    let result_kind = classify_logged_protection_result(status, datadome_status, decision);
+    let datadome_status = datadome_status
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "missing_or_invalid".to_string());
+
+    match result_kind {
+        ProtectionResultKind::Blocked => log::info!(
+            "[datadome] protection decision=blocked api_status={} datadome_status={} method={} route=short_circuit",
+            status.as_u16(),
+            datadome_status,
+            method,
+        ),
+        ProtectionResultKind::Allowed => log::info!(
+            "[datadome] protection decision=allowed api_status={} datadome_status={} method={} route=continue",
+            status.as_u16(),
+            datadome_status,
+            method,
+        ),
+        ProtectionResultKind::FailedOpen => log::warn!(
+            "[datadome] protection decision=failed_open api_status={} datadome_status={} method={} route=continue",
+            status.as_u16(),
+            datadome_status,
+            method,
+        ),
     }
 }
 
@@ -645,15 +835,24 @@ fn truncate_utf8(value: &str, limit: i32) -> String {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::{Arc, Mutex};
 
-    use crate::integrations::datadome::DataDomeConfig;
+    use crate::integrations::datadome::{
+        DataDomeConfig, ProtectionExclusionRuleConfig, ProtectionMatcherConfig,
+        ProtectionTestBypassConfig,
+    };
+    use crate::platform::GeoInfo;
     use crate::platform::test_support::{
-        HashMapSecretStore, NoopConfigStore, NoopSecretStore, build_services_with_config_and_secret,
+        HashMapConfigStore, HashMapSecretStore, NoopConfigStore, NoopSecretStore, StubHttpClient,
+        build_services_with_config_and_secret, build_services_with_config_and_secret_and_client_ip,
+        build_services_with_secret_and_http_client, noop_services_with_client_ip,
     };
     use crate::settings::Settings;
 
     use super::*;
+
+    static FASTLY_IS_STAGING_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn protection_integration() -> Arc<DataDomeIntegration> {
         let config = DataDomeConfig {
@@ -662,6 +861,770 @@ mod tests {
             ..DataDomeConfig::default()
         };
         DataDomeIntegration::try_new(config).expect("should create integration")
+    }
+
+    fn request_for_filter() -> Request<EdgeBody> {
+        request_builder()
+            .method(Method::GET.as_str())
+            .uri("https://publisher.example/page")
+            .body(EdgeBody::empty())
+            .expect("should build filter request")
+    }
+
+    fn filter_with_staging(
+        integration: &DataDomeIntegration,
+        settings: &Settings,
+        services: &RuntimeServices,
+        request: &mut Request<EdgeBody>,
+    ) -> RequestFilterDecision {
+        let _guard = FASTLY_IS_STAGING_ENV_LOCK
+            .lock()
+            .expect("should lock staging environment test guard");
+        temp_env::with_var(crate::constants::ENV_FASTLY_IS_STAGING, Some("1"), || {
+            futures::executor::block_on(integration.filter_protection_request(RequestFilterInput {
+                settings,
+                services,
+                request,
+                geo_info: None,
+                is_integration_route: false,
+            }))
+        })
+    }
+
+    fn filter_marks_request(
+        config: DataDomeConfig,
+        services: &RuntimeServices,
+    ) -> Request<EdgeBody> {
+        filter_marks_request_with_geo(config, services, None)
+    }
+
+    fn filter_marks_request_with_geo(
+        config: DataDomeConfig,
+        services: &RuntimeServices,
+        geo_info: Option<&GeoInfo>,
+    ) -> Request<EdgeBody> {
+        filter_marks_request_for_uri(config, services, geo_info, "https://publisher.example/page")
+    }
+
+    fn filter_marks_request_for_uri(
+        config: DataDomeConfig,
+        services: &RuntimeServices,
+        geo_info: Option<&GeoInfo>,
+        uri: &str,
+    ) -> Request<EdgeBody> {
+        let integration =
+            DataDomeIntegration::try_new(config).expect("should create DataDome integration");
+        let settings = Settings::default();
+        let mut request = request_builder()
+            .method(Method::GET.as_str())
+            .uri(uri)
+            .body(EdgeBody::empty())
+            .expect("should build filter request");
+        let decision = futures::executor::block_on(integration.filter_protection_request(
+            RequestFilterInput {
+                settings: &settings,
+                services,
+                request: &mut request,
+                geo_info,
+                is_integration_route: false,
+            },
+        ));
+        assert!(
+            matches!(decision, RequestFilterDecision::Continue(_)),
+            "an excluded request should continue without a Protection API response"
+        );
+        request
+    }
+
+    fn has_client_tag_suppression_marker(request: &Request<EdgeBody>) -> bool {
+        request
+            .extensions()
+            .get::<super::super::DataDomeClientTagSuppressed>()
+            .is_some()
+    }
+
+    #[test]
+    fn protection_test_bypass_skips_api_suppresses_tag_and_strips_header() {
+        let config = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_test_bypass: Some(ProtectionTestBypassConfig {
+                enabled: true,
+                credential_secret_store: "ts_secrets".to_string(),
+                credential_secret_name: "datadome_test_bypass".to_string(),
+            }),
+            ..DataDomeConfig::default()
+        };
+        let integration = DataDomeIntegration::try_new(config).expect("should create integration");
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "datadome_test_bypass".to_string(),
+            b"temporary-test-credential-32-bytes!".to_vec(),
+        );
+        let http_client = Arc::new(StubHttpClient::new());
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(secrets),
+            http_client.clone(),
+        );
+        let settings = Settings::default();
+        let mut request = request_for_filter();
+        request.headers_mut().insert(
+            super::super::HEADER_DATADOME_TEST_BYPASS,
+            edgezero_core::http::HeaderValue::from_static("temporary-test-credential-32-bytes!"),
+        );
+
+        let decision = filter_with_staging(&integration, &settings, &services, &mut request);
+
+        assert!(
+            matches!(decision, RequestFilterDecision::Continue(_)),
+            "a matching test credential should continue without a challenge"
+        );
+        assert!(
+            has_client_tag_suppression_marker(&request),
+            "the bypass should suppress the automatic DataDome client tag"
+        );
+        assert!(
+            request
+                .headers()
+                .get(super::super::HEADER_DATADOME_TEST_BYPASS)
+                .is_none(),
+            "the bypass credential must not reach the publisher origin"
+        );
+        assert!(
+            http_client.recorded_backend_names().is_empty(),
+            "a matching test credential must not call the Protection API"
+        );
+    }
+
+    #[test]
+    fn protection_test_bypass_header_is_stripped_when_unconfigured_or_disabled() {
+        for protection_test_bypass in [
+            None,
+            Some(ProtectionTestBypassConfig {
+                enabled: false,
+                credential_secret_store: "ts_secrets".to_string(),
+                credential_secret_name: "datadome_test_bypass".to_string(),
+            }),
+        ] {
+            let config = DataDomeConfig {
+                enabled: true,
+                enable_protection: true,
+                protection_test_bypass,
+                ..DataDomeConfig::default()
+            };
+            let integration =
+                DataDomeIntegration::try_new(config).expect("should create integration");
+            let mut secrets = HashMap::new();
+            secrets.insert(
+                "datadome_server_side_key".to_string(),
+                b"server-side-key".to_vec(),
+            );
+            let http_client = Arc::new(StubHttpClient::new());
+            http_client.push_response_with_headers(
+                200,
+                Vec::new(),
+                vec![(HEADER_DATADOME_RESPONSE, "200")],
+            );
+            let services = build_services_with_secret_and_http_client(
+                HashMapSecretStore::new(secrets),
+                http_client.clone(),
+            );
+            let settings = Settings::default();
+            let mut request = request_for_filter();
+            request.headers_mut().insert(
+                super::super::HEADER_DATADOME_TEST_BYPASS,
+                edgezero_core::http::HeaderValue::from_static("stale-test-credential"),
+            );
+
+            let decision = filter_with_staging(&integration, &settings, &services, &mut request);
+
+            assert!(
+                matches!(decision, RequestFilterDecision::Continue(_)),
+                "an allowed Protection API response should continue"
+            );
+            assert!(
+                request
+                    .headers()
+                    .get(super::super::HEADER_DATADOME_TEST_BYPASS)
+                    .is_none(),
+                "the bypass header must be stripped when the bypass is unconfigured or disabled"
+            );
+            assert!(
+                !has_client_tag_suppression_marker(&request),
+                "an inactive bypass must not suppress the DataDome client tag"
+            );
+            assert_eq!(
+                http_client.recorded_backend_names().len(),
+                1,
+                "an inactive bypass must still call the Protection API"
+            );
+        }
+    }
+
+    #[test]
+    fn protection_test_bypass_is_inactive_outside_staging() {
+        let config = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_test_bypass: Some(ProtectionTestBypassConfig {
+                enabled: true,
+                credential_secret_store: "ts_secrets".to_string(),
+                credential_secret_name: "datadome_test_bypass".to_string(),
+            }),
+            ..DataDomeConfig::default()
+        };
+        let integration = DataDomeIntegration::try_new(config).expect("should create integration");
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "datadome_server_side_key".to_string(),
+            b"server-side-key".to_vec(),
+        );
+        secrets.insert(
+            "datadome_test_bypass".to_string(),
+            b"temporary-test-credential-32-bytes!".to_vec(),
+        );
+        let http_client = Arc::new(StubHttpClient::new());
+        http_client.push_response_with_headers(
+            200,
+            Vec::new(),
+            vec![(HEADER_DATADOME_RESPONSE, "200")],
+        );
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(secrets),
+            http_client.clone(),
+        );
+        let settings = Settings::default();
+        let mut request = request_for_filter();
+        request.headers_mut().insert(
+            super::super::HEADER_DATADOME_TEST_BYPASS,
+            edgezero_core::http::HeaderValue::from_static("temporary-test-credential-32-bytes!"),
+        );
+
+        let _guard = FASTLY_IS_STAGING_ENV_LOCK
+            .lock()
+            .expect("should lock staging environment test guard");
+        let decision = temp_env::with_var(
+            crate::constants::ENV_FASTLY_IS_STAGING,
+            None::<&str>,
+            || {
+                futures::executor::block_on(integration.filter_protection_request(
+                    RequestFilterInput {
+                        settings: &settings,
+                        services: &services,
+                        request: &mut request,
+                        geo_info: None,
+                        is_integration_route: false,
+                    },
+                ))
+            },
+        );
+
+        assert!(
+            matches!(decision, RequestFilterDecision::Continue(_)),
+            "an allowed Protection API response should continue"
+        );
+        assert!(
+            request
+                .headers()
+                .get(super::super::HEADER_DATADOME_TEST_BYPASS)
+                .is_none(),
+            "the bypass credential must be stripped outside staging"
+        );
+        assert!(
+            !has_client_tag_suppression_marker(&request),
+            "the bypass must not suppress the DataDome client tag outside staging"
+        );
+        assert_eq!(
+            http_client.recorded_backend_names().len(),
+            1,
+            "the bypass must still call the Protection API outside staging"
+        );
+    }
+
+    #[test]
+    fn protection_test_bypass_wins_over_other_exclusions() {
+        let config = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_exclusion_rules: vec![ProtectionExclusionRuleConfig {
+                id: "staging-page-exclusion".to_string(),
+                enabled: true,
+                methods: Vec::new(),
+                matcher: ProtectionMatcherConfig::PathExact {
+                    paths: vec!["/page".to_string()],
+                },
+            }],
+            protection_test_bypass: Some(ProtectionTestBypassConfig {
+                enabled: true,
+                credential_secret_store: "ts_secrets".to_string(),
+                credential_secret_name: "datadome_test_bypass".to_string(),
+            }),
+            ..DataDomeConfig::default()
+        };
+        let integration = DataDomeIntegration::try_new(config).expect("should create integration");
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "datadome_test_bypass".to_string(),
+            b"temporary-test-credential-32-bytes!".to_vec(),
+        );
+        let http_client = Arc::new(StubHttpClient::new());
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(secrets),
+            http_client.clone(),
+        );
+        let settings = Settings::default();
+        let mut request = request_for_filter();
+        request.headers_mut().insert(
+            super::super::HEADER_DATADOME_TEST_BYPASS,
+            edgezero_core::http::HeaderValue::from_static("temporary-test-credential-32-bytes!"),
+        );
+
+        let decision = filter_with_staging(&integration, &settings, &services, &mut request);
+
+        assert!(
+            matches!(decision, RequestFilterDecision::Continue(_)),
+            "a matching test credential should continue"
+        );
+        assert!(
+            has_client_tag_suppression_marker(&request),
+            "a matching test credential should suppress the tag even on an excluded path"
+        );
+        assert!(
+            http_client.recorded_backend_names().is_empty(),
+            "a matching test credential must not call the Protection API"
+        );
+    }
+
+    #[test]
+    fn protection_test_bypass_strips_invalid_credential_without_bypassing() {
+        let config = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_test_bypass: Some(ProtectionTestBypassConfig {
+                enabled: true,
+                credential_secret_store: "ts_secrets".to_string(),
+                credential_secret_name: "datadome_test_bypass".to_string(),
+            }),
+            ..DataDomeConfig::default()
+        };
+        let integration = DataDomeIntegration::try_new(config).expect("should create integration");
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "datadome_server_side_key".to_string(),
+            b"server-side-key".to_vec(),
+        );
+        secrets.insert(
+            "datadome_test_bypass".to_string(),
+            b"temporary-test-credential-32-bytes!".to_vec(),
+        );
+        let http_client = Arc::new(StubHttpClient::new());
+        http_client.push_response_with_headers(
+            200,
+            Vec::new(),
+            vec![(HEADER_DATADOME_RESPONSE, "200")],
+        );
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(secrets),
+            http_client.clone(),
+        );
+        let settings = Settings::default();
+        let mut request = request_for_filter();
+        request.headers_mut().insert(
+            super::super::HEADER_DATADOME_TEST_BYPASS,
+            edgezero_core::http::HeaderValue::from_static("wrong-credential"),
+        );
+
+        let decision = filter_with_staging(&integration, &settings, &services, &mut request);
+
+        assert!(
+            matches!(decision, RequestFilterDecision::Continue(_)),
+            "an allowed Protection API response should continue"
+        );
+        assert!(
+            !has_client_tag_suppression_marker(&request),
+            "a non-matching credential must not suppress the DataDome client tag"
+        );
+        assert!(
+            request
+                .headers()
+                .get(super::super::HEADER_DATADOME_TEST_BYPASS)
+                .is_none(),
+            "an invalid bypass credential must not reach the publisher origin"
+        );
+        assert_eq!(
+            http_client.recorded_backend_names().len(),
+            1,
+            "a non-matching credential must still call the Protection API"
+        );
+    }
+
+    #[test]
+    fn duplicate_test_bypass_headers_fail_closed_and_are_all_stripped() {
+        let config = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_test_bypass: Some(ProtectionTestBypassConfig {
+                enabled: true,
+                credential_secret_store: "ts_secrets".to_string(),
+                credential_secret_name: "datadome_test_bypass".to_string(),
+            }),
+            ..DataDomeConfig::default()
+        };
+        let integration = DataDomeIntegration::try_new(config).expect("should create integration");
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "datadome_server_side_key".to_string(),
+            b"server-side-key".to_vec(),
+        );
+        secrets.insert(
+            "datadome_test_bypass".to_string(),
+            b"temporary-test-credential-32-bytes!".to_vec(),
+        );
+        let http_client = Arc::new(StubHttpClient::new());
+        http_client.push_response_with_headers(
+            200,
+            Vec::new(),
+            vec![(HEADER_DATADOME_RESPONSE, "200")],
+        );
+        let services = build_services_with_secret_and_http_client(
+            HashMapSecretStore::new(secrets),
+            http_client.clone(),
+        );
+        let settings = Settings::default();
+        let mut request = request_for_filter();
+        for value in [
+            "temporary-test-credential-32-bytes!",
+            "temporary-test-credential-32-bytes!",
+        ] {
+            request.headers_mut().append(
+                super::super::HEADER_DATADOME_TEST_BYPASS,
+                edgezero_core::http::HeaderValue::from_static(value),
+            );
+        }
+
+        let decision = filter_with_staging(&integration, &settings, &services, &mut request);
+
+        assert!(matches!(decision, RequestFilterDecision::Continue(_)));
+        assert!(
+            request
+                .headers()
+                .get(super::super::HEADER_DATADOME_TEST_BYPASS)
+                .is_none(),
+            "all duplicate bypass values should be stripped"
+        );
+        assert!(!has_client_tag_suppression_marker(&request));
+        assert_eq!(http_client.recorded_backend_names().len(), 1);
+    }
+
+    #[test]
+    fn test_bypass_credential_requires_at_least_32_bytes() {
+        for (credential, should_match) in [
+            (Some("1234567890123456789012345678901"), false),
+            (Some("12345678901234567890123456789012"), true),
+            (Some(""), false),
+            (None, false),
+        ] {
+            let config = DataDomeConfig {
+                enabled: true,
+                enable_protection: true,
+                protection_test_bypass: Some(ProtectionTestBypassConfig {
+                    enabled: true,
+                    credential_secret_store: "ts_secrets".to_string(),
+                    credential_secret_name: "datadome_test_bypass".to_string(),
+                }),
+                ..DataDomeConfig::default()
+            };
+            let integration =
+                DataDomeIntegration::try_new(config).expect("should create integration");
+            let mut secrets = HashMap::new();
+            secrets.insert(
+                "datadome_server_side_key".to_string(),
+                b"server-side-key".to_vec(),
+            );
+            if let Some(credential) = credential {
+                secrets.insert(
+                    "datadome_test_bypass".to_string(),
+                    credential.as_bytes().to_vec(),
+                );
+            }
+            let http_client = Arc::new(StubHttpClient::new());
+            if !should_match {
+                http_client.push_response_with_headers(
+                    200,
+                    Vec::new(),
+                    vec![(HEADER_DATADOME_RESPONSE, "200")],
+                );
+            }
+            let services = build_services_with_secret_and_http_client(
+                HashMapSecretStore::new(secrets),
+                http_client.clone(),
+            );
+            let settings = Settings::default();
+            let mut request = request_for_filter();
+            let supplied = credential.unwrap_or("12345678901234567890123456789012");
+            request.headers_mut().insert(
+                super::super::HEADER_DATADOME_TEST_BYPASS,
+                edgezero_core::http::HeaderValue::from_str(supplied)
+                    .expect("should build bypass header"),
+            );
+
+            let decision = filter_with_staging(&integration, &settings, &services, &mut request);
+
+            assert!(matches!(decision, RequestFilterDecision::Continue(_)));
+            assert_eq!(has_client_tag_suppression_marker(&request), should_match);
+            assert_eq!(
+                http_client.recorded_backend_names().is_empty(),
+                should_match,
+                "only a credential meeting the minimum should skip the API"
+            );
+        }
+    }
+
+    #[test]
+    fn protection_result_classifier_and_suppression_log_level_cover_outcomes() {
+        let continue_decision = RequestFilterDecision::Continue(RequestFilterEffects::default());
+        let blocked_decision = RequestFilterDecision::Respond {
+            response: Box::new(Response::new(EdgeBody::empty())),
+            effects: RequestFilterEffects::default(),
+        };
+
+        assert_eq!(
+            classify_logged_protection_result(StatusCode::OK, Some(200), &continue_decision),
+            ProtectionResultKind::Allowed
+        );
+        assert_eq!(
+            classify_logged_protection_result(StatusCode::FORBIDDEN, Some(403), &blocked_decision),
+            ProtectionResultKind::Blocked
+        );
+        for (status, datadome_status) in [
+            (StatusCode::OK, None),
+            (StatusCode::OK, Some(403)),
+            (StatusCode::CREATED, Some(201)),
+        ] {
+            assert_eq!(
+                classify_logged_protection_result(status, datadome_status, &continue_decision),
+                ProtectionResultKind::FailedOpen
+            );
+        }
+        assert_eq!(suppression_skip_log_level(true, true), log::Level::Info);
+        assert_eq!(suppression_skip_log_level(true, false), log::Level::Debug);
+    }
+
+    #[test]
+    fn ip_exclusions_mark_requests_for_client_tag_suppression() {
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
+        let mut inline = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_excluded_ip_cidrs: vec!["192.0.2.0/24".to_string()],
+            ..DataDomeConfig::default()
+        };
+        let inline_request =
+            filter_marks_request(inline.clone(), &noop_services_with_client_ip(ip));
+        assert!(
+            has_client_tag_suppression_marker(&inline_request),
+            "inline IP exclusions should mark the request"
+        );
+
+        inline.protection_excluded_ip_cidrs.clear();
+        inline.protection_excluded_ip_cidr_sources =
+            vec![super::super::ProtectionIpCidrSourceConfig {
+                config_store: "datadome-test-source".to_string(),
+                key: "inline-source".to_string(),
+            }];
+        let mut source_values = HashMap::new();
+        source_values.insert("inline-source".to_string(), "192.0.2.0/24".to_string());
+        let source_services = build_services_with_config_and_secret_and_client_ip(
+            HashMapConfigStore::new(source_values),
+            NoopSecretStore,
+            ip,
+        );
+        let source_request = filter_marks_request(inline, &source_services);
+        assert!(
+            has_client_tag_suppression_marker(&source_request),
+            "Config Store IP exclusions should mark the request"
+        );
+
+        let structured_ip = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_exclusion_rules: vec![ProtectionExclusionRuleConfig {
+                id: "structured-ip".to_string(),
+                enabled: true,
+                methods: Vec::new(),
+                matcher: ProtectionMatcherConfig::IpCidr {
+                    cidrs: vec!["192.0.2.0/24".to_string()],
+                },
+            }],
+            ..DataDomeConfig::default()
+        };
+        let structured_request =
+            filter_marks_request(structured_ip, &noop_services_with_client_ip(ip));
+        assert!(
+            has_client_tag_suppression_marker(&structured_request),
+            "structured IP exclusions should mark the request"
+        );
+
+        let structured_source = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_exclusion_rules: vec![ProtectionExclusionRuleConfig {
+                id: "structured-ip-source".to_string(),
+                enabled: true,
+                methods: Vec::new(),
+                matcher: ProtectionMatcherConfig::IpCidrSource {
+                    config_store: "datadome-test-source".to_string(),
+                    key: "structured-source".to_string(),
+                },
+            }],
+            ..DataDomeConfig::default()
+        };
+        let mut structured_values = HashMap::new();
+        structured_values.insert("structured-source".to_string(), "192.0.2.0/24".to_string());
+        let structured_services = build_services_with_config_and_secret_and_client_ip(
+            HashMapConfigStore::new(structured_values),
+            NoopSecretStore,
+            ip,
+        );
+        let structured_source_request =
+            filter_marks_request(structured_source, &structured_services);
+        assert!(
+            has_client_tag_suppression_marker(&structured_source_request),
+            "structured Config Store IP exclusions should mark the request"
+        );
+    }
+
+    #[test]
+    fn non_ip_exclusions_do_not_mark_requests_for_client_tag_suppression() {
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
+        let cases = [
+            (
+                ProtectionMatcherConfig::PathExact {
+                    paths: vec!["/exact".to_string()],
+                },
+                "https://publisher.example/exact",
+            ),
+            (
+                ProtectionMatcherConfig::PathPrefix {
+                    prefixes: vec!["/prefix/".to_string()],
+                },
+                "https://publisher.example/prefix/page",
+            ),
+            (
+                ProtectionMatcherConfig::PathRegex {
+                    patterns: vec![r"^/regex/[0-9]+$".to_string()],
+                },
+                "https://publisher.example/regex/42",
+            ),
+            (
+                ProtectionMatcherConfig::QueryParamNonEmpty {
+                    names: vec!["skip".to_string()],
+                },
+                "https://publisher.example/page?skip=yes",
+            ),
+        ];
+
+        for (matcher, uri) in cases {
+            let config = DataDomeConfig {
+                enabled: true,
+                enable_protection: true,
+                protection_exclusion_rules: vec![ProtectionExclusionRuleConfig {
+                    id: "non-ip".to_string(),
+                    enabled: true,
+                    methods: Vec::new(),
+                    matcher,
+                }],
+                ..DataDomeConfig::default()
+            };
+            let request =
+                filter_marks_request_for_uri(config, &noop_services_with_client_ip(ip), None, uri);
+            assert!(
+                !has_client_tag_suppression_marker(&request),
+                "matching non-IP exclusion should not mark {uri}"
+            );
+        }
+    }
+
+    #[test]
+    fn overlapping_path_and_ip_exclusions_still_mark_request() {
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
+        let config = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_exclusion_rules: vec![
+                ProtectionExclusionRuleConfig {
+                    id: "path-first".to_string(),
+                    enabled: true,
+                    methods: Vec::new(),
+                    matcher: ProtectionMatcherConfig::PathExact {
+                        paths: vec!["/page".to_string()],
+                    },
+                },
+                ProtectionExclusionRuleConfig {
+                    id: "ip-second".to_string(),
+                    enabled: true,
+                    methods: Vec::new(),
+                    matcher: ProtectionMatcherConfig::IpCidr {
+                        cidrs: vec!["192.0.2.0/24".to_string()],
+                    },
+                },
+            ],
+            ..DataDomeConfig::default()
+        };
+
+        let request = filter_marks_request(config, &noop_services_with_client_ip(ip));
+
+        assert!(
+            has_client_tag_suppression_marker(&request),
+            "overlapping IP exclusion should suppress even when path remains the primary reason"
+        );
+    }
+
+    #[test]
+    fn asn_exclusions_do_not_mark_requests_for_client_tag_suppression() {
+        let config = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_excluded_asns: vec![64500],
+            ..DataDomeConfig::default()
+        };
+        let geo_info = GeoInfo {
+            city: String::new(),
+            country: String::new(),
+            continent: String::new(),
+            latitude: 0.0,
+            longitude: 0.0,
+            metro_code: 0,
+            region: None,
+            asn: Some(64500),
+        };
+        let request = filter_marks_request_with_geo(
+            config,
+            &noop_services_with_client_ip(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))),
+            Some(&geo_info),
+        );
+        assert!(
+            !has_client_tag_suppression_marker(&request),
+            "ASN exclusions should not mark the request"
+        );
+    }
+
+    #[test]
+    fn non_matching_ip_does_not_mark_request_for_client_tag_suppression() {
+        let config = DataDomeConfig {
+            enabled: true,
+            enable_protection: true,
+            protection_excluded_ip_cidrs: vec!["192.0.2.0/24".to_string()],
+            ..DataDomeConfig::default()
+        };
+        let request = filter_marks_request(
+            config,
+            &noop_services_with_client_ip(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10))),
+        );
+        assert!(
+            !has_client_tag_suppression_marker(&request),
+            "a non-matching IP should not mark the request"
+        );
     }
 
     #[test]
@@ -748,7 +1711,7 @@ mod tests {
         // the Protection API.
         let services = build_services_with_config_and_secret(NoopConfigStore, NoopSecretStore);
         let settings = Settings::default();
-        let request = request_builder()
+        let mut request = request_builder()
             .method(Method::OPTIONS.as_str())
             .uri("https://publisher.example/_ts/api/v1/identify")
             .body(EdgeBody::empty())
@@ -759,7 +1722,7 @@ mod tests {
             RequestFilterInput {
                 settings: &settings,
                 services: &services,
-                request: &request,
+                request: &mut request,
                 geo_info: None,
                 is_integration_route: false,
             },

--- a/crates/trusted-server-core/src/integrations/datadome/protection_scope.rs
+++ b/crates/trusted-server-core/src/integrations/datadome/protection_scope.rs
@@ -91,12 +91,52 @@ pub(super) struct ProtectionRequestFacts<'a> {
     pub(super) asn: Option<u32>,
 }
 
+/// Typed reason why `DataDome` protection was skipped.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(super) enum ProtectionSkipReason {
+    Method,
+    ClientIp,
+    ClientIpSource,
+    Asn,
+    PathExact,
+    PathPrefix,
+    PathRegex,
+    QueryParamNonEmpty,
+    IpCidr,
+    IpCidrSource,
+}
+
+impl ProtectionSkipReason {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Method => "method",
+            Self::ClientIp => "client_ip",
+            Self::ClientIpSource => "client_ip_source",
+            Self::Asn => "asn",
+            Self::PathExact => "path_exact",
+            Self::PathPrefix => "path_prefix",
+            Self::PathRegex => "path_regex",
+            Self::QueryParamNonEmpty => "query_param_non_empty",
+            Self::IpCidr => "ip_cidr",
+            Self::IpCidrSource => "ip_cidr_source",
+        }
+    }
+
+    pub(super) const fn is_ip_based(self) -> bool {
+        matches!(
+            self,
+            Self::ClientIp | Self::ClientIpSource | Self::IpCidr | Self::IpCidrSource
+        )
+    }
+}
+
 /// Result of evaluating whether `DataDome` protection should run.
 pub(super) enum ProtectionScopeDecision {
     Protect,
     Skip {
         rule_id: String,
-        reason: &'static str,
+        reason: ProtectionSkipReason,
+        suppress_client_tag: bool,
     },
 }
 
@@ -210,51 +250,75 @@ impl ProtectionScope {
         facts: &ProtectionRequestFacts<'_>,
         services: &RuntimeServices,
     ) -> ProtectionScopeDecision {
-        if self.excluded_methods.matches(facts.method) {
-            return ProtectionScopeDecision::Skip {
-                rule_id: "excluded-methods".to_string(),
-                reason: "method",
-            };
-        }
+        let mut primary = self
+            .excluded_methods
+            .matches(facts.method)
+            .then(|| ("excluded-methods".to_string(), ProtectionSkipReason::Method));
 
         if let Some(client_ip) = facts.client_ip {
             if cidrs_match(&self.excluded_ip_cidrs, client_ip) {
+                let (rule_id, reason) = primary.unwrap_or_else(|| {
+                    (
+                        "excluded-ip-cidrs".to_string(),
+                        ProtectionSkipReason::ClientIp,
+                    )
+                });
                 return ProtectionScopeDecision::Skip {
-                    rule_id: "excluded-ip-cidrs".to_string(),
-                    reason: "client_ip",
+                    rule_id,
+                    reason,
+                    suppress_client_tag: true,
                 };
             }
 
             for source in &self.excluded_ip_cidr_sources {
                 if source.matches(client_ip, services, self.ip_list_cache_ttl) {
+                    let (rule_id, reason) = primary.unwrap_or_else(|| {
+                        (source.rule_id(), ProtectionSkipReason::ClientIpSource)
+                    });
                     return ProtectionScopeDecision::Skip {
-                        rule_id: source.rule_id(),
-                        reason: "client_ip_source",
+                        rule_id,
+                        reason,
+                        suppress_client_tag: true,
                     };
                 }
             }
         }
 
-        if facts
-            .asn
-            .is_some_and(|asn| self.excluded_asns.contains(&asn))
+        if primary.is_none()
+            && facts
+                .asn
+                .is_some_and(|asn| self.excluded_asns.contains(&asn))
         {
-            return ProtectionScopeDecision::Skip {
-                rule_id: "excluded-asns".to_string(),
-                reason: "asn",
-            };
+            primary = Some(("excluded-asns".to_string(), ProtectionSkipReason::Asn));
         }
 
         for rule in &self.exclusion_rules {
+            let reason = rule.matcher.reason();
+            if primary.is_some() && !reason.is_ip_based() {
+                continue;
+            }
             if rule.matches(facts, services, self.ip_list_cache_ttl) {
-                return ProtectionScopeDecision::Skip {
-                    rule_id: rule.id.clone(),
-                    reason: rule.matcher.reason(),
-                };
+                let suppress_client_tag = reason.is_ip_based();
+                let (rule_id, reason) = primary.unwrap_or_else(|| (rule.id.clone(), reason));
+                if suppress_client_tag {
+                    return ProtectionScopeDecision::Skip {
+                        rule_id,
+                        reason,
+                        suppress_client_tag,
+                    };
+                }
+                primary = Some((rule_id, reason));
             }
         }
 
-        ProtectionScopeDecision::Protect
+        match primary {
+            Some((rule_id, reason)) => ProtectionScopeDecision::Skip {
+                rule_id,
+                reason,
+                suppress_client_tag: false,
+            },
+            None => ProtectionScopeDecision::Protect,
+        }
     }
 }
 
@@ -489,15 +553,15 @@ impl ProtectionMatcher {
         }
     }
 
-    fn reason(&self) -> &'static str {
+    fn reason(&self) -> ProtectionSkipReason {
         match self {
-            ProtectionMatcher::PathExact(_) => "path_exact",
-            ProtectionMatcher::PathPrefix(_) => "path_prefix",
-            ProtectionMatcher::PathRegex(_) => "path_regex",
-            ProtectionMatcher::QueryParamNonEmpty(_) => "query_param_non_empty",
-            ProtectionMatcher::Asn(_) => "asn",
-            ProtectionMatcher::IpCidr(_) => "ip_cidr",
-            ProtectionMatcher::IpCidrSource(_) => "ip_cidr_source",
+            ProtectionMatcher::PathExact(_) => ProtectionSkipReason::PathExact,
+            ProtectionMatcher::PathPrefix(_) => ProtectionSkipReason::PathPrefix,
+            ProtectionMatcher::PathRegex(_) => ProtectionSkipReason::PathRegex,
+            ProtectionMatcher::QueryParamNonEmpty(_) => ProtectionSkipReason::QueryParamNonEmpty,
+            ProtectionMatcher::Asn(_) => ProtectionSkipReason::Asn,
+            ProtectionMatcher::IpCidr(_) => ProtectionSkipReason::IpCidr,
+            ProtectionMatcher::IpCidrSource(_) => ProtectionSkipReason::IpCidrSource,
         }
     }
 }
@@ -741,7 +805,8 @@ mod tests {
         assert!(matches!(
             decision,
             ProtectionScopeDecision::Skip {
-                reason: "method",
+                reason: ProtectionSkipReason::Method,
+                suppress_client_tag: false,
                 ..
             }
         ));
@@ -758,7 +823,11 @@ mod tests {
 
         assert!(matches!(
             decision,
-            ProtectionScopeDecision::Skip { reason: "asn", .. }
+            ProtectionScopeDecision::Skip {
+                reason: ProtectionSkipReason::Asn,
+                suppress_client_tag: false,
+                ..
+            }
         ));
     }
 
@@ -783,7 +852,8 @@ mod tests {
         assert!(matches!(
             decision,
             ProtectionScopeDecision::Skip {
-                reason: "client_ip",
+                reason: ProtectionSkipReason::ClientIp,
+                suppress_client_tag: true,
                 ..
             }
         ));
@@ -817,7 +887,8 @@ mod tests {
         assert!(matches!(
             decision,
             ProtectionScopeDecision::Skip {
-                reason: "client_ip_source",
+                reason: ProtectionSkipReason::ClientIpSource,
+                suppress_client_tag: true,
                 ..
             }
         ));
@@ -840,13 +911,127 @@ mod tests {
         assert!(matches!(
             scope.evaluate(&facts("GET", "/app.JSON", None, None, None), &services),
             ProtectionScopeDecision::Skip {
-                reason: "path_regex",
+                reason: ProtectionSkipReason::PathRegex,
+                suppress_client_tag: false,
                 ..
             }
         ));
         assert!(matches!(
             scope.evaluate(&facts("POST", "/app.JSON", None, None, None), &services),
             ProtectionScopeDecision::Protect
+        ));
+    }
+
+    #[test]
+    fn method_skip_detects_overlapping_inline_ip_exclusion() {
+        let mut config = config_with_protection();
+        config.protection_excluded_methods = vec!["GET".to_string()];
+        config.protection_excluded_ip_cidrs = vec!["192.0.2.0/24".to_string()];
+        let scope = ProtectionScope::compile(&config).expect("should compile scope");
+        let services = crate::platform::test_support::noop_services();
+
+        let decision = scope.evaluate(
+            &facts(
+                "GET",
+                "/page",
+                None,
+                Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))),
+                None,
+            ),
+            &services,
+        );
+
+        assert!(matches!(
+            decision,
+            ProtectionScopeDecision::Skip {
+                reason: ProtectionSkipReason::Method,
+                suppress_client_tag: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn earlier_non_ip_skip_detects_later_structured_ip_exclusion() {
+        for primary_asn in [None, Some(64500)] {
+            let mut config = config_with_protection();
+            config.protection_excluded_asns = primary_asn.into_iter().collect();
+            config.protection_exclusion_rules = vec![
+                ProtectionExclusionRuleConfig {
+                    id: "path".to_string(),
+                    enabled: primary_asn.is_none(),
+                    methods: Vec::new(),
+                    matcher: ProtectionMatcherConfig::PathExact {
+                        paths: vec!["/page".to_string()],
+                    },
+                },
+                ProtectionExclusionRuleConfig {
+                    id: "ip".to_string(),
+                    enabled: true,
+                    methods: Vec::new(),
+                    matcher: ProtectionMatcherConfig::IpCidr {
+                        cidrs: vec!["192.0.2.0/24".to_string()],
+                    },
+                },
+            ];
+            let scope = ProtectionScope::compile(&config).expect("should compile scope");
+            let services = crate::platform::test_support::noop_services();
+
+            let decision = scope.evaluate(
+                &facts(
+                    "GET",
+                    "/page",
+                    None,
+                    Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))),
+                    primary_asn,
+                ),
+                &services,
+            );
+
+            assert!(matches!(
+                decision,
+                ProtectionScopeDecision::Skip {
+                    reason: ProtectionSkipReason::Asn | ProtectionSkipReason::PathExact,
+                    suppress_client_tag: true,
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn method_scoped_structured_ip_does_not_suppress_when_scope_does_not_apply() {
+        let mut config = config_with_protection();
+        config.protection_excluded_methods = vec!["POST".to_string()];
+        config.protection_exclusion_rules = vec![ProtectionExclusionRuleConfig {
+            id: "get-ip".to_string(),
+            enabled: true,
+            methods: vec!["GET".to_string()],
+            matcher: ProtectionMatcherConfig::IpCidr {
+                cidrs: vec!["192.0.2.0/24".to_string()],
+            },
+        }];
+        let scope = ProtectionScope::compile(&config).expect("should compile scope");
+        let services = crate::platform::test_support::noop_services();
+
+        let decision = scope.evaluate(
+            &facts(
+                "POST",
+                "/page",
+                None,
+                Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))),
+                None,
+            ),
+            &services,
+        );
+
+        assert!(matches!(
+            decision,
+            ProtectionScopeDecision::Skip {
+                reason: ProtectionSkipReason::Method,
+                suppress_client_tag: false,
+                ..
+            }
         ));
     }
 
@@ -870,7 +1055,8 @@ mod tests {
                 &services
             ),
             ProtectionScopeDecision::Skip {
-                reason: "query_param_non_empty",
+                reason: ProtectionSkipReason::QueryParamNonEmpty,
+                suppress_client_tag: false,
                 ..
             }
         ));

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -1428,6 +1428,35 @@ mod tests {
     }
 
     #[test]
+    fn head_inserts_queue_gam_attribution_before_guard_and_ad_requests() {
+        let targeting_index = GPT_BOOTSTRAP_JS
+            .find("gpt.setConfig({ targeting: { ts: 'true' } })")
+            .expect("should apply the fixed page-level GAM targeting pair");
+        let guard_index = GPT_BOOTSTRAP_JS
+            .find("if (ts.adInit) return;")
+            .expect("should retain the preinstalled adInit guard");
+        let display_index = GPT_BOOTSTRAP_JS
+            .find("googletag.display(divId);")
+            .expect("should retain the executable GPT display call");
+        let refresh_index = GPT_BOOTSTRAP_JS
+            .find("googletag.pubads().refresh(slotsNeedingRefresh);")
+            .expect("should retain the bounded GPT refresh call");
+
+        assert!(
+            targeting_index < guard_index,
+            "should enqueue attribution before the preinstalled adInit guard"
+        );
+        assert!(
+            targeting_index < display_index,
+            "should enqueue attribution before the executable display call"
+        );
+        assert!(
+            targeting_index < refresh_index,
+            "should enqueue attribution before the executable refresh call"
+        );
+    }
+
+    #[test]
     fn head_injector_integration_id() {
         let integration = GptIntegration::new(test_config());
         assert_eq!(

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -68,6 +68,10 @@ pub struct GptConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
+    /// Enable page-level `ts=true` delivery attribution in GAM.
+    #[serde(default)]
+    pub gam_attribution_enabled: bool,
+
     /// URL for the GPT bootstrap script (default: Google's CDN).
     #[serde(default = "default_script_url")]
     #[validate(url)]
@@ -487,10 +491,17 @@ impl IntegrationHeadInjector for GptIntegration {
     /// route changes (see `auction/endpoints.rs`).
     /// The `POST /auction` endpoint is not involved in scroll or refresh flows.
     fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+        let gam_attribution_flag = self
+            .config
+            .gam_attribution_enabled
+            .then_some("window.__tsjs_gam_attribution_enabled=true;")
+            .unwrap_or_default();
+
         let mut scripts = vec![
-            "<script>window.__tsjs_gpt_enabled=true;\
-             window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>"
-                .to_string(),
+            format!(
+                "<script>window.__tsjs_gpt_enabled=true;{gam_attribution_flag}\
+                 window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>"
+            ),
             format!("<script>{}</script>", GPT_BOOTSTRAP_JS),
         ];
 
@@ -507,6 +518,14 @@ impl IntegrationHeadInjector for GptIntegration {
         }
 
         scripts
+    }
+
+    fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+        if self.config.gam_attribution_enabled {
+            vec![("data-ts-gam-attribution", "true")]
+        } else {
+            Vec::new()
+        }
     }
 }
 
@@ -549,6 +568,7 @@ mod tests {
     fn test_config() -> GptConfig {
         GptConfig {
             enabled: true,
+            gam_attribution_enabled: false,
             script_url: default_script_url(),
             cache_ttl_seconds: 3600,
             rewrite_script: true,
@@ -571,6 +591,29 @@ mod tests {
             .uri(uri)
             .body(EdgeBody::empty())
             .expect("should build HTTP request")
+    }
+
+    #[test]
+    fn gam_attribution_defaults_to_disabled() {
+        let config: GptConfig =
+            serde_json::from_value(serde_json::json!({})).expect("should parse defaults");
+
+        assert!(!config.gam_attribution_enabled);
+    }
+
+    #[test]
+    fn gam_attribution_deserializes_explicit_values() {
+        let disabled: GptConfig = serde_json::from_value(serde_json::json!({
+            "gam_attribution_enabled": false
+        }))
+        .expect("should parse explicit false");
+        let enabled: GptConfig = serde_json::from_value(serde_json::json!({
+            "gam_attribution_enabled": true
+        }))
+        .expect("should parse explicit true");
+
+        assert!(!disabled.gam_attribution_enabled);
+        assert!(enabled.gam_attribution_enabled);
     }
 
     // -- URL detection --
@@ -1145,6 +1188,38 @@ mod tests {
             inserts[0],
             "<script>window.__tsjs_gpt_enabled=true;window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>",
             "should set the enable flag and call the GPT shim activation function"
+        );
+        assert!(
+            integration.tsjs_script_tag_attributes().is_empty(),
+            "should not authorize GAM attribution metadata by default"
+        );
+    }
+
+    #[test]
+    fn gam_attribution_true_adds_both_activation_signals_without_a_new_insert() {
+        let integration = GptIntegration::new(GptConfig {
+            gam_attribution_enabled: true,
+            ..test_config()
+        });
+        let document_state = IntegrationDocumentState::default();
+        let context = IntegrationHtmlContext {
+            request_host: "edge.example.com",
+            request_scheme: "https",
+            origin_host: "origin.example.com",
+            document_state: &document_state,
+        };
+
+        let inserts = integration.head_inserts(&context);
+
+        assert_eq!(inserts.len(), 2, "should not add another head insert");
+        assert!(
+            inserts[0].contains("window.__tsjs_gam_attribution_enabled=true;"),
+            "should activate the early bootstrap marker"
+        );
+        assert_eq!(
+            integration.tsjs_script_tag_attributes(),
+            vec![("data-ts-gam-attribution", "true")],
+            "should authorize the bundle fallback on the publisher tag"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -491,11 +491,11 @@ impl IntegrationHeadInjector for GptIntegration {
     /// route changes (see `auction/endpoints.rs`).
     /// The `POST /auction` endpoint is not involved in scroll or refresh flows.
     fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
-        let gam_attribution_flag = self
-            .config
-            .gam_attribution_enabled
-            .then_some("window.__tsjs_gam_attribution_enabled=true;")
-            .unwrap_or_default();
+        let gam_attribution_flag = if self.config.gam_attribution_enabled {
+            "window.__tsjs_gam_attribution_enabled=true;"
+        } else {
+            ""
+        };
 
         let mut scripts = vec![
             format!(

--- a/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
+++ b/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
@@ -17,6 +17,24 @@
 (function () {
   if (typeof window === "undefined") return;
   var ts = (window.tsjs = window.tsjs || {});
+  var tag;
+
+  if (window.__tsjs_gam_attribution_enabled === true) {
+    tag = window.googletag = window.googletag || { cmd: [] };
+    tag.cmd = tag.cmd || [];
+    tag.cmd.push(function () {
+      try {
+        var gpt = window.googletag;
+        if (gpt && typeof gpt.setConfig === "function") {
+          // "ts" is the fixed GAM key, not the local window.tsjs alias.
+          gpt.setConfig({ targeting: { ts: 'true' } });
+        }
+      } catch (_) {
+        // Attribution must not interrupt the existing bootstrap queue.
+      }
+    });
+  }
+
   if (ts.adInit) return;
 
   // Track whether the publisher disabled GPT initial load. Read the effective
@@ -38,7 +56,9 @@
     return true;
   }
 
-  (window.googletag = window.googletag || { cmd: [] }).cmd.push(function () {
+  tag = tag || (window.googletag = window.googletag || { cmd: [] });
+  tag.cmd = tag.cmd || [];
+  tag.cmd.push(function () {
     var gpt = window.googletag;
     syncInitialLoadDisabled(gpt);
     if (

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
@@ -98,17 +98,19 @@ pub struct IntegrationScriptContext<'a> {
     pub document_state: &'a IntegrationDocumentState,
 }
 
+type IntegrationDocumentStateMap = BTreeMap<(&'static str, TypeId), Arc<dyn Any + Send + Sync>>;
+
 /// Per-document state shared between HTML/script rewriters and post-processors.
 ///
 /// This exists to support multi-phase HTML processing without requiring a second HTML parse.
 #[derive(Clone, Default)]
 pub struct IntegrationDocumentState {
-    inner: Arc<Mutex<BTreeMap<&'static str, Arc<dyn Any + Send + Sync>>>>,
+    inner: Arc<Mutex<IntegrationDocumentStateMap>>,
 }
 
 impl std::fmt::Debug for IntegrationDocumentState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let keys: Vec<&'static str> = {
+        let keys: Vec<(&'static str, TypeId)> = {
             let guard = self
                 .inner
                 .lock()
@@ -136,7 +138,7 @@ impl IntegrationDocumentState {
             .inner
             .lock()
             .expect("should lock integration document state");
-        let value = guard.get(integration_id)?;
+        let value = guard.get(&(integration_id, TypeId::of::<T>()))?;
         let cloned: Arc<dyn Any + Send + Sync> = Arc::clone(value);
         cloned.downcast::<T>().ok()
     }
@@ -159,17 +161,15 @@ impl IntegrationDocumentState {
             .lock()
             .expect("should lock integration document state");
 
-        if let Some(existing) = guard.get(integration_id)
+        let key = (integration_id, TypeId::of::<T>());
+        if let Some(existing) = guard.get(&key)
             && let Ok(downcast) = Arc::clone(existing).downcast::<T>()
         {
             return downcast;
         }
 
         let value: Arc<T> = Arc::new(init());
-        guard.insert(
-            integration_id,
-            Arc::clone(&value) as Arc<dyn Any + Send + Sync>,
-        );
+        guard.insert(key, Arc::clone(&value) as Arc<dyn Any + Send + Sync>);
         value
     }
 
@@ -327,7 +327,7 @@ pub trait IntegrationProxy: Send + Sync {
 pub struct RequestFilterInput<'a> {
     pub settings: &'a Settings,
     pub services: &'a RuntimeServices,
-    pub request: &'a Request<EdgeBody>,
+    pub request: &'a mut Request<EdgeBody>,
     pub geo_info: Option<&'a GeoInfo>,
     /// Whether the request matches a registered integration proxy route.
     pub is_integration_route: bool,
@@ -1345,6 +1345,8 @@ mod tests {
     }
 
     struct EnrichingRequestFilter;
+    #[derive(Clone, Copy)]
+    struct RequestAnnotation;
 
     #[async_trait(?Send)]
     impl IntegrationRequestFilter for EnrichingRequestFilter {
@@ -1354,8 +1356,9 @@ mod tests {
 
         async fn filter_request(
             &self,
-            _input: RequestFilterInput<'_>,
+            input: RequestFilterInput<'_>,
         ) -> Result<RequestFilterDecision, Report<TrustedServerError>> {
+            input.request.extensions_mut().insert(RequestAnnotation);
             Ok(RequestFilterDecision::Continue(RequestFilterEffects {
                 request_headers: vec![HeaderMutation::set("x-datadome-isbot", "1")],
                 response_headers: vec![HeaderMutation::set("x-dd-b", "allowed")],
@@ -1400,6 +1403,37 @@ mod tests {
                 .expect("should build echo response");
             Ok(response)
         }
+    }
+
+    #[test]
+    fn document_state_keeps_multiple_types_for_one_integration() {
+        let state = IntegrationDocumentState::default();
+        let number = state.get_or_insert_with("test", || 7_u32);
+        let label = state.get_or_insert_with("test", || "first".to_string());
+        let repeated_number = state.get_or_insert_with("test", || 99_u32);
+
+        assert!(
+            Arc::ptr_eq(&number, &repeated_number),
+            "repeated insertion should preserve the original typed state"
+        );
+        assert_eq!(
+            *state.get::<u32>("test").expect("should retrieve number"),
+            7,
+            "should retain numeric state"
+        );
+        assert_eq!(
+            state
+                .get::<String>("test")
+                .expect("should retrieve label")
+                .as_str(),
+            "first",
+            "should retain string state under the same integration ID"
+        );
+        assert_eq!(
+            label.as_str(),
+            "first",
+            "should return inserted string state"
+        );
     }
 
     #[test]
@@ -1486,6 +1520,10 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("1"),
             "should apply DataDome-style request enrichment before routing"
+        );
+        assert!(
+            req.extensions().get::<RequestAnnotation>().is_some(),
+            "should preserve private request annotations for downstream routing"
         );
         match outcome {
             RequestFilterRegistryOutcome::Continue(effects) => {

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -1058,6 +1058,16 @@ impl IntegrationRegistry {
         inserts
     }
 
+    /// Collect static attributes for the publisher TSJS bundle tag.
+    #[must_use]
+    pub fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+        self.inner
+            .head_injectors
+            .iter()
+            .flat_map(|injector| injector.tsjs_script_tag_attributes())
+            .collect()
+    }
+
     /// Provide a snapshot of registered integrations and their hooks.
     #[must_use]
     pub fn registered_integrations(&self) -> Vec<IntegrationMetadata> {
@@ -1325,6 +1335,58 @@ mod tests {
     use crate::constants::COOKIE_TS_EC;
     use crate::platform::test_support::noop_services;
     use http::{HeaderValue, StatusCode, header};
+
+    struct DefaultMetadataHeadInjector;
+
+    impl IntegrationHeadInjector for DefaultMetadataHeadInjector {
+        fn integration_id(&self) -> &'static str {
+            "default-metadata"
+        }
+
+        fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    struct StaticMetadataHeadInjector;
+
+    impl IntegrationHeadInjector for StaticMetadataHeadInjector {
+        fn integration_id(&self) -> &'static str {
+            "static-metadata"
+        }
+
+        fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+            vec![
+                ("data-ts-gam-attribution", "true"),
+                ("data-test-order", "second"),
+            ]
+        }
+    }
+
+    #[test]
+    fn tsjs_script_tag_attributes_preserve_registration_order_and_default_empty() {
+        let registry = IntegrationRegistry::from_rewriters_with_head_injectors(
+            Vec::new(),
+            Vec::new(),
+            vec![
+                Arc::new(DefaultMetadataHeadInjector),
+                Arc::new(StaticMetadataHeadInjector),
+            ],
+        );
+
+        assert_eq!(
+            registry.tsjs_script_tag_attributes(),
+            vec![
+                ("data-ts-gam-attribution", "true"),
+                ("data-test-order", "second"),
+            ],
+            "should omit default-empty metadata and preserve registered attribute order"
+        );
+    }
 
     // Mock integration proxy for testing
     struct MockProxy;

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -575,6 +575,11 @@ pub trait IntegrationHeadInjector: Send + Sync {
     fn integration_id(&self) -> &'static str;
     /// Return HTML snippets to insert at the start of `<head>`.
     fn head_inserts(&self, ctx: &IntegrationHtmlContext<'_>) -> Vec<String>;
+
+    /// Return attributes to add to the publisher TSJS bundle tag.
+    fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+        Vec::new()
+    }
 }
 
 /// Registration payload returned by integration builders.

--- a/crates/trusted-server-core/src/platform/test_support.rs
+++ b/crates/trusted-server-core/src/platform/test_support.rs
@@ -631,6 +631,25 @@ pub(crate) fn build_services_with_config_and_secret(
         .build()
 }
 
+pub(crate) fn build_services_with_config_and_secret_and_client_ip(
+    config_store: impl PlatformConfigStore + 'static,
+    secret_store: impl PlatformSecretStore + 'static,
+    client_ip: IpAddr,
+) -> RuntimeServices {
+    RuntimeServices::builder()
+        .config_store(Arc::new(config_store))
+        .secret_store(Arc::new(secret_store))
+        .kv_store(Arc::new(edgezero_core::key_value_store::NoopKvStore))
+        .backend(Arc::new(NoopBackend))
+        .http_client(Arc::new(NoopHttpClient))
+        .geo(Arc::new(NoopGeo))
+        .client_info(ClientInfo {
+            client_ip: Some(client_ip),
+            ..ClientInfo::default()
+        })
+        .build()
+}
+
 pub(crate) fn build_request_signing_services() -> RuntimeServices {
     let signing_key = SigningKey::generate(&mut OsRng);
     let key_b64 = general_purpose::STANDARD.encode(signing_key.as_bytes());
@@ -751,6 +770,14 @@ pub(crate) fn build_services_with_secret_and_http_client(
     secret_store: impl PlatformSecretStore + 'static,
     http_client: Arc<dyn PlatformHttpClient>,
 ) -> RuntimeServices {
+    build_services_with_secret_http_client_and_client_ip(secret_store, http_client, None)
+}
+
+pub(crate) fn build_services_with_secret_http_client_and_client_ip(
+    secret_store: impl PlatformSecretStore + 'static,
+    http_client: Arc<dyn PlatformHttpClient>,
+    client_ip: Option<IpAddr>,
+) -> RuntimeServices {
     RuntimeServices::builder()
         .config_store(Arc::new(NoopConfigStore))
         .secret_store(Arc::new(secret_store))
@@ -759,7 +786,7 @@ pub(crate) fn build_services_with_secret_and_http_client(
         .http_client(http_client)
         .geo(Arc::new(NoopGeo))
         .client_info(ClientInfo {
-            client_ip: None,
+            client_ip,
             tls_protocol: None,
             tls_cipher: None,
             ..ClientInfo::default()

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -8736,9 +8736,14 @@ mod tests {
 
         #[test]
         fn ad_slots_script_contains_slot_data() {
-            let slots = vec![make_slot()];
+            let mut slot = make_slot();
+            slot.targeting
+                .insert("ts".to_string(), "operator-value".to_string());
+            let slots = vec![slot];
             let config = make_config();
             let script = build_ad_slots_script(&slots, &config, "/");
+            let slot_json = crate::publisher::build_slot_json(&slots[0], &config, "example")
+                .expect("should build slot JSON");
             assert!(
                 script.contains("window.tsjs=window.tsjs||{}"),
                 "should initialise tsjs namespace"
@@ -8752,6 +8757,10 @@ mod tests {
             assert!(
                 !script.contains("__ts_request_id"),
                 "must NOT contain request_id"
+            );
+            assert_eq!(
+                slot_json["targeting"]["ts"], "operator-value",
+                "should forward operator-provided ts targeting verbatim"
             );
         }
 

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -59,7 +59,7 @@ use crate::http_util::{RequestInfo, is_navigation_request, serve_static_with_eta
 use crate::integrations::IntegrationRegistry;
 use crate::platform::{GeoInfo, PlatformBackendSpec, PlatformHttpRequest, RuntimeServices};
 use crate::price_bucket::{PriceGranularity, price_bucket};
-use crate::response_privacy::CDN_CACHE_HEADERS;
+use crate::response_privacy::enforce_synthesized_html_cache_privacy;
 use crate::rsc_flight::RscFlightUrlRewriter;
 use crate::settings::Settings;
 use crate::streaming_processor::{
@@ -358,6 +358,7 @@ struct ProcessResponseParams<'a> {
     integration_registry: &'a IntegrationRegistry,
     ad_slots_script: Option<&'a str>,
     ad_bids_state: &'a Arc<Mutex<Option<String>>>,
+    suppress_datadome_client_side_tag: bool,
     gpt_diagnostics:
         Option<&'a crate::integrations::gpt_diagnostics::GptDiagnosticsRequestDecision>,
 }
@@ -384,6 +385,7 @@ impl PublisherBodyProcessor {
                 integration_registry,
                 ad_slots_script: params.ad_slots_script.as_deref().map(str::to_string),
                 ad_bids_state: Arc::clone(&params.ad_bids_state),
+                suppress_datadome_client_side_tag: params.suppress_datadome_client_side_tag,
                 gpt_diagnostics: params.gpt_diagnostics.clone(),
             })?)
         } else if is_rsc_flight {
@@ -461,6 +463,7 @@ fn process_response_streaming<W: Write>(
             integration_registry: params.integration_registry,
             ad_slots_script: params.ad_slots_script.map(str::to_string),
             ad_bids_state: params.ad_bids_state.clone(),
+            suppress_datadome_client_side_tag: params.suppress_datadome_client_side_tag,
             gpt_diagnostics: params.gpt_diagnostics.cloned(),
         })?;
         StreamingPipeline::new(config, processor)
@@ -945,6 +948,7 @@ struct HtmlStreamProcessorParams<'a> {
     integration_registry: &'a IntegrationRegistry,
     ad_slots_script: Option<String>,
     ad_bids_state: Arc<Mutex<Option<String>>>,
+    suppress_datadome_client_side_tag: bool,
     gpt_diagnostics: Option<crate::integrations::gpt_diagnostics::GptDiagnosticsRequestDecision>,
 }
 
@@ -961,7 +965,8 @@ fn create_html_stream_processor(
         params.request_scheme,
     )
     .with_ad_state(params.ad_slots_script, params.ad_bids_state)
-    .with_gpt_diagnostics(params.gpt_diagnostics);
+    .with_gpt_diagnostics(params.gpt_diagnostics)
+    .with_datadome_client_tag_suppression(params.suppress_datadome_client_side_tag);
 
     Ok(create_html_processor(config))
 }
@@ -1082,6 +1087,8 @@ pub struct OwnedProcessResponseParams {
     pub(crate) dispatched_auction: Option<DispatchedAuction>,
     /// Price granularity used to bucket bids when building `tsjs.bids`.
     pub(crate) price_granularity: PriceGranularity,
+    /// Whether to omit Trusted Server's automatic `DataDome` client-side tag.
+    pub(crate) suppress_datadome_client_side_tag: bool,
     /// Request-scoped conditional diagnostics delivery decision.
     pub(crate) gpt_diagnostics:
         Option<crate::integrations::gpt_diagnostics::GptDiagnosticsRequestDecision>,
@@ -1417,6 +1424,30 @@ pub async fn publisher_response_into_streaming_response(
     }
 }
 
+/// Returns whether a request can render an HTML document context.
+fn is_html_document_request(req: &Request<EdgeBody>) -> bool {
+    if let Some(destination) = req
+        .headers()
+        .get("sec-fetch-dest")
+        .and_then(|value| value.to_str().ok())
+    {
+        return matches!(
+            destination.trim().to_ascii_lowercase().as_str(),
+            "document" | "embed" | "fencedframe" | "frame" | "iframe" | "object"
+        );
+    }
+
+    is_navigation_request(req)
+}
+
+/// Removes request headers that can produce a bodyless or partial origin response.
+fn strip_conditional_and_range_headers(req: &mut Request<EdgeBody>) {
+    req.headers_mut().remove(header::IF_NONE_MATCH);
+    req.headers_mut().remove(header::IF_MODIFIED_SINCE);
+    req.headers_mut().remove(header::RANGE);
+    req.headers_mut().remove(header::IF_RANGE);
+}
+
 /// Returns `true` when a buffered publisher response should carry a body and a
 /// recomputed `Content-Length`.
 ///
@@ -1430,6 +1461,21 @@ fn response_carries_body(method: &Method, status: StatusCode) -> bool {
         && status != StatusCode::NO_CONTENT
         && status != StatusCode::RESET_CONTENT
         && status != StatusCode::NOT_MODIFIED
+}
+
+/// Prevent shared caches from replaying tag-suppressed HTML to other clients.
+fn apply_datadome_client_tag_cache_privacy(
+    response: &mut Response<EdgeBody>,
+    method: &Method,
+    suppress_datadome_client_side_tag: bool,
+    content_type: &str,
+) {
+    if suppress_datadome_client_side_tag
+        && response_carries_body(method, response.status())
+        && is_html_content_type(content_type)
+    {
+        enforce_synthesized_html_cache_privacy(response);
+    }
 }
 
 /// Drop a bodiless response's body and correct its framing headers.
@@ -1548,6 +1594,7 @@ pub fn stream_publisher_body<W: Write>(
         integration_registry,
         ad_slots_script: params.ad_slots_script.as_deref(),
         ad_bids_state: &params.ad_bids_state,
+        suppress_datadome_client_side_tag: params.suppress_datadome_client_side_tag,
         gpt_diagnostics: params.gpt_diagnostics.as_ref(),
     };
     process_response_streaming(body, output, &borrowed)
@@ -1641,6 +1688,7 @@ pub async fn stream_publisher_body_async<W: Write>(
         integration_registry,
         ad_slots_script: params.ad_slots_script.as_deref().map(str::to_string),
         ad_bids_state: params.ad_bids_state.clone(),
+        suppress_datadome_client_side_tag: params.suppress_datadome_client_side_tag,
         gpt_diagnostics: params.gpt_diagnostics.clone(),
     }) {
         Ok(processor) => processor,
@@ -2846,11 +2894,16 @@ pub async fn handle_publisher_request(
         }
     );
 
-    if should_run_ad_stack {
-        req.headers_mut().remove(header::IF_NONE_MATCH);
-        req.headers_mut().remove(header::IF_MODIFIED_SINCE);
-        req.headers_mut().remove(header::RANGE);
-        req.headers_mut().remove(header::IF_RANGE);
+    let suppress_datadome_client_side_tag = req
+        .extensions()
+        .get::<crate::integrations::datadome::DataDomeClientTagSuppressed>()
+        .is_some();
+    if should_run_ad_stack || (suppress_datadome_client_side_tag && is_html_document_request(&req))
+    {
+        // HTML document contexts whose output may be synthesized must not
+        // receive a cached 304 or partial 206. Non-document subresources contain
+        // no executable injected tag, so retain their validators and ranges.
+        strip_conditional_and_range_headers(&mut req);
     }
 
     // Only advertise encodings the rewrite pipeline can decode and re-encode.
@@ -2876,6 +2929,7 @@ pub async fn handle_publisher_request(
     // sets the flag unconditionally and tolerates buffered fallback): adapters
     // without streaming support may reject the flag outright rather than
     // silently buffering, which would fail every publisher fetch.
+    let request_method = req.method().clone();
     let mut platform_request = PlatformHttpRequest::new(req, backend_name);
     if services.http_client().supports_streaming_responses() {
         platform_request = platform_request.with_stream_response();
@@ -2960,23 +3014,7 @@ pub async fn handle_publisher_request(
         .and_then(|h| h.to_str().ok())
         .unwrap_or_default();
     if should_run_ad_stack && is_html_content_type(origin_content_type) {
-        response.headers_mut().insert(
-            header::CACHE_CONTROL,
-            HeaderValue::from_static("private, no-store"),
-        );
-        response.headers_mut().remove(header::ETAG);
-        response.headers_mut().remove(header::LAST_MODIFIED);
-        // Every CDN-targeted cache directive, not just the browser-facing
-        // `Cache-Control` above: an origin emitting any of these would otherwise
-        // instruct an intermediary to store a synthesized per-navigation
-        // document. `Surrogate-Control` and `Fastly-Surrogate-Control` cover
-        // Fastly; `CDN-Cache-Control` is the standard targeted field (RFC 9213)
-        // and `Cloudflare-CDN-Cache-Control` is the Cloudflare-specific field
-        // that overrides it there, so both are needed to close the gap on the
-        // Cloudflare adapter.
-        for directive in CDN_CACHE_HEADERS {
-            response.headers_mut().remove(*directive);
-        }
+        enforce_synthesized_html_cache_privacy(&mut response);
     }
 
     let content_type = response
@@ -3068,6 +3106,12 @@ pub async fn handle_publisher_request(
                 content_encoding
             );
 
+            apply_datadome_client_tag_cache_privacy(
+                &mut response,
+                &request_method,
+                suppress_datadome_client_side_tag,
+                &content_type,
+            );
             let body = std::mem::replace(response.body_mut(), EdgeBody::empty());
             response.headers_mut().remove(header::CONTENT_LENGTH);
 
@@ -3083,6 +3127,7 @@ pub async fn handle_publisher_request(
                     content_type,
                     ad_slots_script: ad_slots_script.clone(),
                     ad_bids_state: ad_bids_state.clone(),
+                    suppress_datadome_client_side_tag,
                     auction_observation,
                     auction_request: auction_request_for_telemetry,
                     dispatched_auction,
@@ -4156,7 +4201,8 @@ mod tests {
     use crate::auction::types::{AdFormat, AdSlot, MediaType};
     use crate::integrations::IntegrationRegistry;
     use crate::platform::test_support::{
-        StubHttpClient, build_services_with_http_client, noop_services,
+        NoopSecretStore, StubHttpClient, build_services_with_http_client,
+        build_services_with_secret_http_client_and_client_ip, noop_services,
         noop_services_with_telemetry_sink,
     };
     use crate::test_support::tests::create_test_settings;
@@ -4444,6 +4490,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: Default::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         }
     }
 
@@ -5323,6 +5370,152 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn suppressed_navigation_removes_conditional_and_range_headers() {
+        let settings = create_test_settings();
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response_with_headers(
+            200,
+            b"<html><body>origin</body></html>".to_vec(),
+            vec![("content-type", "text/html; charset=utf-8")],
+        );
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let mut req = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("https://publisher.example/page")
+            .header(header::HOST, "publisher.example")
+            .header("sec-fetch-dest", "document")
+            .header(header::IF_NONE_MATCH, "\"cached-page\"")
+            .header(header::IF_MODIFIED_SINCE, "Wed, 21 Oct 2015 07:28:00 GMT")
+            .header(header::RANGE, "bytes=0-18")
+            .header(header::IF_RANGE, "\"cached-page\"")
+            .body(EdgeBody::empty())
+            .expect("should build conditional request");
+        req.extensions_mut()
+            .insert(crate::integrations::datadome::DataDomeClientTagSuppressed);
+
+        let _response = run_publisher_proxy(&settings, &services, req).await;
+
+        let headers = stub
+            .recorded_request_headers()
+            .into_iter()
+            .next()
+            .expect("should record one outbound request");
+        for header_name in [
+            header::IF_NONE_MATCH,
+            header::IF_MODIFIED_SINCE,
+            header::RANGE,
+            header::IF_RANGE,
+        ] {
+            assert!(
+                headers
+                    .iter()
+                    .all(|(name, _)| !name.eq_ignore_ascii_case(header_name.as_str())),
+                "suppressed navigations must not forward {header_name}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn suppressed_iframe_removes_conditional_and_range_headers() {
+        let settings = create_test_settings();
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response_with_headers(
+            200,
+            b"<html><body>frame</body></html>".to_vec(),
+            vec![("content-type", "text/html; charset=utf-8")],
+        );
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let mut req = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("https://publisher.example/frame")
+            .header(header::HOST, "publisher.example")
+            .header("sec-fetch-dest", "iframe")
+            .header(header::IF_NONE_MATCH, "\"cached-frame\"")
+            .header(header::IF_MODIFIED_SINCE, "Wed, 21 Oct 2015 07:28:00 GMT")
+            .header(header::RANGE, "bytes=0-18")
+            .header(header::IF_RANGE, "\"cached-frame\"")
+            .body(EdgeBody::empty())
+            .expect("should build conditional iframe request");
+        req.extensions_mut()
+            .insert(crate::integrations::datadome::DataDomeClientTagSuppressed);
+
+        let _response = run_publisher_proxy(&settings, &services, req).await;
+
+        let headers = stub
+            .recorded_request_headers()
+            .into_iter()
+            .next()
+            .expect("should record one outbound request");
+        for header_name in [
+            header::IF_NONE_MATCH,
+            header::IF_MODIFIED_SINCE,
+            header::RANGE,
+            header::IF_RANGE,
+        ] {
+            assert!(
+                headers
+                    .iter()
+                    .all(|(name, _)| !name.eq_ignore_ascii_case(header_name.as_str())),
+                "suppressed iframe documents must not forward {header_name}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn suppressed_subresource_preserves_conditional_and_range_headers() {
+        let settings = create_test_settings();
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response_with_headers(
+            200,
+            b"video".to_vec(),
+            vec![("content-type", "video/mp4")],
+        );
+        let services = build_services_with_http_client(
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>
+        );
+        let mut req = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("https://publisher.example/video.mp4")
+            .header(header::HOST, "publisher.example")
+            .header("sec-fetch-dest", "video")
+            .header(header::IF_NONE_MATCH, "\"cached-video\"")
+            .header(header::IF_MODIFIED_SINCE, "Wed, 21 Oct 2015 07:28:00 GMT")
+            .header(header::RANGE, "bytes=0-18")
+            .header(header::IF_RANGE, "\"cached-video\"")
+            .body(EdgeBody::empty())
+            .expect("should build conditional subresource request");
+        req.extensions_mut()
+            .insert(crate::integrations::datadome::DataDomeClientTagSuppressed);
+
+        let _response = run_publisher_proxy(&settings, &services, req).await;
+
+        let headers = stub
+            .recorded_request_headers()
+            .into_iter()
+            .next()
+            .expect("should record one outbound request");
+        for (header_name, expected) in [
+            (header::IF_NONE_MATCH, "\"cached-video\""),
+            (header::IF_MODIFIED_SINCE, "Wed, 21 Oct 2015 07:28:00 GMT"),
+            (header::RANGE, "bytes=0-18"),
+            (header::IF_RANGE, "\"cached-video\""),
+        ] {
+            assert_eq!(
+                headers
+                    .iter()
+                    .find(|(name, _)| name.eq_ignore_ascii_case(header_name.as_str()))
+                    .map(|(_, value)| value.as_str()),
+                Some(expected),
+                "suppressed subresources should preserve {header_name}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn publisher_origin_fetch_leaves_stream_response_disabled_when_unsupported() {
         let settings = create_test_settings();
         let stub = Arc::new(StubHttpClient::new());
@@ -5434,6 +5627,233 @@ mod tests {
             ec_context.ec_value(),
             None,
             "handler must not self-generate an EC ID; generation is the adapter's real-browser-gated responsibility",
+        );
+    }
+
+    #[tokio::test]
+    async fn datadome_filter_marker_survives_into_publisher_html_pipeline() {
+        let mut settings = create_test_settings();
+        settings
+            .integrations
+            .insert_config(
+                "datadome",
+                &serde_json::json!({
+                    "enabled": true,
+                    "enable_protection": true,
+                    "protection_excluded_ip_cidrs": ["192.0.2.0/24"],
+                    "client_side_key": "test-client-key",
+                }),
+            )
+            .expect("should configure DataDome integration");
+        let registry = IntegrationRegistry::new(&settings)
+            .expect("should create integration registry with DataDome");
+        let stub = Arc::new(StubHttpClient::new());
+        stub.push_response_with_headers(
+            200,
+            b"<html><head></head><body>content</body></html>".to_vec(),
+            vec![("content-type", "text/html; charset=utf-8")],
+        );
+        let services = build_services_with_secret_http_client_and_client_ip(
+            NoopSecretStore,
+            Arc::clone(&stub) as Arc<dyn crate::platform::PlatformHttpClient>,
+            Some("192.0.2.10".parse().expect("should parse client IP")),
+        );
+        let mut req = HttpRequest::builder()
+            .method(Method::GET)
+            .uri("https://publisher.example/page")
+            .header(header::HOST, "publisher.example")
+            .header("sec-fetch-dest", "document")
+            .body(EdgeBody::empty())
+            .expect("should build request");
+
+        let filter_outcome = registry
+            .filter_request(crate::integrations::RequestFilterRegistryInput {
+                settings: &settings,
+                services: &services,
+                req: &mut req,
+                geo_info: None,
+            })
+            .await
+            .expect("should run DataDome filter");
+        assert!(matches!(
+            filter_outcome,
+            crate::integrations::RequestFilterRegistryOutcome::Continue(_)
+        ));
+        let publisher_response = run_publisher_proxy(&settings, &services, req).await;
+        let response = buffer_publisher_response_async(
+            publisher_response,
+            &Method::GET,
+            &settings,
+            &registry,
+            &AuctionOrchestrator::new(settings.auction.clone()),
+            &services,
+        )
+        .await
+        .expect("should buffer publisher response");
+        let html = response_body_string(response);
+
+        assert!(!html.contains("window.ddjskey"));
+        assert!(!html.contains("/integrations/datadome/tags.js"));
+        assert_eq!(
+            stub.recorded_backend_names().len(),
+            1,
+            "only the publisher origin should be called"
+        );
+    }
+
+    #[test]
+    fn suppressed_datadome_tag_reaches_publisher_html_pipeline() {
+        let mut settings = create_test_settings();
+        settings
+            .integrations
+            .insert_config(
+                "datadome",
+                &serde_json::json!({
+                    "enabled": true,
+                    "client_side_key": "test-client-key",
+                }),
+            )
+            .expect("should configure DataDome integration");
+        let registry = IntegrationRegistry::new(&settings)
+            .expect("should create integration registry with DataDome");
+        let mut params = make_stream_params(&settings, "identity");
+        params.content_type = "text/html; charset=utf-8".to_string();
+        params.suppress_datadome_client_side_tag = true;
+        let mut output = Vec::new();
+
+        stream_publisher_body(
+            EdgeBody::from(b"<html><head></head><body>content</body></html>".to_vec()),
+            &mut output,
+            &params,
+            &settings,
+            &registry,
+        )
+        .expect("should process suppressed HTML");
+
+        let html = String::from_utf8(output).expect("should produce UTF-8 HTML");
+        assert!(
+            !html.contains("window.ddjskey"),
+            "publisher processing should omit the DataDome client configuration"
+        );
+        assert!(
+            !html.contains("/integrations/datadome/tags.js"),
+            "publisher processing should omit the DataDome client tag URL"
+        );
+    }
+
+    #[test]
+    fn suppressed_datadome_html_is_private_and_not_shared_cached() {
+        let mut response = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CACHE_CONTROL, "public, max-age=600")
+            .header("surrogate-control", "max-age=600")
+            .header("fastly-surrogate-control", "max-age=600")
+            .header("cloudflare-cdn-cache-control", "max-age=600")
+            .header("cdn-cache-control", "max-age=600")
+            .header(header::ETAG, "\"origin-tag\"")
+            .header(header::LAST_MODIFIED, "Wed, 21 Oct 2015 07:28:00 GMT")
+            .body(EdgeBody::empty())
+            .expect("should build cacheable HTML response");
+
+        super::apply_datadome_client_tag_cache_privacy(
+            &mut response,
+            &Method::GET,
+            true,
+            "text/html; charset=utf-8",
+        );
+
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("private, no-store"),
+            "suppressed HTML should be private and non-storable"
+        );
+        assert!(
+            response.headers().get("surrogate-control").is_none(),
+            "suppressed HTML should not retain Surrogate-Control"
+        );
+        assert!(
+            response.headers().get("fastly-surrogate-control").is_none(),
+            "suppressed HTML should not retain Fastly-Surrogate-Control"
+        );
+        assert!(
+            response
+                .headers()
+                .get("cloudflare-cdn-cache-control")
+                .is_none(),
+            "suppressed HTML should not retain Cloudflare-CDN-Cache-Control"
+        );
+        assert!(
+            response.headers().get("cdn-cache-control").is_none(),
+            "suppressed HTML should not retain CDN-Cache-Control"
+        );
+        for header_name in [header::ETAG, header::LAST_MODIFIED] {
+            assert!(
+                !response.headers().contains_key(&header_name),
+                "suppressed HTML should not retain {header_name}"
+            );
+        }
+
+        let mut no_store_response = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CACHE_CONTROL, "no-store")
+            .body(EdgeBody::empty())
+            .expect("should build no-store HTML response");
+        super::apply_datadome_client_tag_cache_privacy(
+            &mut no_store_response,
+            &Method::GET,
+            true,
+            "text/html; charset=utf-8",
+        );
+        assert_eq!(
+            no_store_response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("private, no-store"),
+            "suppressed HTML should use the exact synthesized-HTML policy"
+        );
+    }
+
+    #[test]
+    fn datadome_cache_privacy_does_not_change_non_html_or_unsuppressed_responses() {
+        let mut response = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CACHE_CONTROL, "public, max-age=600")
+            .header("surrogate-control", "max-age=600")
+            .body(EdgeBody::empty())
+            .expect("should build cacheable response");
+
+        super::apply_datadome_client_tag_cache_privacy(
+            &mut response,
+            &Method::GET,
+            false,
+            "text/html; charset=utf-8",
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("public, max-age=600"),
+            "unsuppressed HTML should retain its existing cache policy"
+        );
+
+        super::apply_datadome_client_tag_cache_privacy(
+            &mut response,
+            &Method::GET,
+            true,
+            "text/css",
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("public, max-age=600"),
+            "non-HTML should retain its existing cache policy"
         );
     }
 
@@ -6392,6 +6812,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
 
         let mut output = Vec::new();
@@ -6440,6 +6861,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
 
         let mut output = Vec::new();
@@ -6477,6 +6899,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let body = EdgeBody::from_stream(futures::stream::iter(vec![Ok::<_, io::Error>(
             bytes::Bytes::from_static(b"<html><body>live</body></html>"),
@@ -6592,6 +7015,7 @@ mod tests {
                 dispatched_auction: None,
                 price_granularity: crate::price_bucket::PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             };
             let body = EdgeBody::stream(futures::stream::iter(vec![
                 bytes::Bytes::from_static(b"body{background:url('https://origin.example.com/"),
@@ -6645,6 +7069,7 @@ mod tests {
                 dispatched_auction: None,
                 price_granularity: crate::price_bucket::PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             };
             let compressed =
                 gzip_encode(b"body{background:url('https://origin.example.com/asset.png')}");
@@ -6701,6 +7126,7 @@ mod tests {
                 dispatched_auction: None,
                 price_granularity: crate::price_bucket::PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             };
             let compressed =
                 deflate_encode(b"body{background:url('https://origin.example.com/asset.png')}");
@@ -6757,6 +7183,7 @@ mod tests {
                 dispatched_auction: None,
                 price_granularity: crate::price_bucket::PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             };
             let compressed =
                 brotli_encode(b"body{background:url('https://origin.example.com/asset.png')}");
@@ -6813,6 +7240,7 @@ mod tests {
                 dispatched_auction: None,
                 price_granularity: crate::price_bucket::PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             };
             let compressed =
                 brotli_encode(b"body{background:url('https://origin.example.com/asset.png')}");
@@ -6857,6 +7285,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         }
     }
 
@@ -7051,6 +7480,7 @@ mod tests {
                 )),
                 price_granularity: crate::price_bucket::PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             };
             let body = EdgeBody::stream(futures::stream::iter(vec![
                 bytes::Bytes::from_static(b"<html><head></head><body>hello"),
@@ -7115,6 +7545,7 @@ mod tests {
                 )),
                 price_granularity: crate::price_bucket::PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             };
             // The `</body>` that triggers bid injection lives in the SECOND gzip
             // member. `flate2::read::GzDecoder` decodes only the first member, so
@@ -7178,6 +7609,7 @@ mod tests {
                 )),
                 price_granularity: crate::price_bucket::PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             };
             let body = EdgeBody::stream(futures::stream::iter(vec![bytes::Bytes::from_static(
                 b"body{background:url('https://origin.example.com/asset.png')}",
@@ -7234,6 +7666,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let publisher_response = PublisherResponse::Stream {
             response,
@@ -7370,6 +7803,7 @@ mod tests {
             dispatched_auction,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         }
     }
 
@@ -7721,6 +8155,7 @@ mod tests {
                 )),
                 price_granularity: PriceGranularity::default(),
                 gpt_diagnostics: None,
+                suppress_datadome_client_side_tag: false,
             }
         };
         let make_stream_response = || PublisherResponse::Stream {
@@ -7900,6 +8335,7 @@ mod tests {
             )),
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let publisher_response = PublisherResponse::Stream {
             response,
@@ -7967,6 +8403,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let mut output = Vec::new();
 
@@ -8017,6 +8454,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
 
         let bogus_body = EdgeBody::from(b"<html>not gzip</html>".to_vec());
@@ -8125,6 +8563,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
         let mut output = Vec::new();
         stream_publisher_body(body, &mut output, &params, &settings, &registry)
@@ -8182,6 +8621,7 @@ mod tests {
             dispatched_auction: None,
             price_granularity: crate::price_bucket::PriceGranularity::default(),
             gpt_diagnostics: None,
+            suppress_datadome_client_side_tag: false,
         };
 
         let mut output = Vec::new();

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -7754,7 +7754,15 @@ mod tests {
     }
 
     fn streaming_finalize_response(params: OwnedProcessResponseParams, body: EdgeBody) -> EdgeBody {
-        let settings = Arc::new(create_test_settings());
+        streaming_finalize_response_with_settings(params, body, create_test_settings())
+    }
+
+    fn streaming_finalize_response_with_settings(
+        params: OwnedProcessResponseParams,
+        body: EdgeBody,
+        settings: Settings,
+    ) -> EdgeBody {
+        let settings = Arc::new(settings);
         let registry = Arc::new(
             IntegrationRegistry::new(&settings).expect("should create integration registry"),
         );
@@ -7805,6 +7813,40 @@ mod tests {
             gpt_diagnostics: None,
             suppress_datadome_client_side_tag: false,
         }
+    }
+
+    #[test]
+    fn streaming_finalize_emits_gam_attribution_head_before_origin_eof() {
+        let mut settings = create_test_settings();
+        settings
+            .integrations
+            .insert_config(
+                "gpt",
+                &serde_json::json!({
+                    "enabled": true,
+                    "gam_attribution_enabled": true
+                }),
+            )
+            .expect("should insert GPT config");
+
+        let body = streaming_finalize_response_with_settings(
+            html_stream_params("", None),
+            origin_chunk_then_pending(bytes::Bytes::from_static(
+                b"<html><head></head><body><p>origin remains pending</p>",
+            )),
+            settings,
+        );
+        let html = String::from_utf8(first_lazy_body_chunk(body).to_vec())
+            .expect("should emit UTF-8 HTML");
+
+        assert!(
+            html.contains("__tsjs_gam_attribution_enabled=true"),
+            "first rewritten head chunk should carry the primary activation flag: {html}"
+        );
+        assert!(
+            html.contains("data-ts-gam-attribution=\"true\""),
+            "first rewritten head chunk should authorize the bundle fallback: {html}"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/response_privacy.rs
+++ b/crates/trusted-server-core/src/response_privacy.rs
@@ -24,6 +24,27 @@ pub const CDN_CACHE_HEADERS: &[&str] = &[
     "cloudflare-cdn-cache-control",
 ];
 
+fn strip_cdn_cache_headers(response: &mut Response) {
+    for name in CDN_CACHE_HEADERS {
+        response.headers_mut().remove(*name);
+    }
+}
+
+/// Forces synthesized HTML to be private and non-storable.
+///
+/// Use this exact policy whenever Trusted Server changes an origin HTML
+/// representation with request-specific content: force `private, no-store`,
+/// remove origin validators, and remove all CDN-targeted cache directives.
+pub(crate) fn enforce_synthesized_html_cache_privacy(response: &mut Response) {
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, no-store"),
+    );
+    response.headers_mut().remove(header::ETAG);
+    response.headers_mut().remove(header::LAST_MODIFIED);
+    strip_cdn_cache_headers(response);
+}
+
 /// Forces cookie-bearing responses to stay private to shared caches.
 ///
 /// Any response that sets a per-user cookie (notably the EC identity cookie)
@@ -37,13 +58,11 @@ pub fn enforce_set_cookie_cache_privacy(response: &mut Response) {
     if !response.headers().contains_key(header::SET_COOKIE) {
         return;
     }
-    // Surrogate cache headers must come off every cookie-bearing response, even
+    // Shared-cache control headers must come off every cookie-bearing response, even
     // one already carrying a stricter `no-store`/`private` directive — they are
     // independent of Cache-Control and would otherwise let a shared cache store
     // and replay one visitor's Set-Cookie.
-    for name in CDN_CACHE_HEADERS {
-        response.headers_mut().remove(*name);
-    }
+    strip_cdn_cache_headers(response);
     // Cache-Control directives are case-insensitive (RFC 9111 §5.2), so match
     // against a lowercased copy — `No-Store` / `Private` must count.
     let already_uncacheable = response
@@ -147,6 +166,37 @@ mod tests {
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect();
         s
+    }
+
+    #[test]
+    fn synthesized_html_is_forced_no_store_without_validators_or_cdn_headers() {
+        let mut response = response_builder()
+            .header(header::CACHE_CONTROL, "private, max-age=600")
+            .header(header::ETAG, "\"origin\"")
+            .header(header::LAST_MODIFIED, "Wed, 21 Oct 2015 07:28:00 GMT")
+            .header("surrogate-control", "max-age=600")
+            .header("fastly-surrogate-control", "max-age=600")
+            .header("cdn-cache-control", "max-age=600")
+            .header("cloudflare-cdn-cache-control", "max-age=600")
+            .body(edgezero_core::body::Body::empty())
+            .expect("should build response");
+
+        enforce_synthesized_html_cache_privacy(&mut response);
+
+        assert_eq!(
+            response.headers()[header::CACHE_CONTROL],
+            "private, no-store",
+            "synthesized HTML should always be non-storable"
+        );
+        for header_name in [header::ETAG.as_str(), header::LAST_MODIFIED.as_str()]
+            .into_iter()
+            .chain(CDN_CACHE_HEADERS.iter().copied())
+        {
+            assert!(
+                !response.headers().contains_key(header_name),
+                "synthesized HTML should remove {header_name}"
+            );
+        }
     }
 
     #[test]

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -11,9 +11,23 @@ pub fn tsjs_script_src(module_ids: &[&str]) -> String {
 /// `<script>` tag for injecting the tsjs bundle.
 #[must_use]
 pub fn tsjs_script_tag(module_ids: &[&str]) -> String {
+    tsjs_script_tag_with_attributes(module_ids, &[])
+}
+
+/// Publisher `<script>` tag for the tsjs bundle with trusted static attributes.
+#[must_use]
+pub fn tsjs_script_tag_with_attributes(
+    module_ids: &[&str],
+    attributes: &[(&'static str, &'static str)],
+) -> String {
+    let attributes = attributes
+        .iter()
+        .map(|(name, value)| format!(" {name}=\"{value}\""))
+        .collect::<String>();
+
     format!(
-        "<script src=\"{}\" id=\"trustedserver-js\"></script>",
-        tsjs_script_src(module_ids)
+        "<script src=\"{}\" id=\"trustedserver-js\"{attributes}></script>",
+        tsjs_script_src(module_ids),
     )
 }
 
@@ -171,18 +185,38 @@ mod tests {
     }
 
     #[test]
-    fn tsjs_unified_helpers_use_all_module_ids() {
-        let ids = all_module_ids();
+    fn publisher_tsjs_script_tag_renders_static_attributes() {
+        let module_ids = ["gpt"];
+        let src = tsjs_script_src(&module_ids);
 
         assert_eq!(
-            tsjs_unified_script_src(),
+            tsjs_script_tag_with_attributes(&module_ids, &[("data-ts-gam-attribution", "true")]),
+            format!(
+                "<script src=\"{src}\" id=\"trustedserver-js\" data-ts-gam-attribution=\"true\"></script>"
+            ),
+            "should render trusted static attributes on the publisher bundle tag"
+        );
+        assert_eq!(
+            tsjs_script_tag(&module_ids),
+            format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>"),
+            "should keep the generic tag byte-for-byte unmarked"
+        );
+    }
+
+    #[test]
+    fn tsjs_unified_helpers_use_all_module_ids() {
+        let ids = all_module_ids();
+        let src = tsjs_unified_script_src();
+
+        assert_eq!(
+            src,
             tsjs_script_src(&ids),
             "should hash all module IDs for the unified script source"
         );
         assert_eq!(
             tsjs_unified_script_tag(),
-            tsjs_script_tag(&ids),
-            "should wrap the all-module unified script source"
+            format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>"),
+            "should keep the all-module generic tag byte-for-byte unmarked"
         );
     }
 

--- a/crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts
+++ b/crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts
@@ -9,6 +9,7 @@ test.describe("Script injection", () => {
 
     const src = await scriptTag.getAttribute("src");
     expect(src).toContain("/static/tsjs=");
+    await expect(scriptTag).not.toHaveAttribute("data-ts-gam-attribution");
   });
 
   test("no unexpected console errors on page load", async ({ page }) => {

--- a/crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml
+++ b/crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml
@@ -86,6 +86,7 @@ rewrite_sdk = true
 
 [integrations.gpt]
 enabled = false
+gam_attribution_enabled = false
 script_url = "https://ads.example.com/gpt.js"
 cache_ttl_seconds = 3600
 rewrite_script = true

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -287,6 +287,8 @@ type GptWindow = Window & {
   __tsjs_slim_prebid_url?: string;
 };
 
+const executingPublisherScript = typeof document === 'undefined' ? null : document.currentScript;
+
 // ------------------------------------------------------------------
 // Shim implementation
 // ------------------------------------------------------------------
@@ -305,6 +307,25 @@ function ensureGoogleTagStub(win: GptWindow): Partial<GoogleTag> {
   const tag = (win.googletag = win.googletag ?? {});
   tag.cmd = tag.cmd ?? [];
   return tag;
+}
+
+function installTrustedServerPageTargeting(): void {
+  if (executingPublisherScript?.getAttribute('data-ts-gam-attribution') !== 'true') {
+    return;
+  }
+
+  const win = window as GptWindow;
+  const tag = ensureGoogleTagStub(win);
+  tag.cmd!.push(() => {
+    try {
+      const gpt = win.googletag;
+      if (typeof gpt?.setConfig === 'function') {
+        gpt.setConfig({ targeting: { ts: 'true' } });
+      }
+    } catch (error) {
+      log.warn('[tsjs-gpt] GAM attribution targeting failed', error);
+    }
+  });
 }
 
 /**
@@ -1892,6 +1913,7 @@ if (typeof window !== 'undefined') {
     installGptShim();
   }
 
+  installTrustedServerPageTargeting();
   installTsAdInit();
   installSpaAuctionHook();
   installSlimPrebidLoader();

--- a/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
@@ -1874,7 +1874,7 @@ describe('installTsAdInit', () => {
       setTargeting: vi.fn().mockReturnThis(),
       clearTargeting,
       getSlotElementId: vi.fn().mockReturnValue('div-old-route'),
-      getTargeting: vi.fn().mockReturnValue([]),
+      getTargeting: vi.fn((key: string) => (key === 'ts' ? ['publisher-value'] : [])),
     };
     const mockPubads = {
       enableSingleRequest: vi.fn(),
@@ -1908,6 +1908,7 @@ describe('installTsAdInit', () => {
     expect(clearTargeting).toHaveBeenCalledWith('hb_cache_path');
     expect(clearTargeting).toHaveBeenCalledWith('ts_initial');
     expect(clearTargeting).toHaveBeenCalledWith('pos');
+    expect(clearTargeting).not.toHaveBeenCalledWith('ts');
     expect(mockPubads.refresh).not.toHaveBeenCalled();
     expect((window as TestWindow).tsjs!.divToSlotId).toEqual({});
     expect((window as TestWindow).tsjs!.prevSlotTargetingKeys).toEqual({});

--- a/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
@@ -33,6 +33,8 @@ interface MockGoogleTag {
   pubads: () => unknown;
   enableServices: () => void;
   display: (divId: string) => void;
+  getConfig?: (key: string) => Record<string, unknown>;
+  setConfig?: (config: Record<string, unknown>) => void;
 }
 
 // `tsjs` is declared globally as the full `TsjsApi`; `Omit` drops it from
@@ -40,7 +42,24 @@ interface MockGoogleTag {
 type TestWindow = Omit<Window, 'tsjs'> & {
   googletag?: MockGoogleTag;
   tsjs?: Partial<TsjsApi>;
+  __tsjs_gam_attribution_enabled?: boolean;
 };
+
+function makeGoogleTag(overrides: Partial<MockGoogleTag> = {}): MockGoogleTag {
+  const pubads = {
+    getSlots: vi.fn(() => []),
+    refresh: vi.fn(),
+  };
+
+  return {
+    cmd: [],
+    defineSlot: vi.fn(),
+    pubads: vi.fn(() => pubads),
+    enableServices: vi.fn(),
+    display: vi.fn(),
+    ...overrides,
+  };
+}
 
 function runBootstrap(): void {
   // Evaluate in the jsdom global scope, exactly as an inline <script> would.
@@ -60,6 +79,7 @@ describe('gpt_bootstrap.js fallback', () => {
   beforeEach(() => {
     delete (window as TestWindow).tsjs;
     delete (window as TestWindow).googletag;
+    delete (window as TestWindow).__tsjs_gam_attribution_enabled;
     rafQueue = [];
     (
       window as { requestAnimationFrame: typeof window.requestAnimationFrame }
@@ -81,7 +101,111 @@ describe('gpt_bootstrap.js fallback', () => {
     delete (window as unknown as Record<string, unknown>).requestAnimationFrame;
     delete (window as TestWindow).tsjs;
     delete (window as TestWindow).googletag;
+    delete (window as TestWindow).__tsjs_gam_attribution_enabled;
     vi.restoreAllMocks();
+  });
+
+  it('does not create googletag before the guard when attribution is omitted or false', () => {
+    for (const flag of [undefined, false]) {
+      const bundleAdInit = vi.fn();
+      (window as TestWindow).tsjs = { adInit: bundleAdInit };
+      delete (window as TestWindow).googletag;
+      if (flag === undefined) {
+        delete (window as TestWindow).__tsjs_gam_attribution_enabled;
+      } else {
+        (window as TestWindow).__tsjs_gam_attribution_enabled = flag;
+      }
+
+      runBootstrap();
+
+      expect((window as TestWindow).googletag).toBeUndefined();
+      expect((window as TestWindow).tsjs!.adInit).toBe(bundleAdInit);
+    }
+  });
+
+  it('queues string-valued page targeting before a later publisher command', () => {
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn();
+    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig });
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+    const publisherCommand = vi.fn();
+    queue.push(publisherCommand);
+    [...queue].forEach((command) => command());
+
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+    expect(setConfig.mock.invocationCallOrder[0]).toBeLessThan(
+      publisherCommand.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('queues targeting before the preinstalled adInit guard without replacing bundle APIs', () => {
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn();
+    const bundleAdInit = vi.fn();
+    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig });
+    (window as TestWindow).tsjs = { adInit: bundleAdInit };
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+
+    expect(queue).toHaveLength(1);
+    expect((window as TestWindow).tsjs!.adInit).toBe(bundleAdInit);
+    expect((window as TestWindow).tsjs!.scheduleInitialAdInit).toBeUndefined();
+    queue.forEach((command) => command());
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+  });
+
+  it('keeps bootstrap installation working when setConfig is unavailable', () => {
+    const queue: Array<() => void> = [];
+    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue });
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+
+    expect(() => [...queue].forEach((command) => command())).not.toThrow();
+    expect(typeof (window as TestWindow).tsjs!.adInit).toBe('function');
+    expect(typeof (window as TestWindow).tsjs!.scheduleInitialAdInit).toBe('function');
+  });
+
+  it('isolates a throwing setConfig from later publisher commands', () => {
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn(() => {
+      throw new Error('publisher setConfig failed');
+    });
+    const publisherCommand = vi.fn();
+    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig });
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+    queue.push(publisherCommand);
+
+    expect(() => [...queue].forEach((command) => command())).not.toThrow();
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+    expect(publisherCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('still tracks the wrapped legacy disableInitialLoad path', () => {
+    const queue: Array<() => void> = [];
+    const disableInitialLoad = vi.fn();
+    const pubads = {
+      disableInitialLoad,
+      getSlots: vi.fn(() => []),
+      refresh: vi.fn(),
+    };
+    (window as TestWindow).googletag = makeGoogleTag({
+      cmd: queue,
+      pubads: vi.fn(() => pubads),
+    });
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+    [...queue].forEach((command) => command());
+    pubads.disableInitialLoad();
+
+    expect(disableInitialLoad).toHaveBeenCalledTimes(1);
+    expect((window as TestWindow).tsjs!.gptInitialLoadDisabled).toBe(true);
   });
 
   it('installs fallback adInit and scheduleInitialAdInit when the bundle is absent', () => {

--- a/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
@@ -174,8 +174,18 @@ describe('gpt_bootstrap.js fallback', () => {
     const setConfig = vi.fn(() => {
       throw new Error('publisher setConfig failed');
     });
+    const disableInitialLoad = vi.fn();
+    const pubads = {
+      disableInitialLoad,
+      getSlots: vi.fn(() => []),
+      refresh: vi.fn(),
+    };
     const publisherCommand = vi.fn();
-    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig });
+    (window as TestWindow).googletag = makeGoogleTag({
+      cmd: queue,
+      setConfig,
+      pubads: vi.fn(() => pubads),
+    });
     (window as TestWindow).__tsjs_gam_attribution_enabled = true;
 
     runBootstrap();
@@ -184,6 +194,10 @@ describe('gpt_bootstrap.js fallback', () => {
     expect(() => [...queue].forEach((command) => command())).not.toThrow();
     expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
     expect(publisherCommand).toHaveBeenCalledTimes(1);
+    expect(typeof (window as TestWindow).tsjs!.adInit).toBe('function');
+    pubads.disableInitialLoad();
+    expect(disableInitialLoad).toHaveBeenCalledTimes(1);
+    expect((window as TestWindow).tsjs!.gptInitialLoadDisabled).toBe(true);
   });
 
   it('still tracks the wrapped legacy disableInitialLoad path', () => {

--- a/crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts
@@ -420,6 +420,227 @@ describe('GPT shim – runtime gating', () => {
   });
 });
 
+describe('GPT GAM attribution bundle fallback', () => {
+  interface AttributionPubAds {
+    getSlots: () => unknown[];
+    refresh: (...args: unknown[]) => void;
+  }
+
+  interface AttributionGoogleTag {
+    cmd: Array<() => void>;
+    pubads: () => AttributionPubAds;
+    defineSlot: (...args: unknown[]) => unknown;
+    display: (...args: unknown[]) => void;
+    getConfig?: (keys: string | string[]) => Record<string, unknown> | undefined;
+    setConfig?: (config: Record<string, unknown>) => void;
+  }
+
+  type AttributionWindow = Omit<Window, 'tsjs'> & {
+    tsjs?: Partial<TsjsApi>;
+    googletag?: AttributionGoogleTag;
+    __tsjs_gpt_enabled?: boolean;
+    __tsjs_installGptShim?: unknown;
+    __tsjs_slim_prebid_url?: string;
+  };
+
+  let win: AttributionWindow;
+  let executingScript: HTMLScriptElement | null;
+  let originalCurrentScriptDescriptor: PropertyDescriptor | undefined;
+  let originalPushState: History['pushState'];
+  let originalReplaceState: History['replaceState'];
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+  function makeGoogleTag(overrides: Partial<AttributionGoogleTag> = {}): AttributionGoogleTag {
+    const pubads: AttributionPubAds = {
+      getSlots: vi.fn(() => []),
+      refresh: vi.fn(),
+    };
+
+    return {
+      cmd: [],
+      pubads: vi.fn(() => pubads),
+      defineSlot: vi.fn(),
+      display: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  function attributedScript(ownerDocument: Document = document): HTMLScriptElement {
+    const script = ownerDocument.createElement('script');
+    script.id = 'trustedserver-js';
+    script.setAttribute('data-ts-gam-attribution', 'true');
+    return script;
+  }
+
+  async function importFreshGptBundle(): Promise<void> {
+    await import('../../../src/integrations/gpt/index');
+  }
+
+  beforeEach(async () => {
+    const guard = await importGuardModule();
+    guard.resetGuardState();
+    vi.resetModules();
+
+    win = window as AttributionWindow;
+    delete win.tsjs;
+    delete win.googletag;
+    delete win.__tsjs_gpt_enabled;
+    delete win.__tsjs_installGptShim;
+    delete win.__tsjs_slim_prebid_url;
+
+    executingScript = null;
+    originalCurrentScriptDescriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
+    Object.defineProperty(document, 'currentScript', {
+      configurable: true,
+      get: () => executingScript,
+    });
+
+    originalPushState = history.pushState;
+    originalReplaceState = history.replaceState;
+    addEventListenerSpy = vi.spyOn(window, 'addEventListener').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    const guard = await importGuardModule();
+    guard.resetGuardState();
+    history.pushState = originalPushState;
+    history.replaceState = originalReplaceState;
+    if (originalCurrentScriptDescriptor) {
+      Object.defineProperty(document, 'currentScript', originalCurrentScriptDescriptor);
+    } else {
+      delete (document as unknown as Record<string, unknown>).currentScript;
+    }
+    delete win.tsjs;
+    delete win.googletag;
+    delete win.__tsjs_gpt_enabled;
+    delete win.__tsjs_installGptShim;
+    delete win.__tsjs_slim_prebid_url;
+    vi.restoreAllMocks();
+  });
+
+  it('reuses the existing queue and pushes exact targeting before adInit exists', async () => {
+    const queue: Array<() => void> = [];
+    const adInitAtPush: Array<unknown> = [];
+    const arrayPush = queue.push.bind(queue);
+    queue.push = (...callbacks: Array<() => void>) => {
+      callbacks.forEach(() => adInitAtPush.push(win.tsjs?.adInit));
+      return arrayPush(...callbacks);
+    };
+    const setConfig = vi.fn();
+    const tag = makeGoogleTag({ cmd: queue, setConfig });
+    win.googletag = tag;
+    executingScript = attributedScript();
+    const initialScriptCount = document.scripts.length;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await importFreshGptBundle();
+
+    expect(win.googletag!.cmd).toBe(queue);
+    expect(adInitAtPush[0]).toBeUndefined();
+    expect(queue.length).toBeGreaterThan(0);
+    queue[0]();
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+    expect(document.scripts).toHaveLength(initialScriptCount);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['no current script', null],
+    ['missing attribute', undefined],
+    ['empty attribute', ''],
+    ['false attribute', 'false'],
+    ['non-exact attribute', 'TRUE'],
+  ])('fails closed for %s', async (_label, attributeValue) => {
+    if (attributeValue === null) {
+      executingScript = null;
+    } else {
+      executingScript = document.createElement('script');
+      if (attributeValue !== undefined) {
+        executingScript.setAttribute('data-ts-gam-attribution', attributeValue);
+      }
+    }
+
+    await importFreshGptBundle();
+
+    expect(win.googletag).toBeUndefined();
+  });
+
+  it('ignores a marked duplicate-ID decoy when the executing tag is unmarked', async () => {
+    const decoy = attributedScript();
+    document.head.appendChild(decoy);
+    executingScript = document.createElement('script');
+    executingScript.id = 'trustedserver-js';
+
+    await importFreshGptBundle();
+
+    expect(win.googletag).toBeUndefined();
+    decoy.remove();
+  });
+
+  it('characterizes a marked document.write clone as able to activate', async () => {
+    const clonedDocument = document.implementation.createHTMLDocument('nested clone');
+    clonedDocument.write('<script id="trustedserver-js" data-ts-gam-attribution="true"></script>');
+    clonedDocument.close();
+    executingScript = clonedDocument.querySelector('script');
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn();
+    win.googletag = makeGoogleTag({ cmd: queue, setConfig });
+
+    await importFreshGptBundle();
+    queue[0]();
+
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+  });
+
+  it.each(['missing', 'throwing'])(
+    'keeps module installation working with %s setConfig',
+    async (setConfigMode) => {
+      const queue: Array<() => void> = [];
+      const setConfig =
+        setConfigMode === 'throwing'
+          ? vi.fn(() => {
+              throw new Error('publisher setConfig failed');
+            })
+          : undefined;
+      win.googletag = makeGoogleTag({ cmd: queue, setConfig });
+      win.__tsjs_slim_prebid_url = 'https://cdn.example.com/slim-prebid.js';
+      executingScript = attributedScript();
+
+      await importFreshGptBundle();
+
+      expect(() => [...queue].forEach((command) => command())).not.toThrow();
+      expect(typeof win.tsjs?.adInit).toBe('function');
+      expect(typeof win.tsjs?.scheduleInitialAdInit).toBe('function');
+      expect(win.tsjs?.spaHookInstalled).toBe(true);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+      expect(addEventListenerSpy).toHaveBeenCalledWith('load', expect.any(Function));
+      expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+      if (setConfig) {
+        expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+      }
+    }
+  );
+
+  it('preserves GPT-enabled shim behavior without queuing attribution when unmarked', async () => {
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn();
+    const tag = makeGoogleTag({ cmd: queue, setConfig });
+    win.googletag = tag;
+    win.__tsjs_gpt_enabled = true;
+    executingScript = document.createElement('script');
+
+    await importFreshGptBundle();
+    [...queue].forEach((command) => command());
+    const guard = await importGuardModule();
+
+    expect(guard.isGuardInstalled()).toBe(true);
+    expect(win.googletag).toBe(tag);
+    expect(win.googletag!.cmd).toBe(queue);
+    expect(setConfig).not.toHaveBeenCalled();
+    expect(typeof win.tsjs?.adInit).toBe('function');
+  });
+});
+
 describe('GPT debug ADM iframe hardening', () => {
   it('sandbox token list omits allow-same-origin', async () => {
     const mod = await import('../../../src/integrations/gpt/index');

--- a/crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts
@@ -414,9 +414,11 @@ describe('prebid/installPrebidNpm', () => {
     delete testWindow.__tsjs_prebid_diagnostics;
     delete testWindow.tsjs;
     delete mockPbjs['__tsApsBidResponseListenerInstalled'];
+    delete mockPbjs.bidderSettings;
   });
 
   afterEach(() => {
+    delete mockPbjs.bidderSettings;
     vi.restoreAllMocks();
   });
 
@@ -1130,6 +1132,35 @@ describe('prebid/installPrebidNpm', () => {
   });
 
   describe('requestBids shim', () => {
+    it('preserves publisher ts adserverTargeting while adding trustedServer settings', () => {
+      const publisherTargeting = [{ key: 'ts', val: () => 'publisher-value' }];
+      mockPbjs.bidderSettings = {
+        exampleBidder: { adserverTargeting: publisherTargeting },
+      };
+      const pbjs = installPrebidNpm();
+
+      pbjs.requestBids({
+        adUnits: [{ bids: [{ bidder: 'exampleBidder', params: {} }] }],
+      } as unknown as RequestBidsArg);
+
+      const bidderSettings = mockPbjs.bidderSettings as {
+        exampleBidder: { adserverTargeting: typeof publisherTargeting };
+        trustedServer: {
+          allowAlternateBidderCodes: boolean;
+          allowedAlternateBidderCodes: string[];
+        };
+      };
+      expect(bidderSettings.exampleBidder.adserverTargeting).toBe(publisherTargeting);
+      expect(bidderSettings.exampleBidder.adserverTargeting[0].key).toBe('ts');
+      expect(bidderSettings.exampleBidder.adserverTargeting[0].val()).toBe('publisher-value');
+      expect(bidderSettings.trustedServer).toEqual(
+        expect.objectContaining({
+          allowAlternateBidderCodes: true,
+          allowedAlternateBidderCodes: ['*'],
+        })
+      );
+    });
+
     it('injects trustedServer bidder into every ad unit', () => {
       const pbjs = installPrebidNpm();
 
@@ -1850,25 +1881,33 @@ describe('prebid/installRefreshHandler', () => {
 
   it('auctions refreshed TS initial slots and clears stale TS targeting before refresh', () => {
     const originalRefresh = vi.fn();
-    const clearTargeting = vi.fn();
+    const slotTargeting = new Map<string, string[]>([
+      ['ts_initial', ['1']],
+      ['zone', ['homepage']],
+    ]);
+    const clearTargeting = vi.fn((key: string) => {
+      slotTargeting.delete(key);
+    });
+    const setTargeting = vi.fn((key: string, value: string | string[]) => {
+      slotTargeting.set(key, Array.isArray(value) ? value : [value]);
+    });
     const gptSlot = {
       getSlotElementId: vi.fn(() => 'div-ad-homepage-header'),
-      getTargeting: vi.fn((key: string) => {
-        if (key === 'ts_initial') return ['1'];
-        if (key === 'zone') return ['homepage'];
-        return [];
-      }),
+      getTargeting: vi.fn((key: string) => slotTargeting.get(key) ?? []),
       getSizes: vi.fn(() => [
         { getWidth: () => 970, getHeight: () => 250 },
         { getWidth: () => 728, getHeight: () => 90 },
       ]),
       clearTargeting,
+      setTargeting,
     };
     const pubads = {
       refresh: originalRefresh,
       getSlots: vi.fn(() => [gptSlot]),
     };
-    const setTargetingForGPTAsync = vi.fn();
+    const setTargetingForGPTAsync = vi.fn(() => {
+      gptSlot.setTargeting('ts', 'prebid-value');
+    });
     mockPbjs.setTargetingForGPTAsync = setTargetingForGPTAsync;
     testWindow.googletag = {
       cmd: { push: (fn: () => void) => fn() },
@@ -1918,12 +1957,17 @@ describe('prebid/installRefreshHandler', () => {
     expect(clearTargeting).toHaveBeenCalledWith('hb_adid');
     expect(clearTargeting).toHaveBeenCalledWith('hb_cache_host');
     expect(clearTargeting).toHaveBeenCalledWith('hb_cache_path');
+    expect(clearTargeting).not.toHaveBeenCalledWith('ts');
     expect(originalRefresh).not.toHaveBeenCalled();
 
     const bidsBackHandler = mockRequestBids.mock.calls[0][0].bidsBackHandler;
     bidsBackHandler();
 
     expect(setTargetingForGPTAsync).toHaveBeenCalled();
+    expect(setTargetingForGPTAsync.mock.invocationCallOrder[0]).toBeLessThan(
+      originalRefresh.mock.invocationCallOrder[0]
+    );
+    expect(slotTargeting.get('ts')).toEqual(['prebid-value']);
     expect(originalRefresh).toHaveBeenCalledWith([gptSlot], undefined);
   });
 

--- a/docs/guide/integrations/datadome.md
+++ b/docs/guide/integrations/datadome.md
@@ -86,6 +86,7 @@ patterns = ["(?i)\\.(avi|flv|mka|mkv|mov|mp4|mpeg|mpg|mp3|flac|ogg|ogm|opus|wav|
 | `protection_excluded_ip_cidr_sources`  | array   | `[]`                             | Config Store sources containing dynamic client IP CIDR bypass lists     |
 | `protection_ip_list_cache_ttl_seconds` | integer | `300`                            | Process-local cache TTL for Config Store-backed IP CIDR bypass lists    |
 | `protection_exclusion_rules`           | array   | Static asset path regex          | Structured method/path/query/IP/ASN exclusion rules                     |
+| `protection_test_bypass`               | object  | omitted                          | Staging-only fixed-header bypass; secret must contain at least 32 bytes |
 | `enable_graphql_support`               | boolean | `false`                          | Reserved for future GraphQL body inspection; ignored in v1              |
 | `client_side_key`                      | string  | `""`                             | DataDome client-side JavaScript key used for tag injection              |
 | `inject_client_side_tag`               | boolean | `true`                           | Auto-inject the browser tag when `client_side_key` is non-empty         |
@@ -168,10 +169,95 @@ A request is protected when all of the following are true:
 5. The client IP does not match `protection_excluded_ip_cidrs` or any Config Store-backed CIDR source.
 6. The client ASN is not listed in `protection_excluded_asns`.
 7. No `protection_exclusion_rules` match.
+8. The request does not contain a matching enabled `protection_test_bypass` credential while `FASTLY_IS_STAGING=1`.
 
 Static assets are excluded by default using a case-insensitive file-extension regex. Trusted Server internal routes such as `/static/tsjs=`, `/integrations/`, `/first-party/`, admin routes, discovery routes, and signature-verification routes are also excluded by default.
 
 Auction traffic at `/auction` is protected by default.
+
+### Staging test bypass
+
+For short-lived browser automation on an access-controlled staging site, you
+can configure a static header credential that skips only the server-side
+Protection API:
+
+```toml
+# Runtime activation also requires FASTLY_IS_STAGING=1.
+[integrations.datadome.protection_test_bypass]
+enabled = true
+credential_secret_store = "ts_secrets"
+credential_secret_name = "datadome_test_bypass"
+```
+
+`protection_test_bypass` requires `enable_protection = true`; it is disabled
+when omitted and is runtime-active only when `FASTLY_IS_STAGING=1`.
+`FASTLY_IS_STAGING` is supplied at runtime by Fastly (`1` in staging and `0` in
+production); it is not compiled into or promoted with the Wasm artifact. Verify
+staging through the `X-TS-ENV: staging` response signal and the integration
+activation log, and verify production omits that response signal. A retained
+section cannot bypass protection in a production or other non-staging runtime.
+Store a randomly generated credential containing at least 32 bytes of
+high-entropy material in the configured Secret Store, configure this section
+only while needed, protect the site with an outer access control such as Basic
+Auth, and remove the section when testing finishes.
+
+Whenever the enabled DataDome request filter runs on the Fastly adapter, the
+fixed `x-ts-datadome-bypass` header is removed before configuration or
+credential checks. It therefore cannot reach DataDome or the publisher origin
+through that path when the bypass is absent, disabled, inactive, or invalid.
+Active credentials are compared in constant time and never logged. Duplicate
+header values fail closed. Scope the header to the staging origin; do not attach
+it to every request in a browser context because that can disclose the
+credential to third-party origins. With Playwright:
+
+```ts
+await context.route('https://staging.example.com/**', async (route) => {
+  const headers = {
+    ...route.request().headers(),
+    'x-ts-datadome-bypass': process.env.DATADOME_TEST_BYPASS!,
+  }
+  await route.continue({ headers })
+})
+```
+
+### Client-side tag suppression behavior
+
+On the Fastly adapter, a request that matches an IP-based DataDome exclusion
+or the configured test-bypass credential also omits Trusted Server's
+automatically injected client-side DataDome tag from processed HTML. This keeps
+the client-side layer consistent with the server-side Protection API skip.
+
+This behavior applies to:
+
+- `protection_excluded_ip_cidrs`;
+- `protection_excluded_ip_cidr_sources`;
+- structured `ip_cidr` rules;
+- structured `ip_cidr_source` rules; and
+- a matching enabled `protection_test_bypass` credential in a staging runtime.
+
+Method, ASN, path, query-parameter, static-asset, and internal-route exclusions
+alone do not suppress the client-side tag. However, a simultaneous matching IP
+exclusion suppresses it regardless of which first-match rule and reason are
+logged. DataDome tags already present in publisher HTML are not removed or
+changed by this behavior, and `/integrations/datadome/tags.js` remains available
+when requested directly.
+
+Because the processed HTML differs by client IP or test credential,
+tag-suppressed HTML is marked `private, no-store`, has origin validators
+removed, and has shared-surrogate cache directives removed. This response-time
+policy cannot invalidate tag-bearing HTML already held by a shared cache in
+front of Trusted Server. Guaranteed suppression requires bypassing or purging
+that cache, or avoiding shared caching ahead of Trusted Server.
+
+IP-exclusion suppression skips are logged at `info` for navigations and `debug`
+for subresources; matching test-bypass events remain at `info` as security audit
+events. Protection API result logs classify `allowed`, `blocked`, and
+`failed_open` outcomes and use distinct `api_status` and `datadome_status`
+fields. For example:
+
+```text
+[datadome] protection decision=skipped rule=protection-test-bypass reason=test_bypass client_tag=omitted method=GET
+```
 
 ### Structured exclusion rules
 

--- a/docs/guide/integrations/gpt.md
+++ b/docs/guide/integrations/gpt.md
@@ -53,6 +53,7 @@ Add GPT configuration to `trusted-server.toml`:
 ```toml
 [integrations.gpt]
 enabled = true
+gam_attribution_enabled = false
 script_url = "https://securepubads.g.doubleclick.net/tag/js/gpt.js"
 cache_ttl_seconds = 3600
 rewrite_script = true
@@ -60,12 +61,18 @@ rewrite_script = true
 
 ### Configuration Options
 
-| Field               | Type    | Required | Default                                                | Description                                |
-| ------------------- | ------- | -------- | ------------------------------------------------------ | ------------------------------------------ |
-| `enabled`           | boolean | No       | `true`                                                 | Enable/disable the integration             |
-| `script_url`        | string  | No       | `https://securepubads.g.doubleclick.net/tag/js/gpt.js` | URL for the GPT bootstrap script           |
-| `cache_ttl_seconds` | integer | No       | `3600`                                                 | Cache TTL for proxied scripts (60--86400s) |
-| `rewrite_script`    | boolean | No       | `true`                                                 | Whether to rewrite GPT script URLs in HTML |
+| Field                     | Type    | Required | Default                                                | Description                                                       |
+| ------------------------- | ------- | -------- | ------------------------------------------------------ | ----------------------------------------------------------------- |
+| `enabled`                 | boolean | No       | `true`                                                 | Enable/disable the integration                                    |
+| `gam_attribution_enabled` | boolean | No       | `false`                                                | Add fixed page-level `ts=true` targeting for GAM cohort reporting |
+| `script_url`              | string  | No       | `https://securepubads.g.doubleclick.net/tag/js/gpt.js` | URL for the GPT bootstrap script                                  |
+| `cache_ttl_seconds`       | integer | No       | `3600`                                                 | Cache TTL for proxied scripts (60--86400s)                        |
+| `rewrite_script`          | boolean | No       | `true`                                                 | Whether to rewrite GPT script URLs in HTML                        |
+
+The environment override
+`TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED` works only when
+`gam_attribution_enabled` is already present under `[integrations.gpt]` in the
+TOML file. EdgeZero v0.0.4 cannot create a missing configuration leaf.
 
 ## Endpoints
 
@@ -108,6 +115,65 @@ Takes over `googletag.cmd` so every queued callback is wrapped before GPT execut
 - EC ID injection as page-level key-value targeting
 - Consent gating of ad requests
 - Ad-unit path rewriting for A/B testing
+
+### GAM Treatment Attribution
+
+Setting `gam_attribution_enabled = true` adds the fixed page-level GPT targeting
+value `ts=true`. It is applied before publisher GPT initialization and remains
+for the browser document's lifetime, so initial, lazy, refresh, publisher-owned,
+and SPA-route requests inherit it unless another targeting consumer clears or
+overrides the key. The attribution switch is independently controlled and
+defaults to `false`, but the GPT integration's `enabled` master switch must also
+be `true`.
+
+This key is distinct from the existing slot-level `ts_initial=1` value.
+`ts_initial` retains its current cleanup lifecycle; Trusted Server does not
+clear the page-level `ts` value during Prebid refresh or SPA cleanup.
+
+For an eligible publisher document whose activation script was not cloned,
+`ts=true` means Trusted Server emitted the rewritten document head before the
+GPT request. It does not prove that the response body completed, that a Trusted
+Server bid won, or that an impression was caused by treatment. A publisher can
+copy the activation script with `srcdoc` or `document.write`; treat any marker
+on an unrewritten nested document as contamination, not attribution proof.
+
+Before enabling attribution in a cohort:
+
+1. Complete privacy and CSP review, create the reportable predefined `true`
+   value in the target GAM network, and verify the chosen GAM reporting surface
+   and billing approval.
+2. Audit the short `ts` key across publisher GPT code, effective Prebid
+   `bidderSettings[*].adserverTargeting` output (including
+   `setTargetingForGPTAsync`), the effective creative-opportunity targeting map,
+   and every GAM consumer that can affect eligibility, pricing, protection, or
+   routing. Trusted Server accepts and forwards operator targeting verbatim; it
+   does not reserve, filter, or intercept a slot-level `ts` key at runtime.
+3. With treatment routing stopped, deploy attribution enabled and validate
+   initial, lazy, refresh, publisher-owned, and SPA requests. Confirm every
+   excluded path reports zero marked requests, then save a short paired-report
+   dry run that satisfies the invariants below before starting the cohort.
+
+For reporting, save one exact eligible universe: GAM network, inventory units,
+routes, formats, time zone, date window, metrics, and all exclusions. Report A
+is the nonduplicated total for that universe. Report B uses identical filters
+and metrics plus exactly `ts=true`. If Enhanced Key-Value reporting is
+unavailable, unapproved, or incompatible, use an exactly filtered legacy
+key-value report and never sum its repeated key-value rows. Derive control as
+`A - B`, and require `0 <= B <= A` for every metric. A violation invalidates the
+whole report pair; never clamp a negative result. Use the same reporting-latency
+and invalid-traffic maturation window for both reports.
+
+GAM results are descriptive delivery attribution, not a causal treatment
+effect. Aggregate monitoring and synthetic/manual samples can detect obvious
+failures but cannot prove marker completeness on every production request
+without request-correlated telemetry.
+
+For a normal rollback, first stop and verify new treatment assignment at the
+router, record a clean reporting boundary, and let already-open documents drain.
+Exclude the drain interval, then set `gam_attribution_enabled = false` after
+marked traffic reaches zero for the agreed interval. An emergency kill may flip
+the setting immediately, but the affected interval and subsequent drain must be
+treated as invalid for experiment reporting.
 
 ## Use Cases
 

--- a/docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md
+++ b/docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md
@@ -905,8 +905,9 @@ This task must not add buffering or adapter logic.
   - saved report pairs are exported after the same reporting-latency and
     invalid-traffic window, and monitoring/synthetic samples do not prove
     per-response marker completeness;
-  - normal rollback stops and verifies routing before flipping the setting,
-    then excludes the open-document drain interval;
+  - normal rollback stops and verifies routing, records the boundary, keeps
+    attribution enabled through the excluded open-document drain, and flips the
+    setting only after marked traffic reaches zero;
   - an emergency kill flips immediately and invalidates the affected/drain
     interval.
 
@@ -1018,7 +1019,7 @@ This task must not add buffering or adapter logic.
   git log --oneline --decorate -8
   ```
 
-  Expected: a clean worktree, seven focused implementation commits, and no
+  Expected: a clean worktree, focused implementation commits, and no
   production changes to creative-opportunity filtering, Prebid interception,
   streaming buffering, or adapter behavior.
 
@@ -1052,10 +1053,11 @@ remain separate from Tasks 1-8 because they require publisher/router/GAM access.
       `0 <= Report B <= Report A` for every selected metric.
 - [ ] Start the sticky treatment cohort only after every gate passes; use GAM
       share versus router allocation only as a diagnostic.
-- [ ] For normal rollback, close the clean report boundary, stop and verify new
-      treatment routing, disable attribution, and exclude the marked-document
-      drain interval. For an emergency kill, disable immediately and invalidate
-      the affected plus drain intervals.
+- [ ] For normal rollback, stop and verify new treatment routing, close the
+      clean report boundary, keep attribution enabled while marked documents
+      drain through the excluded interval, and disable only after marked traffic
+      reaches zero for the agreed interval. For an emergency kill, disable
+      immediately and invalidate the affected plus drain intervals.
 
 ## Definition of done
 

--- a/docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md
+++ b/docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md
@@ -1,0 +1,1076 @@
+# GAM Page-Delivery Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a disabled-by-default `gam_attribution_enabled` GPT option that marks every eligible request from a Trusted Server head-emitted publisher document with the fixed page-level GAM value `ts=true`.
+
+**Architecture:** One parsed `GptConfig` instance controls both delivery paths. The raw head bootstrap is the primary, earliest queue insertion; integration-owned publisher-tag metadata adds `data-ts-gam-attribution="true"` to the synchronous bundle for a `document.currentScript`-gated fallback. Existing slot targeting, Prebid refresh cleanup, creative-opportunity forwarding, and Fastly streaming behavior remain unchanged.
+
+**Tech Stack:** Rust 1.95, Serde, `validator`, `lol_html`, TypeScript, Vitest/jsdom, Playwright, Google Publisher Tag
+
+---
+
+**Issue:** [#1027](https://github.com/IABTechLab/trusted-server/issues/1027)
+
+**Design:** `docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md`
+
+## Fixed contracts
+
+| Concern            | Contract                                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| Marker             | Exactly page-level `ts=true`; no configurable name/value, alias, or dual write                       |
+| Default            | `[integrations.gpt] gam_attribution_enabled = false`                                                 |
+| Kill switch        | Disables only attribution; GPT proxying, shim, `adInit`, and `ts_initial` remain active              |
+| Primary path       | Raw GPT bootstrap queues targeting before `if (ts.adInit) return;`                                   |
+| Fallback           | Existing synchronous publisher bundle, authorized only by its own `document.currentScript` attribute |
+| Publisher tag      | One tag; `data-ts-gam-attribution="true"` only for enabled GPT attribution                           |
+| Streaming meaning  | Rewritten head emitted before the request, not complete response success; no new buffering           |
+| Slot targeting     | `ts_initial=1` lifecycle unchanged; page-level `ts` is never added to cleanup arrays                 |
+| Operator targeting | Forwarded verbatim; characterize collisions but add no validator, filter, or interception            |
+| Analysis           | Descriptive GAM delivery attribution, not a causal treatment effect                                  |
+
+Run every command block from the repository root unless that block begins with
+an explicit `cd`. Treat separate command blocks as separate shell sessions.
+
+## File map
+
+| File                                                                                       | Responsibility                                                                         |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `crates/trusted-server-core/src/integrations/gpt.rs`                                       | Parse the option, emit the inline activation flag, and expose publisher-tag metadata   |
+| `crates/trusted-server-core/src/integrations/registry.rs`                                  | Define the default-empty tag-attribute hook and aggregate enabled integration metadata |
+| `crates/trusted-server-core/src/tsjs.rs`                                                   | Render an attributed publisher bundle tag without changing generic/creative tag output |
+| `crates/trusted-server-core/src/html_processor.rs`                                         | Pass registry-owned attributes to the single synchronous publisher bundle tag          |
+| `crates/trusted-server-core/src/integrations/gpt_bootstrap.js`                             | Queue the primary `setConfig({ targeting: { ts: "true" } })` callback                  |
+| `crates/trusted-server-js/lib/src/integrations/gpt/index.ts`                               | Queue the `document.currentScript`-authorized fallback                                 |
+| `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`                 | Execute the raw bootstrap and prove ordering/failure isolation                         |
+| `crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts`                         | Prove exact executing-tag activation and fail-closed cases                             |
+| `crates/trusted-server-core/src/creative_opportunities.rs`                                 | Characterize verbatim operator `ts` targeting; production code remains unchanged       |
+| `crates/trusted-server-core/src/publisher.rs`                                              | Characterize wire forwarding and marked-head-before-EOF streaming                      |
+| `crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts`                       | Freeze GPT slot cleanup behavior                                                       |
+| `crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts`                      | Characterize Prebid-produced slot-level collisions and cleanup behavior                |
+| `crates/trusted-server-cli/tests/config_env_overlay.rs`                                    | Prove the typed CLI environment override updates an existing TOML leaf                 |
+| `trusted-server.example.toml`                                                              | Publish the disabled default                                                           |
+| `crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml` | Keep the browser fixture explicitly default-off                                        |
+| `crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts`    | Smoke-test absence of the activation attribute in the default-off deployment           |
+| `docs/guide/integrations/gpt.md`                                                           | Document configuration, semantics, audit, reporting, and rollback prerequisites        |
+
+## Task 1: Add the GPT attribution option and integration-owned metadata
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/gpt.rs:64-94`
+- Modify: `crates/trusted-server-core/src/integrations/gpt.rs:467-510`
+- Modify: `crates/trusted-server-core/src/integrations/gpt.rs:549-559`
+- Modify: `crates/trusted-server-core/src/integrations/registry.rs:572-579`
+- Test: `crates/trusted-server-core/src/integrations/gpt.rs`
+
+- [ ] **Step 1: Write failing configuration and head-injector tests.**
+
+  Add tests that deserialize omitted, explicit-false, and explicit-true values,
+  then exercise both activation outputs. Use behavior-oriented assertions like:
+
+  ```rust
+  #[test]
+  fn gam_attribution_defaults_to_disabled() {
+      let config: GptConfig =
+          serde_json::from_value(serde_json::json!({})).expect("should parse defaults");
+      assert!(!config.gam_attribution_enabled);
+  }
+
+  #[test]
+  fn gam_attribution_true_adds_both_activation_signals_without_a_new_insert() {
+      let integration = GptIntegration::new(GptConfig {
+          gam_attribution_enabled: true,
+          ..test_config()
+      });
+      let document_state = IntegrationDocumentState::default();
+      let context = IntegrationHtmlContext {
+          request_host: "edge.example.com",
+          request_scheme: "https",
+          origin_host: "origin.example.com",
+          document_state: &document_state,
+      };
+      let inserts = integration.head_inserts(&context);
+
+      assert_eq!(inserts.len(), 2);
+      assert!(inserts[0].contains("window.__tsjs_gam_attribution_enabled=true;"));
+      assert_eq!(
+          integration.tsjs_script_tag_attributes(),
+          vec![("data-ts-gam-attribution", "true")]
+      );
+  }
+  ```
+
+  Retain the current exact-string assertion for the false first insert. Add
+  `gam_attribution_enabled: false` to `test_config()` and any other full
+  `GptConfig` literals.
+
+- [ ] **Step 2: Run the focused tests and confirm RED.**
+
+  Run:
+
+  ```bash
+  cargo test-fastly gam_attribution
+  ```
+
+  Expected: compilation fails because `GptConfig::gam_attribution_enabled` and
+  `IntegrationHeadInjector::tsjs_script_tag_attributes` do not exist.
+
+- [ ] **Step 3: Add the default-empty trait hook and parsed field.**
+
+  Add an object-safe default method beside `head_inserts`:
+
+  ```rust
+  pub trait IntegrationHeadInjector: Send + Sync {
+      fn integration_id(&self) -> &'static str;
+      fn head_inserts(&self, ctx: &IntegrationHtmlContext<'_>) -> Vec<String>;
+
+      fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+          Vec::new()
+      }
+  }
+  ```
+
+  Add the flat field to `GptConfig`:
+
+  ```rust
+  /// Enable page-level `ts=true` delivery attribution in GAM.
+  #[serde(default)]
+  pub gam_attribution_enabled: bool,
+  ```
+
+  Do not add a configurable key or value.
+
+- [ ] **Step 4: Emit the true-only inline flag without changing false bytes.**
+
+  Build the first insert with an empty-or-fixed fragment:
+
+  ```rust
+  let gam_attribution_flag = self
+      .config
+      .gam_attribution_enabled
+      .then_some("window.__tsjs_gam_attribution_enabled=true;")
+      .unwrap_or_default();
+
+  let mut scripts = vec![
+      format!(
+          "<script>window.__tsjs_gpt_enabled=true;{gam_attribution_flag}\
+           window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>"
+      ),
+      format!("<script>{}</script>", GPT_BOOTSTRAP_JS),
+  ];
+  ```
+
+  Verify the false string remains exactly:
+
+  ```text
+  <script>window.__tsjs_gpt_enabled=true;window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>
+  ```
+
+- [ ] **Step 5: Override the metadata hook from the same `GptConfig`.**
+
+  ```rust
+  fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+      if self.config.gam_attribution_enabled {
+          vec![("data-ts-gam-attribution", "true")]
+      } else {
+          Vec::new()
+      }
+  }
+  ```
+
+  Do not store this state in `HtmlProcessorConfig` or
+  `IntegrationDocumentState`.
+
+- [ ] **Step 6: Run focused and neighboring GPT tests.**
+
+  ```bash
+  cargo test-fastly gam_attribution
+  cargo test-fastly head_injector
+  ```
+
+  Expected: PASS; false preserves two current inserts, true adds the flag and
+  metadata while still emitting two inserts when `slim_prebid_url` is absent.
+
+- [ ] **Step 7: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/integrations/gpt.rs crates/trusted-server-core/src/integrations/registry.rs
+  git commit -m "Add GPT GAM attribution option"
+  ```
+
+## Task 2: Put activation metadata on only the publisher bundle tag
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/registry.rs:1043-1054`
+- Modify: `crates/trusted-server-core/src/tsjs.rs:11-39`
+- Modify: `crates/trusted-server-core/src/html_processor.rs:324-360`
+- Test: `crates/trusted-server-core/src/integrations/registry.rs`
+- Test: `crates/trusted-server-core/src/tsjs.rs:161-187`
+- Test: `crates/trusted-server-core/src/html_processor.rs:768-820`
+- Test: `crates/trusted-server-core/src/html_processor.rs:1637-1671`
+
+- [ ] **Step 1: Write failing registry and tag-rendering tests.**
+
+  Add a test head injector whose metadata method returns the attribution pair.
+  Assert registry aggregation is deterministic and preserves the default-empty
+  behavior of injectors that implement only `head_inserts`.
+
+  Add exact tag tests:
+
+  ```rust
+  #[test]
+  fn publisher_script_tag_renders_static_attributes() {
+      let ids = ["gpt"];
+      let src = tsjs_script_src(&ids);
+
+      assert_eq!(
+          tsjs_script_tag_with_attributes(
+              &ids,
+              &[("data-ts-gam-attribution", "true")]
+          ),
+          format!(
+              "<script src=\"{src}\" id=\"trustedserver-js\" \
+               data-ts-gam-attribution=\"true\"></script>"
+          )
+      );
+      assert_eq!(
+          tsjs_script_tag(&ids),
+          format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>")
+      );
+  }
+  ```
+
+  The final string must contain no formatting whitespace introduced only by the
+  multiline example.
+
+- [ ] **Step 2: Write a failing HTML matrix test.**
+
+  Process `<html><head></head><body></body></html>` with:
+  1. a real enabled GPT registry with attribution true;
+  2. enabled GPT with attribution false; and
+  3. no GPT integration.
+
+  Assert exactly one `#trustedserver-js` tag in every case, the attribute only
+  in case 1, and integration head inserts remain before the external bundle.
+  Also retain the generic `tsjs_unified_script_tag()` exact-output test so
+  creative/all-modules callers stay unmarked.
+
+- [ ] **Step 3: Run the tests and confirm RED.**
+
+  ```bash
+  cargo test-fastly tsjs_script_tag
+  cargo test-fastly integration_head_injector
+  ```
+
+  Expected: FAIL because the registry aggregator and attributed publisher
+  helper are not implemented.
+
+- [ ] **Step 4: Aggregate integration-owned static attributes.**
+
+  Add beside `IntegrationRegistry::head_inserts`:
+
+  ```rust
+  #[must_use]
+  pub fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+      self.inner
+          .head_injectors
+          .iter()
+          .flat_map(|injector| injector.tsjs_script_tag_attributes())
+          .collect()
+  }
+  ```
+
+  Keep the hook default-empty so existing integration injectors and test doubles
+  compile without changes.
+
+- [ ] **Step 5: Add the publisher-only tag helper.**
+
+  Render only trusted, compile-time static attribute pairs:
+
+  ```rust
+  #[must_use]
+  pub fn tsjs_script_tag_with_attributes(
+      module_ids: &[&str],
+      attributes: &[(&'static str, &'static str)],
+  ) -> String {
+      let attributes = attributes
+          .iter()
+          .map(|(name, value)| format!(" {name}=\"{value}\""))
+          .collect::<String>();
+      format!(
+          "<script src=\"{}\" id=\"trustedserver-js\"{attributes}></script>",
+          tsjs_script_src(module_ids)
+      )
+  }
+  ```
+
+  Have `tsjs_script_tag(module_ids)` retain its exact output, either directly or
+  by delegating with an empty slice. Do not change
+  `tsjs_unified_script_tag()` or either creative call site.
+
+- [ ] **Step 6: Wire only the publisher HTML path.**
+
+  Replace the single `html_processor.rs` call with:
+
+  ```rust
+  let immediate_ids = integrations.js_module_ids_immediate();
+  let script_attributes = integrations.tsjs_script_tag_attributes();
+  snippet.push_str(&tsjs::tsjs_script_tag_with_attributes(
+      &immediate_ids,
+      &script_attributes,
+  ));
+  ```
+
+  Preserve source order: ad slots, integration head inserts, diagnostics
+  bootstrap, one synchronous bundle, diagnostics module, deferred bundles.
+
+- [ ] **Step 7: Run focused tests.**
+
+  ```bash
+  cargo test-fastly tsjs_script_tag
+  cargo test-fastly integration_head_injector
+  cargo test-fastly golden_script_tag
+  ```
+
+  Expected: PASS; false/non-GPT/generic output is unmarked and true output has
+  one attributed publisher tag.
+
+- [ ] **Step 8: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/integrations/registry.rs crates/trusted-server-core/src/tsjs.rs crates/trusted-server-core/src/html_processor.rs
+  git commit -m "Authorize GAM attribution bundle"
+  ```
+
+## Task 3: Queue the primary marker before the bootstrap guard
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/gpt_bootstrap.js:17-45`
+- Modify: `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts:8-220`
+- Test: `crates/trusted-server-core/src/integrations/gpt.rs:1131-1454`
+
+- [ ] **Step 1: Extend the raw-source test harness.**
+
+  Add the optional page flag and `setConfig` surface:
+
+  ```typescript
+  interface MockGoogleTag {
+    cmd: MockCommandQueue
+    setConfig?: (config: Record<string, unknown>) => void
+    // retain the existing members
+  }
+
+  type TestWindow = Omit<Window, 'tsjs'> & {
+    googletag?: MockGoogleTag
+    tsjs?: Partial<TsjsApi>
+    __tsjs_gam_attribution_enabled?: boolean
+  }
+
+  function makeGoogleTag(
+    overrides: Partial<MockGoogleTag> = {}
+  ): MockGoogleTag {
+    return {
+      cmd: [],
+      defineSlot: vi.fn(),
+      pubads: vi.fn(() => ({})),
+      enableServices: vi.fn(),
+      display: vi.fn(),
+      ...overrides,
+    }
+  }
+  ```
+
+  Delete the flag in both `beforeEach` and `afterEach`.
+
+- [ ] **Step 2: Write failing behavioral tests.**
+
+  Cover all of these independently:
+  - default/false plus a preinstalled `ts.adInit` returns without creating
+    `window.googletag`;
+  - true queues the exact string-valued targeting callback before a publisher
+    callback appended after `runBootstrap()`;
+  - true plus preinstalled `ts.adInit` still queues and applies targeting but
+    does not replace `adInit` or install the fallback scheduler;
+  - missing `setConfig` is a no-op and the initial-load detector and `adInit`
+    still install;
+  - throwing `setConfig` is caught inside the marker callback, and a later
+    publisher callback still executes;
+  - the wrapped `disableInitialLoad` path still records
+    `ts.gptInitialLoadDisabled`.
+
+  Use a real array queue, append a publisher spy after bootstrap execution, and
+  drain a snapshot in order:
+
+  ```typescript
+  const queue: Array<() => void> = []
+  const setConfig = vi.fn()
+  ;(window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig })
+  ;(window as TestWindow).__tsjs_gam_attribution_enabled = true
+
+  runBootstrap()
+  const publisherCommand = vi.fn()
+  queue.push(publisherCommand)
+  ;[...queue].forEach((command) => command())
+
+  expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } })
+  expect(setConfig.mock.invocationCallOrder[0]).toBeLessThan(
+    publisherCommand.mock.invocationCallOrder[0]
+  )
+  ```
+
+- [ ] **Step 3: Run the raw bootstrap tests and confirm RED.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  npx vitest run test/integrations/gpt/gpt_bootstrap.test.ts
+  ```
+
+  Expected: targeting assertions fail because the raw bootstrap returns before
+  any marker enqueue.
+
+- [ ] **Step 4: Implement one flag-gated queue initialization before the guard.**
+
+  Preserve the local `ts` namespace and reuse `tag` in the existing detector:
+
+  ```javascript
+  var ts = (window.tsjs = window.tsjs || {})
+  var tag
+
+  if (window.__tsjs_gam_attribution_enabled === true) {
+    tag = window.googletag = window.googletag || { cmd: [] }
+    tag.cmd = tag.cmd || []
+    tag.cmd.push(function () {
+      try {
+        var gpt = window.googletag
+        if (gpt && typeof gpt.setConfig === 'function') {
+          // "ts" is the fixed GAM key, not the local window.tsjs alias.
+          gpt.setConfig({ targeting: { ts: 'true' } })
+        }
+      } catch (_) {
+        // Attribution must not interrupt the existing bootstrap queue.
+      }
+    })
+  }
+
+  if (ts.adInit) return
+
+  tag = tag || (window.googletag = window.googletag || { cmd: [] })
+  tag.cmd = tag.cmd || []
+  tag.cmd.push(function () {
+    // existing initial-load detector body, unchanged
+  })
+  ```
+
+  Do not add a global deduplication state machine, network call, beacon, cookie
+  read, slot-level key, or third head insert.
+
+- [ ] **Step 5: Add/retain Rust source-order assertions.**
+
+  In `gpt.rs`, assert the embedded bootstrap's attribution enqueue occurs before
+  `if (ts.adInit) return;` and before the executable
+  `googletag.display(` and `googletag.pubads().refresh(` tokens. Do not compare
+  against comment-only `display()`/`refresh()` text. Retain `ts_initial`
+  assertions and the two-insert count.
+
+- [ ] **Step 6: Run focused JS and Rust tests.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  npx vitest run test/integrations/gpt/gpt_bootstrap.test.ts
+  cd ../../..
+  cargo test-fastly head_inserts
+  ```
+
+  Expected: PASS; default behavior is unchanged and every failure mode is
+  isolated from the existing bootstrap.
+
+- [ ] **Step 7: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/integrations/gpt_bootstrap.js crates/trusted-server-core/src/integrations/gpt.rs crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+  git commit -m "Queue page-level GAM attribution"
+  ```
+
+## Task 4: Add the exact-executing-tag bundle fallback
+
+**Files:**
+
+- Modify: `crates/trusted-server-js/lib/src/integrations/gpt/index.ts:259-307`
+- Modify: `crates/trusted-server-js/lib/src/integrations/gpt/index.ts:1878-1898`
+- Modify: `crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts:350-421`
+
+- [ ] **Step 1: Add a test helper that controls `document.currentScript`.**
+
+  In the runtime-gating suite, install a configurable getter before a fresh
+  dynamic import and restore it afterward:
+
+  ```typescript
+  let executingScript: HTMLScriptElement | null
+
+  Object.defineProperty(document, 'currentScript', {
+    configurable: true,
+    get: () => executingScript,
+  })
+  ```
+
+  Use actual `<script>` elements. Do not authorize tests through
+  `querySelector('#trustedserver-js')`.
+
+- [ ] **Step 2: Write failing activation and fail-closed tests.**
+
+  Prove:
+  - the executing tag with exact `data-ts-gam-attribution="true"` reuses the
+    existing `cmd` array and queues `{ targeting: { ts: 'true' } }`;
+  - missing, empty, `"false"`, or non-exact attribute values do not activate;
+  - `document.currentScript === null` fails closed;
+  - a marked duplicate-ID decoy does not activate when the executing tag is
+    unmarked;
+  - a marked executing tag can activate even if its ID was copied via
+    `srcdoc`/`document.write`, documenting contamination rather than asserting
+    an untrue rewrite guarantee;
+  - the marker queue push occurs while `window.tsjs.adInit` is still absent;
+  - missing or throwing `setConfig` does not prevent `adInit`, SPA, loader, or
+    render-bridge installation;
+  - GPT-enabled but attribution-disabled imports retain current shim/stub
+    behavior while queuing no marker;
+  - with neither the old enable flag nor the new attribute, a plain import still
+    leaves `window.googletag` undefined.
+
+- [ ] **Step 3: Run the suite and confirm RED.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  npx vitest run test/integrations/gpt/index.test.ts
+  ```
+
+  Expected: activation cases fail because the bundle does not inspect its
+  executing tag.
+
+- [ ] **Step 4: Capture the executing tag during module evaluation.**
+
+  Add one module-local capture, not a global lookup:
+
+  ```typescript
+  const executingPublisherScript =
+    typeof document === 'undefined' ? null : document.currentScript
+  ```
+
+  Preserve the `HTMLOrSVGScriptElement | null` type returned by the DOM API or
+  narrow safely by capability; do not use an unchecked ID query.
+
+- [ ] **Step 5: Add a defensive helper using existing GPT types.**
+
+  ```typescript
+  function installTrustedServerPageTargeting(): void {
+    if (
+      executingPublisherScript?.getAttribute('data-ts-gam-attribution') !==
+      'true'
+    ) {
+      return
+    }
+
+    const win = window as GptWindow
+    const tag = ensureGoogleTagStub(win)
+    tag.cmd!.push(() => {
+      try {
+        const gpt = win.googletag
+        if (typeof gpt?.setConfig === 'function') {
+          gpt.setConfig({ targeting: { ts: 'true' } })
+        }
+      } catch (error) {
+        log.warn('[tsjs-gpt] GAM attribution targeting failed', error)
+      }
+    })
+  }
+  ```
+
+  Reuse `GoogleTagConfig` and optional `GoogleTag.setConfig` exactly as they
+  exist. Do not add a new type surface or throw from the callback.
+
+- [ ] **Step 6: Call it in the approved initialization order.**
+
+  ```typescript
+  if (win.__tsjs_gpt_enabled === true) {
+    installGptShim()
+  }
+
+  installTrustedServerPageTargeting()
+  installTsAdInit()
+  installSpaAuctionHook()
+  installSlimPrebidLoader()
+  installTsRenderBridge()
+  ```
+
+  The bootstrap remains primary; duplicate same-value page targeting is
+  intentional and idempotent.
+
+- [ ] **Step 7: Run focused and neighboring GPT suites.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  npx vitest run \
+    test/integrations/gpt/index.test.ts \
+    test/integrations/gpt/gpt_bootstrap.test.ts \
+    test/integrations/gpt/ad_init.test.ts
+  ```
+
+  Expected: PASS with no new script element, request, or slot targeting.
+
+- [ ] **Step 8: Commit.**
+
+  ```bash
+  git add crates/trusted-server-js/lib/src/integrations/gpt/index.ts crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts
+  git commit -m "Add GAM attribution bundle fallback"
+  ```
+
+## Task 5: Characterize targeting collisions and preserve cleanup boundaries
+
+**Files:**
+
+- Test: `crates/trusted-server-core/src/creative_opportunities.rs:1710-1760`
+- Test: `crates/trusted-server-core/src/publisher.rs:8737-8756`
+- Test: `crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts:1870`
+- Test: `crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts:1851`
+- Test: `crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts` publisher-settings coverage
+
+This task adds characterization only. Do not change
+`CreativeOpportunitySlot` parsing, `to_ad_slot`, `build_slot_json`,
+`TS_BASE_TARGETING_KEYS`, `TS_REFRESH_TARGETING_KEYS`, or Prebid interception
+code.
+
+- [ ] **Step 1: Freeze verbatim operator targeting in Rust tests.**
+
+  Add `"ts": "operator-value"` to a test `CreativeOpportunitySlot.targeting`.
+  Assert both:
+
+  ```rust
+  assert_eq!(
+      ad_slot.targeting.get("ts"),
+      Some(&serde_json::Value::String("operator-value".to_owned()))
+  );
+  assert_eq!(
+      build_slot_json(&slot, &config, "example")["targeting"]["ts"],
+      "operator-value"
+  );
+  ```
+
+  This is evidence for the external launch audit, not authorization to filter
+  the key.
+
+- [ ] **Step 2: Freeze GPT slot-cleanup behavior.**
+
+  Extend the existing stale-targeting route test with a slot-level `ts` value.
+  Assert:
+
+  ```typescript
+  expect(clearTargeting).not.toHaveBeenCalledWith('ts')
+  expect(clearTargeting).toHaveBeenCalledWith('ts_initial')
+  ```
+
+  The page-level marker is not a member of the slot cleanup list.
+
+- [ ] **Step 3: Characterize publisher `bidderSettings` preservation.**
+
+  Seed:
+
+  ```typescript
+  mockPbjs.bidderSettings = {
+    exampleBidder: {
+      adserverTargeting: [{ key: 'ts', val: () => 'publisher-value' }],
+    },
+  }
+  ```
+
+  Run the existing wrapped `requestBids` path and assert that adding
+  `trustedServer.allowAlternateBidderCodes` does not delete or rewrite the
+  publisher's `adserverTargeting` entry. Delete or reset `bidderSettings` in the
+  suite cleanup so this collision fixture cannot leak into unrelated tests.
+
+- [ ] **Step 4: Characterize `setTargetingForGPTAsync` collision behavior.**
+
+  In the existing Prebid refresh test, make the mock
+  `setTargetingForGPTAsync` apply slot-level `ts=prebid-value`. Assert it runs
+  before delegated refresh, `clearTargeting('ts')` was not called, and no
+  Trusted Server wrapper filters the value. Retain the current
+  `ts_initial`/`hb_*` clearing assertions.
+
+- [ ] **Step 5: Run characterization suites.**
+
+  ```bash
+  cargo test-fastly to_ad_slot
+  cargo test-fastly ad_slots_script_contains_slot_data
+  cd crates/trusted-server-js/lib
+  npx vitest run \
+    test/integrations/gpt/ad_init.test.ts \
+    test/integrations/prebid/index.test.ts
+  ```
+
+  Expected: PASS without production-code changes. If a test reveals current
+  filtering, stop and reconcile the spec instead of adding compensating
+  behavior.
+
+- [ ] **Step 6: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/creative_opportunities.rs crates/trusted-server-core/src/publisher.rs crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts
+  git commit -m "Characterize targeting collisions"
+  ```
+
+## Task 6: Characterize marked-head streaming before origin EOF
+
+**Files:**
+
+- Test: `crates/trusted-server-core/src/publisher.rs:7756-7885`
+- Verify unchanged: `crates/trusted-server-core/src/streaming_processor.rs:297-364`
+- Verify unchanged: `crates/trusted-server-adapter-fastly/src/main.rs:322-358`
+
+This task must not add buffering or adapter logic.
+
+- [ ] **Step 1: Add a test-only settings-aware streaming helper.**
+
+  Let the existing `streaming_finalize_response` delegate to a sibling that
+  accepts `Settings`. The helper still builds
+  `IntegrationRegistry::new(&settings)` and polls the same lazy body; do not
+  alter production parameters.
+
+- [ ] **Step 2: Add the before-EOF regression.**
+
+  Configure enabled GPT attribution in test settings, send an HTML origin chunk
+  followed by permanent `Pending`, and poll exactly one client chunk:
+
+  ```rust
+  #[test]
+  fn streaming_finalize_emits_gam_attribution_head_before_origin_eof() {
+      let mut settings = create_test_settings();
+      settings
+          .integrations
+          .insert_config(
+              "gpt",
+              &serde_json::json!({
+                  "enabled": true,
+                  "gam_attribution_enabled": true
+              }),
+          )
+          .expect("should insert GPT config");
+
+      let body = streaming_finalize_response_with_settings(
+          html_stream_params("", None),
+          origin_chunk_then_pending(bytes::Bytes::from_static(
+              b"<html><head></head><body><p>origin remains pending</p>"
+          )),
+          settings,
+      );
+      let html = String::from_utf8(first_lazy_body_chunk(body).to_vec())
+          .expect("should emit UTF-8 HTML");
+
+      assert!(html.contains("__tsjs_gam_attribution_enabled=true"));
+      assert!(html.contains("data-ts-gam-attribution=\"true\""));
+  }
+  ```
+
+  If the rewriter needs more input to flush, use the established large-prefix or
+  auction-hold fixture pattern; never complete the origin stream to make the
+  test pass.
+
+- [ ] **Step 3: Run the new and existing streaming/error regressions.**
+
+  ```bash
+  cargo test-fastly streaming_finalize_emits_gam_attribution_head_before_origin_eof
+  cargo test-fastly streaming_finalize_emits_compressed_html_before_origin_eof
+  cargo test-fastly stream_publisher_body_surfaces_mid_stream_decode_error
+  ```
+
+  Expected: PASS. The new marker is in the first rewritten head chunk, and the
+  existing later decoder error still surfaces as truncation rather than
+  reclassification or buffering.
+
+- [ ] **Step 4: Confirm the diff contains test code only for this task.**
+
+  ```bash
+  git diff -- crates/trusted-server-core/src/publisher.rs crates/trusted-server-core/src/streaming_processor.rs crates/trusted-server-adapter-fastly/src/main.rs
+  ```
+
+  Expected: `publisher.rs` test module changes only; no production streaming or
+  Fastly adapter changes.
+
+- [ ] **Step 5: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/publisher.rs
+  git commit -m "Define GAM attribution streaming semantics"
+  ```
+
+## Task 7: Publish configuration, environment, browser-smoke, and operator docs
+
+**Files:**
+
+- Modify: `trusted-server.example.toml:105-109`
+- Modify: `crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml:87-91`
+- Modify: `crates/trusted-server-cli/tests/config_env_overlay.rs`
+- Modify: `crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts:4-12`
+- Modify: `docs/guide/integrations/gpt.md:49-110`
+
+- [ ] **Step 1: Write the failing typed-CLI overlay test.**
+
+  Add:
+
+  ```rust
+  const GAM_ATTRIBUTION_ENV: &str =
+      "TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED";
+  ```
+
+  Use `ts config push` with `GAM_ATTRIBUTION_ENV=true` and inspect the stored
+  blob envelope:
+
+  ```rust
+  assert_eq!(
+      envelope["data"]["integrations"]["gpt"]["gam_attribution_enabled"],
+      serde_json::Value::Bool(true)
+  );
+  ```
+
+  Run before adding the fixture leaf to demonstrate EdgeZero v0.0.4 cannot
+  create the missing leaf.
+
+- [ ] **Step 2: Confirm the overlay test is RED.**
+
+  ```bash
+  ./scripts/test-cli.sh
+  ```
+
+  Expected: the new assertion fails because the base TOML does not yet contain
+  `gam_attribution_enabled`.
+
+- [ ] **Step 3: Add the explicit disabled leaf to both TOML files.**
+
+  ```toml
+  [integrations.gpt]
+  enabled = false
+  gam_attribution_enabled = false
+  ```
+
+  Preserve the surrounding GPT URL/cache/rewrite fields. The comprehensive
+  browser fixture remains GPT-disabled and attribution-disabled.
+
+- [ ] **Step 4: Extend the default-off browser smoke.**
+
+  In `script-injection.spec.ts`, keep the existing one-tag/source assertion and
+  add:
+
+  ```typescript
+  await expect(script).not.toHaveAttribute('data-ts-gam-attribution')
+  ```
+
+  Do not add a second Playwright project or enable GPT globally. Enabled
+  behavior is covered deterministically by Rust/Vitest and later by the external
+  deployment validation.
+
+- [ ] **Step 5: Update the GPT configuration reference.**
+
+  Add `gam_attribution_enabled = false` to the snippet and a table row stating:
+  - type boolean;
+  - optional;
+  - default false;
+  - independently enables fixed page-level GAM `ts=true` attribution.
+
+  State that an environment override works only when this TOML leaf already
+  exists:
+
+  ```text
+  TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED
+  ```
+
+- [ ] **Step 6: Add the operator attribution section.**
+
+  Near “Command Queue Patch,” document:
+  - `ts=true` is page-level and persists for the browser document;
+  - `ts_initial=1` remains slot-level and is cleared on its existing lifecycle;
+  - the marker means an eligible, non-cloned TS publisher pipeline emitted the
+    head, not that a TS bid won or the body completed;
+  - the fixed short key must pass publisher GPT, Prebid
+    `bidderSettings/adserverTargeting/setTargetingForGPTAsync`, effective
+    creative-opportunity map, and GAM-consumer collision audits;
+  - there is no runtime filtering of operator targeting;
+  - privacy/CSP review, reportable predefined value, Enhanced-or-exact-legacy
+    report dry run, and excluded-path zero counts are launch gates;
+  - Report A is the non-duplicated eligible-scope total, Report B uses the same
+    dates/time zone/inventory/metrics plus exactly `ts=true`, and legacy
+    Key-values rows are never summed;
+  - control is `Report A - Report B`; every interpreted metric must satisfy
+    `0 <= Report B <= Report A`, and a violation invalidates the complete pair
+    rather than being clamped;
+  - saved report pairs are exported after the same reporting-latency and
+    invalid-traffic window, and monitoring/synthetic samples do not prove
+    per-response marker completeness;
+  - normal rollback stops and verifies routing before flipping the setting,
+    then excludes the open-document drain interval;
+  - an emergency kill flips immediately and invalidates the affected/drain
+    interval.
+
+  Label GAM results descriptive delivery attribution, not causal analysis. Do
+  not update `docs/guide/integrations/gam.md`, which describes a separate future
+  integration.
+
+- [ ] **Step 7: Run configuration, docs, and browser checks.**
+
+  ```bash
+  ./scripts/test-cli.sh
+  cd docs
+  npm run format
+  npm run build
+  cd ..
+  ./scripts/integration-tests-browser.sh
+  ```
+
+  Expected: CLI overlay PASS; docs format/build PASS; Next.js and WordPress
+  browser suites PASS with an unmarked default-off publisher tag.
+
+- [ ] **Step 8: Commit.**
+
+  ```bash
+  git add trusted-server.example.toml crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml crates/trusted-server-cli/tests/config_env_overlay.rs crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts docs/guide/integrations/gpt.md
+  git commit -m "Document GAM attribution configuration"
+  ```
+
+## Task 8: Run the complete repository verification matrix
+
+**Files:**
+
+- Verify all files changed in Tasks 1-7
+- Follow: `CLAUDE.md`
+
+- [ ] **Step 1: Format and inspect before the expensive matrix.**
+
+  ```bash
+  cargo fmt --all
+  cd crates/trusted-server-js/lib
+  npm run format
+  cd ../../../docs
+  npm run format
+  cd ..
+  git diff --check
+  git status --short
+  ```
+
+  Expected: formatters succeed and only intended feature files are modified. If
+  a formatter changes committed content, inspect and commit that correction
+  before continuing.
+
+- [ ] **Step 2: Run all target-matched Rust lints.**
+
+  ```bash
+  cargo clippy-fastly
+  cargo clippy-axum
+  cargo clippy-cloudflare
+  cargo clippy-cloudflare-wasm
+  cargo clippy-spin-native
+  cargo clippy-spin-wasm
+  ```
+
+  Expected: PASS with `-D warnings`. Do not substitute bare workspace clippy.
+
+- [ ] **Step 3: Run all target-matched Rust suites.**
+
+  ```bash
+  cargo test-fastly
+  cargo test-axum
+  cargo test-cloudflare
+  cargo test-spin
+  cargo test --manifest-path crates/trusted-server-integration-tests/Cargo.toml --test parity
+  ./scripts/test-cli.sh
+  ```
+
+  Expected: PASS. Do not use bare `cargo test --workspace`.
+
+- [ ] **Step 4: Run the full TypeScript build, tests, lint, and format check.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  node build-all.mjs
+  npx vitest run
+  npm run lint
+  npm run format
+  ```
+
+  Expected: all bundles build and all tests/lint/format checks pass.
+
+- [ ] **Step 5: Run docs and browser integration gates.**
+
+  ```bash
+  cd docs
+  npm run format
+  npm run build
+  cd ..
+  ./scripts/integration-tests-browser.sh
+  ```
+
+  Expected: docs build and both browser frameworks pass.
+
+- [ ] **Step 6: Recheck the final diff and commits.**
+
+  ```bash
+  cargo fmt --all -- --check
+  git diff --check
+  git status --short
+  git log --oneline --decorate -8
+  ```
+
+  Expected: a clean worktree, seven focused implementation commits, and no
+  production changes to creative-opportunity filtering, Prebid interception,
+  streaming buffering, or adapter behavior.
+
+## External launch gates (not repository implementation)
+
+Do not mark implementation complete as “experiment ready” until an operator
+records these artifacts for the target GAM network. These steps intentionally
+remain separate from Tasks 1-8 because they require publisher/router/GAM access.
+
+- [ ] Create or verify the one predefined reportable key/value `ts=true` and
+      retain the target-network 10-character preflight evidence.
+- [ ] Freeze the exact eligible route/site/ad-unit/format/time-zone/window
+      manifest and derive both saved reports and every exclusion query from it.
+- [ ] Record Enhanced key-value availability, metric compatibility, owner
+      approval, and displayed billing terms; otherwise enable the key for legacy
+      reporting and validate the exact `ts=true` filter without summing
+      Key-values rows.
+- [ ] Retain zero-count evidence or an identical independent filter for every
+      excluded path: non-experiment TS, smoke/direct/operations, IMA/video,
+      direct tags, server-side GAM, and excluded nested inventory.
+- [ ] Complete publisher GPT, Prebid, effective creative-opportunity map, and
+      every GAM targeting-consumer collision audits with owners, queries,
+      timestamps, and re-audit triggers.
+- [ ] Complete privacy/data-governance and CSP eligibility reviews.
+- [ ] With treatment routing stopped, deploy
+      `gam_attribution_enabled = true` to the validation deployment.
+- [ ] Validate initial/lazy/refresh/publisher-owned/SPA requests, control
+      absence, `ts_initial` isolation, CSP execution, fallback incident
+      detection, and the disabled kill switch.
+- [ ] Save a short paired Report A/Report B dry run and verify
+      `0 <= Report B <= Report A` for every selected metric.
+- [ ] Start the sticky treatment cohort only after every gate passes; use GAM
+      share versus router allocation only as a diagnostic.
+- [ ] For normal rollback, close the clean report boundary, stop and verify new
+      treatment routing, disable attribution, and exclude the marked-document
+      drain interval. For an emergency kill, disable immediately and invalidate
+      the affected plus drain intervals.
+
+## Definition of done
+
+- The repository behavior and automated tests satisfy every code-addressable
+  design acceptance criterion; experiment-readiness remains explicitly gated
+  on the external checklist above.
+- `gam_attribution_enabled` is default-off, externally overridable only from an
+  existing TOML leaf, and does not disable any existing GPT behavior.
+- Enabled publisher documents receive both activation signals, and at least one
+  callback successfully applies the single effective page-level `ts=true` value
+  before publisher GPT requests. The same-value fallback callback remains safe.
+- Generic/creative tags, production/control pages, and default-off fixtures are
+  unmarked.
+- `ts_initial`, slot cleanup, arbitrary operator targeting, Prebid behavior,
+  Fastly streaming, and adapters have no production behavior changes.
+- All `CLAUDE.md` target-matched gates pass.
+- External GAM artifacts are explicitly outstanding until an authorized
+  operator completes the launch checklist.

--- a/docs/superpowers/plans/2026-08-03-datadome-ip-excluded-client-tag.md
+++ b/docs/superpowers/plans/2026-08-03-datadome-ip-excluded-client-tag.md
@@ -1,0 +1,470 @@
+# DataDome IP-excluded client tag suppression — Implementation Plan
+
+> **Status:** Approved for implementation
+>
+> **For implementers:** Work task by task and keep the workspace buildable.
+> Follow `CLAUDE.md`: use target-matched Cargo aliases, do not use bare
+> workspace tests, and do not add an internal HTTP header for request state.
+
+**Goal:** When Fastly's authoritative client IP matches a DataDome IP exclusion,
+skip the Protection API call and omit only Trusted Server's automatically
+injected DataDome client tag from every processed HTML response.
+
+**Issue:** #994
+**Design:**
+`docs/superpowers/specs/2026-08-03-datadome-ip-excluded-client-tag-design.md`
+
+## Approved behavior
+
+| Request condition                                             | Protection API  | Trusted Server auto-injected tag | Publisher-originated tag |
+| ------------------------------------------------------------- | --------------- | -------------------------------- | ------------------------ |
+| Inline IP CIDR match                                          | Skipped         | Omitted                          | Unchanged                |
+| Config Store IP CIDR-source match                             | Skipped         | Omitted                          | Unchanged                |
+| Structured `ip_cidr` match                                    | Skipped         | Omitted                          | Unchanged                |
+| Structured `ip_cidr_source` match                             | Skipped         | Omitted                          | Unchanged                |
+| ASN, method, path, query, static, or internal-route exclusion | Skipped         | Preserved                        | Unchanged                |
+| No exclusion match                                            | Called normally | Preserved                        | Unchanged                |
+| Protection API fail-open                                      | Continued       | Preserved                        | Unchanged                |
+
+The Fastly-only scope means that other adapters receive the default
+non-suppressed value. Do not add a configuration option and do not modify their
+request-filter wiring.
+
+## Runtime contracts
+
+1. **Trusted identity source:** determine exclusion from
+   `RuntimeServices::client_info().client_ip`, never a caller-provided header.
+2. **Single evaluation:** use the existing `ProtectionScope` decision. Do not
+   evaluate CIDRs a second time while injecting HTML; this avoids diverging
+   Config Store/cache behavior.
+3. **Private marker:** communicate the decision with a typed request extension,
+   never a request/response header. The marker cannot leak to the origin or
+   client.
+4. **Precise scope:** tag suppression uses typed scope metadata and applies whenever an IP exclusion overlaps the primary first-match skip reason.
+5. **Cache safety:** an HTML response with the tag omitted differs by client IP.
+   A suppressed processed HTML response must be `private, no-store` and have
+   `Surrogate-Control` and `Fastly-Surrogate-Control` removed. Do not alter
+   cache headers when the response is not processed HTML, because this feature
+   does not alter that body.
+6. **No behavior drift:** DataDome proxy endpoints, response-header effects,
+   `rewrite_sdk`, and DataDome tags that were already in origin HTML retain
+   their current behavior.
+
+## File map
+
+| File                                                                          | Change                                                                                                                                                  |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `crates/trusted-server-core/src/integrations/registry.rs`                     | Permit filters to attach private typed request extensions while retaining header-effect semantics. Extend the HTML context with the propagated boolean. |
+| `crates/trusted-server-core/src/integrations/datadome.rs`                     | Define the crate-private marker and have the head injector honor the HTML-context flag.                                                                 |
+| `crates/trusted-server-core/src/integrations/datadome/protection.rs`          | Recognize IP scope skips, attach the marker, and add `client_tag=omitted` to the existing info log.                                                     |
+| `crates/trusted-server-core/src/html_processor.rs`                            | Carry the per-response suppression boolean from config to all integration HTML contexts.                                                                |
+| `crates/trusted-server-core/src/publisher.rs`                                 | Snapshot the marker before origin dispatch, propagate it through every HTML streaming path, and apply cache privacy to suppressed processed HTML.       |
+| `docs/guide/integrations/datadome.md`                                         | Document the Fastly IP-exclusion behavior and its limits.                                                                                               |
+| `docs/superpowers/specs/2026-08-03-datadome-ip-excluded-client-tag-design.md` | Already updated with the cache-variance safeguard.                                                                                                      |
+
+No changes are expected in `trusted-server.example.toml`, JavaScript bundles,
+or non-Fastly adapters.
+
+---
+
+## Task 1: Make the request-filter input capable of private annotations
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/registry.rs`
+- Test: its existing `#[cfg(test)]` module
+
+The current `RequestFilterInput` holds `&Request<EdgeBody>`. Change it to hold
+`&mut Request<EdgeBody>` so a request filter can add a typed extension. This is
+the narrowest safe transport because the registry already has exclusive mutable
+access to the request while it invokes each filter.
+
+- [ ] **Step 1: Add a regression test for an extension-producing filter.** Create
+      a test-only zero-sized marker and filter that writes it to
+      `input.request.extensions_mut()`. Run `IntegrationRegistry::filter_request`
+      and assert the original mutable request has the marker afterward. In the
+      same test, verify normal `RequestFilterEffects` still apply their request
+      header mutation and return their response header mutation.
+- [ ] **Step 2: Change `RequestFilterInput::request` to a mutable borrow.** Keep
+      the `IntegrationRequestFilter` method signature and `RequestFilterEffects`
+      unchanged.
+- [ ] **Step 3: Update `IntegrationRegistry::filter_request`.** Pass its existing
+      `&mut Request` directly to each `RequestFilterInput`. Keep the ordering:
+      filter mutation first, then registry-applied request-header effects, then
+      the next filter.
+- [ ] **Step 4: Update all direct filter tests and test filters.** Calls that build
+      `RequestFilterInput` must construct a mutable request and pass
+      `request: &mut request`. Read-only filters should continue to compile by
+      simply not mutating the request.
+- [ ] **Step 5: Run focused tests.**
+
+```bash
+cargo test-fastly integrations::registry
+```
+
+**Acceptance:** a filter can retain a typed marker for downstream route handling
+without emitting a synthetic `x-*` header, and existing header effects retain
+their behavior.
+
+---
+
+## Task 2: Mark IP-based DataDome exclusions and log the outcome
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/datadome.rs`
+- Modify: `crates/trusted-server-core/src/integrations/datadome/protection.rs`
+- Test: `crates/trusted-server-core/src/integrations/datadome/protection.rs`
+- Reuse: `crates/trusted-server-core/src/integrations/datadome/protection_scope.rs`
+
+- [ ] **Step 1: Add a crate-private marker in `datadome.rs`.** Define a
+      zero-sized type with a behavior-oriented name, such as
+      `DataDomeClientTagSuppressed`. It must be visible to `publisher.rs` and
+      `protection.rs` through `pub(crate)`, but must not be exported as public
+      integration configuration or API.
+- [ ] **Step 2: Add an IP-reason predicate beside protection logging.** Centralize
+      the exact four eligible scope reasons in one helper:
+
+```rust
+matches!(reason, "client_ip" | "client_ip_source" | "ip_cidr" | "ip_cidr_source")
+```
+
+      Do not infer eligibility from rule ID: Config Store source rule IDs are
+      operator-configured strings.
+
+- [ ] **Step 3: Make `filter_protection_request` own a mutable input and pass it
+      mutably to `is_request_protected`.** In the existing
+      `ProtectionScopeDecision::Skip` arm:
+  1. determine whether the reason is IP-based;
+  2. if so, insert the typed marker into `input.request.extensions_mut()`;
+  3. call the updated skip logger with `client_tag_omitted = true`; and
+  4. return `false` exactly as today so the Protection API is not called.
+
+     Do not set the marker for the early method/integration/internal-route
+     returns. Do not set it when the API call returns a fail-open error.
+
+- [ ] **Step 4: Update `log_protection_skip`.** Keep IP exclusions at `info` and
+      non-IP exclusions at `debug`. For the IP branch, extend the existing
+      structured text after the reason with `client_tag=omitted`; retain rule,
+      reason, method, host, and path, but do not include the client IP. The
+      desired shape is:
+
+```text
+[datadome] protection decision=skipped rule=excluded-ip-cidrs reason=client_ip client_tag=omitted method=GET
+```
+
+- [ ] **Step 5: Add filter-level marker tests.** Add small helpers in the
+      protection test module to build `RuntimeServices` with a fixed client IP,
+      optional Config Store data, and a mutable request. For each case, call
+      `filter_protection_request`, assert it returns `Continue`, and inspect the
+      request extension:
+  - inline `protection_excluded_ip_cidrs` match → marker present;
+  - `protection_excluded_ip_cidr_sources` match → marker present;
+  - structured `ProtectionMatcherConfig::IpCidr` match → marker present;
+  - structured `ProtectionMatcherConfig::IpCidrSource` match → marker present.
+
+    Clear the process-global CIDR-source test cache before and after source
+    tests so cached values cannot affect another case.
+
+- [ ] **Step 6: Add negative filter-level tests.** Assert the marker is absent
+      for a non-matching IP, a configured ASN match, a structured path match,
+      a structured query match, an excluded method, and an internal/integration
+      route. Reuse the existing `ProtectionScope` unit tests for matching
+      semantics; these new tests verify only the new side effect.
+- [ ] **Step 7: Preserve API-call behavior.** For an IP marker test, use an HTTP
+      client double that records calls or errors if called. Assert no Protection
+      API request is sent. This protects against accidentally marking a request
+      while still invoking DataDome.
+- [ ] **Step 8: Run focused tests.**
+
+```bash
+cargo test-fastly datadome::protection
+cargo test-fastly datadome::protection_scope
+```
+
+**Acceptance:** typed scope metadata adds the private marker whenever an
+applicable IP exclusion matches, including overlap with an earlier primary skip
+reason. Navigation suppression uses the augmented informational log,
+subresources use debug, and non-overlapping/fail-open paths keep their current
+tag behavior.
+
+---
+
+## Task 3: Thread suppression through publisher response processing
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/publisher.rs`
+- Modify: `crates/trusted-server-core/src/html_processor.rs`
+- Modify: `crates/trusted-server-core/src/integrations/registry.rs`
+- Test: `publisher.rs` and `html_processor.rs` test modules
+
+### Data flow to implement
+
+```text
+DataDomeClientTagSuppressed request extension
+  -> bool captured by handle_publisher_request before origin dispatch
+  -> OwnedProcessResponseParams
+  -> ProcessResponseParams / HtmlStreamProcessorParams
+  -> HtmlProcessorConfig
+  -> IntegrationHtmlContext
+  -> DataDomeIntegration::head_inserts
+```
+
+- [ ] **Step 1: Capture the marker once in `handle_publisher_request`.** Read
+      `req.extensions().get::<DataDomeClientTagSuppressed>().is_some()` before
+      `req` is rewritten and moved into `PlatformHttpRequest`. Store the boolean
+      only in the `PublisherResponse::Stream` parameters, because that is the
+      only response route that passes through HTML injection.
+- [ ] **Step 2: Add a boolean to the owned and borrowed publisher-processing
+      parameter structs.** Add a clearly named field such as
+      `suppress_datadome_client_side_tag` to:
+  - `OwnedProcessResponseParams`;
+  - `ProcessResponseParams`; and
+  - `HtmlStreamProcessorParams`.
+
+    Pass it through all three existing HTML construction sites:
+
+  - `PublisherBodyProcessor::new` for async buffered processing;
+  - `process_response_streaming` for synchronous processing; and
+  - `stream_publisher_body_async` for the Fastly streaming auction-hold path.
+
+    Every test fixture that constructs `OwnedProcessResponseParams` directly
+    must set `false` unless it explicitly exercises suppression.
+
+- [ ] **Step 3: Extend `HtmlProcessorConfig`.** Add the same boolean, default it
+      to `false` in `from_settings`, and add a narrow builder method used by
+      `create_html_stream_processor`. Update direct `HtmlProcessorConfig`
+      fixtures and the benchmark fixture to set `false` explicitly.
+- [ ] **Step 4: Extend `IntegrationHtmlContext`.** Add the boolean as immutable
+      request-scoped context. Populate it at both construction sites in
+      `html_processor.rs`:
+  - the streaming `<head>` element handler; and
+  - `HtmlWithPostProcessing::process_chunk` for full-document post-processors.
+
+    Update every test helper that constructs `IntegrationHtmlContext` to set
+    `false` by default.
+
+- [ ] **Step 5: Add plumbing tests.**
+  - `HtmlProcessorConfig::from_settings` defaults to non-suppressed.
+  - A test head injector records the context flag and sees `true` when a config
+    is built with suppression.
+  - A `publisher.rs` route test inserts the DataDome marker into a request,
+    receives a processable HTML `PublisherResponse::Stream`, and verifies the
+    owned parameters carry `true`.
+  - A buffered and a streaming-body path both preserve `true` to head injection.
+
+- [ ] **Step 6: Run focused tests.**
+
+```bash
+cargo test-fastly html_processor
+cargo test-fastly publisher
+```
+
+**Acceptance:** the decision is read once from a private request extension and
+is available to every head injector for every processed HTML response, including
+Fastly's streaming path.
+
+---
+
+## Task 4: Omit only Trusted Server's injected DataDome tag
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/datadome.rs`
+- Test: `crates/trusted-server-core/src/integrations/datadome.rs`
+- Test: `crates/trusted-server-core/src/html_processor.rs` or `publisher.rs`
+
+- [ ] **Step 1: Add a direct head-injector regression test.** With a client-side
+      key configured and `ctx.suppress_datadome_client_side_tag = true`, assert
+      `head_inserts()` returns an empty vector. The same config with `false`
+      must still return exactly one snippet containing both `window.ddjskey` and
+      the configured tag URL.
+- [ ] **Step 2: Implement the guard as the first condition in
+      `DataDomeIntegration::head_inserts`.** Return an empty vector when the
+      context flag is true; otherwise retain all current serialization,
+      escaping, blank-key, and `inject_client_side_tag` behavior unchanged.
+- [ ] **Step 3: Add an end-to-end HTML pipeline test.** Configure the DataDome
+      integration with a client-side key, process representative HTML with
+      suppression enabled, and assert the result contains neither:
+
+```text
+window.ddjskey=
+/integrations/datadome/tags.js
+```
+
+      Repeat with suppression disabled and assert both appear.
+
+- [ ] **Step 4: Pin publisher-originated-tag behavior.** Feed origin HTML that
+      contains a DataDome `tags.js` element. With suppression enabled, assert
+      that element remains in output and is rewritten by `rewrite_sdk` exactly
+      as before. This distinguishes automatic injection from origin markup.
+- [ ] **Step 5: Pin direct route behavior.** Retain or add a DataDome proxy test
+      showing that `GET /integrations/datadome/tags.js` remains registered and
+      fetches/proxies the SDK normally; suppression affects only HTML injection.
+- [ ] **Step 6: Run focused tests.**
+
+```bash
+cargo test-fastly datadome
+```
+
+**Acceptance:** suppression removes only the generated configuration/script
+pair; nothing removes publisher markup or disables DataDome endpoints.
+
+---
+
+## Task 5: Make tag-suppressed processed HTML private
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/publisher.rs`
+- Test: `crates/trusted-server-core/src/publisher.rs`
+
+The automatic tag makes the processed HTML vary by client IP. Cache privacy is
+therefore a correctness and protection requirement, not an optional
+optimization.
+
+- [ ] **Step 1: Add a failing cache-privacy test.** Build a `PublisherResponse`
+      with a processable HTML content type, suppression `true`, and cacheable
+      origin headers (`Cache-Control`, `Surrogate-Control`, and
+      `Fastly-Surrogate-Control`). Assert the stream response is:
+  - `Cache-Control: private, no-store`; and
+  - missing both surrogate cache headers.
+
+- [ ] **Step 2: Apply privacy only in the `ResponseRoute::Stream` HTML arm.**
+      After response classification confirms a processable HTML stream, use the
+      existing per-user ad-stack policy as the model. Do not alter cache headers
+      for CSS, RSC, non-processable pass-through, unsupported encodings, HEAD,
+      204/205/304, or responses without suppression: none has a body variation
+      created by this feature.
+- [ ] **Step 3: Add non-regression cache tests.** Verify that:
+  - non-suppressed processed HTML keeps its existing cache headers unless
+    another existing policy changes them;
+  - a suppressed CSS/non-HTML stream is not made private by this feature; and
+  - existing ad-stack privacy behavior remains unchanged when both features are
+    active.
+
+- [ ] **Step 4: Run focused tests.**
+
+```bash
+cargo test-fastly publisher
+```
+
+**Acceptance:** newly synthesized tagless HTML is private and non-storable,
+while unchanged responses retain their existing cacheability. A shared cache in
+front of Trusted Server that already holds tag-bearing HTML must be bypassed or
+purged for guaranteed suppression.
+
+---
+
+## Task 6: Add Fastly-path regression coverage
+
+**Files:**
+
+- Modify: `crates/trusted-server-adapter-fastly/src/app.rs` tests only if the
+  existing dispatch helpers can exercise the DataDome registry with a stubbed
+  publisher response.
+- Otherwise, document the existing core filter + publisher pipeline tests as
+  the executable behavioral coverage; do not refactor Fastly production code
+  merely to enable a duplicate test.
+
+- [ ] **Step 1: Extend the existing Fastly request-filter dispatch regression
+      test or add a focused equivalent.** Configure a DataDome request filter,
+      insert trusted `ClientInfo` into the request extensions with a matching
+      IP, and confirm the filter runs before publisher routing.
+- [ ] **Step 2: Assert that the routed request retains the private DataDome
+      marker.** The assertion must inspect request extensions or the processed
+      HTML result, not an HTTP header.
+- [ ] **Step 3: Ensure no actual DataDome API call occurs for the matching IP.**
+      Use a recording/failing HTTP client or the existing Fastly test seam.
+- [ ] **Step 4: Add the non-matching counterpart.** It must not receive the
+      marker and must continue to inject the configured tag when HTML is
+      processed.
+- [ ] **Step 5: Run Fastly adapter tests.**
+
+```bash
+cargo test-fastly
+```
+
+**Acceptance:** the production adapter's actual filter ordering preserves the
+marker from authoritative Fastly client metadata through publisher HTML
+processing. If the current test seam cannot stub a full origin response, retain
+this as focused request-filter-order coverage and rely on Task 3's core
+pipeline tests for body output rather than expanding adapter production code.
+
+---
+
+## Task 7: Document operator-visible behavior
+
+**Files:**
+
+- Modify: `docs/guide/integrations/datadome.md`
+- Do not modify: `trusted-server.example.toml`
+
+- [ ] **Step 1: Add a subsection adjacent to “Protected traffic” or “Client-side
+      setup.”** State that, on Fastly, an IP exclusion skips the Protection API
+      and suppresses only Trusted Server's automatic DataDome tag injection on
+      processed HTML.
+- [ ] **Step 2: List the four covered IP sources.** Use the exact configuration
+      names and structured rule types.
+- [ ] **Step 3: State the exclusions that do not suppress the client tag.** ASN,
+      method, path, query, static-asset, and internal-route exclusions retain
+      normal auto-injection.
+- [ ] **Step 4: State the limits.** Publisher-originated/manual tags are not
+      removed; `/integrations/datadome/tags.js` remains available; no new
+      configuration is required; and tag-suppressed processed HTML is private
+      to prevent shared-cache replay.
+- [ ] **Step 5: Add the diagnostic example.** Use an example-only host/IP and
+      include `client_tag=omitted` with rule and reason.
+- [ ] **Step 6: Format-check the changed documentation.**
+
+```bash
+cd docs
+npx prettier --check guide/integrations/datadome.md \
+  superpowers/specs/2026-08-03-datadome-ip-excluded-client-tag-design.md \
+  superpowers/plans/2026-08-03-datadome-ip-excluded-client-tag.md
+```
+
+**Acceptance:** operators can predict exactly when the tag will be omitted and
+understand that this is an IP-based Fastly behavior, not a general exclusion
+side effect.
+
+---
+
+## Final verification
+
+- [ ] Confirm the working tree contains only the intended core, Fastly-test,
+      guide, spec, and plan changes.
+- [ ] Run formatting.
+
+```bash
+cargo fmt --all -- --check
+```
+
+- [ ] Run the relevant target-matched test suites.
+
+```bash
+cargo test-fastly
+cargo test-axum
+cargo test-cloudflare
+```
+
+- [ ] Run required lint suites.
+
+```bash
+cargo clippy-fastly
+cargo clippy-axum
+cargo clippy-cloudflare
+```
+
+- [ ] Run the docs check from Task 7.
+- [ ] Review the diff for accidental exposure of the marker as a request or
+      response header, duplicate CIDR evaluation, unintended publisher-tag
+      removal, or shared-cacheable tag-suppressed HTML.
+
+## Deferred acceptance
+
+Do **not** perform live production/browser verification in this change. After
+deployment, the separate testing workflow should verify that a matching
+whitelisted IP receives processed HTML without Trusted Server's
+`/integrations/datadome/tags.js` injection, while an unlisted IP retains it.

--- a/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
@@ -2,6 +2,8 @@
 
 Date: 2026-07-15
 
+Updated: 2026-08-14
+
 Status: Design
 
 ## Problem
@@ -20,16 +22,17 @@ the experiment marker:
 - it is cleared before later client-side refresh auctions; and
 - it is set on matched slots rather than every GPT request on the page.
 
-The experiment needs a document-delivery marker. Every request issued by the
-document-local GPT PubAds service after marker installation in an HTML document
-successfully rewritten by Trusted Server must contain `ts=true`, including
-initial requests, publisher-owned slots, lazy slots, and refreshes. Production
-documents cannot be modified, so the control cohort remains unmarked.
+The experiment needs a document-delivery marker. When attribution is explicitly
+enabled, every request issued by the document-local GPT PubAds service after
+Trusted Server rewrites and emits the document head must contain `ts=true`,
+including initial requests, publisher-owned slots, lazy slots, and refreshes.
+Production documents cannot be modified, so the control cohort remains
+unmarked.
 
 ## Goals
 
-1. Add `ts=true` to every in-scope GPT PubAds request made during the lifetime
-   of an HTML document successfully rewritten by Trusted Server.
+1. Add `ts=true` to every in-scope GPT PubAds request made after Trusted Server
+   rewrites and emits the document head.
 2. Leave production/control pages unchanged.
 3. Preserve the existing `ts_initial=1` slot-ownership and refresh lifecycle.
 4. Support GAM reports that count treatment impressions and clicks and derive
@@ -38,22 +41,26 @@ documents cannot be modified, so the control cohort remains unmarked.
    performance.
 6. Define the data-quality checks needed when an unmarked request is used as the
    control baseline.
+7. Keep attribution disabled by default and independently reversible without
+   disabling the GPT integration.
 
 ## Non-goals
 
 - Implement or change the cookie-based A/B router. The experiment infrastructure
   owns sticky cohort assignment and routes only the treatment cohort through
   Trusted Server.
-- Prove that a Trusted Server server-side bid won the GAM auction. `ts=true`
-  means that the page was delivered through Trusted Server, regardless of
-  whether the winning demand was a server-side bid, a direct GAM line item, Ad
-  Exchange, or backfill.
-- Mark GAM traffic outside a successfully rewritten document's local GPT PubAds
-  service. IMA/video SDK requests, direct tags, and server-side GAM requests
-  require separate instrumentation and are outside this design. A nested
-  document's GPT instance is in scope only when that nested HTML response is
-  independently routed through Trusted Server and satisfies the same rewrite,
-  ordering, CSP, and audit prerequisites.
+- Prove that a Trusted Server server-side bid won the GAM auction. For an
+  in-scope document satisfying the non-cloned activation prerequisite, `ts=true`
+  means that Trusted Server emitted the document head through its publisher
+  pipeline, regardless of whether the winning demand was a server-side bid, a
+  direct GAM line item, Ad Exchange, or backfill.
+- Mark GAM traffic outside a document-local GPT PubAds service whose head was
+  processed by the enabled publisher attribution pipeline. IMA/video SDK
+  requests, direct tags, and server-side GAM requests require separate
+  instrumentation and are outside this design. Nested inventory is eligible
+  only when its own response is independently routed, rewritten, and validated;
+  the activation attribute is not proof of those facts because publisher code
+  can copy it into `srcdoc` or `document.write` markup.
 - Replace `ts_initial`, `hb_*`, line-item, bidder, or creative reporting.
 - Add a client-side analytics beacon or a Trusted Server telemetry event.
 - Make GAM click tracking more complete. The marker only segments clicks that
@@ -62,14 +69,22 @@ documents cannot be modified, so the control cohort remains unmarked.
 
 ## Assumptions and prerequisites
 
-- The GPT integration is enabled on every page routed into the treatment cohort.
-  A page served through Trusted Server without the GPT integration does not
-  receive the GPT head bootstrap and cannot satisfy this design.
-- The response enters and successfully completes Trusted Server HTML rewriting,
-  contains a literal `<head>` element, and reaches that element before any
-  publisher script issues a GAM request. Pass-through or buffered-unmodified
-  responses, rewrite failures, and origin markup that omits `<head>` cannot
-  satisfy the marker guarantee.
+- The GPT integration and its separate `gam_attribution_enabled` setting are
+  enabled on every Trusted Server deployment receiving treatment traffic. The
+  attribution setting defaults to `false`; enabling GPT alone does not emit the
+  marker or its activation signals.
+- The response enters Trusted Server HTML rewriting, contains a literal `<head>`
+  element, and Trusted Server rewrites and emits that head before any publisher
+  script issues a GAM request. Pass-through or buffered-unmodified responses and
+  origin markup that omits `<head>` cannot satisfy the marker guarantee.
+- On the existing no-post-processor Fastly streaming path, the rewritten head
+  can reach the browser before origin EOF or rewriter finalization. `ts=true`
+  therefore certifies successful head rewrite and emission, not successful
+  completion of the remaining body. A later origin, decode, or rewrite failure
+  can truncate an already marked page; the request remains treatment traffic and
+  the delivery failure is monitored separately. This design adds no response
+  buffering; configurations with HTML post-processors retain their existing
+  buffering behavior.
 - The publisher Content Security Policy allows Trusted Server's bare inline
   scripts to execute. Initial `adSlots`, the GPT enable flag, the GPT bootstrap,
   and the `bids`/`adInit` invocation are all nonce-less inline scripts; Trusted
@@ -77,12 +92,14 @@ documents cannot be modified, so the control cohort remains unmarked.
   policy that blocks those scripts makes the initial TS ad stack inert and is
   ineligible at launch even if it allows the synchronous first-party TSJS
   bundle.
-- Each in-scope HTML document uses one document-local GPT PubAds service. Nested
-  documents are not implicitly covered by a marked parent: each nested HTML
-  response must be independently routed through Trusted Server and rewritten to
-  receive the marker. IMA/video, direct-tag, server-side GAM, and any nested GPT
-  inventory whose document is not independently rewritten must be excluded from
-  the experiment and paired reports.
+- Each in-scope HTML document uses one document-local GPT PubAds service. A
+  marked parent does not mark a nested GPT instance. The publisher-only bundle
+  attribute is deliberately non-secret and can be copied, so the implementation
+  cannot guarantee that an unrewritten nested document never activates the
+  fallback. IMA/video, direct-tag, server-side GAM, and nested inventory not
+  independently routed, rewritten, and validated must be excluded from the
+  experiment and paired reports. A copied activation attribute is a measurement
+  contamination incident, not evidence that the nested document is eligible.
 - Treatment and control traffic use the same GAM network and comparable
   inventory. Report filters can isolate the pages and time window eligible for
   the experiment.
@@ -126,64 +143,103 @@ Add a separate page-level GPT key-value:
 ts=true
 ```
 
+The marker contract is fixed: the target GAM network rejected the longer
+`trusted_server` request name under its enforced 10-character limit. Trusted
+Server therefore emits exactly `ts=true`, with no configurable key or value and
+no alias or dual-write path.
+
+Attribution has a separate, disabled-by-default GPT setting:
+
+```toml
+[integrations.gpt]
+gam_attribution_enabled = false
+```
+
+The equivalent environment override is
+`TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED`. Trusted Server's
+environment overlay only replaces leaves that are present in the TOML source,
+so an operator relying on that override must retain
+`gam_attribution_enabled = false` under `[integrations.gpt]` in the base file.
+When the setting is `false`, enabling GPT preserves current behavior: the dormant
+gated bootstrap code may still be present, but no attribution callback is
+enqueued or executed and no inline attribution flag, bundle activation
+attribute, or fallback is activated. This setting is the attribution kill switch
+and does not disable GPT proxying, script rewriting, the GPT shim, `adInit`, or
+`ts_initial`.
+
+When attribution is enabled, `head_inserts` adds
+`window.__tsjs_gam_attribution_enabled=true` to the integration's existing first
+inline head insert; it does not add a third insert. That inline flag authorizes
+the raw bootstrap's primary marker path. It is deliberately not the bundle
+fallback signal because CSP can block the inline insert that defines it.
+
 The early GPT bootstrap will enqueue page-level targeting before publisher GPT
-commands execute. The enqueue must occur after `window.tsjs` is initialized but
-before the existing `if (ts.adInit) return;` guard:
+commands execute only when the inline attribution flag is exactly `true`. The
+enqueue must occur after `window.tsjs` is initialized but before the existing
+`if (ts.adInit) return;` guard:
 
 ```text
 (function () {
   if (typeof window === "undefined") return;
   var ts = (window.tsjs = window.tsjs || {});
-  var tag = (window.googletag = window.googletag || { cmd: [] });
-  tag.cmd = tag.cmd || [];
-  tag.cmd.push(function () {
-    try {
-      if (typeof googletag.setConfig === "function") {
-        googletag.setConfig({ targeting: { ts: "true" } });
+  var tag;
+  if (window.__tsjs_gam_attribution_enabled === true) {
+    tag = (window.googletag = window.googletag || { cmd: [] });
+    tag.cmd = tag.cmd || [];
+    tag.cmd.push(function () {
+      try {
+        if (typeof googletag.setConfig === "function") {
+          googletag.setConfig({ targeting: { ts: "true" } });
+        }
+      } catch (_) {
+        // Attribution must not interrupt the existing bootstrap.
       }
-    } catch (_) {
-      // Attribution must not interrupt the existing bootstrap.
-    }
-  });
+    });
+  }
 
   if (ts.adInit) return;
-  // Existing initial-load detector and adInit stub follow.
+  // Existing initial-load detector and adInit stub follow, reusing `tag` when
+  // attribution initialized it and preserving their current path otherwise.
 })();
 ```
 
 The exact implementation must follow the repository's JavaScript formatting and
 defensive checks. The important contract is that the page-level targeting
 command is queued by the head bootstrap before the origin page can queue its GPT
-setup or request ads. Page attribution is independent of whether the bootstrap
-needs to install `ts.adInit`, so the existing guard may skip only the ad-init
-stub and detector setup, never the marker enqueue. An unavailable targeting API
-may skip only the marker callback; it must not prevent later queued publisher or
-Trusted Server callbacks from running.
+setup or request ads when attribution is enabled. Page attribution is
+independent of whether the bootstrap needs to install `ts.adInit`, so the
+existing guard may skip only the ad-init stub and detector setup, never an
+enabled marker enqueue. An unavailable targeting API may skip only the marker
+callback; it must not prevent later queued publisher or Trusted Server callbacks
+from running.
 
-The existing initial-load detector immediately below the new marker must reuse
-the initialized `tag.cmd` reference rather than repeat its current
-`(window.googletag = window.googletag || { cmd: [] }).cmd` expression. This
-keeps queue initialization and both bootstrap callbacks on one consistent path.
+The existing initial-load detector immediately below the new marker reuses the
+initialized `tag.cmd` reference when attribution created it and follows its
+current initialization path otherwise. In particular, attribution disabled plus
+a pre-existing `ts.adInit` must still return without creating
+`window.googletag`; the new default-off setting cannot change current runtime
+behavior.
 
 Moving queue initialization above the `ts.adInit` guard intentionally creates a
-standard `window.googletag` command-queue stub on every rewritten, GPT-enabled
-page, including a page where `ts.adInit` already exists and GPT never loads. The
-stub is inert by itself and preserves the marker-before-guard guarantee; it is
-not an accidental behavior to remove during implementation review.
+standard `window.googletag` command-queue stub on every attribution-enabled page,
+including a page where `ts.adInit` already exists and GPT never loads. The stub
+is inert by itself and preserves the marker-before-guard guarantee; it is not an
+accidental behavior to remove during implementation review.
 
 The TypeScript GPT bundle will defensively enqueue the same page-level targeting
 at module initialization after the existing flag-gated shim block and before
-`installTsAdInit()`, only when the existing publisher-page bundle tag carries a
-non-executable GPT activation attribute. The HTML pipeline adds that attribute
-when the GPT integration is enabled. A pre-existing `ts.adInit` is already
-covered by placing the bootstrap marker before the guard and is not a reason for
-the fallback.
+`installTsAdInit()`, only when the executing publisher-page bundle tag carries
+the non-executable `data-ts-gam-attribution="true"` attribute. The HTML pipeline
+adds that attribute only when GPT and `gam_attribution_enabled` are both enabled.
+A pre-existing `ts.adInit` is already covered by placing the bootstrap marker
+before the guard and is not a reason for the fallback.
 
 The fallback exists to preserve delivery-path attribution if the inline
 bootstrap unexpectedly stops executing while the synchronous first-party bundle
 still runs before publisher GPT. It does not recover `adSlots`, bids, the
 `adInit` invocation, or the initial TS auction: those are also nonce-less inline
-scripts. A fallback-only marker therefore still truthfully means "page delivered
+scripts. On an eligible publisher document whose activation tag was not copied,
+a fallback-only marker therefore still truthfully means "document head emitted
 through Trusted Server," but it also indicates a deployment state that was
 ineligible at launch. Synthetic validation must treat that state as a
 measurement incident, pause interpretation, and exclude the affected time window
@@ -228,12 +284,15 @@ An in-scope GAM request is in the treatment cohort when it contains:
 ts=true
 ```
 
-The marker means:
+For an in-scope document that satisfies the non-cloned activation prerequisite,
+the marker means:
 
-> The containing page was delivered through Trusted Server.
+> Trusted Server rewrote and emitted the containing document's `<head>` through
+> the enabled publisher attribution pipeline before the in-scope GPT request.
 
 It does not mean:
 
+- the complete streamed response reached the browser or finished rewriting;
 - a Trusted Server bidder returned a bid;
 - a Trusted Server bid won;
 - Trusted Server rendered the winning creative; or
@@ -251,10 +310,10 @@ with the A/B router's expected cookie cohort share.
 
 ### Relationship to `ts_initial`
 
-| Key            | Scope      | Lifetime                     | Meaning                                   |
-| -------------- | ---------- | ---------------------------- | ----------------------------------------- |
-| `ts=true`      | Page-level | Entire browser page lifetime | Page was delivered through Trusted Server |
-| `ts_initial=1` | Slot-level | Initial TS-managed request   | Initial slot request was prepared by TS   |
+| Key            | Scope      | Lifetime                     | Meaning                                             |
+| -------------- | ---------- | ---------------------------- | --------------------------------------------------- |
+| `ts=true`      | Page-level | Entire browser page lifetime | Eligible, non-cloned TS pipeline emitted page head  |
+| `ts_initial=1` | Slot-level | Initial TS-managed request   | Initial slot request was prepared by Trusted Server |
 
 The two keys answer different questions and coexist. No code or report should
 infer that one is an alias for the other. The value contract is exactly
@@ -268,6 +327,7 @@ Sticky A/B cookie
   -> control: browser receives production page
        -> publisher GPT runs without the `ts` key
   -> treatment: request is routed through Trusted Server
+       -> deployment has `gam_attribution_enabled = true`
        -> GPT head bootstrap queues page-level `ts=true`
        -> GPT bundle defensively queues the same marker
        -> GPT library drains the command queue
@@ -287,23 +347,55 @@ The marker covers:
 
 All bullets refer to slots using the same document-local GPT PubAds service.
 Requests from IMA/video SDKs, direct tags, or server-side GAM integrations are
-not covered merely because the containing document is marked. A nested GPT
-instance is marked only when Trusted Server separately rewrites that nested
-document and injects the attribution paths into its own `<head>`.
+not covered merely because the containing document is marked. Nested inventory
+is eligible only when Trusted Server separately routes and rewrites that
+document and validation proves the same request and report contract. Because a
+publisher can copy the non-secret activation tag into `srcdoc` or
+`document.write` content, marker presence alone does not prove that a nested
+document was independently rewritten.
 
 A full browser navigation creates a new page and repeats cookie-based routing.
-The new page receives the marker only when that navigation is routed through
-Trusted Server.
+The new page receives the marker only when that navigation is routed through a
+Trusted Server deployment with `gam_attribution_enabled = true`, its head is
+rewritten and emitted, and a marker callback successfully applies page-level
+targeting before its first in-scope GPT request.
 
 ## Component changes
+
+### GPT configuration and head activation
+
+`crates/trusted-server-core/src/integrations/gpt.rs` will add
+`gam_attribution_enabled: bool` to `GptConfig` with Serde's ordinary `false`
+default. Configuration tests must cover an omitted field, explicit `false`,
+explicit `true`, and an environment override whose base TOML includes the leaf.
+The example configuration will show the field as disabled.
+
+`GptIntegration::head_inserts` keeps its current number and order of scripts.
+When attribution is enabled, it appends the inline attribution flag to the
+existing GPT enable/shim insert; when disabled, that insert remains byte-for-byte
+equivalent to its current behavior apart from formatting that does not affect
+execution.
+
+The same parsed `GptConfig` instance must authorize the publisher bundle-tag
+attribute without reparsing settings or relying on head-insert side effects.
+Add a default-empty `IntegrationHeadInjector::tsjs_script_tag_attributes()`
+hook, override it in `GptIntegration` to return only
+`data-ts-gam-attribution="true"` when attribution is enabled, and aggregate the
+attributes through `IntegrationRegistry`. `html_processor.rs` passes that
+registry-owned attribute list to a new publisher-only
+`tsjs_script_tag_with_attributes` helper. Keep the existing
+`tsjs_script_tag` and `tsjs_unified_script_tag` output unchanged for creative,
+test, and other generic callers. This makes the bootstrap and fallback derive
+from one integration-owned setting while avoiding a GPT-specific
+`HtmlProcessorConfig` field or order-dependent document-state mutation.
 
 ### Early GPT bootstrap
 
 `crates/trusted-server-core/src/integrations/gpt_bootstrap.js` owns the
 behavior. It will set the page-level key in its earliest GPT command callback,
-before the `ts.adInit` early-return guard. The targeting code stays inside the
-existing raw bootstrap script returned by `head_inserts`; it must not add a
-third head insert.
+before the `ts.adInit` early-return guard, only when the inline attribution flag
+is exactly `true`. The targeting code stays inside the existing raw bootstrap
+script returned by `head_inserts`; it must not add a third head insert.
 
 The operation must be idempotent. Calling
 `googletag.setConfig({ targeting: { ts: 'true' } })` more than once with the
@@ -324,34 +416,38 @@ initialization after the existing flag-gated `installGptShim()` block and before
 `installTsAdInit()` when the publisher-page bundle's activation attribute is
 present. The helper creates or reuses the standard GPT command queue, enqueues
 the same defensive `setConfig({ targeting: { ts: 'true' } })` call, and does not
-read the experiment cookie or wait for an auction. Extend the local `GoogleTag`
-interface with optional `setConfig?(config: Record<string, unknown>): void` so
-the fallback remains defensive when the API is unavailable.
+read the experiment cookie or wait for an auction. The existing optional
+`GoogleTag.setConfig` method and `GoogleTagConfig extends Record<string,
+unknown>` types already cover this call and must be reused rather than extended.
 
 The bootstrap remains the primary path because it is injected first. The bundle
 call is a redundant fallback and must not delay module initialization, create a
-request, or add slot-level targeting. A plain GPT module import without the
-activation attribute must preserve the existing runtime-gating contract and must
-not create `window.googletag`.
+request, or add slot-level targeting. The attribution helper must not create
+`window.googletag` independently when the activation attribute is absent. A
+standalone module import with neither the existing GPT-enable flag nor the new
+attribute must preserve the current runtime-gating contract and leave
+`window.googletag` untouched.
 
 ### Non-executable bundle activation
 
 The publisher HTML pipeline in
 `crates/trusted-server-core/src/html_processor.rs`, using a separate,
 publisher-page-only tag helper in `crates/trusted-server-core/src/tsjs.rs`, will
-add a `data-ts-gpt-enabled="true"` attribute to the existing synchronous
-`#trustedserver-js` bundle tag when GPT is enabled. The attribute is data, not
-an inline executable, so CSP can block the inline GPT head inserts while still
-allowing the external bundle to detect that it owns page attribution.
+add a `data-ts-gam-attribution="true"` attribute to the existing synchronous
+`#trustedserver-js` bundle tag only when GPT and `gam_attribution_enabled` are
+both enabled. The attribute is data, not an inline executable, so CSP can block
+the inline GPT head inserts while still allowing the external bundle to detect
+that it owns page attribution.
 
 At module initialization, the GPT bundle captures `document.currentScript` and
-requires that executing synchronous script to carry `data-ts-gpt-enabled="true"`
-before the fallback may create a GPT stub. It must fail closed when the
-executing script cannot be identified. Do not authorize activation through a
-global `#trustedserver-js` lookup: the generic unified tag uses the same ID in
-creative and test contexts, and duplicate IDs could select the wrong element.
-Binding the signal to the executing tag keeps the activation decision explicit
-and testable without relying on an inline global flag.
+requires that executing synchronous script to carry
+`data-ts-gam-attribution="true"` before the fallback may create a GPT stub. It
+must fail closed when the executing script cannot be identified. Do not
+authorize activation through a global `#trustedserver-js` lookup: the generic
+unified tag uses the same ID in creative and test contexts, and duplicate IDs
+could select the wrong element. Binding the signal to the executing tag keeps
+the activation decision explicit and testable without relying on an inline
+global flag.
 
 The existing `window.__tsjs_gpt_enabled` flag continues to activate
 `installGptShim()` when inline scripts run. It cannot activate the CSP fallback
@@ -368,46 +464,47 @@ bundle outside the publisher GPT integration. Do not add a new script tag or
 change the integration's existing head-insert count.
 
 Extend the `tsjs.rs` and `html_processor.rs` tests to prove that the existing
-publisher-page bundle tag gains the activation attribute only when GPT is in the
-enabled immediate module set, remains a single external tag, and omits the
-attribute for non-GPT publisher bundles and generic all-modules tags. Bundle
-tests must also prove that an unrelated or duplicate element with
-`id="trustedserver-js"` cannot activate the fallback.
+publisher-page bundle tag gains the activation attribute only when GPT and
+`gam_attribution_enabled` are both enabled, remains a single external tag, and
+omits the attribute for attribution-disabled, non-GPT, and generic all-modules
+bundles. Bundle tests must also prove that an unrelated or duplicate element
+with `id="trustedserver-js"` cannot activate the fallback.
 
 ### GPT Rust integration tests
 
 `crates/trusted-server-core/src/integrations/gpt.rs` already tests the embedded
 bootstrap returned by `head_inserts`. Extend those tests to prove that:
 
-- the bootstrap contains page-level `ts=true` targeting;
+- omitted and explicit-false configuration emit neither the inline attribution
+  flag nor publisher-tag attribute metadata;
+- explicit-true configuration emits the inline attribution flag and exposes the
+  publisher-tag attribute metadata;
+- the bootstrap contains the flag-gated page-level `ts=true` targeting;
 - the marker enqueue appears before the `if (ts.adInit) return;` guard;
 - the targeting setup is queued before `ts.adInit` can issue `display` or
   `refresh`;
 - the existing `ts_initial` marker remains present; and
-- the enabled integration without `slim_prebid_url` still emits exactly the
+- the attribution-enabled integration without `slim_prebid_url` still emits
+  exactly the
   existing two head inserts, proving the marker was added to the bootstrap
   instead of a new tag.
 
 ### Bootstrap execution tests
 
-Add `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`
-as a Vitest/jsdom behavioral test for the raw bootstrap. The test reads
-`crates/trusted-server-core/src/integrations/gpt_bootstrap.js` with Node's
-`readFileSync`, resolves the source path relative to `import.meta.url` rather
-than the process working directory, and creates an isolated
-`new JSDOM(html, { runScripts: 'outside-only' })` realm. Before evaluating the
-exact source with that realm's `window.eval`, the test must assert that
-`globalThis === window` and `typeof global === 'undefined'` inside the realm.
-This is required because Vitest's default jsdom `window.eval` runs in Node's
-realm under the current configuration. The harness supplies a minimal mocked GPT
-command queue and `pubads` service. It must not evaluate the source in Node's
-global context, copy the bootstrap into a test fixture, or add a JavaScript
-runtime dependency to Rust.
+Extend the existing
+`crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`
+Vitest/jsdom behavioral test for the raw bootstrap. Preserve its established
+`process.cwd()` source resolution and `new Function(BOOTSTRAP_SOURCE)` execution
+strategy unless a separate test-harness change demonstrates a concrete need to
+replace them. The tests continue to execute the checked-in raw source rather
+than a copied fixture and add no JavaScript runtime dependency to Rust.
 
 The harness must prove that:
 
-- the attribution callback is queued before a publisher callback added after the
-  injected bootstrap;
+- attribution disabled preserves the existing pre-installed-`ts.adInit` behavior
+  without creating `window.googletag`;
+- attribution enabled queues the callback before a publisher callback added
+  after the injected bootstrap;
 - draining the queue calls `googletag.setConfig` with page-level `ts=true`
   before the publisher callback runs;
 - a pre-existing `ts.adInit` does not prevent the attribution callback from
@@ -428,10 +525,14 @@ its existing dynamic-import and `vi.resetModules()` pattern. Prove that module
 initialization with the bundle activation attribute queues page-level `ts=true`
 after any existing flag-gated shim installation and before installing
 `ts.adInit`, that it reuses an existing GPT command queue, and that unavailable
-or throwing `setConfig` does not stop the remaining GPT module installers.
-Retain the existing assertion that a plain module import without an activation
-signal does not create `window.googletag`. A duplicate call after the bootstrap
-must remain safe and must not create another script or network request.
+or throwing `setConfig` does not stop the remaining GPT module installers. The
+attribution helper must not create a stub independently when its attribute is
+absent: a standalone import with neither the existing GPT-enable flag nor the
+new attribute leaves `window.googletag` untouched. An attribution-disabled but
+GPT-enabled deployment preserves today's flag-gated shim and stub behavior; it
+only omits the attribution callback and fallback. A duplicate call after the
+bootstrap must remain safe and must not create another script or network
+request.
 
 ### Slot cleanup constraints
 
@@ -445,11 +546,18 @@ No refresh-lifecycle change is required. In particular:
 Leaving these components unchanged is part of the design: slot cleanup cannot
 remove a page-level key set through `googletag.setConfig`.
 
+No new `CreativeOpportunitySlot` parsing, filtering, or startup validation is
+added. Trusted Server continues accepting and forwarding operator targeting
+maps verbatim. The external launch audit—not runtime code—must reject an
+effective configuration containing slot-level `ts`.
+
 ### Documentation
 
 Document the distinction between page-level `ts=true` and slot-level
 `ts_initial=1` in `docs/guide/integrations/gpt.md`, near the existing command
-queue documentation. Include the GAM setup and reporting preconditions below; do
+queue documentation. Document `gam_attribution_enabled`, its default-off and
+kill-switch behavior, the fixed marker contract, and the GAM setup and reporting
+preconditions below. Add the disabled field to `trusted-server.example.toml`; do
 not add this current integration to a planned-future GAM document.
 
 ## GAM configuration
@@ -457,49 +565,58 @@ not add this current integration to a planned-future GAM document.
 GAM configuration is a deployment prerequisite and must be completed before the
 experiment starts because key-value reporting is not retroactive.
 
-The request contract is `ts=true`: key name `ts`, predefined value `true`. The
-key name is provisional pending a GAM preflight (see issue #1027). The GPT/GAM
-`CustomTargetingKey.name` (the code sent in the ad request) is documented as
-limited to 10 characters in the SOAP/REST API, which would rule out a fuller
-name such as `trusted_server` (14); other Help Center material implies 20, and
-these describe different provisioning surfaces, so the enforced limit must be
-confirmed in the target network before the contract is fixed. If the confirmed
-limit permits a longer name, a more descriptive, less collision-prone key is
-preferred over `ts`. Because `ts` is short, it carries a real collision risk with
-common publisher timestamp or cache-buster keys, which makes the cross-system
-collision audit a hard launch gate, not a formality. If any publisher, Trusted
-Server configuration, or GAM object already uses `ts`, the experiment must stop
-until the collision is removed or the contract is explicitly revised everywhere
-before treatment traffic begins.
+The request contract is finalized as key name `ts`, predefined value `true`.
+The target-network preflight rejected `trusted_server` (14 characters) under
+the enforced 10-character request-name limit, consistent with the SOAP/REST
+`CustomTargetingKey` contract. Because `ts` is short, it carries a real collision
+risk with common publisher timestamp or cache-buster keys, which makes the
+cross-system collision audit a hard launch gate, not a formality. If any
+publisher, Trusted Server configuration, Prebid targeting source, or GAM object
+already uses `ts`, the experiment must stop until the collision is removed.
+Changing the finalized contract or silently filtering established targeting is
+out of scope.
 
-1. In **Inventory > Key-values**, create or verify a key whose request name is
-   the finalized marker key (`ts` pending the preflight in issue #1027). When the
-   key is created, confirm the enforced key-name and value length limits on the
-   provisioning surface actually used: the SOAP/REST
-   [`CustomTargetingKey`](https://developers.google.com/ad-manager/api/reference/v202511/CustomTargetingService.CustomTargetingKey)
-   documents a 10-character key-`name` limit and a 40-character value limit, but
-   the UI surface may differ, so verify against the target network rather than
-   assuming.
+1. In **Inventory > Key-values**, create or verify the `ts` key and retain the
+   target-network preflight result with the experiment runbook. The SOAP/REST
+   [`CustomTargetingKey`](https://developers.google.com/ad-manager/api/reference/v202605/CustomTargetingService.CustomTargetingKey)
+   documents the enforced 10-character request-name limit and a 40-character
+   value limit.
 2. Use a predefined value named `true`.
-3. Enable `ts` as a dedicated reportable Enhanced key-value dimension. If the
-   network does not support Enhanced key-value dimensions, use a report filtered
-   to the single legacy key-value `ts=true`; never sum unfiltered legacy
-   **Key-values** dimension rows.
+3. Preflight whether the target network has Enhanced key-value reporting and
+   confirm the publisher has approved its Premium reporting activation and
+   displayed CPM terms, minimum/maximum charge, and non-prorated monthly billing.
+   Record the result. If approved and compatible with the selected metrics,
+   enable `ts` as a dedicated Enhanced dimension. Otherwise, enable `ts` for
+   legacy reporting and prove with a target-network dry run that the exact
+   legacy `ts=true` filter and chosen metrics are available; never sum unfiltered
+   legacy **Key-values** rows. See
+   [Access Premium reporting](https://support.google.com/admanager/answer/16176700)
+   and [Report on targeting keys](https://support.google.com/admanager/answer/14528835).
 4. Reserve `ts` for Trusted Server page attribution.
 5. Audit existing publisher GPT code and every GAM object that consumes custom
    targeting for an existing `ts` key before deployment. This includes line
    items, proposal line items, rules, protections, yield configuration, and any
    network-specific custom-targeting surface.
-6. Audit every `CreativeOpportunitySlot.targeting` map from all effective
+6. Audit Prebid-generated GPT targeting, including `pbjs.bidderSettings`, each
+   bidder's and standard key's `adserverTargeting`, and every call to
+   `setTargetingForGPTAsync`. Record every path capable of producing a slot-level
+   `ts`; any occurrence is a launch blocker because GPT slot targeting overrides
+   the page-level value.
+7. Audit every `CreativeOpportunitySlot.targeting` map from all effective
    `trusted-server.toml` configuration sources. The arbitrary operator-supplied
    map is copied to GPT slots, where a slot-level `ts` value would override the
    page-level marker. Any occurrence is a launch blocker; do not silently
    discard it because that could change established operator targeting.
-7. Audit publisher code for every operation that can remove or supersede the
+8. Audit publisher code for every operation that can remove or supersede the
    marker after initial GPT setup. Search for `setConfig({ targeting: null })`,
    a `ts: null` or different `ts` value, `pubads().clearTargeting()` with no key
    or with `ts`, and slot-level `ts` targeting. Account for equivalent calls
    assembled dynamically.
+
+The runbook records the audit owner, exact queries or search procedures, result
+artifact, timestamp, and re-audit trigger. A deployment, publisher GPT, Prebid,
+or GAM targeting change affecting the audited surfaces invalidates the prior
+result and blocks attribution until the audit is repeated.
 
 The audit is a hard precondition. If `ts` already has another meaning, or any
 GAM object targets or acts on `ts=true`, the experiment owner must resolve the
@@ -526,12 +643,19 @@ Every comparison must apply identical filters for:
 - geography and device categories, when used; and
 - any consent or traffic-quality exclusions.
 
+Before launch, the experiment owner freezes an authoritative scope manifest
+containing those values, the eligible route/site inventory, exact ad-unit list,
+owner, version, and activation timestamp. Report A, Report B, router/access-log
+queries, synthetic URLs, and any external denominators must all reference that
+same manifest. A scope change closes the current reporting window and requires a
+new manifest version and fresh preflight.
+
 Do not compare the TS cohort with all unmarked network traffic unless all that
 traffic is eligible for the same experiment. Likewise, exclude smoke tests,
 direct hits, operations traffic, and any other TS-served page outside the cookie
 experiment. The marker identifies the delivery path, not the router's cohort
-assignment, so all such requests also carry `ts=true` when the GPT integration
-runs.
+assignment, so all such requests also carry `ts=true` when attribution is
+enabled for their Trusted Server deployment.
 
 The route owner must use router or access logs to prove that non-experiment TS
 traffic is absent from the eligible inventory during the measurement window. If
@@ -540,21 +664,28 @@ dimension, GAM cannot remove it from Report B because its marker is identical to
 the cohort marker; the experiment must not launch. Record the owner, query,
 expected zero threshold, and response procedure in the experiment runbook.
 
+Before treatment routing begins, run and retain a zero-count query for every
+excluded path: non-experiment Trusted Server traffic, smoke/direct/operations
+traffic, IMA/video, direct tags, server-side GAM, and excluded nested inventory.
+Any non-zero result blocks launch unless an independent dimension excludes the
+same traffic from both saved reports.
+
 ### Cohort calculations
 
-Use two reports with identical date boundaries, time zone, inventory filters,
-traffic-quality filters, and metric definitions:
+Create and retain two saved reports with identical date boundaries, time zone,
+inventory filters, traffic-quality filters, and metric definitions:
 
 1. **Report A — experiment total.** Do not include **Placement**, legacy
    **Key-values**, **Targeting**, **Yield group**, or another dimension that can
    represent one event more than once. This report provides one non-duplicated
    total for every metric in the eligible experiment scope.
 2. **Report B — TS treatment.** Use the dedicated Enhanced `ts` dimension
-   filtered to `ts=true`. If Enhanced key-value dimensions are unavailable, use
-   the legacy **Key-values** dimension filtered to exactly `ts=true` and do not
-   sum any other key-value rows. Do not add **Placement**, **Targeting**,
-   **Yield group**, or any unrelated dimension that can represent the filtered
-   treatment event more than once.
+   filtered to `ts=true`. If Enhanced key-value dimensions are unavailable,
+   unapproved, or incompatible with the saved metric pair, use the legacy
+   **Key-values** dimension filtered to exactly `ts=true` and do not sum any
+   other key-value rows. Do not add **Placement**, **Targeting**, **Yield
+   group**, or any unrelated dimension that can represent the filtered treatment
+   event more than once.
 
 The legacy **Key-values** dimension can emit the same impression or click on
 multiple rows when a request contains multiple key-values. It therefore cannot
@@ -582,6 +713,19 @@ Export both reports after the same GAM reporting-latency and invalid-traffic
 adjustment window. If GAM restates one report, rerun the pair before applying
 the subtraction.
 
+For every paired metric and reporting window, validate:
+
+```text
+0 <= Report B <= Report A
+derived_control = Report A - Report B
+```
+
+A negative derived control, Report B greater than Report A, mismatched report
+definition, incompatible metric, missing saved definition, or non-zero excluded
+traffic is a fail-closed reporting incident. Do not publish or interpret that
+window; correct the inputs and rerun the complete pair after the same reporting
+latency and invalid-traffic adjustment window.
+
 Use total metrics when the goal includes all GAM demand sources. GAM's
 `Ad server impressions` and `Ad server clicks` metrics exclude Ad Exchange and
 AdSense, so those narrower metrics should only be used when that exclusion is
@@ -589,30 +733,33 @@ intentional. GAM counts impressions and clicks according to its own tracking
 rules; adding `ts=true` does not create new impression or click trackers. See
 [Counting impressions and clicks](https://support.google.com/admanager/answer/2521337).
 
-Both reports must use the same non-targeted impression and click metric names.
-Do not use targeted-impression or targeted-click metrics for this attribution:
-`ts` is intentionally forbidden from line-item targeting, so metrics limited to
-keys used for targeting do not represent the requested delivery-path cohort.
-Record the exact selected GAM metric names with the saved report definitions
-before launch.
+Both reports must use the same metric names, and the target-network dry run must
+prove that each metric is compatible with the chosen Enhanced or legacy
+dimension and filters. Prefer non-targeted impression and click metrics because
+`ts` is forbidden from line-item targeting; targeted metrics limited to keys
+used for targeting do not represent this delivery-path cohort. If GAM cannot
+produce an identical compatible metric in both reports, omit that metric rather
+than substitute different definitions. Record the exact selected metric names
+and successful dry-run exports before launch.
 
-### Unequal cohort sizes
+### Descriptive rates for unequal cohort sizes
 
 The treatment cohort is intentionally small, so raw TS and production totals are
-not directly comparable. Reports should show the raw counts, but experiment
-conclusions should compare normalized measures where compatible metrics are
-available:
+not directly comparable. GAM may show raw counts and descriptive normalized
+rates where compatible metrics are available:
 
 - impressions per GAM ad request;
 - fill rate;
 - clicks per impression (CTR); and
 - revenue per thousand impressions or requests.
 
-Impressions per routed pageview or per assigned visitor require a denominator
-from the A/B router or site analytics. GAM alone cannot identify unmarked
-production pageviews that made no ad request. Any cross-system experiment
-analysis is outside the implementation but should use the same time and
-eligibility filters.
+These rates describe GAM delivery; they do not estimate a causal treatment
+effect. Impressions per routed pageview or per assigned visitor require a
+denominator from the A/B router or site analytics because GAM cannot identify
+unmarked production pageviews that made no ad request. Any causal analysis is
+outside this implementation and requires a separately approved design defining
+the eligible population, router/site denominators, analysis window, and stopping
+rules.
 
 ### Data-quality checks
 
@@ -631,9 +778,16 @@ A gap between expected and observed treatment share is a measurement incident,
 not evidence of production performance, until missing-marker and request-volume
 differences are ruled out. Because router assignment and GAM delivery normally
 use page or visitor counts versus ad-request or impression counts, this share
-comparison is a diagnostic rather than direct proof of marker coverage. It can
-measure coverage directly only when the router or site analytics supplies a
-matched request- or page-level denominator.
+comparison is a diagnostic rather than direct proof of marker coverage. A
+request-correlated router or site denominator can strengthen the aggregate
+coverage estimate, but without new request-correlated telemetry it still cannot
+prove marker presence on every production request.
+
+Neither aggregate share nor a scheduled synthetic sample proves that every
+production response or ad request carried the expected marker. Automated tests
+establish code-path invariants; production checks provide sampled operational
+evidence. The runbook must not describe either diagnostic as per-response
+coverage telemetry.
 
 Checks 2–3 use a scheduled synthetic browser crawl of representative experiment
 URLs. The crawler supplies known treatment and control cookies, captures GAM
@@ -647,11 +801,11 @@ On treatment URLs with matched creative opportunities, the crawler must also
 detect the fallback-only CSP state: capture CSP violations and verify that the
 injected `adSlots`, `bids`, and initial `adInit` handoff executed. A page that
 has `ts=true` only because the external bundle ran, while those inline scripts
-were blocked, remains correctly marked as TS-delivered but raises a measurement
-incident. Since GAM cannot separate those requests afterward, the incident owner
-must pause interpretation and exclude the affected time range from both reports
-when clean boundaries can be established; otherwise the experiment result is
-invalid.
+were blocked, remains correctly marked as having a TS-emitted head but raises a
+measurement incident. Since GAM cannot separate those requests afterward, the
+incident owner must pause interpretation and exclude the affected time range
+from both reports when clean boundaries can be established; otherwise the
+experiment result is invalid.
 
 ## Failure handling
 
@@ -659,14 +813,24 @@ The marker is best-effort instrumentation and must never block ads or page
 delivery.
 
 - If GPT never loads, there is no GAM request to classify.
-- If a response is not successfully HTML-rewritten, has no literal `<head>`, or
-  issues an in-scope GPT request before the injected head content runs, neither
-  targeting path can mark that request. Such traffic is ineligible for the
-  experiment and must be detected before launch or excluded from analysis.
+- If attribution is disabled, the dormant gated bootstrap source may remain, but
+  no attribution callback is enqueued or executed and no activation flag or
+  attribute is emitted; GPT otherwise keeps its current behavior.
+- If Trusted Server does not rewrite and emit a literal `<head>`, or an in-scope
+  GPT request occurs before the injected head content runs, neither targeting
+  path can mark that request. Such traffic is ineligible for the experiment and
+  must be detected before launch or excluded from analysis.
+- If an origin, decoder, or rewriter failure occurs after Fastly emitted the
+  rewritten head, the browser may already have queued `ts=true`. Any resulting
+  request remains treatment because the marker represents head delivery, not
+  full-response completion. The client may receive a truncated document; the
+  delivery failure is logged and investigated separately rather than being
+  reclassified as control.
 - If CSP blocks Trusted Server's nonce-less inline scripts, the initial TS ad
   stack is inert and the page is ineligible even when the first-party bundle
-  queues the attribution marker. The fallback prevents a TS-delivered page from
-  leaking into the inferred control cohort; it does not make the deployment
+  queues the attribution marker. The fallback prevents a page whose head was
+  emitted through Trusted Server from leaking into the inferred control cohort;
+  it does not make the deployment
   healthy. If CSP blocks both inline scripts and the bundle, attribution also
   fails.
 - If `googletag.setConfig` is unavailable when a queued command runs, the
@@ -677,6 +841,10 @@ delivery.
   applies slot-level `ts`, GPT gives the slot-level value precedence. The
   deployment audit prevents this collision; runtime filtering or interception is
   out of scope because it could silently alter established targeting behavior.
+- If Prebid `bidderSettings`, bidder or standard `adserverTargeting`, or
+  `setTargetingForGPTAsync` applies slot-level `ts`, the slot value can supersede
+  the page marker. The launch audit and characterization tests cover these paths;
+  Trusted Server does not filter or intercept them.
 - If publisher code calls `setConfig({ targeting: null })`, sets `ts: null` or a
   different value, calls legacy `pubads().clearTargeting()` for all keys or for
   `ts`, or applies slot-level `ts`, the effective marker can be removed or
@@ -692,35 +860,39 @@ added by this feature.
 ## Privacy and consent
 
 `ts=true` contains no unique user identifier, cookie value, page URL, or auction
-data. It describes only the delivery path of the current document. Because only
-the cookie-sticky treatment cohort is routed through Trusted Server for this
-experiment, the value also reveals treatment-path membership for that GAM
-request. It is therefore cohort information even though it does not expose the
-assignment cookie or identify a person by itself.
+data. Its intended meaning is the head-delivery path of an eligible document;
+outside that scope, copied activation is contamination rather than proof of
+delivery. Because only the cookie-sticky treatment cohort is routed through
+Trusted Server for this experiment, the value also reveals treatment-path
+membership for that GAM request. It is therefore cohort information even though
+it does not expose the assignment cookie or identify a person by itself.
 
 The implementation does not read the experiment cookie. Routing happens before
 Trusted Server handles the request. Existing consent gates continue to decide
 whether GAM requests or auctions occur. The marker does not create an ad request
-that would otherwise be suppressed. Before enabling the key, the experiment
-owner must complete the publisher's privacy/data-governance review for sending
-this treatment-path attribute to GAM and confirm that existing consent and
-data-use terms cover it.
+that would otherwise be suppressed. Before enabling
+`gam_attribution_enabled`, the experiment owner must complete the publisher's
+privacy/data-governance review for sending this treatment-path attribute to GAM
+and confirm that existing consent and data-use terms cover it.
 
 ## Testing strategy
 
 ### Automated tests
 
-1. Extend Rust GPT head-insert tests to assert page-level `ts=true` targeting is
-   in the existing raw bootstrap, occurs before the `ts.adInit` guard and any
-   bootstrap `display()` or `refresh()` call, and does not change the expected
-   head-insert count.
+1. Extend GPT configuration and head-insert tests for omitted, false, and true
+   `gam_attribution_enabled` values. Assert that the true case authorizes
+   page-level `ts=true` before the `ts.adInit` guard and any bootstrap `display()`
+   or `refresh()` call without changing the expected head-insert count; false
+   must preserve current output and behavior.
 2. Extend the TSJS tag and HTML processor tests to prove the non-executable GPT
-   activation attribute appears only on the enabled publisher-page bundle and
-   adds no script tag.
-3. Add the Vitest/jsdom raw-bootstrap harness described above. Exercise the
+   activation attribute appears only when GPT and attribution are both enabled
+   on the publisher-page bundle and adds no script tag.
+3. Extend the existing Vitest/jsdom raw-bootstrap harness described above.
+   Exercise the
    bootstrap with `googletag.setConfig` available, unavailable, and throwing,
-   and prove a later publisher callback still runs in every case. Set
-   `window.tsjs.adInit` before evaluation and prove the marker still runs.
+   and prove a later publisher callback still runs in every enabled case. Prove
+   the disabled case preserves existing behavior, then set `window.tsjs.adInit`
+   before evaluation and prove only the enabled marker still runs.
 4. Extend the existing GPT bundle tests to prove module initialization queues
    the fallback marker and remains non-blocking when `setConfig` is unavailable
    or throws.
@@ -732,12 +904,30 @@ data-use terms cover it.
    operator targeting map is forwarded verbatim, documenting why the deployment
    audit must reject a configured `ts` key rather than assuming the client
    overwrites or filters it.
-8. Run the project-required target-matched Rust and JavaScript checks for the
-   touched files.
+8. Add Prebid characterization tests covering `bidderSettings`, custom
+   `adserverTargeting`, and `setTargetingForGPTAsync` so a generated slot-level
+   `ts` collision is visible and remains a launch-audit responsibility rather
+   than being silently filtered.
+9. Extend no-post-processor streaming regression coverage to prove an
+   attribution-enabled Fastly response can emit the marked rewritten head before
+   origin EOF. Preserve the existing later-error/truncation behavior,
+   documenting that the marker does not certify complete response delivery and
+   adds no buffering.
+10. Add focused Vitest/jsdom bundle-DOM coverage for the synchronous publisher
+    tag, proving `document.currentScript` is the attributed element and
+    false/non-publisher/duplicate-tag cases fail closed. Characterize a publisher
+    copying the attributed tag through `srcdoc` or `document.write`: the clone can
+    activate the fallback, so tests must not encode the false guarantee that only
+    independently rewritten nested documents can be marked. Manual browser/GAM
+    validation below covers the real deployed bundle without expanding the
+    repository's single-config Playwright harness.
+11. Run the project-required target-matched Rust and JavaScript checks for the
+    touched files.
 
 ### Browser/GAM validation
 
-Before experiment launch:
+Before experiment launch, with `gam_attribution_enabled = true` on the treatment
+deployment:
 
 1. Load a treatment page using a known treatment cookie.
 2. Confirm the initial in-scope GAM request contains `ts=true` using GPT
@@ -746,57 +936,77 @@ Before experiment launch:
    `ts=true`.
 4. Load the equivalent production page with a control cookie and confirm the key
    is absent.
-5. Confirm `ts_initial=1` remains limited to its existing initial-slot
+5. Disable `gam_attribution_enabled` on a Trusted Server validation deployment
+   and confirm GPT still functions while the inline flag, activation attribute,
+   and `ts` request key are absent.
+6. Confirm `ts_initial=1` remains limited to its existing initial-slot
    lifecycle.
-6. Validate the deployed CSP by proving `adSlots`, the GPT bootstrap, `bids`,
+7. Validate the deployed CSP by proving `adSlots`, the GPT bootstrap, `bids`,
    and the initial `adInit` handoff execute on a representative page with
    matched slots. A page that runs only the external bundle is ineligible even
    if the fallback marker appears.
-7. Set an unrelated page-level targeting key after `ts=true` and confirm both
+8. Set an unrelated page-level targeting key after `ts=true` and confirm both
    keys remain on a later request. Treat an explicit page-level or per-key clear
    as a failed publisher-code audit, not supported behavior.
-8. Validate that IMA/video, direct-tag, server-side GAM, and nested GPT
+9. Validate that IMA/video, direct-tag, server-side GAM, and nested GPT
    inventory without an independently TS-rewritten document is absent from the
    experiment and paired report scope. Directly validate any independently
    rewritten nested documents that are intentionally included.
-9. Run a short GAM report and verify treatment totals appear under `ts=true`
-   while overall totals remain unchanged apart from normal reporting latency.
+10. Run a short GAM report and verify treatment totals appear under `ts=true`
+    while overall totals remain unchanged apart from normal reporting latency.
 
 ## Rollout
 
-1. Audit response eligibility, including HTML rewriting, `<head>` ordering, CSP,
+1. Create the fixed reportable `ts=true` GAM key/value and record the intended
+   Enhanced or legacy reporting path, compatibility requirements, and billing
+   decision.
+2. Freeze the eligible-scope manifest and draft the saved Report A/Report B
+   definitions and excluded-path queries from that manifest.
+3. Audit response eligibility, including head rewrite/emission, ordering, CSP,
    and publisher GPT calls that could precede or remove the marker.
-2. Audit the `ts` key across publisher GPT code, effective `trusted-server.toml`
-   creative-opportunity targeting maps, and every GAM custom-targeting consumer.
-3. Prove through router or access logs that non-experiment traffic is excluded
-   from the TS route or independently separable in both paired GAM reports.
-4. Exclude IMA/video, direct-tag, server-side GAM, and nested GPT inventory
-   whose document is not independently rewritten. Inventory in intentionally
-   rewritten nested documents must pass the same request and report validation
-   as the top-level document.
-5. Create and enable the reportable GAM key and predefined value.
-6. Deploy the Trusted Server marker before assigning experiment traffic.
+4. Audit `ts` across publisher GPT code, Prebid-generated targeting, effective
+   `trusted-server.toml` creative-opportunity targeting maps, and every GAM
+   custom-targeting consumer. Retain the owner, evidence, timestamp, and re-audit
+   trigger.
+5. Exclude IMA/video, direct-tag, server-side GAM, and nested GPT inventory not
+   independently routed, rewritten, and validated. Treat copied activation in an
+   excluded nested document as contamination.
+6. Deploy `gam_attribution_enabled = true` while treatment routing remains
+   stopped.
 7. Provision the scheduled synthetic crawl, assign an incident owner, and obtain
-   one successful treatment/control run covering initial, lazy, refreshed, and
-   CSP execution checks.
-8. Validate treatment and control requests manually.
-9. Start the small cookie-sticky cohort.
-10. Compare observed GAM treatment share with the router allocation before using
-    the results for performance decisions.
-11. Monitor normalized metrics over a sufficiently large window; do not infer a
-    treatment effect from unequal raw totals.
+   one successful treatment/control run covering initial, lazy, refreshed, CSP,
+   fallback, and disabled-setting checks.
+8. On the validation deployment, validate treatment and control requests
+   manually, retain zero-count results for every excluded path, and save a short
+   paired-report dry run that proves the selected dimensions, filters, metrics,
+   and `0 <= Report B <= Report A` invariants.
+9. Start the small cookie-sticky treatment cohort only after every configuration,
+   collision, privacy, CSP, synthetic, exclusion, and reporting gate passes.
+10. Compare observed GAM treatment share with router allocation only as a
+    diagnostic before interpreting descriptive delivery results.
 
-Rollback stops adding the page-level key to newly loaded documents. Already-open
-documents—including long-lived SPA sessions—retain page-level targeting and may
-continue issuing marked lazy or refreshed requests after the code rollback.
-Record the rollback timestamp, end the experiment reports at the last clean
-pre-rollback boundary, and exclude the post-rollback drain interval from both
-cohorts. The drain ends only after router/access logs and GAM show no remaining
-`ts=true` traffic for one complete agreed reporting interval and a fresh
-synthetic navigation confirms that new documents are unmarked. If marked traffic
-persists, the interval remains excluded rather than being inferred as control.
-Historical GAM rows recorded while the key was active remain valid, and the GAM
+Rollback is ordered so newly routed treatment traffic cannot become unmarked
+control. First record the last clean reporting boundary and stop new treatment
+assignment/routing. Verify through router or access logs that routing stopped;
+then set `gam_attribution_enabled = false` and deploy the kill switch. Fresh
+Trusted Server documents must keep normal GPT behavior while omitting the
+marker. Already-open documents—including long-lived SPA sessions and any marked
+document restored from a cache—retain page-level targeting and may continue
+issuing marked lazy or refreshed requests. Exclude the entire post-boundary
+drain interval from both cohorts. The drain ends only after router/access logs
+and GAM show no remaining `ts=true` traffic for one complete, runbook-defined
+reporting interval and a fresh synthetic navigation confirms that new documents
+are unmarked. If marked traffic persists, the interval remains excluded rather
+than being inferred as control. Historical GAM rows remain valid, and the GAM
 key may stay defined and reportable for historical analysis.
+
+If an active privacy, targeting-collision, or ad-delivery incident requires an
+immediate kill, deploy `gam_attribution_enabled = false` without waiting for
+router verification. Treat the affected window and subsequent drain interval as
+invalid for both cohorts, then stop and verify treatment routing and follow the
+same drain-completion rule. The emergency path prioritizes serving safety over a
+clean experiment boundary; it must never reinterpret newly unmarked treatment
+traffic as control.
 
 ## Alternatives considered
 
@@ -818,25 +1028,46 @@ Rejected as the sole path. Placing the enqueue before the existing `ts.adInit`
 guard correctly handles a pre-installed ad-init implementation. The bundle is
 not needed for that case. It remains useful when the inline script unexpectedly
 stops executing but the synchronous first-party bundle still runs: without the
-fallback, a TS-delivered treatment page would be silently inferred as control.
+fallback, a treatment page with a TS-emitted head would be silently inferred as
+control.
 The fallback does not rescue the simultaneously blocked TS ad-stack scripts, so
 that state is an incident rather than an eligible deployment mode.
+
+### Enable attribution whenever GPT is enabled
+
+Rejected because an upgrade would begin disclosing cohort/path information and
+reserving the short `ts` key on every existing GPT deployment before its
+collision, privacy, and reporting prerequisites were complete. The independent,
+default-off setting permits deliberate rollout and rollback without removing the
+GPT proxy, shim, or auction behavior.
+
+### Buffer the existing Fastly streaming HTML path until the complete rewrite succeeds
+
+Rejected because the marker must run from the rewritten head before publisher
+GPT requests, while the no-post-processor Fastly path deliberately streams that
+head before origin EOF. Adding full-response buffering to that path would change
+latency, memory use, and first contentful paint. On that in-scope path, the
+marker therefore certifies successful head rewrite and emission; later stream
+completion is a separate delivery concern. Existing configurations that
+register an HTML post-processor retain their current buffering behavior; this
+feature adds none.
 
 ### Use a longer descriptive key name such as `trusted_server`
 
 A descriptive name would lower the collision risk that the short `ts` key
-carries. Rejected because GAM limits a custom-targeting key name to 10
-characters, so `trusted_server` (14) cannot be created as a reportable key. The
-short `ts` name is therefore mandatory, and the cross-system collision audit is
-the compensating control. Do not dual-write `ts` alongside any longer alias: two
-names for one cohort would increase GAM setup and audit surface and permit
+carries. Rejected because the target-network provisioning preflight enforced a
+10-character request-name limit and rejected `trusted_server` (14), even though
+other GAM help surfaces describe a 20-character limit. The short `ts` name is
+therefore mandatory for this deployment, and the cross-system collision audit
+is the compensating control. Do not dual-write `ts` alongside any longer alias:
+two names for one cohort would increase GAM setup and audit surface and permit
 silent drift between reports. Only `ts=true` is valid.
 
 ### Configure `ts=true` in creative-opportunity slot targeting
 
 Rejected because creative-opportunity targeting applies only to matched slots.
-The experiment requirement covers every request from each successfully rewritten
-document's local GPT PubAds service.
+The experiment requirement covers every request after the enabled publisher
+pipeline emits the document head for its local GPT PubAds service.
 
 ### Rewrite `cust_params` on GAM network requests
 
@@ -851,36 +1082,59 @@ baseline limitation and requires coverage checks.
 
 ## Acceptance criteria
 
-1. For a deployment that satisfies the documented GPT-integration, HTML-rewrite,
-   `<head>` ordering, CSP, reserved-key, request-scope, and targeting-cleanup
-   prerequisites—and in which a Trusted Server marker callback runs before the
-   first request—every request from that rewritten document's local GPT PubAds
-   service carries `ts=true`, including initial, lazy, refreshed,
-   publisher-owned, and SPA-route requests. A nested document is covered only
-   when its own HTML response independently satisfies the same prerequisites.
-2. Production/control pages remain unmodified and do not carry `ts` from this
+1. `gam_attribution_enabled` defaults to `false`. With omitted or false
+   configuration, dormant gated bootstrap source may remain present, but no
+   attribution callback is enqueued or executed and no inline attribution flag,
+   bundle activation attribute, or fallback is activated. Current GPT, shim,
+   `adInit`, and `ts_initial` behavior is preserved, and setting the field to
+   `false` independently disables attribution.
+2. For an enabled deployment that satisfies the documented head-rewrite,
+   ordering, CSP, reserved-key, request-scope, and targeting-cleanup
+   prerequisites—and in which at least one callback successfully applies
+   page-level targeting before the first request, with no later clear or
+   override—every request from that document's local GPT PubAds service carries
+   `ts=true`, including initial, lazy, refreshed, publisher-owned, and SPA-route
+   requests.
+3. For an in-scope document satisfying the non-cloned activation prerequisite,
+   the marker means the Trusted Server publisher pipeline rewrote and emitted
+   that document's head before the request. It does not certify complete streamed
+   response delivery. This feature adds no buffering; on the existing streaming
+   Fastly path, a later truncation does not reclassify an already marked request
+   as control.
+4. Production/control pages remain unmodified and do not carry `ts` from this
    feature.
-3. `ts_initial=1` retains its current slot-level initial-request lifecycle.
-4. The new key is not cleared by Prebid refresh or SPA slot cleanup.
-5. No publisher code, effective Trusted Server creative-opportunity targeting
-   map, or GAM custom-targeting consumer changes ad eligibility, pricing,
-   protection, routing, or the marker value because of the measurement key.
-6. The marker adds no unique identifier, cookie value, network request, or
-   blocking work. Its disclosure of treatment-path membership to GAM has passed
-   the publisher's privacy/data-governance review.
-7. GAM can report treatment impressions and clicks under `ts=true`, and the
-   control counts can be derived within the same experiment scope using
-   identical non-targeted metrics.
-8. Known treatment requests are validated directly for marker presence, and the
-   observed GAM treatment share is compared diagnostically with the router's
-   expected cohort allocation before experiment results are interpreted.
-9. Non-experiment TS traffic is absent from the route during the measurement
-   window or excluded from both paired GAM reports with identical filters.
-10. Only `ts=true` is emitted and reported; no other value (for example `ts=1`)
-    and no alternative key name (for example `trusted_server`) alias or
-    dual-write compatibility path exists.
-11. CSP-compatible inline execution is proven before launch. A fallback-only
+5. `ts_initial=1` retains its current slot-level initial-request lifecycle, and
+   `ts` is not cleared by Prebid refresh or SPA slot cleanup.
+6. No publisher code, Prebid-generated targeting, effective Trusted Server
+   creative-opportunity targeting map, or GAM custom-targeting consumer changes
+   ad eligibility, pricing, protection, routing, or the marker value because of
+   the measurement key.
+7. The marker adds no unique identifier, cookie value, network request,
+   response buffering, or blocking work. Its disclosure of treatment-path
+   membership to GAM has passed the publisher's privacy/data-governance review.
+8. The target-network preflight has fixed the only contract as `ts=true`; no
+   other value, alternative key name, alias, configurable marker, or dual-write
+   path exists.
+9. The exact Enhanced or legacy reporting path, billing approval, dimensions,
+   filters, and compatible metrics pass a target-network dry run. Saved Report A
+   and Report B use the same frozen eligible-scope manifest and satisfy
+   `0 <= Report B <= Report A` for every interpreted metric; violations invalidate
+   the pair rather than being clamped or reported.
+10. GAM output is described as delivery attribution, not a causal treatment
+    effect. Known treatment/control requests are sampled directly, while
+    aggregate marker share is compared diagnostically with router allocation;
+    neither check is represented as proof of per-response production coverage.
+11. Every excluded traffic path has a retained zero-count preflight or an
+    independent filter applied identically to both saved reports.
+12. Nested inventory is included only when independently routed, rewritten, and
+    validated. Because the activation tag is clonable, marker presence alone is
+    not proof of eligibility; copied activation in excluded inventory is a
+    contamination incident.
+13. CSP-compatible inline execution is proven before launch. A fallback-only
     page remains attributed to treatment but raises an incident and cannot be
     treated as a healthy experiment page.
-12. Rollback reporting excludes already-open documents until observed marked
-    traffic has drained according to the documented boundary rule.
+14. Normal rollback stops and verifies new treatment routing before deploying
+    the attribution kill switch, and reporting excludes already-open or cached
+    marked documents until observed traffic drains according to the documented
+    boundary rule. An emergency kill invalidates the affected and drain windows
+    instead of treating newly unmarked traffic as control.

--- a/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
@@ -986,19 +986,20 @@ deployment:
     diagnostic before interpreting descriptive delivery results.
 
 Rollback is ordered so newly routed treatment traffic cannot become unmarked
-control. First record the last clean reporting boundary and stop new treatment
-assignment/routing. Verify through router or access logs that routing stopped;
-then set `gam_attribution_enabled = false` and deploy the kill switch. Fresh
-Trusted Server documents must keep normal GPT behavior while omitting the
-marker. Already-open documents—including long-lived SPA sessions and any marked
-document restored from a cache—retain page-level targeting and may continue
-issuing marked lazy or refreshed requests. Exclude the entire post-boundary
-drain interval from both cohorts. The drain ends only after router/access logs
-and GAM show no remaining `ts=true` traffic for one complete, runbook-defined
-reporting interval and a fresh synthetic navigation confirms that new documents
-are unmarked. If marked traffic persists, the interval remains excluded rather
-than being inferred as control. Historical GAM rows remain valid, and the GAM
-key may stay defined and reportable for historical analysis.
+control. First stop new treatment assignment/routing and verify through router
+or access logs that routing stopped, then record the last clean reporting
+boundary. Keep `gam_attribution_enabled = true` while already-open
+documents—including long-lived SPA sessions and any marked document restored
+from a cache—drain; they retain page-level targeting and may continue issuing
+marked lazy or refreshed requests. Exclude the entire post-boundary drain
+interval from both cohorts. The drain ends only after router/access logs and GAM
+show no remaining `ts=true` traffic for one complete, runbook-defined reporting
+interval. Then set `gam_attribution_enabled = false`, deploy the kill switch,
+and use a fresh synthetic Trusted Server navigation to confirm normal GPT
+behavior while the marker is absent. If marked traffic persists, keep
+attribution enabled and the interval excluded rather than inferring it as
+control. Historical GAM rows remain valid, and the GAM key may stay defined and
+reportable for historical analysis.
 
 If an active privacy, targeting-collision, or ad-delivery incident requires an
 immediate kill, deploy `gam_attribution_enabled = false` without waiting for
@@ -1133,8 +1134,8 @@ baseline limitation and requires coverage checks.
 13. CSP-compatible inline execution is proven before launch. A fallback-only
     page remains attributed to treatment but raises an incident and cannot be
     treated as a healthy experiment page.
-14. Normal rollback stops and verifies new treatment routing before deploying
-    the attribution kill switch, and reporting excludes already-open or cached
-    marked documents until observed traffic drains according to the documented
-    boundary rule. An emergency kill invalidates the affected and drain windows
-    instead of treating newly unmarked traffic as control.
+14. Normal rollback stops and verifies new treatment routing, records the clean
+    boundary, and keeps attribution enabled until already-open or cached marked
+    documents drain according to the documented rule. Only then is the kill
+    switch deployed. An emergency kill invalidates the affected and drain
+    windows instead of treating newly unmarked traffic as control.

--- a/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
@@ -1,0 +1,886 @@
+# GAM `ts=true` attribution for Trusted Server A/B traffic
+
+Date: 2026-07-15
+
+Status: Design
+
+## Problem
+
+A publisher will route a small, cookie-sticky A/B cohort through Trusted Server
+while the control cohort continues through the existing production path. The
+publisher wants Google Ad Manager (GAM) reporting to identify impressions and
+clicks generated on pages served through Trusted Server and compare them with
+the unmodified production cohort.
+
+Trusted Server currently adds the slot-level key-value `ts_initial=1` while it
+prepares initial GPT slots. That key has a different lifecycle and meaning from
+the experiment marker:
+
+- it identifies the initial slot request prepared by Trusted Server;
+- it is cleared before later client-side refresh auctions; and
+- it is set on matched slots rather than every GPT request on the page.
+
+The experiment needs a document-delivery marker. Every request issued by the
+document-local GPT PubAds service after marker installation in an HTML document
+successfully rewritten by Trusted Server must contain `ts=true`, including
+initial requests, publisher-owned slots, lazy slots, and refreshes. Production
+documents cannot be modified, so the control cohort remains unmarked.
+
+## Goals
+
+1. Add `ts=true` to every in-scope GPT PubAds request made during the lifetime
+   of an HTML document successfully rewritten by Trusted Server.
+2. Leave production/control pages unchanged.
+3. Preserve the existing `ts_initial=1` slot-ownership and refresh lifecycle.
+4. Support GAM reports that count treatment impressions and clicks and derive
+   the control counts within the same experiment scope.
+5. Avoid changing auction eligibility, ad delivery, consent behavior, or page
+   performance.
+6. Define the data-quality checks needed when an unmarked request is used as the
+   control baseline.
+
+## Non-goals
+
+- Implement or change the cookie-based A/B router. The experiment infrastructure
+  owns sticky cohort assignment and routes only the treatment cohort through
+  Trusted Server.
+- Prove that a Trusted Server server-side bid won the GAM auction. `ts=true`
+  means that the page was delivered through Trusted Server, regardless of
+  whether the winning demand was a server-side bid, a direct GAM line item, Ad
+  Exchange, or backfill.
+- Mark GAM traffic outside a successfully rewritten document's local GPT PubAds
+  service. IMA/video SDK requests, direct tags, and server-side GAM requests
+  require separate instrumentation and are outside this design. A nested
+  document's GPT instance is in scope only when that nested HTML response is
+  independently routed through Trusted Server and satisfies the same rewrite,
+  ordering, CSP, and audit prerequisites.
+- Replace `ts_initial`, `hb_*`, line-item, bidder, or creative reporting.
+- Add a client-side analytics beacon or a Trusted Server telemetry event.
+- Make GAM click tracking more complete. The marker only segments clicks that
+  GAM already records.
+- Provide billing-grade or causal experiment analysis from GAM alone.
+
+## Assumptions and prerequisites
+
+- The GPT integration is enabled on every page routed into the treatment cohort.
+  A page served through Trusted Server without the GPT integration does not
+  receive the GPT head bootstrap and cannot satisfy this design.
+- The response enters and successfully completes Trusted Server HTML rewriting,
+  contains a literal `<head>` element, and reaches that element before any
+  publisher script issues a GAM request. Pass-through or buffered-unmodified
+  responses, rewrite failures, and origin markup that omits `<head>` cannot
+  satisfy the marker guarantee.
+- The publisher Content Security Policy allows Trusted Server's bare inline
+  scripts to execute. Initial `adSlots`, the GPT enable flag, the GPT bootstrap,
+  and the `bids`/`adInit` invocation are all nonce-less inline scripts; Trusted
+  Server does not currently propagate a publisher nonce or update CSP hashes. A
+  policy that blocks those scripts makes the initial TS ad stack inert and is
+  ineligible at launch even if it allows the synchronous first-party TSJS
+  bundle.
+- Each in-scope HTML document uses one document-local GPT PubAds service. Nested
+  documents are not implicitly covered by a marked parent: each nested HTML
+  response must be independently routed through Trusted Server and rewritten to
+  receive the marker. IMA/video, direct-tag, server-side GAM, and any nested GPT
+  inventory whose document is not independently rewritten must be excluded from
+  the experiment and paired reports.
+- Treatment and control traffic use the same GAM network and comparable
+  inventory. Report filters can isolate the pages and time window eligible for
+  the experiment.
+- The experiment owner can obtain the expected treatment allocation from the
+  cookie router, even though Trusted Server does not read or emit that cookie.
+- Publisher code and Trusted Server creative-opportunity slot configuration do
+  not reuse `ts` for another meaning, set a slot-level `ts` value, or clear
+  page-level targeting after Trusted Server targeting runs. The deployment audit
+  must inspect `trusted-server.toml` targeting maps and search publisher code
+  for `setTargeting`, `setConfig`, and `clearTargeting` uses that could
+  overwrite or remove the reserved key. If such behavior exists, it must be
+  resolved before launch; silently filtering operator targeting or wrapping
+  publisher GPT APIs is out of scope.
+
+## Existing behavior
+
+The GPT integration has two related pieces:
+
+1. `crates/trusted-server-core/src/integrations/gpt_bootstrap.js` is injected at
+   the start of `<head>`. It creates the GPT command queue early and installs
+   the minimal `window.tsjs.adInit` implementation used before the richer bundle
+   is available.
+2. `crates/trusted-server-js/lib/src/integrations/gpt/index.ts` installs the
+   richer GPT integration and applies slot-level auction targeting.
+
+Both initial-render paths set `ts_initial=1` on slots handled by `adInit`. The
+Prebid refresh integration includes `ts_initial` in its list of stale
+slot-targeting keys and clears it before subsequent client-side refresh
+auctions. SPA cleanup also clears stale `ts_initial` targeting before applying
+new route state.
+
+This behavior is correct for `ts_initial` and must not change. It is not
+sufficient for a page-level treatment marker because it does not cover all GPT
+slots and intentionally does not persist across refreshes.
+
+## Decision
+
+Add a separate page-level GPT key-value:
+
+```text
+ts=true
+```
+
+The early GPT bootstrap will enqueue page-level targeting before publisher GPT
+commands execute. The enqueue must occur after `window.tsjs` is initialized but
+before the existing `if (ts.adInit) return;` guard:
+
+```text
+(function () {
+  if (typeof window === "undefined") return;
+  var ts = (window.tsjs = window.tsjs || {});
+  var tag = (window.googletag = window.googletag || { cmd: [] });
+  tag.cmd = tag.cmd || [];
+  tag.cmd.push(function () {
+    try {
+      if (typeof googletag.setConfig === "function") {
+        googletag.setConfig({ targeting: { ts: "true" } });
+      }
+    } catch (_) {
+      // Attribution must not interrupt the existing bootstrap.
+    }
+  });
+
+  if (ts.adInit) return;
+  // Existing initial-load detector and adInit stub follow.
+})();
+```
+
+The exact implementation must follow the repository's JavaScript formatting and
+defensive checks. The important contract is that the page-level targeting
+command is queued by the head bootstrap before the origin page can queue its GPT
+setup or request ads. Page attribution is independent of whether the bootstrap
+needs to install `ts.adInit`, so the existing guard may skip only the ad-init
+stub and detector setup, never the marker enqueue. An unavailable targeting API
+may skip only the marker callback; it must not prevent later queued publisher or
+Trusted Server callbacks from running.
+
+The existing initial-load detector immediately below the new marker must reuse
+the initialized `tag.cmd` reference rather than repeat its current
+`(window.googletag = window.googletag || { cmd: [] }).cmd` expression. This
+keeps queue initialization and both bootstrap callbacks on one consistent path.
+
+Moving queue initialization above the `ts.adInit` guard intentionally creates a
+standard `window.googletag` command-queue stub on every rewritten, GPT-enabled
+page, including a page where `ts.adInit` already exists and GPT never loads. The
+stub is inert by itself and preserves the marker-before-guard guarantee; it is
+not an accidental behavior to remove during implementation review.
+
+The TypeScript GPT bundle will defensively enqueue the same page-level targeting
+at module initialization after the existing flag-gated shim block and before
+`installTsAdInit()`, only when the existing publisher-page bundle tag carries a
+non-executable GPT activation attribute. The HTML pipeline adds that attribute
+when the GPT integration is enabled. A pre-existing `ts.adInit` is already
+covered by placing the bootstrap marker before the guard and is not a reason for
+the fallback.
+
+The fallback exists to preserve delivery-path attribution if the inline
+bootstrap unexpectedly stops executing while the synchronous first-party bundle
+still runs before publisher GPT. It does not recover `adSlots`, bids, the
+`adInit` invocation, or the initial TS auction: those are also nonce-less inline
+scripts. A fallback-only marker therefore still truthfully means "page delivered
+through Trusted Server," but it also indicates a deployment state that was
+ineligible at launch. Synthetic validation must treat that state as a
+measurement incident, pause interpretation, and exclude the affected time window
+from both paired reports if the incident contaminates collected results. GAM
+cannot distinguish fallback-only pages from normally executing treatment pages
+because both intentionally use the same marker.
+
+Neither targeting path can cover a response that was not HTML-rewritten, markup
+without `<head>`, a policy that blocks both injected paths, or a publisher GPT
+request issued before the injected head content runs. Those are deployment
+eligibility and coverage-validation concerns, not runtime conditions the
+targeting code can repair.
+
+The implementation uses GPT's current page-level `googletag.setConfig` API
+rather than the deprecated `pubads().setTargeting()` API. See
+[GPT configuration API migration](https://developers.google.com/publisher-tag/guides/config-migration).
+Page-level targeting is the right scope because GPT applies it to all slots
+associated with the `pubads` service. Once installed, it remains effective for
+initial, lazy, and refreshed requests for the life of the page. Existing slot
+targeting may add or override other keys without requiring Trusted Server to
+discover every publisher slot.
+
+GPT merges page-level targeting per key across `setConfig` calls. Enqueuing
+`ts=true` from both Trusted Server paths is therefore idempotent, and a
+publisher call that sets an unrelated targeting key preserves `ts`. The explicit
+clear operations are a per-key `null`, a whole-targeting `null`, or the
+equivalent legacy `pubads().clearTargeting()` calls. See
+[GPT key-value targeting](https://developers.google.com/publisher-tag/guides/key-value-targeting).
+
+`ts` is intentionally not added to the slot-targeting cleanup arrays. Those
+arrays manage per-auction state. Clearing page-level `ts` during refresh or SPA
+navigation would incorrectly move a treatment page into the unmarked control
+cohort.
+
+## Attribution contract
+
+### Treatment
+
+An in-scope GAM request is in the treatment cohort when it contains:
+
+```text
+ts=true
+```
+
+The marker means:
+
+> The containing page was delivered through Trusted Server.
+
+It does not mean:
+
+- a Trusted Server bidder returned a bid;
+- a Trusted Server bid won;
+- Trusted Server rendered the winning creative; or
+- the request was the first impression for the slot.
+
+### Control
+
+The production path cannot be changed. Within the exact experiment inventory,
+time window, and publisher scope, an unmarked GAM request is treated as control.
+
+This is an inference rather than an explicit `ts=false` assertion. A treatment
+request that loses its marker would be misclassified as control. The rollout
+therefore requires coverage checks that compare the observed GAM treatment share
+with the A/B router's expected cookie cohort share.
+
+### Relationship to `ts_initial`
+
+| Key            | Scope      | Lifetime                     | Meaning                                   |
+| -------------- | ---------- | ---------------------------- | ----------------------------------------- |
+| `ts=true`      | Page-level | Entire browser page lifetime | Page was delivered through Trusted Server |
+| `ts_initial=1` | Slot-level | Initial TS-managed request   | Initial slot request was prepared by TS   |
+
+The two keys answer different questions and coexist. No code or report should
+infer that one is an alias for the other. The value contract is exactly
+`ts=true`: do not emit, accept, or report any other value (for example `ts=1`),
+and do not dual-write an alternative key name such as `trusted_server`.
+
+## Request lifecycle
+
+```text
+Sticky A/B cookie
+  -> control: browser receives production page
+       -> publisher GPT runs without the `ts` key
+  -> treatment: request is routed through Trusted Server
+       -> GPT head bootstrap queues page-level `ts=true`
+       -> GPT bundle defensively queues the same marker
+       -> GPT library drains the command queue
+       -> publisher and TS define/display/refresh slots
+       -> every in-scope PubAds request carries `ts=true`
+```
+
+The marker covers:
+
+- Trusted Server-defined initial slots;
+- publisher-defined slots reused by Trusted Server;
+- publisher slots that are not part of a Trusted Server creative opportunity;
+- slots created lazily after initial page load;
+- publisher-initiated refreshes;
+- Prebid-managed refreshes; and
+- SPA route changes within the same browser document.
+
+All bullets refer to slots using the same document-local GPT PubAds service.
+Requests from IMA/video SDKs, direct tags, or server-side GAM integrations are
+not covered merely because the containing document is marked. A nested GPT
+instance is marked only when Trusted Server separately rewrites that nested
+document and injects the attribution paths into its own `<head>`.
+
+A full browser navigation creates a new page and repeats cookie-based routing.
+The new page receives the marker only when that navigation is routed through
+Trusted Server.
+
+## Component changes
+
+### Early GPT bootstrap
+
+`crates/trusted-server-core/src/integrations/gpt_bootstrap.js` owns the
+behavior. It will set the page-level key in its earliest GPT command callback,
+before the `ts.adInit` early-return guard. The targeting code stays inside the
+existing raw bootstrap script returned by `head_inserts`; it must not add a
+third head insert.
+
+The operation must be idempotent. Calling
+`googletag.setConfig({ targeting: { ts: 'true' } })` more than once with the
+same value is harmless, but the bootstrap should avoid adding a new global state
+machine solely for deduplication.
+
+The bootstrap already binds the local variable `ts` to the `window.tsjs`
+namespace, so the targeting key `ts` and that variable are unrelated names that
+sit only a few lines apart. Add a clarifying comment at the targeting call so a
+maintainer does not read the key as the namespace. The value is the string
+`'true'`, never the boolean `true`: GPT targeting values must be strings.
+
+### TypeScript GPT bundle fallback
+
+`crates/trusted-server-js/lib/src/integrations/gpt/index.ts` will add a small
+`installTrustedServerPageTargeting()` helper and call it during GPT module
+initialization after the existing flag-gated `installGptShim()` block and before
+`installTsAdInit()` when the publisher-page bundle's activation attribute is
+present. The helper creates or reuses the standard GPT command queue, enqueues
+the same defensive `setConfig({ targeting: { ts: 'true' } })` call, and does not
+read the experiment cookie or wait for an auction. Extend the local `GoogleTag`
+interface with optional `setConfig?(config: Record<string, unknown>): void` so
+the fallback remains defensive when the API is unavailable.
+
+The bootstrap remains the primary path because it is injected first. The bundle
+call is a redundant fallback and must not delay module initialization, create a
+request, or add slot-level targeting. A plain GPT module import without the
+activation attribute must preserve the existing runtime-gating contract and must
+not create `window.googletag`.
+
+### Non-executable bundle activation
+
+The publisher HTML pipeline in
+`crates/trusted-server-core/src/html_processor.rs`, using a separate,
+publisher-page-only tag helper in `crates/trusted-server-core/src/tsjs.rs`, will
+add a `data-ts-gpt-enabled="true"` attribute to the existing synchronous
+`#trustedserver-js` bundle tag when GPT is enabled. The attribute is data, not
+an inline executable, so CSP can block the inline GPT head inserts while still
+allowing the external bundle to detect that it owns page attribution.
+
+At module initialization, the GPT bundle captures `document.currentScript` and
+requires that executing synchronous script to carry `data-ts-gpt-enabled="true"`
+before the fallback may create a GPT stub. It must fail closed when the
+executing script cannot be identified. Do not authorize activation through a
+global `#trustedserver-js` lookup: the generic unified tag uses the same ID in
+creative and test contexts, and duplicate IDs could select the wrong element.
+Binding the signal to the executing tag keeps the activation decision explicit
+and testable without relying on an inline global flag.
+
+The existing `window.__tsjs_gpt_enabled` flag continues to activate
+`installGptShim()` when inline scripts run. It cannot activate the CSP fallback
+because the server sets it from an inline head insert—the execution path CSP may
+block. Migrating shim activation to the data attribute is out of scope; module
+initialization preserves the current flag-gated shim installation, then runs the
+attribute-gated page-targeting helper, then installs `ts.adInit` and the
+remaining GPT bundle hooks.
+
+This signal must be limited to the publisher-page bundle generated from the
+enabled integration registry. Do not infer activation merely because the GPT
+module exists in an all-modules bundle: creative and test tooling can load that
+bundle outside the publisher GPT integration. Do not add a new script tag or
+change the integration's existing head-insert count.
+
+Extend the `tsjs.rs` and `html_processor.rs` tests to prove that the existing
+publisher-page bundle tag gains the activation attribute only when GPT is in the
+enabled immediate module set, remains a single external tag, and omits the
+attribute for non-GPT publisher bundles and generic all-modules tags. Bundle
+tests must also prove that an unrelated or duplicate element with
+`id="trustedserver-js"` cannot activate the fallback.
+
+### GPT Rust integration tests
+
+`crates/trusted-server-core/src/integrations/gpt.rs` already tests the embedded
+bootstrap returned by `head_inserts`. Extend those tests to prove that:
+
+- the bootstrap contains page-level `ts=true` targeting;
+- the marker enqueue appears before the `if (ts.adInit) return;` guard;
+- the targeting setup is queued before `ts.adInit` can issue `display` or
+  `refresh`;
+- the existing `ts_initial` marker remains present; and
+- the enabled integration without `slim_prebid_url` still emits exactly the
+  existing two head inserts, proving the marker was added to the bootstrap
+  instead of a new tag.
+
+### Bootstrap execution tests
+
+Add `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`
+as a Vitest/jsdom behavioral test for the raw bootstrap. The test reads
+`crates/trusted-server-core/src/integrations/gpt_bootstrap.js` with Node's
+`readFileSync`, resolves the source path relative to `import.meta.url` rather
+than the process working directory, and creates an isolated
+`new JSDOM(html, { runScripts: 'outside-only' })` realm. Before evaluating the
+exact source with that realm's `window.eval`, the test must assert that
+`globalThis === window` and `typeof global === 'undefined'` inside the realm.
+This is required because Vitest's default jsdom `window.eval` runs in Node's
+realm under the current configuration. The harness supplies a minimal mocked GPT
+command queue and `pubads` service. It must not evaluate the source in Node's
+global context, copy the bootstrap into a test fixture, or add a JavaScript
+runtime dependency to Rust.
+
+The harness must prove that:
+
+- the attribution callback is queued before a publisher callback added after the
+  injected bootstrap;
+- draining the queue calls `googletag.setConfig` with page-level `ts=true`
+  before the publisher callback runs;
+- a pre-existing `ts.adInit` does not prevent the attribution callback from
+  being queued or executed;
+- a publisher callback queued after the bootstrap still runs when
+  `googletag.setConfig` throws;
+- an unavailable or throwing `googletag.setConfig` does not prevent the existing
+  `disableInitialLoad` wrapper from being installed;
+- `ts.adInit` remains installed when attribution setup is unavailable or throws;
+  and
+- calling the wrapped `disableInitialLoad` still records
+  `ts.gptInitialLoadDisabled`.
+
+### Bundle fallback tests
+
+Extend `crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts` using
+its existing dynamic-import and `vi.resetModules()` pattern. Prove that module
+initialization with the bundle activation attribute queues page-level `ts=true`
+after any existing flag-gated shim installation and before installing
+`ts.adInit`, that it reuses an existing GPT command queue, and that unavailable
+or throwing `setConfig` does not stop the remaining GPT module installers.
+Retain the existing assertion that a plain module import without an activation
+signal does not create `window.googletag`. A duplicate call after the bootstrap
+must remain safe and must not create another script or network request.
+
+### Slot cleanup constraints
+
+No refresh-lifecycle change is required. In particular:
+
+- do not add `ts` to `TS_REFRESH_TARGETING_KEYS`;
+- do not add `ts` to `TS_BASE_TARGETING_KEYS`;
+- do not rename or remove `TS_INITIAL_TARGETING_KEY`; and
+- do not copy `ts` onto individual slots.
+
+Leaving these components unchanged is part of the design: slot cleanup cannot
+remove a page-level key set through `googletag.setConfig`.
+
+### Documentation
+
+Document the distinction between page-level `ts=true` and slot-level
+`ts_initial=1` in `docs/guide/integrations/gpt.md`, near the existing command
+queue documentation. Include the GAM setup and reporting preconditions below; do
+not add this current integration to a planned-future GAM document.
+
+## GAM configuration
+
+GAM configuration is a deployment prerequisite and must be completed before the
+experiment starts because key-value reporting is not retroactive.
+
+The request contract is `ts=true`: key name `ts`, predefined value `true`. The
+key name is provisional pending a GAM preflight (see issue #1027). The GPT/GAM
+`CustomTargetingKey.name` (the code sent in the ad request) is documented as
+limited to 10 characters in the SOAP/REST API, which would rule out a fuller
+name such as `trusted_server` (14); other Help Center material implies 20, and
+these describe different provisioning surfaces, so the enforced limit must be
+confirmed in the target network before the contract is fixed. If the confirmed
+limit permits a longer name, a more descriptive, less collision-prone key is
+preferred over `ts`. Because `ts` is short, it carries a real collision risk with
+common publisher timestamp or cache-buster keys, which makes the cross-system
+collision audit a hard launch gate, not a formality. If any publisher, Trusted
+Server configuration, or GAM object already uses `ts`, the experiment must stop
+until the collision is removed or the contract is explicitly revised everywhere
+before treatment traffic begins.
+
+1. In **Inventory > Key-values**, create or verify a key whose request name is
+   the finalized marker key (`ts` pending the preflight in issue #1027). When the
+   key is created, confirm the enforced key-name and value length limits on the
+   provisioning surface actually used: the SOAP/REST
+   [`CustomTargetingKey`](https://developers.google.com/ad-manager/api/reference/v202511/CustomTargetingService.CustomTargetingKey)
+   documents a 10-character key-`name` limit and a 40-character value limit, but
+   the UI surface may differ, so verify against the target network rather than
+   assuming.
+2. Use a predefined value named `true`.
+3. Enable `ts` as a dedicated reportable Enhanced key-value dimension. If the
+   network does not support Enhanced key-value dimensions, use a report filtered
+   to the single legacy key-value `ts=true`; never sum unfiltered legacy
+   **Key-values** dimension rows.
+4. Reserve `ts` for Trusted Server page attribution.
+5. Audit existing publisher GPT code and every GAM object that consumes custom
+   targeting for an existing `ts` key before deployment. This includes line
+   items, proposal line items, rules, protections, yield configuration, and any
+   network-specific custom-targeting surface.
+6. Audit every `CreativeOpportunitySlot.targeting` map from all effective
+   `trusted-server.toml` configuration sources. The arbitrary operator-supplied
+   map is copied to GPT slots, where a slot-level `ts` value would override the
+   page-level marker. Any occurrence is a launch blocker; do not silently
+   discard it because that could change established operator targeting.
+7. Audit publisher code for every operation that can remove or supersede the
+   marker after initial GPT setup. Search for `setConfig({ targeting: null })`,
+   a `ts: null` or different `ts` value, `pubads().clearTargeting()` with no key
+   or with `ts`, and slot-level `ts` targeting. Account for equivalent calls
+   assembled dynamically.
+
+The audit is a hard precondition. If `ts` already has another meaning, or any
+GAM object targets or acts on `ts=true`, the experiment owner must resolve the
+collision before deployment. The measurement marker is not intended to change ad
+eligibility, pricing, protection, or routing. A pre-existing targeting consumer
+for `ts=true` would make the A/B test measure a traffic or demand change at the
+same time as Trusted Server delivery.
+
+Undefined values do not appear in standard key-value reports even when the key
+is reportable, so value `true` must exist before treatment traffic begins. See
+[Add key-values](https://support.google.com/admanager/answer/9796369) and
+[Report on targeting keys](https://support.google.com/admanager/answer/14528835).
+
+## Reporting and comparison
+
+### Report scope
+
+Every comparison must apply identical filters for:
+
+- publisher/network;
+- experiment start and end time;
+- sites or inventory included in the cookie experiment;
+- ad units and formats;
+- geography and device categories, when used; and
+- any consent or traffic-quality exclusions.
+
+Do not compare the TS cohort with all unmarked network traffic unless all that
+traffic is eligible for the same experiment. Likewise, exclude smoke tests,
+direct hits, operations traffic, and any other TS-served page outside the cookie
+experiment. The marker identifies the delivery path, not the router's cohort
+assignment, so all such requests also carry `ts=true` when the GPT integration
+runs.
+
+The route owner must use router or access logs to prove that non-experiment TS
+traffic is absent from the eligible inventory during the measurement window. If
+such traffic cannot be prevented and has no independent inventory or reportable
+dimension, GAM cannot remove it from Report B because its marker is identical to
+the cohort marker; the experiment must not launch. Record the owner, query,
+expected zero threshold, and response procedure in the experiment runbook.
+
+### Cohort calculations
+
+Use two reports with identical date boundaries, time zone, inventory filters,
+traffic-quality filters, and metric definitions:
+
+1. **Report A — experiment total.** Do not include **Placement**, legacy
+   **Key-values**, **Targeting**, **Yield group**, or another dimension that can
+   represent one event more than once. This report provides one non-duplicated
+   total for every metric in the eligible experiment scope.
+2. **Report B — TS treatment.** Use the dedicated Enhanced `ts` dimension
+   filtered to `ts=true`. If Enhanced key-value dimensions are unavailable, use
+   the legacy **Key-values** dimension filtered to exactly `ts=true` and do not
+   sum any other key-value rows. Do not add **Placement**, **Targeting**,
+   **Yield group**, or any unrelated dimension that can represent the filtered
+   treatment event more than once.
+
+The legacy **Key-values** dimension can emit the same impression or click on
+multiple rows when a request contains multiple key-values. It therefore cannot
+provide Report A or a summable totals row. See
+[Avoid double counting report totals](https://support.google.com/admanager/answer/7642799).
+
+For this paired report scope, define:
+
+```text
+total_impressions = Report A impressions
+ts_impressions = Report B impressions
+prod_impressions = total_impressions - ts_impressions
+
+total_clicks = Report A GAM-recorded clicks
+ts_clicks = Report B GAM-recorded clicks
+prod_clicks = total_clicks - ts_clicks
+```
+
+If the selected GAM report exposes an explicit unassigned or `(not set)` row,
+that row may be used only as a cross-check. The paired Report A minus Report B
+calculation remains the control definition because production cannot send an
+explicit value. The experiment owner must retain both report definitions with
+the results so later analysis can verify that their filters and metrics match.
+Export both reports after the same GAM reporting-latency and invalid-traffic
+adjustment window. If GAM restates one report, rerun the pair before applying
+the subtraction.
+
+Use total metrics when the goal includes all GAM demand sources. GAM's
+`Ad server impressions` and `Ad server clicks` metrics exclude Ad Exchange and
+AdSense, so those narrower metrics should only be used when that exclusion is
+intentional. GAM counts impressions and clicks according to its own tracking
+rules; adding `ts=true` does not create new impression or click trackers. See
+[Counting impressions and clicks](https://support.google.com/admanager/answer/2521337).
+
+Both reports must use the same non-targeted impression and click metric names.
+Do not use targeted-impression or targeted-click metrics for this attribution:
+`ts` is intentionally forbidden from line-item targeting, so metrics limited to
+keys used for targeting do not represent the requested delivery-path cohort.
+Record the exact selected GAM metric names with the saved report definitions
+before launch.
+
+### Unequal cohort sizes
+
+The treatment cohort is intentionally small, so raw TS and production totals are
+not directly comparable. Reports should show the raw counts, but experiment
+conclusions should compare normalized measures where compatible metrics are
+available:
+
+- impressions per GAM ad request;
+- fill rate;
+- clicks per impression (CTR); and
+- revenue per thousand impressions or requests.
+
+Impressions per routed pageview or per assigned visitor require a denominator
+from the A/B router or site analytics. GAM alone cannot identify unmarked
+production pageviews that made no ad request. Any cross-system experiment
+analysis is outside the implementation but should use the same time and
+eligibility filters.
+
+### Data-quality checks
+
+During the experiment, monitor:
+
+1. observed `ts=true` ad-request or impression share versus the router's
+   expected treatment allocation;
+2. scheduled synthetic marker presence on initial, lazy, and refreshed treatment
+   requests;
+3. scheduled synthetic marker absence on production requests;
+4. non-experiment traffic served through Trusted Server;
+5. unexpected `ts` values or line-item targeting;
+6. report freshness and GAM invalid-traffic adjustments.
+
+A gap between expected and observed treatment share is a measurement incident,
+not evidence of production performance, until missing-marker and request-volume
+differences are ruled out. Because router assignment and GAM delivery normally
+use page or visitor counts versus ad-request or impression counts, this share
+comparison is a diagnostic rather than direct proof of marker coverage. It can
+measure coverage directly only when the router or site analytics supplies a
+matched request- or page-level denominator.
+
+Checks 2–3 use a scheduled synthetic browser crawl of representative experiment
+URLs. The crawler supplies known treatment and control cookies, captures GAM
+network requests, and triggers initial, lazy, and refreshed slots. A failed
+marker assertion is an operational measurement incident. This is external
+validation rather than a site beacon or Trusted Server telemetry event; if the
+experiment owner cannot operate the crawl, checks 2–3 become documented manual
+samples and must not be represented as continuous production metrics.
+
+On treatment URLs with matched creative opportunities, the crawler must also
+detect the fallback-only CSP state: capture CSP violations and verify that the
+injected `adSlots`, `bids`, and initial `adInit` handoff executed. A page that
+has `ts=true` only because the external bundle ran, while those inline scripts
+were blocked, remains correctly marked as TS-delivered but raises a measurement
+incident. Since GAM cannot separate those requests afterward, the incident owner
+must pause interpretation and exclude the affected time range from both reports
+when clean boundaries can be established; otherwise the experiment result is
+invalid.
+
+## Failure handling
+
+The marker is best-effort instrumentation and must never block ads or page
+delivery.
+
+- If GPT never loads, there is no GAM request to classify.
+- If a response is not successfully HTML-rewritten, has no literal `<head>`, or
+  issues an in-scope GPT request before the injected head content runs, neither
+  targeting path can mark that request. Such traffic is ineligible for the
+  experiment and must be detected before launch or excluded from analysis.
+- If CSP blocks Trusted Server's nonce-less inline scripts, the initial TS ad
+  stack is inert and the page is ineligible even when the first-party bundle
+  queues the attribution marker. The fallback prevents a TS-delivered page from
+  leaking into the inferred control cohort; it does not make the deployment
+  healthy. If CSP blocks both inline scripts and the bundle, attribution also
+  fails.
+- If `googletag.setConfig` is unavailable when a queued command runs, the
+  targeting step is a defensive no-op and must not throw. Supported treatment
+  deployments must use a GPT version with the configuration API; browser/GAM
+  validation detects an unsupported or missing API before experiment launch.
+- If publisher code or a Trusted Server creative-opportunity targeting map
+  applies slot-level `ts`, GPT gives the slot-level value precedence. The
+  deployment audit prevents this collision; runtime filtering or interception is
+  out of scope because it could silently alter established targeting behavior.
+- If publisher code calls `setConfig({ targeting: null })`, sets `ts: null` or a
+  different value, calls legacy `pubads().clearTargeting()` for all keys or for
+  `ts`, or applies slot-level `ts`, the effective marker can be removed or
+  superseded. The publisher-code audit and refresh validation are required
+  because this design deliberately does not intercept those APIs.
+- If the marker is absent on a treatment request, GAM classifies it with the
+  unmarked baseline. Coverage monitoring is the mitigation.
+- GAM configuration or reporting failures do not affect ad serving.
+
+No retry, beacon, cookie read, backend request, or persistent client state is
+added by this feature.
+
+## Privacy and consent
+
+`ts=true` contains no unique user identifier, cookie value, page URL, or auction
+data. It describes only the delivery path of the current document. Because only
+the cookie-sticky treatment cohort is routed through Trusted Server for this
+experiment, the value also reveals treatment-path membership for that GAM
+request. It is therefore cohort information even though it does not expose the
+assignment cookie or identify a person by itself.
+
+The implementation does not read the experiment cookie. Routing happens before
+Trusted Server handles the request. Existing consent gates continue to decide
+whether GAM requests or auctions occur. The marker does not create an ad request
+that would otherwise be suppressed. Before enabling the key, the experiment
+owner must complete the publisher's privacy/data-governance review for sending
+this treatment-path attribute to GAM and confirm that existing consent and
+data-use terms cover it.
+
+## Testing strategy
+
+### Automated tests
+
+1. Extend Rust GPT head-insert tests to assert page-level `ts=true` targeting is
+   in the existing raw bootstrap, occurs before the `ts.adInit` guard and any
+   bootstrap `display()` or `refresh()` call, and does not change the expected
+   head-insert count.
+2. Extend the TSJS tag and HTML processor tests to prove the non-executable GPT
+   activation attribute appears only on the enabled publisher-page bundle and
+   adds no script tag.
+3. Add the Vitest/jsdom raw-bootstrap harness described above. Exercise the
+   bootstrap with `googletag.setConfig` available, unavailable, and throwing,
+   and prove a later publisher callback still runs in every case. Set
+   `window.tsjs.adInit` before evaluation and prove the marker still runs.
+4. Extend the existing GPT bundle tests to prove module initialization queues
+   the fallback marker and remains non-blocking when `setConfig` is unavailable
+   or throws.
+5. Retain assertions for `ts_initial=1` to prevent accidental replacement.
+6. Retain refresh tests proving stale `ts_initial` and `hb_*` slot targeting is
+   cleared. Add an explicit assertion or source-level invariant that page-level
+   `ts` is not included in slot cleanup lists.
+7. Extend creative-opportunity configuration tests to demonstrate that an
+   operator targeting map is forwarded verbatim, documenting why the deployment
+   audit must reject a configured `ts` key rather than assuming the client
+   overwrites or filters it.
+8. Run the project-required target-matched Rust and JavaScript checks for the
+   touched files.
+
+### Browser/GAM validation
+
+Before experiment launch:
+
+1. Load a treatment page using a known treatment cookie.
+2. Confirm the initial in-scope GAM request contains `ts=true` using GPT
+   Publisher Console, Delivery Inspector, or the browser network panel.
+3. Trigger a lazy slot and a refresh; confirm both requests still contain
+   `ts=true`.
+4. Load the equivalent production page with a control cookie and confirm the key
+   is absent.
+5. Confirm `ts_initial=1` remains limited to its existing initial-slot
+   lifecycle.
+6. Validate the deployed CSP by proving `adSlots`, the GPT bootstrap, `bids`,
+   and the initial `adInit` handoff execute on a representative page with
+   matched slots. A page that runs only the external bundle is ineligible even
+   if the fallback marker appears.
+7. Set an unrelated page-level targeting key after `ts=true` and confirm both
+   keys remain on a later request. Treat an explicit page-level or per-key clear
+   as a failed publisher-code audit, not supported behavior.
+8. Validate that IMA/video, direct-tag, server-side GAM, and nested GPT
+   inventory without an independently TS-rewritten document is absent from the
+   experiment and paired report scope. Directly validate any independently
+   rewritten nested documents that are intentionally included.
+9. Run a short GAM report and verify treatment totals appear under `ts=true`
+   while overall totals remain unchanged apart from normal reporting latency.
+
+## Rollout
+
+1. Audit response eligibility, including HTML rewriting, `<head>` ordering, CSP,
+   and publisher GPT calls that could precede or remove the marker.
+2. Audit the `ts` key across publisher GPT code, effective `trusted-server.toml`
+   creative-opportunity targeting maps, and every GAM custom-targeting consumer.
+3. Prove through router or access logs that non-experiment traffic is excluded
+   from the TS route or independently separable in both paired GAM reports.
+4. Exclude IMA/video, direct-tag, server-side GAM, and nested GPT inventory
+   whose document is not independently rewritten. Inventory in intentionally
+   rewritten nested documents must pass the same request and report validation
+   as the top-level document.
+5. Create and enable the reportable GAM key and predefined value.
+6. Deploy the Trusted Server marker before assigning experiment traffic.
+7. Provision the scheduled synthetic crawl, assign an incident owner, and obtain
+   one successful treatment/control run covering initial, lazy, refreshed, and
+   CSP execution checks.
+8. Validate treatment and control requests manually.
+9. Start the small cookie-sticky cohort.
+10. Compare observed GAM treatment share with the router allocation before using
+    the results for performance decisions.
+11. Monitor normalized metrics over a sufficiently large window; do not infer a
+    treatment effect from unequal raw totals.
+
+Rollback stops adding the page-level key to newly loaded documents. Already-open
+documents—including long-lived SPA sessions—retain page-level targeting and may
+continue issuing marked lazy or refreshed requests after the code rollback.
+Record the rollback timestamp, end the experiment reports at the last clean
+pre-rollback boundary, and exclude the post-rollback drain interval from both
+cohorts. The drain ends only after router/access logs and GAM show no remaining
+`ts=true` traffic for one complete agreed reporting interval and a fresh
+synthetic navigation confirms that new documents are unmarked. If marked traffic
+persists, the interval remains excluded rather than being inferred as control.
+Historical GAM rows recorded while the key was active remain valid, and the GAM
+key may stay defined and reportable for historical analysis.
+
+## Alternatives considered
+
+### Reuse `ts_initial=1`
+
+Rejected because the key is slot-level, covers only TS-managed initial slots,
+and is deliberately cleared on refresh. Changing its lifecycle would also break
+its existing ownership semantics.
+
+### Add slot-level `ts=true` in `adInit`
+
+Rejected because it would miss publisher-owned or lazy slots that do not pass
+through `adInit`, and existing refresh cleanup could remove it. It would measure
+auction participation rather than page delivery.
+
+### Set `ts=true` only in the bootstrap
+
+Rejected as the sole path. Placing the enqueue before the existing `ts.adInit`
+guard correctly handles a pre-installed ad-init implementation. The bundle is
+not needed for that case. It remains useful when the inline script unexpectedly
+stops executing but the synchronous first-party bundle still runs: without the
+fallback, a TS-delivered treatment page would be silently inferred as control.
+The fallback does not rescue the simultaneously blocked TS ad-stack scripts, so
+that state is an incident rather than an eligible deployment mode.
+
+### Use a longer descriptive key name such as `trusted_server`
+
+A descriptive name would lower the collision risk that the short `ts` key
+carries. Rejected because GAM limits a custom-targeting key name to 10
+characters, so `trusted_server` (14) cannot be created as a reportable key. The
+short `ts` name is therefore mandatory, and the cross-system collision audit is
+the compensating control. Do not dual-write `ts` alongside any longer alias: two
+names for one cohort would increase GAM setup and audit surface and permit
+silent drift between reports. Only `ts=true` is valid.
+
+### Configure `ts=true` in creative-opportunity slot targeting
+
+Rejected because creative-opportunity targeting applies only to matched slots.
+The experiment requirement covers every request from each successfully rewritten
+document's local GPT PubAds service.
+
+### Rewrite `cust_params` on GAM network requests
+
+Rejected because it depends on GPT's internal request construction and encoding,
+adds interception risk, and duplicates a supported GPT targeting API.
+
+### Mark production explicitly with `ts=false`
+
+Preferred in a fully controlled experiment, but unavailable because the
+production path cannot be changed. The design documents the resulting unmarked
+baseline limitation and requires coverage checks.
+
+## Acceptance criteria
+
+1. For a deployment that satisfies the documented GPT-integration, HTML-rewrite,
+   `<head>` ordering, CSP, reserved-key, request-scope, and targeting-cleanup
+   prerequisites—and in which a Trusted Server marker callback runs before the
+   first request—every request from that rewritten document's local GPT PubAds
+   service carries `ts=true`, including initial, lazy, refreshed,
+   publisher-owned, and SPA-route requests. A nested document is covered only
+   when its own HTML response independently satisfies the same prerequisites.
+2. Production/control pages remain unmodified and do not carry `ts` from this
+   feature.
+3. `ts_initial=1` retains its current slot-level initial-request lifecycle.
+4. The new key is not cleared by Prebid refresh or SPA slot cleanup.
+5. No publisher code, effective Trusted Server creative-opportunity targeting
+   map, or GAM custom-targeting consumer changes ad eligibility, pricing,
+   protection, routing, or the marker value because of the measurement key.
+6. The marker adds no unique identifier, cookie value, network request, or
+   blocking work. Its disclosure of treatment-path membership to GAM has passed
+   the publisher's privacy/data-governance review.
+7. GAM can report treatment impressions and clicks under `ts=true`, and the
+   control counts can be derived within the same experiment scope using
+   identical non-targeted metrics.
+8. Known treatment requests are validated directly for marker presence, and the
+   observed GAM treatment share is compared diagnostically with the router's
+   expected cohort allocation before experiment results are interpreted.
+9. Non-experiment TS traffic is absent from the route during the measurement
+   window or excluded from both paired GAM reports with identical filters.
+10. Only `ts=true` is emitted and reported; no other value (for example `ts=1`)
+    and no alternative key name (for example `trusted_server`) alias or
+    dual-write compatibility path exists.
+11. CSP-compatible inline execution is proven before launch. A fallback-only
+    page remains attributed to treatment but raises an incident and cannot be
+    treated as a healthy experiment page.
+12. Rollback reporting excludes already-open documents until observed marked
+    traffic has drained according to the documented boundary rule.

--- a/docs/superpowers/specs/2026-08-03-datadome-ip-excluded-client-tag-design.md
+++ b/docs/superpowers/specs/2026-08-03-datadome-ip-excluded-client-tag-design.md
@@ -1,0 +1,335 @@
+# DataDome IP-excluded client tag suppression
+
+**Issue:** #994
+**Date:** 2026-08-03
+**Status:** Proposed
+
+## Problem
+
+Trusted Server has two DataDome protection layers:
+
+1. Server-side Protection API validation, which can be skipped for configured
+   client IP CIDRs.
+2. Client-side tag auto-injection, which adds `window.ddjskey`,
+   `window.ddoptions`, and the configured `tags.js` script to processed HTML.
+
+When a request matches an IP-based server-side exclusion, the Protection API is
+skipped, but the client-side tag is currently still injected. The browser can
+therefore continue running client-side DataDome protection for a request that
+was explicitly whitelisted at Trusted Server.
+
+The desired behavior is that Fastly requests skipped by an IP-based DataDome
+exclusion also omit Trusted Server's automatically injected client-side tag.
+
+## Goals
+
+- Suppress Trusted Server's automatically injected DataDome client-side tag for
+  Fastly requests skipped by an IP-based protection exclusion.
+- Reuse the existing authoritative protection-scope decision.
+- Cover all supported IP-based exclusion mechanisms:
+  - `protection_excluded_ip_cidrs`
+  - `protection_excluded_ip_cidr_sources`
+  - structured `ip_cidr` rules
+  - structured `ip_cidr_source` rules
+- Preserve current behavior for non-IP exclusions.
+- Leave publisher-originated or manually configured DataDome tags untouched.
+- Add an informational diagnostic indicating that the client tag is omitted.
+- Keep the implementation independent of caller-supplied IP headers.
+- Prevent a shared cache from replaying IP-specific, tag-suppressed HTML to
+  non-excluded visitors.
+
+## Non-goals
+
+- Do not add a configuration flag or make this behavior opt-in.
+- Do not change Axum, Cloudflare, or Spin request-filter wiring. This behavior
+  is intentionally scoped to the Fastly adapter, where the DataDome server-side
+  request filter is currently run.
+- Do not suppress DataDome tags that originate in publisher HTML.
+- Do not remove or disable the `/integrations/datadome/tags.js` route.
+- Do not change DataDome signal-collection proxy behavior.
+- Do not change ASN, path, query-parameter, method, static-asset, or internal
+  route exclusions.
+- Do not perform live production verification as part of implementation.
+
+## Confirmed decisions
+
+1. **Adapter scope:** Fastly only.
+2. **IP scope:** all four IP-based exclusion mechanisms listed above.
+3. **Tag scope:** Trusted Server's auto-injected tag only.
+4. **HTML scope:** every HTML response that enters the existing HTML processing
+   pipeline.
+5. **Logging:** enrich the existing IP-exclusion skip log with
+   `client_tag=omitted`, including the matched rule and reason.
+6. **Live testing:** deferred until after implementation and deployment/testing
+   workflow review.
+
+## Current architecture
+
+### Server-side protection
+
+`DataDomeIntegration::is_request_protected()` in
+`crates/trusted-server-core/src/integrations/datadome/protection.rs` evaluates
+method, internal-route, ASN, IP, and structured exclusion conditions. It uses
+the client IP from `RuntimeServices::client_info()`, which is populated from
+trusted Fastly request metadata. It does not use a caller-supplied IP header.
+
+The current function reduces the protection-scope result to a boolean. For an
+IP exclusion it logs the skip and returns `false`, causing the request filter to
+continue without calling the Protection API.
+
+The Fastly EdgeZero fallback path runs this request filter before route
+selection and publisher proxying. The request continues into
+`handle_publisher_request()` after the filter returns a continue decision.
+
+### Client-side injection
+
+`DataDomeIntegration::head_inserts()` in
+`crates/trusted-server-core/src/integrations/datadome.rs` emits the client-side
+snippet when:
+
+- `inject_client_side_tag` is true; and
+- `client_side_key` is non-empty.
+
+The injector currently receives `IntegrationHtmlContext`, which contains HTML
+host/scheme and document state but no request IP or protection decision.
+
+The publisher response path carries request-specific values through:
+
+```text
+Request
+  -> OwnedProcessResponseParams
+  -> HtmlStreamProcessorParams
+  -> HtmlProcessorConfig
+  -> IntegrationHtmlContext
+  -> IntegrationHeadInjector
+```
+
+The existing DataDome attribute rewriter separately rewrites DataDome URLs
+found in publisher HTML. That behavior must remain unchanged.
+
+## Design
+
+### 1. Capture an IP-exclusion marker at the request filter
+
+The request filter must attach a typed, internal request-scoped marker when the
+existing protection-scope evaluation reports `suppress_client_tag` metadata.
+The scope preserves the current first-match rule ID and typed reason for
+logging, while independently checking applicable IP exclusions when an earlier
+method, ASN, path, or query rule already matched. The marker must not be
+inferred from request headers or recomputed later in the HTML pipeline.
+
+The request-filter API currently exposes an immutable request view. Add the
+smallest internal mechanism needed for a filter to attach a typed request
+extension without introducing a caller-visible header. Header mutations should
+continue to use `RequestFilterEffects` as they do today.
+
+The marker should be a zero-sized or otherwise minimal internal type. It only
+needs to answer whether Trusted Server's DataDome client tag should be
+suppressed; the existing skip log supplies the rule ID and reason.
+
+The marker must not be attached for:
+
+- internal or integration routes;
+- method, ASN, path, or query exclusions without an overlapping IP match;
+- unmatched or method-inapplicable IP rules;
+- Protection API fail-open behavior; or
+- requests where `enable_protection` is false and the request filter does not
+  run.
+
+### 2. Enrich the existing skip log
+
+For navigation skips that suppress the tag, extend the existing informational
+log with `client_tag=omitted` (subresource suppression skips use `debug`):
+
+```text
+[datadome] protection decision=skipped rule=excluded-ip-cidrs reason=client_ip client_tag=omitted method=GET
+```
+
+The existing rule ID, reason, and method remain part of the log. Host and path are omitted to avoid placing dynamic request data in the protection logs.
+Client IP values are not included. Non-IP skip logs retain their current
+behavior and level.
+
+This log represents the request policy decision. It may also apply to a
+non-HTML response, for which no HTML tag would have been injected anyway.
+
+### 3. Propagate the marker into HTML processing
+
+Before the publisher request is moved into the platform HTTP client, snapshot
+whether the request carries the marker. Carry that request-scoped boolean
+through `OwnedProcessResponseParams`, `HtmlStreamProcessorParams`, and
+`HtmlProcessorConfig`.
+
+The value should default to `false` in all existing constructors and direct
+unit-test fixtures. Non-Fastly adapters will naturally retain the default
+because they do not currently produce the Fastly request-filter marker.
+
+Expose the value to head injectors through the existing HTML processing context
+or equivalent request-scoped integration context. The propagation must work for
+both:
+
+- the normal buffered HTML path; and
+- the streaming HTML path, including the auction-hold path.
+
+The value is irrelevant for non-HTML, RSC, pass-through, and unmodified
+responses, which should retain their current processing.
+
+### 4. Keep IP-specific HTML out of shared cache
+
+A processed HTML response differs by client IP when the generated tag is
+suppressed. In the `PublisherResponse::Stream` path, when suppression is active
+and the response is HTML, use the shared synthesized-HTML policy:
+`Cache-Control: private, no-store`, no origin validators, and no CDN-targeted
+cache headers. This response-time policy cannot invalidate tag-bearing HTML
+already held by a fronting shared cache; guaranteed suppression requires
+bypassing or purging that cache.
+
+This matches the existing per-user ad-stack cache policy. It prevents Fastly or
+another shared cache from replaying a tag-suppressed response to a visitor whose
+IP does not match an exclusion. Do not change cache headers for non-HTML,
+pass-through, or unmodified responses because their output does not vary by this
+feature.
+
+### 5. Suppress only the generated DataDome snippet
+
+At the start of `DataDomeIntegration::head_inserts()`:
+
+1. Check the request-scoped suppression marker.
+2. If present, return no DataDome head inserts.
+3. Otherwise preserve the current `inject_client_side_tag` and
+   `client_side_key` checks and emit the existing snippet unchanged.
+
+When suppression is active, omit both:
+
+```html
+<script>
+  window.ddjskey=...;window.ddoptions=...;
+</script>
+<script src="/integrations/datadome/tags.js" async></script>
+```
+
+Do not alter:
+
+- publisher-originated DataDome script tags;
+- `rewrite_sdk` behavior;
+- the DataDome SDK proxy route;
+- the signal collection API proxy;
+- DataDome configuration serialization for non-suppressed requests; or
+- injection behavior for requests without the marker.
+
+## Testing plan
+
+### Protection-filter tests
+
+Add or extend tests in
+`crates/trusted-server-core/src/integrations/datadome/protection.rs` to verify
+that the marker is attached for:
+
+- a matching inline IPv4 CIDR;
+- a matching Config Store-backed CIDR source;
+- a matching structured `ip_cidr` rule; and
+- a matching structured `ip_cidr_source` rule.
+
+Verify that the marker is absent for:
+
+- a non-matching IP;
+- an ASN exclusion;
+- a path exclusion;
+- a query-parameter exclusion;
+- an excluded method; and
+- an internal or integration route.
+
+Verify the existing protection behavior remains unchanged: IP-matched requests
+continue without a Protection API call.
+
+### Head-injector tests
+
+Add tests in
+`crates/trusted-server-core/src/integrations/datadome.rs` verifying that:
+
+- a configured client tag is omitted when suppression is active;
+- a configured client tag is emitted when suppression is inactive;
+- a blank client-side key remains a no-op; and
+- `inject_client_side_tag = false` remains a no-op.
+
+### HTML pipeline tests
+
+Add coverage for the request-scoped value flowing through the HTML processor,
+including the streaming path. Confirm that a suppressed processed HTML response
+contains neither the injected `window.ddjskey` configuration nor the configured
+DataDome `tags.js` script. For a suppressed HTML stream, assert the response is
+private and has no surrogate cache headers. Confirm a non-suppressed HTML stream
+retains its origin cache behavior.
+
+Confirm that publisher-originated DataDome tags remain in the output and are
+still rewritten according to the existing `rewrite_sdk` behavior.
+
+### Fastly dispatch tests
+
+Add a Fastly adapter dispatch test with:
+
+- DataDome protection enabled;
+- a client IP matching an inline exclusion;
+- a configured client-side key; and
+- an HTML publisher response.
+
+The test should verify that the request continues without a Protection API
+call, the response includes the `client_tag=omitted` decision log through the
+existing test logging seam where available, and the generated tag is absent.
+
+Also cover a non-excluded request to confirm the generated tag remains present.
+
+## Documentation changes
+
+Update `docs/guide/integrations/datadome.md` to state that IP-excluded Fastly
+requests skip both:
+
+- server-side Protection API validation; and
+- Trusted Server's automatic client-side tag injection.
+
+Document that this does not remove or disable publisher-originated DataDome
+tags, and that non-IP exclusions do not automatically suppress the client-side
+tag.
+
+No configuration template changes are required because this behavior has no
+new setting.
+
+## Files expected to change
+
+- `crates/trusted-server-core/src/integrations/registry.rs`
+  - Support the internal request-scoped annotation mechanism.
+- `crates/trusted-server-core/src/integrations/datadome.rs`
+  - Define the marker and conditionally suppress head injection.
+- `crates/trusted-server-core/src/integrations/datadome/protection.rs`
+  - Attach the marker for IP-based scope skips and enrich the skip log.
+- `crates/trusted-server-core/src/integrations/registry.rs` or the relevant
+  HTML context definition
+  - Carry the suppression decision into head injection.
+- `crates/trusted-server-core/src/html_processor.rs`
+  - Carry the request-scoped value into HTML integration context.
+- `crates/trusted-server-core/src/publisher.rs`
+  - Snapshot and propagate the request marker through response processing.
+- `docs/guide/integrations/datadome.md`
+  - Document the behavior.
+- Relevant unit and Fastly adapter test modules.
+
+The exact split between registry request annotations and HTML context plumbing
+should remain minimal and should not introduce a new public configuration API.
+
+## Verification
+
+Implementation verification should use the repository's target-matched
+commands:
+
+```bash
+cargo fmt --all -- --check
+cargo test-fastly
+cargo test-axum
+cargo test-cloudflare
+cargo clippy-fastly
+cargo clippy-axum
+cargo clippy-cloudflare
+```
+
+No live production validation is required for this implementation task. Live
+browser verification will be performed later through the deployment/testing
+workflow.

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -104,6 +104,9 @@ rewrite_sdk = true
 
 [integrations.gpt]
 enabled = false
+# Keep this leaf present when using the corresponding EdgeZero v0.0.4
+# environment override. Attribution remains off until explicitly enabled.
+gam_attribution_enabled = false
 script_url = "https://ads.example.com/gpt.js"
 cache_ttl_seconds = 3600
 rewrite_script = true


### PR DESCRIPTION
## Summary

- Add a default-off `gam_attribution_enabled` GPT option that applies fixed page-level `ts=true` targeting to eligible publisher documents whose rewritten head is emitted by Trusted Server, allowing GAM to describe treatment delivery while the production/control path remains unmarked.
- Apply targeting before publisher GPT initialization through the early bootstrap, with an exact `document.currentScript` attribute-gated TSJS fallback that fails closed and isolates `setConfig` failures.
- Preserve auction behavior, consent, the slot-level `ts_initial` lifecycle, and publisher/Prebid targeting while documenting the collision audit, reporting contract, rollout, monitoring limits, and drain-safe rollback sequence.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-cli/tests/config_env_overlay.rs` | Verify the GAM attribution environment override is applied when the corresponding TOML leaf exists. |
| `crates/trusted-server-core/src/creative_opportunities.rs` | Characterize that operator-provided slot-level `ts` targeting remains forwarded unchanged. |
| `crates/trusted-server-core/src/html_processor.rs` | Add integration-provided attributes to publisher TSJS tags and cover enabled, disabled, and source-order behavior. |
| `crates/trusted-server-core/src/integrations/gpt.rs` | Add the default-off setting and drive both inline activation and fallback authorization from the parsed GPT configuration. |
| `crates/trusted-server-core/src/integrations/gpt_bootstrap.js` | Queue page-level `ts=true` before the existing `adInit` guard and isolate attribution failures from later GPT commands. |
| `crates/trusted-server-core/src/integrations/registry.rs` | Add and test the integration hook that supplies trusted static attributes for publisher bundle tags. |
| `crates/trusted-server-core/src/publisher.rs` | Cover streaming-head attribution semantics and operator-targeting preservation. |
| `crates/trusted-server-core/src/tsjs.rs` | Render trusted static attributes on publisher TSJS tags without changing generic or creative tag output. |
| `crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts` | Verify attribution metadata is absent from the default-off integration fixture. |
| `crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml` | Keep the new configuration leaf explicit and disabled in integration tests. |
| `crates/trusted-server-js/lib/src/integrations/gpt/index.ts` | Add the executing-script-gated bundle fallback for page-level GAM targeting. |
| `crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts` | Verify SPA cleanup does not clear the page-level `ts` key. |
| `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts` | Exercise activation ordering, disabled behavior, unavailable or throwing `setConfig`, and bootstrap continuity. |
| `crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts` | Cover exact fallback authorization, fail-closed cases, duplicate-ID decoys, cloned tags, and error isolation. |
| `crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts` | Characterize publisher and Prebid-generated `ts` targeting across refreshes. |
| `docs/guide/integrations/gpt.md` | Document configuration, environment-overlay requirements, attribution semantics, collision checks, reporting, rollout, and rollback. |
| `docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md` | Add the reviewed implementation and verification plan. |
| `docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md` | Finalize the fixed marker contract, streaming meaning, reporting scope, and operational safeguards. |
| `trusted-server.example.toml` | Add the explicit default-off setting and environment-overlay guidance. |

## Launch gates

This PR completes the repository implementation. Starting the cohort remains gated on target-network GAM provisioning, cross-system collision and privacy/CSP audits, a paired-report dry run, and router-controlled treatment validation described in the design.

GAM results are descriptive delivery attribution, not causal treatment-effect estimates.

## Closes

Closes #1027

## Test plan

- [x] `cargo test-fastly && cargo test-axum`
- [x] `cargo clippy-fastly && cargo clippy-axum`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/trusted-server-js/lib && npx vitest run` (44 files, 847 tests)
- [x] JS format: `cd crates/trusted-server-js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [x] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [x] Manual testing via `fastly compute serve`: confirmed the inline flag, activation attribute, GPT page targeting, and decoded `cust_params` containing `ts=true` on a real GAM request
- [x] Other: Cloudflare and Spin adapter tests/clippy, cross-adapter parity, native CLI tests, and Next.js/WordPress browser integration suites

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` added to production code
- [x] Logging follows project conventions; no direct stdout/stderr logging was added
- [x] New code has tests
- [x] No secrets or credentials committed
