### PR TITLE
Add GAM cohort attribution for Trusted Server traffic

### DIFF
--- a/crates/trusted-server-cli/tests/config_env_overlay.rs
+++ b/crates/trusted-server-cli/tests/config_env_overlay.rs
@@ -29,6 +29,7 @@ ids = ["trusted_server_secrets"]
 "#;
 const REWRITE_ENV: &str = "TRUSTED_SERVER__AUCTION__REWRITE_CREATIVES";
 const SANITIZE_ENV: &str = "TRUSTED_SERVER__AUCTION__SANITIZE_CREATIVES";
+const GAM_ATTRIBUTION_ENV: &str = "TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED";
 
 struct MigratedProject {
     directory: TempDir,
@@ -109,6 +110,49 @@ fn migrated_legacy_config_applies_rewrite_creatives_environment_override() {
         envelope["data"]["auction"]["rewrite_creatives"],
         serde_json::Value::Bool(false),
         "pushed config should contain the environment override"
+    );
+}
+
+#[test]
+fn migrated_legacy_config_applies_gam_attribution_environment_override() {
+    let project = migrated_legacy_project();
+    let output = Command::new(env!("CARGO_BIN_EXE_ts"))
+        .args(["config", "push", "--adapter", "axum", "--manifest"])
+        .arg(&project.manifest_path)
+        .arg("--app-config")
+        .arg(&project.config_path)
+        .args(["--yes", "--no-diff"])
+        .current_dir(project.directory.path())
+        .env(GAM_ATTRIBUTION_ENV, "true")
+        .output()
+        .expect("should run ts config push");
+
+    assert!(
+        output.status.success(),
+        "valid boolean overlay should push successfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let local_store_path = project
+        .directory
+        .path()
+        .join(".edgezero/local-config-trusted_server_config.json");
+    let local_store: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(local_store_path).expect("should read pushed local config"),
+    )
+    .expect("should parse local config store");
+    let envelope_json = local_store
+        .as_object()
+        .and_then(|entries| entries.values().next())
+        .and_then(serde_json::Value::as_str)
+        .expect("should contain a blob envelope");
+    let envelope: serde_json::Value =
+        serde_json::from_str(envelope_json).expect("should parse blob envelope");
+
+    assert_eq!(
+        envelope["data"]["integrations"]["gpt"]["gam_attribution_enabled"],
+        serde_json::Value::Bool(true),
+        "pushed config should contain the GAM attribution environment override"
     );
 }
 

--- a/crates/trusted-server-core/src/creative_opportunities.rs
+++ b/crates/trusted-server-core/src/creative_opportunities.rs
@@ -1711,11 +1711,18 @@ mod tests {
 
     #[test]
     fn to_ad_slot_sets_floor_price_and_formats() {
-        let slot = make_slot("atf", vec!["/"]);
+        let mut slot = make_slot("atf", vec!["/"]);
+        slot.targeting
+            .insert("ts".to_string(), "operator-value".to_string());
         let ad_slot = slot.to_ad_slot();
         assert_eq!(ad_slot.id, "atf");
         assert_eq!(ad_slot.floor_price, Some(0.50));
         assert_eq!(ad_slot.formats.len(), 1);
+        assert_eq!(
+            ad_slot.targeting.get("ts"),
+            Some(&serde_json::Value::String("operator-value".to_owned())),
+            "should preserve operator-provided ts targeting verbatim"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -356,7 +356,11 @@ pub fn create_html_processor(config: HtmlProcessorConfig) -> impl StreamProcesso
                     }
                     // Main bundle: core + non-deferred integrations (synchronous).
                     let immediate_ids = integrations.js_module_ids_immediate();
-                    snippet.push_str(&tsjs::tsjs_script_tag(&immediate_ids));
+                    let script_attributes = integrations.tsjs_script_tag_attributes();
+                    snippet.push_str(&tsjs::tsjs_script_tag_with_attributes(
+                        &immediate_ids,
+                        &script_attributes,
+                    ));
                     // Active diagnostics loads synchronously after core so its
                     // GPT listeners precede publisher scripts in the origin head.
                     if let Some(module_tag) = gpt_diagnostics
@@ -832,6 +836,71 @@ mod tests {
         assert!(
             tsjs_index < title_index,
             "should prepend all injected content before existing head content"
+        );
+    }
+
+    #[test]
+    fn integration_head_injector_marks_only_attribution_enabled_gpt_bundle() {
+        fn process(gam_attribution_enabled: Option<bool>) -> String {
+            let integrations = if let Some(gam_attribution_enabled) = gam_attribution_enabled {
+                let mut settings = create_test_settings();
+                settings
+                    .integrations
+                    .insert_config(
+                        "gpt",
+                        &json!({
+                            "enabled": true,
+                            "gam_attribution_enabled": gam_attribution_enabled
+                        }),
+                    )
+                    .expect("should insert GPT config");
+                IntegrationRegistry::new(&settings).expect("should build GPT registry")
+            } else {
+                IntegrationRegistry::empty_for_tests()
+            };
+            let mut config = create_test_config();
+            config.integrations = integrations;
+            let mut processor = create_html_processor(config);
+            let output = processor
+                .process_chunk(b"<html><head></head><body></body></html>", true)
+                .expect("should process HTML");
+
+            String::from_utf8(output).expect("should produce valid UTF-8")
+        }
+
+        let attributed = process(Some(true));
+        let unattributed = process(Some(false));
+        let without_gpt = process(None);
+
+        for html in [&attributed, &unattributed, &without_gpt] {
+            assert_eq!(
+                html.matches("id=\"trustedserver-js\"").count(),
+                1,
+                "should emit exactly one publisher bundle tag: {html}"
+            );
+        }
+        assert!(
+            attributed.contains("data-ts-gam-attribution=\"true\""),
+            "should mark only an attribution-enabled GPT publisher bundle"
+        );
+        assert!(
+            !unattributed.contains("data-ts-gam-attribution"),
+            "should leave an attribution-disabled GPT publisher bundle unmarked"
+        );
+        assert!(
+            !without_gpt.contains("data-ts-gam-attribution"),
+            "should leave a non-GPT publisher bundle unmarked"
+        );
+
+        let head_insert_index = attributed
+            .find("window.__tsjs_installGptShim")
+            .expect("should include the GPT head insert");
+        let publisher_bundle_index = attributed
+            .find("id=\"trustedserver-js\"")
+            .expect("should include the publisher bundle");
+        assert!(
+            head_insert_index < publisher_bundle_index,
+            "should keep integration head inserts before the publisher bundle"
         );
     }
 

--- a/crates/trusted-server-core/src/html_processor.rs
+++ b/crates/trusted-server-core/src/html_processor.rs
@@ -841,15 +841,15 @@ mod tests {
 
     #[test]
     fn integration_head_injector_marks_only_attribution_enabled_gpt_bundle() {
-        fn process(gam_attribution_enabled: Option<bool>) -> String {
-            let integrations = if let Some(gam_attribution_enabled) = gam_attribution_enabled {
+        fn process(gpt_config: Option<(bool, bool)>) -> String {
+            let integrations = if let Some((enabled, gam_attribution_enabled)) = gpt_config {
                 let mut settings = create_test_settings();
                 settings
                     .integrations
                     .insert_config(
                         "gpt",
                         &json!({
-                            "enabled": true,
+                            "enabled": enabled,
                             "gam_attribution_enabled": gam_attribution_enabled
                         }),
                     )
@@ -868,11 +868,12 @@ mod tests {
             String::from_utf8(output).expect("should produce valid UTF-8")
         }
 
-        let attributed = process(Some(true));
-        let unattributed = process(Some(false));
+        let attributed = process(Some((true, true)));
+        let unattributed = process(Some((true, false)));
+        let disabled_gpt = process(Some((false, true)));
         let without_gpt = process(None);
 
-        for html in [&attributed, &unattributed, &without_gpt] {
+        for html in [&attributed, &unattributed, &disabled_gpt, &without_gpt] {
             assert_eq!(
                 html.matches("id=\"trustedserver-js\"").count(),
                 1,
@@ -886,6 +887,10 @@ mod tests {
         assert!(
             !unattributed.contains("data-ts-gam-attribution"),
             "should leave an attribution-disabled GPT publisher bundle unmarked"
+        );
+        assert!(
+            !disabled_gpt.contains("data-ts-gam-attribution"),
+            "should let the GPT master switch suppress attribution metadata"
         );
         assert!(
             !without_gpt.contains("data-ts-gam-attribution"),

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -1428,6 +1428,35 @@ mod tests {
     }
 
     #[test]
+    fn head_inserts_queue_gam_attribution_before_guard_and_ad_requests() {
+        let targeting_index = GPT_BOOTSTRAP_JS
+            .find("gpt.setConfig({ targeting: { ts: 'true' } })")
+            .expect("should apply the fixed page-level GAM targeting pair");
+        let guard_index = GPT_BOOTSTRAP_JS
+            .find("if (ts.adInit) return;")
+            .expect("should retain the preinstalled adInit guard");
+        let display_index = GPT_BOOTSTRAP_JS
+            .find("googletag.display(divId);")
+            .expect("should retain the executable GPT display call");
+        let refresh_index = GPT_BOOTSTRAP_JS
+            .find("googletag.pubads().refresh(slotsNeedingRefresh);")
+            .expect("should retain the bounded GPT refresh call");
+
+        assert!(
+            targeting_index < guard_index,
+            "should enqueue attribution before the preinstalled adInit guard"
+        );
+        assert!(
+            targeting_index < display_index,
+            "should enqueue attribution before the executable display call"
+        );
+        assert!(
+            targeting_index < refresh_index,
+            "should enqueue attribution before the executable refresh call"
+        );
+    }
+
+    #[test]
     fn head_injector_integration_id() {
         let integration = GptIntegration::new(test_config());
         assert_eq!(

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -68,6 +68,10 @@ pub struct GptConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
+    /// Enable page-level `ts=true` delivery attribution in GAM.
+    #[serde(default)]
+    pub gam_attribution_enabled: bool,
+
     /// URL for the GPT bootstrap script (default: Google's CDN).
     #[serde(default = "default_script_url")]
     #[validate(url)]
@@ -487,10 +491,17 @@ impl IntegrationHeadInjector for GptIntegration {
     /// route changes (see `auction/endpoints.rs`).
     /// The `POST /auction` endpoint is not involved in scroll or refresh flows.
     fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+        let gam_attribution_flag = self
+            .config
+            .gam_attribution_enabled
+            .then_some("window.__tsjs_gam_attribution_enabled=true;")
+            .unwrap_or_default();
+
         let mut scripts = vec![
-            "<script>window.__tsjs_gpt_enabled=true;\
-             window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>"
-                .to_string(),
+            format!(
+                "<script>window.__tsjs_gpt_enabled=true;{gam_attribution_flag}\
+                 window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>"
+            ),
             format!("<script>{}</script>", GPT_BOOTSTRAP_JS),
         ];
 
@@ -507,6 +518,14 @@ impl IntegrationHeadInjector for GptIntegration {
         }
 
         scripts
+    }
+
+    fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+        if self.config.gam_attribution_enabled {
+            vec![("data-ts-gam-attribution", "true")]
+        } else {
+            Vec::new()
+        }
     }
 }
 
@@ -549,6 +568,7 @@ mod tests {
     fn test_config() -> GptConfig {
         GptConfig {
             enabled: true,
+            gam_attribution_enabled: false,
             script_url: default_script_url(),
             cache_ttl_seconds: 3600,
             rewrite_script: true,
@@ -571,6 +591,29 @@ mod tests {
             .uri(uri)
             .body(EdgeBody::empty())
             .expect("should build HTTP request")
+    }
+
+    #[test]
+    fn gam_attribution_defaults_to_disabled() {
+        let config: GptConfig =
+            serde_json::from_value(serde_json::json!({})).expect("should parse defaults");
+
+        assert!(!config.gam_attribution_enabled);
+    }
+
+    #[test]
+    fn gam_attribution_deserializes_explicit_values() {
+        let disabled: GptConfig = serde_json::from_value(serde_json::json!({
+            "gam_attribution_enabled": false
+        }))
+        .expect("should parse explicit false");
+        let enabled: GptConfig = serde_json::from_value(serde_json::json!({
+            "gam_attribution_enabled": true
+        }))
+        .expect("should parse explicit true");
+
+        assert!(!disabled.gam_attribution_enabled);
+        assert!(enabled.gam_attribution_enabled);
     }
 
     // -- URL detection --
@@ -1145,6 +1188,38 @@ mod tests {
             inserts[0],
             "<script>window.__tsjs_gpt_enabled=true;window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>",
             "should set the enable flag and call the GPT shim activation function"
+        );
+        assert!(
+            integration.tsjs_script_tag_attributes().is_empty(),
+            "should not authorize GAM attribution metadata by default"
+        );
+    }
+
+    #[test]
+    fn gam_attribution_true_adds_both_activation_signals_without_a_new_insert() {
+        let integration = GptIntegration::new(GptConfig {
+            gam_attribution_enabled: true,
+            ..test_config()
+        });
+        let document_state = IntegrationDocumentState::default();
+        let context = IntegrationHtmlContext {
+            request_host: "edge.example.com",
+            request_scheme: "https",
+            origin_host: "origin.example.com",
+            document_state: &document_state,
+        };
+
+        let inserts = integration.head_inserts(&context);
+
+        assert_eq!(inserts.len(), 2, "should not add another head insert");
+        assert!(
+            inserts[0].contains("window.__tsjs_gam_attribution_enabled=true;"),
+            "should activate the early bootstrap marker"
+        );
+        assert_eq!(
+            integration.tsjs_script_tag_attributes(),
+            vec![("data-ts-gam-attribution", "true")],
+            "should authorize the bundle fallback on the publisher tag"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -491,11 +491,11 @@ impl IntegrationHeadInjector for GptIntegration {
     /// route changes (see `auction/endpoints.rs`).
     /// The `POST /auction` endpoint is not involved in scroll or refresh flows.
     fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
-        let gam_attribution_flag = self
-            .config
-            .gam_attribution_enabled
-            .then_some("window.__tsjs_gam_attribution_enabled=true;")
-            .unwrap_or_default();
+        let gam_attribution_flag = if self.config.gam_attribution_enabled {
+            "window.__tsjs_gam_attribution_enabled=true;"
+        } else {
+            ""
+        };
 
         let mut scripts = vec![
             format!(

--- a/crates/trusted-server-core/src/integrations/gpt.rs
+++ b/crates/trusted-server-core/src/integrations/gpt.rs
@@ -1430,7 +1430,7 @@ mod tests {
     #[test]
     fn head_inserts_queue_gam_attribution_before_guard_and_ad_requests() {
         let targeting_index = GPT_BOOTSTRAP_JS
-            .find("gpt.setConfig({ targeting: { ts: 'true' } })")
+            .find("gpt.setConfig({ targeting: { ts: \"true\" } })")
             .expect("should apply the fixed page-level GAM targeting pair");
         let guard_index = GPT_BOOTSTRAP_JS
             .find("if (ts.adInit) return;")

--- a/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
+++ b/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
@@ -27,10 +27,13 @@
         var gpt = window.googletag;
         if (gpt && typeof gpt.setConfig === "function") {
           // "ts" is the fixed GAM key, not the local window.tsjs alias.
-          gpt.setConfig({ targeting: { ts: 'true' } });
+          gpt.setConfig({ targeting: { ts: "true" } });
         }
-      } catch (_) {
+      } catch (error) {
         // Attribution must not interrupt the existing bootstrap queue.
+        ts.log &&
+          ts.log.warn &&
+          ts.log.warn("GAM attribution targeting failed", error);
       }
     });
   }

--- a/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
+++ b/crates/trusted-server-core/src/integrations/gpt_bootstrap.js
@@ -17,6 +17,24 @@
 (function () {
   if (typeof window === "undefined") return;
   var ts = (window.tsjs = window.tsjs || {});
+  var tag;
+
+  if (window.__tsjs_gam_attribution_enabled === true) {
+    tag = window.googletag = window.googletag || { cmd: [] };
+    tag.cmd = tag.cmd || [];
+    tag.cmd.push(function () {
+      try {
+        var gpt = window.googletag;
+        if (gpt && typeof gpt.setConfig === "function") {
+          // "ts" is the fixed GAM key, not the local window.tsjs alias.
+          gpt.setConfig({ targeting: { ts: 'true' } });
+        }
+      } catch (_) {
+        // Attribution must not interrupt the existing bootstrap queue.
+      }
+    });
+  }
+
   if (ts.adInit) return;
 
   // Track whether the publisher disabled GPT initial load. Read the effective
@@ -38,7 +56,9 @@
     return true;
   }
 
-  (window.googletag = window.googletag || { cmd: [] }).cmd.push(function () {
+  tag = tag || (window.googletag = window.googletag || { cmd: [] });
+  tag.cmd = tag.cmd || [];
+  tag.cmd.push(function () {
     var gpt = window.googletag;
     syncInitialLoadDisabled(gpt);
     if (

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -1061,11 +1061,21 @@ impl IntegrationRegistry {
     /// Collect static attributes for the publisher TSJS bundle tag.
     #[must_use]
     pub fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
-        let mut attributes = Vec::new();
+        let mut attributes: Vec<(&'static str, &'static str)> = Vec::new();
         for injector in &self.inner.head_injectors {
             for attribute in injector.tsjs_script_tag_attributes() {
-                if !attributes.iter().any(|(name, _)| *name == attribute.0) {
-                    attributes.push(attribute);
+                let existing = attributes
+                    .iter()
+                    .find(|(name, _)| *name == attribute.0)
+                    .copied();
+                match existing {
+                    None => attributes.push(attribute),
+                    Some((_, kept_value)) if kept_value != attribute.1 => log::warn!(
+                        "Integration `{}` emits conflicting value for publisher tag attribute `{}`; keeping the first",
+                        injector.integration_id(),
+                        attribute.0
+                    ),
+                    Some(_) => {}
                 }
             }
         }

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -1061,11 +1061,15 @@ impl IntegrationRegistry {
     /// Collect static attributes for the publisher TSJS bundle tag.
     #[must_use]
     pub fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
-        self.inner
-            .head_injectors
-            .iter()
-            .flat_map(|injector| injector.tsjs_script_tag_attributes())
-            .collect()
+        let mut attributes = Vec::new();
+        for injector in &self.inner.head_injectors {
+            for attribute in injector.tsjs_script_tag_attributes() {
+                if !attributes.iter().any(|(name, _)| *name == attribute.0) {
+                    attributes.push(attribute);
+                }
+            }
+        }
+        attributes
     }
 
     /// Provide a snapshot of registered integrations and their hooks.
@@ -1367,6 +1371,25 @@ mod tests {
         }
     }
 
+    struct ConflictingMetadataHeadInjector;
+
+    impl IntegrationHeadInjector for ConflictingMetadataHeadInjector {
+        fn integration_id(&self) -> &'static str {
+            "conflicting-metadata"
+        }
+
+        fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+            vec![
+                ("data-ts-gam-attribution", "false"),
+                ("data-third-attribute", "third"),
+            ]
+        }
+    }
+
     #[test]
     fn tsjs_script_tag_attributes_preserve_registration_order_and_default_empty() {
         let registry = IntegrationRegistry::from_rewriters_with_head_injectors(
@@ -1375,6 +1398,7 @@ mod tests {
             vec![
                 Arc::new(DefaultMetadataHeadInjector),
                 Arc::new(StaticMetadataHeadInjector),
+                Arc::new(ConflictingMetadataHeadInjector),
             ],
         );
 
@@ -1383,8 +1407,9 @@ mod tests {
             vec![
                 ("data-ts-gam-attribution", "true"),
                 ("data-test-order", "second"),
+                ("data-third-attribute", "third"),
             ],
-            "should omit default-empty metadata and preserve registered attribute order"
+            "should keep the first value for duplicate names and preserve attribute order"
         );
     }
 

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -1058,6 +1058,16 @@ impl IntegrationRegistry {
         inserts
     }
 
+    /// Collect static attributes for the publisher TSJS bundle tag.
+    #[must_use]
+    pub fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+        self.inner
+            .head_injectors
+            .iter()
+            .flat_map(|injector| injector.tsjs_script_tag_attributes())
+            .collect()
+    }
+
     /// Provide a snapshot of registered integrations and their hooks.
     #[must_use]
     pub fn registered_integrations(&self) -> Vec<IntegrationMetadata> {
@@ -1325,6 +1335,58 @@ mod tests {
     use crate::constants::COOKIE_TS_EC;
     use crate::platform::test_support::noop_services;
     use http::{HeaderValue, StatusCode, header};
+
+    struct DefaultMetadataHeadInjector;
+
+    impl IntegrationHeadInjector for DefaultMetadataHeadInjector {
+        fn integration_id(&self) -> &'static str {
+            "default-metadata"
+        }
+
+        fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    struct StaticMetadataHeadInjector;
+
+    impl IntegrationHeadInjector for StaticMetadataHeadInjector {
+        fn integration_id(&self) -> &'static str {
+            "static-metadata"
+        }
+
+        fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+            vec![
+                ("data-ts-gam-attribution", "true"),
+                ("data-test-order", "second"),
+            ]
+        }
+    }
+
+    #[test]
+    fn tsjs_script_tag_attributes_preserve_registration_order_and_default_empty() {
+        let registry = IntegrationRegistry::from_rewriters_with_head_injectors(
+            Vec::new(),
+            Vec::new(),
+            vec![
+                Arc::new(DefaultMetadataHeadInjector),
+                Arc::new(StaticMetadataHeadInjector),
+            ],
+        );
+
+        assert_eq!(
+            registry.tsjs_script_tag_attributes(),
+            vec![
+                ("data-ts-gam-attribution", "true"),
+                ("data-test-order", "second"),
+            ],
+            "should omit default-empty metadata and preserve registered attribute order"
+        );
+    }
 
     // Mock integration proxy for testing
     struct MockProxy;

--- a/crates/trusted-server-core/src/integrations/registry.rs
+++ b/crates/trusted-server-core/src/integrations/registry.rs
@@ -575,6 +575,11 @@ pub trait IntegrationHeadInjector: Send + Sync {
     fn integration_id(&self) -> &'static str;
     /// Return HTML snippets to insert at the start of `<head>`.
     fn head_inserts(&self, ctx: &IntegrationHtmlContext<'_>) -> Vec<String>;
+
+    /// Return attributes to add to the publisher TSJS bundle tag.
+    fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+        Vec::new()
+    }
 }
 
 /// Registration payload returned by integration builders.

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -8736,9 +8736,14 @@ mod tests {
 
         #[test]
         fn ad_slots_script_contains_slot_data() {
-            let slots = vec![make_slot()];
+            let mut slot = make_slot();
+            slot.targeting
+                .insert("ts".to_string(), "operator-value".to_string());
+            let slots = vec![slot];
             let config = make_config();
             let script = build_ad_slots_script(&slots, &config, "/");
+            let slot_json = crate::publisher::build_slot_json(&slots[0], &config, "example")
+                .expect("should build slot JSON");
             assert!(
                 script.contains("window.tsjs=window.tsjs||{}"),
                 "should initialise tsjs namespace"
@@ -8752,6 +8757,10 @@ mod tests {
             assert!(
                 !script.contains("__ts_request_id"),
                 "must NOT contain request_id"
+            );
+            assert_eq!(
+                slot_json["targeting"]["ts"], "operator-value",
+                "should forward operator-provided ts targeting verbatim"
             );
         }
 

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -7754,7 +7754,15 @@ mod tests {
     }
 
     fn streaming_finalize_response(params: OwnedProcessResponseParams, body: EdgeBody) -> EdgeBody {
-        let settings = Arc::new(create_test_settings());
+        streaming_finalize_response_with_settings(params, body, create_test_settings())
+    }
+
+    fn streaming_finalize_response_with_settings(
+        params: OwnedProcessResponseParams,
+        body: EdgeBody,
+        settings: Settings,
+    ) -> EdgeBody {
+        let settings = Arc::new(settings);
         let registry = Arc::new(
             IntegrationRegistry::new(&settings).expect("should create integration registry"),
         );
@@ -7805,6 +7813,40 @@ mod tests {
             gpt_diagnostics: None,
             suppress_datadome_client_side_tag: false,
         }
+    }
+
+    #[test]
+    fn streaming_finalize_emits_gam_attribution_head_before_origin_eof() {
+        let mut settings = create_test_settings();
+        settings
+            .integrations
+            .insert_config(
+                "gpt",
+                &serde_json::json!({
+                    "enabled": true,
+                    "gam_attribution_enabled": true
+                }),
+            )
+            .expect("should insert GPT config");
+
+        let body = streaming_finalize_response_with_settings(
+            html_stream_params("", None),
+            origin_chunk_then_pending(bytes::Bytes::from_static(
+                b"<html><head></head><body><p>origin remains pending</p>",
+            )),
+            settings,
+        );
+        let html = String::from_utf8(first_lazy_body_chunk(body).to_vec())
+            .expect("should emit UTF-8 HTML");
+
+        assert!(
+            html.contains("__tsjs_gam_attribution_enabled=true"),
+            "first rewritten head chunk should carry the primary activation flag: {html}"
+        );
+        assert!(
+            html.contains("data-ts-gam-attribution=\"true\""),
+            "first rewritten head chunk should authorize the bundle fallback: {html}"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -235,16 +235,27 @@ mod tests {
     }
 
     #[test]
-    fn publisher_tsjs_script_tag_rejects_html_sensitive_attribute_values() {
-        for value in ["bad\"value", "bad&value", "bad<value", "bad>value"] {
-            let result = std::panic::catch_unwind(|| {
-                let _ = tsjs_script_tag_with_attributes(&["gpt"], &[("data-safe-name", value)]);
-            });
-            assert!(
-                result.is_err(),
-                "should reject HTML-sensitive value `{value}`"
-            );
-        }
+    #[should_panic(expected = "attribute value should not contain HTML-sensitive characters")]
+    fn publisher_tsjs_script_tag_rejects_double_quote_in_attribute_value() {
+        let _ = tsjs_script_tag_with_attributes(&["gpt"], &[("data-safe-name", "bad\"value")]);
+    }
+
+    #[test]
+    #[should_panic(expected = "attribute value should not contain HTML-sensitive characters")]
+    fn publisher_tsjs_script_tag_rejects_ampersand_in_attribute_value() {
+        let _ = tsjs_script_tag_with_attributes(&["gpt"], &[("data-safe-name", "bad&value")]);
+    }
+
+    #[test]
+    #[should_panic(expected = "attribute value should not contain HTML-sensitive characters")]
+    fn publisher_tsjs_script_tag_rejects_less_than_in_attribute_value() {
+        let _ = tsjs_script_tag_with_attributes(&["gpt"], &[("data-safe-name", "bad<value")]);
+    }
+
+    #[test]
+    #[should_panic(expected = "attribute value should not contain HTML-sensitive characters")]
+    fn publisher_tsjs_script_tag_rejects_greater_than_in_attribute_value() {
+        let _ = tsjs_script_tag_with_attributes(&["gpt"], &[("data-safe-name", "bad>value")]);
     }
 
     #[test]

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -11,9 +11,23 @@ pub fn tsjs_script_src(module_ids: &[&str]) -> String {
 /// `<script>` tag for injecting the tsjs bundle.
 #[must_use]
 pub fn tsjs_script_tag(module_ids: &[&str]) -> String {
+    tsjs_script_tag_with_attributes(module_ids, &[])
+}
+
+/// Publisher `<script>` tag for the tsjs bundle with trusted static attributes.
+#[must_use]
+pub fn tsjs_script_tag_with_attributes(
+    module_ids: &[&str],
+    attributes: &[(&'static str, &'static str)],
+) -> String {
+    let attributes = attributes
+        .iter()
+        .map(|(name, value)| format!(" {name}=\"{value}\""))
+        .collect::<String>();
+
     format!(
-        "<script src=\"{}\" id=\"trustedserver-js\"></script>",
-        tsjs_script_src(module_ids)
+        "<script src=\"{}\" id=\"trustedserver-js\"{attributes}></script>",
+        tsjs_script_src(module_ids),
     )
 }
 
@@ -171,18 +185,38 @@ mod tests {
     }
 
     #[test]
-    fn tsjs_unified_helpers_use_all_module_ids() {
-        let ids = all_module_ids();
+    fn publisher_tsjs_script_tag_renders_static_attributes() {
+        let module_ids = ["gpt"];
+        let src = tsjs_script_src(&module_ids);
 
         assert_eq!(
-            tsjs_unified_script_src(),
+            tsjs_script_tag_with_attributes(&module_ids, &[("data-ts-gam-attribution", "true")]),
+            format!(
+                "<script src=\"{src}\" id=\"trustedserver-js\" data-ts-gam-attribution=\"true\"></script>"
+            ),
+            "should render trusted static attributes on the publisher bundle tag"
+        );
+        assert_eq!(
+            tsjs_script_tag(&module_ids),
+            format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>"),
+            "should keep the generic tag byte-for-byte unmarked"
+        );
+    }
+
+    #[test]
+    fn tsjs_unified_helpers_use_all_module_ids() {
+        let ids = all_module_ids();
+        let src = tsjs_unified_script_src();
+
+        assert_eq!(
+            src,
             tsjs_script_src(&ids),
             "should hash all module IDs for the unified script source"
         );
         assert_eq!(
             tsjs_unified_script_tag(),
-            tsjs_script_tag(&ids),
-            "should wrap the all-module unified script source"
+            format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>"),
+            "should keep the all-module generic tag byte-for-byte unmarked"
         );
     }
 

--- a/crates/trusted-server-core/src/tsjs.rs
+++ b/crates/trusted-server-core/src/tsjs.rs
@@ -22,7 +22,22 @@ pub fn tsjs_script_tag_with_attributes(
 ) -> String {
     let attributes = attributes
         .iter()
-        .map(|(name, value)| format!(" {name}=\"{value}\""))
+        .map(|(name, value)| {
+            debug_assert!(
+                !name.is_empty()
+                    && name.bytes().all(|byte| {
+                        byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'
+                    }),
+                "attribute name should contain only lowercase ASCII letters, digits, and hyphens"
+            );
+            debug_assert!(
+                !value
+                    .bytes()
+                    .any(|byte| matches!(byte, b'"' | b'&' | b'<' | b'>')),
+                "attribute value should not contain HTML-sensitive characters"
+            );
+            format!(" {name}=\"{value}\"")
+        })
         .collect::<String>();
 
     format!(
@@ -201,6 +216,35 @@ mod tests {
             format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>"),
             "should keep the generic tag byte-for-byte unmarked"
         );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "attribute name should contain only lowercase ASCII letters, digits, and hyphens"
+    )]
+    fn publisher_tsjs_script_tag_rejects_invalid_attribute_name() {
+        let _ = tsjs_script_tag_with_attributes(&["gpt"], &[("data-bad_name", "true")]);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "attribute name should contain only lowercase ASCII letters, digits, and hyphens"
+    )]
+    fn publisher_tsjs_script_tag_rejects_empty_attribute_name() {
+        let _ = tsjs_script_tag_with_attributes(&["gpt"], &[("", "true")]);
+    }
+
+    #[test]
+    fn publisher_tsjs_script_tag_rejects_html_sensitive_attribute_values() {
+        for value in ["bad\"value", "bad&value", "bad<value", "bad>value"] {
+            let result = std::panic::catch_unwind(|| {
+                let _ = tsjs_script_tag_with_attributes(&["gpt"], &[("data-safe-name", value)]);
+            });
+            assert!(
+                result.is_err(),
+                "should reject HTML-sensitive value `{value}`"
+            );
+        }
     }
 
     #[test]

--- a/crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts
+++ b/crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts
@@ -9,6 +9,7 @@ test.describe("Script injection", () => {
 
     const src = await scriptTag.getAttribute("src");
     expect(src).toContain("/static/tsjs=");
+    await expect(scriptTag).not.toHaveAttribute("data-ts-gam-attribution");
   });
 
   test("no unexpected console errors on page load", async ({ page }) => {

--- a/crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml
+++ b/crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml
@@ -86,6 +86,7 @@ rewrite_sdk = true
 
 [integrations.gpt]
 enabled = false
+gam_attribution_enabled = false
 script_url = "https://ads.example.com/gpt.js"
 cache_ttl_seconds = 3600
 rewrite_script = true

--- a/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
+++ b/crates/trusted-server-js/lib/src/integrations/gpt/index.ts
@@ -287,6 +287,8 @@ type GptWindow = Window & {
   __tsjs_slim_prebid_url?: string;
 };
 
+const executingPublisherScript = typeof document === 'undefined' ? null : document.currentScript;
+
 // ------------------------------------------------------------------
 // Shim implementation
 // ------------------------------------------------------------------
@@ -305,6 +307,25 @@ function ensureGoogleTagStub(win: GptWindow): Partial<GoogleTag> {
   const tag = (win.googletag = win.googletag ?? {});
   tag.cmd = tag.cmd ?? [];
   return tag;
+}
+
+function installTrustedServerPageTargeting(): void {
+  if (executingPublisherScript?.getAttribute('data-ts-gam-attribution') !== 'true') {
+    return;
+  }
+
+  const win = window as GptWindow;
+  const tag = ensureGoogleTagStub(win);
+  tag.cmd!.push(() => {
+    try {
+      const gpt = win.googletag;
+      if (typeof gpt?.setConfig === 'function') {
+        gpt.setConfig({ targeting: { ts: 'true' } });
+      }
+    } catch (error) {
+      log.warn('[tsjs-gpt] GAM attribution targeting failed', error);
+    }
+  });
 }
 
 /**
@@ -1892,6 +1913,7 @@ if (typeof window !== 'undefined') {
     installGptShim();
   }
 
+  installTrustedServerPageTargeting();
   installTsAdInit();
   installSpaAuctionHook();
   installSlimPrebidLoader();

--- a/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts
@@ -1874,7 +1874,7 @@ describe('installTsAdInit', () => {
       setTargeting: vi.fn().mockReturnThis(),
       clearTargeting,
       getSlotElementId: vi.fn().mockReturnValue('div-old-route'),
-      getTargeting: vi.fn().mockReturnValue([]),
+      getTargeting: vi.fn((key: string) => (key === 'ts' ? ['publisher-value'] : [])),
     };
     const mockPubads = {
       enableSingleRequest: vi.fn(),
@@ -1908,6 +1908,7 @@ describe('installTsAdInit', () => {
     expect(clearTargeting).toHaveBeenCalledWith('hb_cache_path');
     expect(clearTargeting).toHaveBeenCalledWith('ts_initial');
     expect(clearTargeting).toHaveBeenCalledWith('pos');
+    expect(clearTargeting).not.toHaveBeenCalledWith('ts');
     expect(mockPubads.refresh).not.toHaveBeenCalled();
     expect((window as TestWindow).tsjs!.divToSlotId).toEqual({});
     expect((window as TestWindow).tsjs!.prevSlotTargetingKeys).toEqual({});

--- a/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
@@ -33,6 +33,8 @@ interface MockGoogleTag {
   pubads: () => unknown;
   enableServices: () => void;
   display: (divId: string) => void;
+  getConfig?: (key: string) => Record<string, unknown>;
+  setConfig?: (config: Record<string, unknown>) => void;
 }
 
 // `tsjs` is declared globally as the full `TsjsApi`; `Omit` drops it from
@@ -40,7 +42,24 @@ interface MockGoogleTag {
 type TestWindow = Omit<Window, 'tsjs'> & {
   googletag?: MockGoogleTag;
   tsjs?: Partial<TsjsApi>;
+  __tsjs_gam_attribution_enabled?: boolean;
 };
+
+function makeGoogleTag(overrides: Partial<MockGoogleTag> = {}): MockGoogleTag {
+  const pubads = {
+    getSlots: vi.fn(() => []),
+    refresh: vi.fn(),
+  };
+
+  return {
+    cmd: [],
+    defineSlot: vi.fn(),
+    pubads: vi.fn(() => pubads),
+    enableServices: vi.fn(),
+    display: vi.fn(),
+    ...overrides,
+  };
+}
 
 function runBootstrap(): void {
   // Evaluate in the jsdom global scope, exactly as an inline <script> would.
@@ -60,6 +79,7 @@ describe('gpt_bootstrap.js fallback', () => {
   beforeEach(() => {
     delete (window as TestWindow).tsjs;
     delete (window as TestWindow).googletag;
+    delete (window as TestWindow).__tsjs_gam_attribution_enabled;
     rafQueue = [];
     (
       window as { requestAnimationFrame: typeof window.requestAnimationFrame }
@@ -81,7 +101,111 @@ describe('gpt_bootstrap.js fallback', () => {
     delete (window as unknown as Record<string, unknown>).requestAnimationFrame;
     delete (window as TestWindow).tsjs;
     delete (window as TestWindow).googletag;
+    delete (window as TestWindow).__tsjs_gam_attribution_enabled;
     vi.restoreAllMocks();
+  });
+
+  it('does not create googletag before the guard when attribution is omitted or false', () => {
+    for (const flag of [undefined, false]) {
+      const bundleAdInit = vi.fn();
+      (window as TestWindow).tsjs = { adInit: bundleAdInit };
+      delete (window as TestWindow).googletag;
+      if (flag === undefined) {
+        delete (window as TestWindow).__tsjs_gam_attribution_enabled;
+      } else {
+        (window as TestWindow).__tsjs_gam_attribution_enabled = flag;
+      }
+
+      runBootstrap();
+
+      expect((window as TestWindow).googletag).toBeUndefined();
+      expect((window as TestWindow).tsjs!.adInit).toBe(bundleAdInit);
+    }
+  });
+
+  it('queues string-valued page targeting before a later publisher command', () => {
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn();
+    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig });
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+    const publisherCommand = vi.fn();
+    queue.push(publisherCommand);
+    [...queue].forEach((command) => command());
+
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+    expect(setConfig.mock.invocationCallOrder[0]).toBeLessThan(
+      publisherCommand.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('queues targeting before the preinstalled adInit guard without replacing bundle APIs', () => {
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn();
+    const bundleAdInit = vi.fn();
+    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig });
+    (window as TestWindow).tsjs = { adInit: bundleAdInit };
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+
+    expect(queue).toHaveLength(1);
+    expect((window as TestWindow).tsjs!.adInit).toBe(bundleAdInit);
+    expect((window as TestWindow).tsjs!.scheduleInitialAdInit).toBeUndefined();
+    queue.forEach((command) => command());
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+  });
+
+  it('keeps bootstrap installation working when setConfig is unavailable', () => {
+    const queue: Array<() => void> = [];
+    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue });
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+
+    expect(() => [...queue].forEach((command) => command())).not.toThrow();
+    expect(typeof (window as TestWindow).tsjs!.adInit).toBe('function');
+    expect(typeof (window as TestWindow).tsjs!.scheduleInitialAdInit).toBe('function');
+  });
+
+  it('isolates a throwing setConfig from later publisher commands', () => {
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn(() => {
+      throw new Error('publisher setConfig failed');
+    });
+    const publisherCommand = vi.fn();
+    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig });
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+    queue.push(publisherCommand);
+
+    expect(() => [...queue].forEach((command) => command())).not.toThrow();
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+    expect(publisherCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('still tracks the wrapped legacy disableInitialLoad path', () => {
+    const queue: Array<() => void> = [];
+    const disableInitialLoad = vi.fn();
+    const pubads = {
+      disableInitialLoad,
+      getSlots: vi.fn(() => []),
+      refresh: vi.fn(),
+    };
+    (window as TestWindow).googletag = makeGoogleTag({
+      cmd: queue,
+      pubads: vi.fn(() => pubads),
+    });
+    (window as TestWindow).__tsjs_gam_attribution_enabled = true;
+
+    runBootstrap();
+    [...queue].forEach((command) => command());
+    pubads.disableInitialLoad();
+
+    expect(disableInitialLoad).toHaveBeenCalledTimes(1);
+    expect((window as TestWindow).tsjs!.gptInitialLoadDisabled).toBe(true);
   });
 
   it('installs fallback adInit and scheduleInitialAdInit when the bundle is absent', () => {

--- a/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
@@ -174,8 +174,18 @@ describe('gpt_bootstrap.js fallback', () => {
     const setConfig = vi.fn(() => {
       throw new Error('publisher setConfig failed');
     });
+    const disableInitialLoad = vi.fn();
+    const pubads = {
+      disableInitialLoad,
+      getSlots: vi.fn(() => []),
+      refresh: vi.fn(),
+    };
     const publisherCommand = vi.fn();
-    (window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig });
+    (window as TestWindow).googletag = makeGoogleTag({
+      cmd: queue,
+      setConfig,
+      pubads: vi.fn(() => pubads),
+    });
     (window as TestWindow).__tsjs_gam_attribution_enabled = true;
 
     runBootstrap();
@@ -184,6 +194,10 @@ describe('gpt_bootstrap.js fallback', () => {
     expect(() => [...queue].forEach((command) => command())).not.toThrow();
     expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
     expect(publisherCommand).toHaveBeenCalledTimes(1);
+    expect(typeof (window as TestWindow).tsjs!.adInit).toBe('function');
+    pubads.disableInitialLoad();
+    expect(disableInitialLoad).toHaveBeenCalledTimes(1);
+    expect((window as TestWindow).tsjs!.gptInitialLoadDisabled).toBe(true);
   });
 
   it('still tracks the wrapped legacy disableInitialLoad path', () => {

--- a/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
@@ -33,7 +33,6 @@ interface MockGoogleTag {
   pubads: () => unknown;
   enableServices: () => void;
   display: (divId: string) => void;
-  getConfig?: (key: string) => Record<string, unknown>;
   setConfig?: (config: Record<string, unknown>) => void;
 }
 
@@ -174,6 +173,7 @@ describe('gpt_bootstrap.js fallback', () => {
     const setConfig = vi.fn(() => {
       throw new Error('publisher setConfig failed');
     });
+    const warn = vi.fn();
     const disableInitialLoad = vi.fn();
     const pubads = {
       disableInitialLoad,
@@ -181,6 +181,16 @@ describe('gpt_bootstrap.js fallback', () => {
       refresh: vi.fn(),
     };
     const publisherCommand = vi.fn();
+    (window as TestWindow).tsjs = {
+      log: {
+        setLevel: vi.fn(),
+        getLevel: vi.fn(() => 'warn'),
+        info: vi.fn(),
+        warn,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    };
     (window as TestWindow).googletag = makeGoogleTag({
       cmd: queue,
       setConfig,
@@ -193,6 +203,7 @@ describe('gpt_bootstrap.js fallback', () => {
 
     expect(() => [...queue].forEach((command) => command())).not.toThrow();
     expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+    expect(warn).toHaveBeenCalledWith('GAM attribution targeting failed', expect.any(Error));
     expect(publisherCommand).toHaveBeenCalledTimes(1);
     expect(typeof (window as TestWindow).tsjs!.adInit).toBe('function');
     pubads.disableInitialLoad();

--- a/crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts
@@ -420,6 +420,227 @@ describe('GPT shim – runtime gating', () => {
   });
 });
 
+describe('GPT GAM attribution bundle fallback', () => {
+  interface AttributionPubAds {
+    getSlots: () => unknown[];
+    refresh: (...args: unknown[]) => void;
+  }
+
+  interface AttributionGoogleTag {
+    cmd: Array<() => void>;
+    pubads: () => AttributionPubAds;
+    defineSlot: (...args: unknown[]) => unknown;
+    display: (...args: unknown[]) => void;
+    getConfig?: (keys: string | string[]) => Record<string, unknown> | undefined;
+    setConfig?: (config: Record<string, unknown>) => void;
+  }
+
+  type AttributionWindow = Omit<Window, 'tsjs'> & {
+    tsjs?: Partial<TsjsApi>;
+    googletag?: AttributionGoogleTag;
+    __tsjs_gpt_enabled?: boolean;
+    __tsjs_installGptShim?: unknown;
+    __tsjs_slim_prebid_url?: string;
+  };
+
+  let win: AttributionWindow;
+  let executingScript: HTMLScriptElement | null;
+  let originalCurrentScriptDescriptor: PropertyDescriptor | undefined;
+  let originalPushState: History['pushState'];
+  let originalReplaceState: History['replaceState'];
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+  function makeGoogleTag(overrides: Partial<AttributionGoogleTag> = {}): AttributionGoogleTag {
+    const pubads: AttributionPubAds = {
+      getSlots: vi.fn(() => []),
+      refresh: vi.fn(),
+    };
+
+    return {
+      cmd: [],
+      pubads: vi.fn(() => pubads),
+      defineSlot: vi.fn(),
+      display: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  function attributedScript(ownerDocument: Document = document): HTMLScriptElement {
+    const script = ownerDocument.createElement('script');
+    script.id = 'trustedserver-js';
+    script.setAttribute('data-ts-gam-attribution', 'true');
+    return script;
+  }
+
+  async function importFreshGptBundle(): Promise<void> {
+    await import('../../../src/integrations/gpt/index');
+  }
+
+  beforeEach(async () => {
+    const guard = await importGuardModule();
+    guard.resetGuardState();
+    vi.resetModules();
+
+    win = window as AttributionWindow;
+    delete win.tsjs;
+    delete win.googletag;
+    delete win.__tsjs_gpt_enabled;
+    delete win.__tsjs_installGptShim;
+    delete win.__tsjs_slim_prebid_url;
+
+    executingScript = null;
+    originalCurrentScriptDescriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
+    Object.defineProperty(document, 'currentScript', {
+      configurable: true,
+      get: () => executingScript,
+    });
+
+    originalPushState = history.pushState;
+    originalReplaceState = history.replaceState;
+    addEventListenerSpy = vi.spyOn(window, 'addEventListener').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    const guard = await importGuardModule();
+    guard.resetGuardState();
+    history.pushState = originalPushState;
+    history.replaceState = originalReplaceState;
+    if (originalCurrentScriptDescriptor) {
+      Object.defineProperty(document, 'currentScript', originalCurrentScriptDescriptor);
+    } else {
+      delete (document as unknown as Record<string, unknown>).currentScript;
+    }
+    delete win.tsjs;
+    delete win.googletag;
+    delete win.__tsjs_gpt_enabled;
+    delete win.__tsjs_installGptShim;
+    delete win.__tsjs_slim_prebid_url;
+    vi.restoreAllMocks();
+  });
+
+  it('reuses the existing queue and pushes exact targeting before adInit exists', async () => {
+    const queue: Array<() => void> = [];
+    const adInitAtPush: Array<unknown> = [];
+    const arrayPush = queue.push.bind(queue);
+    queue.push = (...callbacks: Array<() => void>) => {
+      callbacks.forEach(() => adInitAtPush.push(win.tsjs?.adInit));
+      return arrayPush(...callbacks);
+    };
+    const setConfig = vi.fn();
+    const tag = makeGoogleTag({ cmd: queue, setConfig });
+    win.googletag = tag;
+    executingScript = attributedScript();
+    const initialScriptCount = document.scripts.length;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await importFreshGptBundle();
+
+    expect(win.googletag!.cmd).toBe(queue);
+    expect(adInitAtPush[0]).toBeUndefined();
+    expect(queue.length).toBeGreaterThan(0);
+    queue[0]();
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+    expect(document.scripts).toHaveLength(initialScriptCount);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['no current script', null],
+    ['missing attribute', undefined],
+    ['empty attribute', ''],
+    ['false attribute', 'false'],
+    ['non-exact attribute', 'TRUE'],
+  ])('fails closed for %s', async (_label, attributeValue) => {
+    if (attributeValue === null) {
+      executingScript = null;
+    } else {
+      executingScript = document.createElement('script');
+      if (attributeValue !== undefined) {
+        executingScript.setAttribute('data-ts-gam-attribution', attributeValue);
+      }
+    }
+
+    await importFreshGptBundle();
+
+    expect(win.googletag).toBeUndefined();
+  });
+
+  it('ignores a marked duplicate-ID decoy when the executing tag is unmarked', async () => {
+    const decoy = attributedScript();
+    document.head.appendChild(decoy);
+    executingScript = document.createElement('script');
+    executingScript.id = 'trustedserver-js';
+
+    await importFreshGptBundle();
+
+    expect(win.googletag).toBeUndefined();
+    decoy.remove();
+  });
+
+  it('characterizes a marked document.write clone as able to activate', async () => {
+    const clonedDocument = document.implementation.createHTMLDocument('nested clone');
+    clonedDocument.write('<script id="trustedserver-js" data-ts-gam-attribution="true"></script>');
+    clonedDocument.close();
+    executingScript = clonedDocument.querySelector('script');
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn();
+    win.googletag = makeGoogleTag({ cmd: queue, setConfig });
+
+    await importFreshGptBundle();
+    queue[0]();
+
+    expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+  });
+
+  it.each(['missing', 'throwing'])(
+    'keeps module installation working with %s setConfig',
+    async (setConfigMode) => {
+      const queue: Array<() => void> = [];
+      const setConfig =
+        setConfigMode === 'throwing'
+          ? vi.fn(() => {
+              throw new Error('publisher setConfig failed');
+            })
+          : undefined;
+      win.googletag = makeGoogleTag({ cmd: queue, setConfig });
+      win.__tsjs_slim_prebid_url = 'https://cdn.example.com/slim-prebid.js';
+      executingScript = attributedScript();
+
+      await importFreshGptBundle();
+
+      expect(() => [...queue].forEach((command) => command())).not.toThrow();
+      expect(typeof win.tsjs?.adInit).toBe('function');
+      expect(typeof win.tsjs?.scheduleInitialAdInit).toBe('function');
+      expect(win.tsjs?.spaHookInstalled).toBe(true);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+      expect(addEventListenerSpy).toHaveBeenCalledWith('load', expect.any(Function));
+      expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+      if (setConfig) {
+        expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } });
+      }
+    }
+  );
+
+  it('preserves GPT-enabled shim behavior without queuing attribution when unmarked', async () => {
+    const queue: Array<() => void> = [];
+    const setConfig = vi.fn();
+    const tag = makeGoogleTag({ cmd: queue, setConfig });
+    win.googletag = tag;
+    win.__tsjs_gpt_enabled = true;
+    executingScript = document.createElement('script');
+
+    await importFreshGptBundle();
+    [...queue].forEach((command) => command());
+    const guard = await importGuardModule();
+
+    expect(guard.isGuardInstalled()).toBe(true);
+    expect(win.googletag).toBe(tag);
+    expect(win.googletag!.cmd).toBe(queue);
+    expect(setConfig).not.toHaveBeenCalled();
+    expect(typeof win.tsjs?.adInit).toBe('function');
+  });
+});
+
 describe('GPT debug ADM iframe hardening', () => {
   it('sandbox token list omits allow-same-origin', async () => {
     const mod = await import('../../../src/integrations/gpt/index');

--- a/crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts
+++ b/crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts
@@ -414,9 +414,11 @@ describe('prebid/installPrebidNpm', () => {
     delete testWindow.__tsjs_prebid_diagnostics;
     delete testWindow.tsjs;
     delete mockPbjs['__tsApsBidResponseListenerInstalled'];
+    delete mockPbjs.bidderSettings;
   });
 
   afterEach(() => {
+    delete mockPbjs.bidderSettings;
     vi.restoreAllMocks();
   });
 
@@ -1130,6 +1132,35 @@ describe('prebid/installPrebidNpm', () => {
   });
 
   describe('requestBids shim', () => {
+    it('preserves publisher ts adserverTargeting while adding trustedServer settings', () => {
+      const publisherTargeting = [{ key: 'ts', val: () => 'publisher-value' }];
+      mockPbjs.bidderSettings = {
+        exampleBidder: { adserverTargeting: publisherTargeting },
+      };
+      const pbjs = installPrebidNpm();
+
+      pbjs.requestBids({
+        adUnits: [{ bids: [{ bidder: 'exampleBidder', params: {} }] }],
+      } as unknown as RequestBidsArg);
+
+      const bidderSettings = mockPbjs.bidderSettings as {
+        exampleBidder: { adserverTargeting: typeof publisherTargeting };
+        trustedServer: {
+          allowAlternateBidderCodes: boolean;
+          allowedAlternateBidderCodes: string[];
+        };
+      };
+      expect(bidderSettings.exampleBidder.adserverTargeting).toBe(publisherTargeting);
+      expect(bidderSettings.exampleBidder.adserverTargeting[0].key).toBe('ts');
+      expect(bidderSettings.exampleBidder.adserverTargeting[0].val()).toBe('publisher-value');
+      expect(bidderSettings.trustedServer).toEqual(
+        expect.objectContaining({
+          allowAlternateBidderCodes: true,
+          allowedAlternateBidderCodes: ['*'],
+        })
+      );
+    });
+
     it('injects trustedServer bidder into every ad unit', () => {
       const pbjs = installPrebidNpm();
 
@@ -1850,25 +1881,33 @@ describe('prebid/installRefreshHandler', () => {
 
   it('auctions refreshed TS initial slots and clears stale TS targeting before refresh', () => {
     const originalRefresh = vi.fn();
-    const clearTargeting = vi.fn();
+    const slotTargeting = new Map<string, string[]>([
+      ['ts_initial', ['1']],
+      ['zone', ['homepage']],
+    ]);
+    const clearTargeting = vi.fn((key: string) => {
+      slotTargeting.delete(key);
+    });
+    const setTargeting = vi.fn((key: string, value: string | string[]) => {
+      slotTargeting.set(key, Array.isArray(value) ? value : [value]);
+    });
     const gptSlot = {
       getSlotElementId: vi.fn(() => 'div-ad-homepage-header'),
-      getTargeting: vi.fn((key: string) => {
-        if (key === 'ts_initial') return ['1'];
-        if (key === 'zone') return ['homepage'];
-        return [];
-      }),
+      getTargeting: vi.fn((key: string) => slotTargeting.get(key) ?? []),
       getSizes: vi.fn(() => [
         { getWidth: () => 970, getHeight: () => 250 },
         { getWidth: () => 728, getHeight: () => 90 },
       ]),
       clearTargeting,
+      setTargeting,
     };
     const pubads = {
       refresh: originalRefresh,
       getSlots: vi.fn(() => [gptSlot]),
     };
-    const setTargetingForGPTAsync = vi.fn();
+    const setTargetingForGPTAsync = vi.fn(() => {
+      gptSlot.setTargeting('ts', 'prebid-value');
+    });
     mockPbjs.setTargetingForGPTAsync = setTargetingForGPTAsync;
     testWindow.googletag = {
       cmd: { push: (fn: () => void) => fn() },
@@ -1918,12 +1957,17 @@ describe('prebid/installRefreshHandler', () => {
     expect(clearTargeting).toHaveBeenCalledWith('hb_adid');
     expect(clearTargeting).toHaveBeenCalledWith('hb_cache_host');
     expect(clearTargeting).toHaveBeenCalledWith('hb_cache_path');
+    expect(clearTargeting).not.toHaveBeenCalledWith('ts');
     expect(originalRefresh).not.toHaveBeenCalled();
 
     const bidsBackHandler = mockRequestBids.mock.calls[0][0].bidsBackHandler;
     bidsBackHandler();
 
     expect(setTargetingForGPTAsync).toHaveBeenCalled();
+    expect(setTargetingForGPTAsync.mock.invocationCallOrder[0]).toBeLessThan(
+      originalRefresh.mock.invocationCallOrder[0]
+    );
+    expect(slotTargeting.get('ts')).toEqual(['prebid-value']);
     expect(originalRefresh).toHaveBeenCalledWith([gptSlot], undefined);
   });
 

--- a/docs/guide/integrations/gpt.md
+++ b/docs/guide/integrations/gpt.md
@@ -72,7 +72,7 @@ rewrite_script = true
 The environment override
 `TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED` works only when
 `gam_attribution_enabled` is already present under `[integrations.gpt]` in the
-TOML file. EdgeZero v0.0.4 cannot create a missing configuration leaf.
+TOML file. The environment overlay cannot create a missing configuration leaf.
 
 ## Endpoints
 

--- a/docs/guide/integrations/gpt.md
+++ b/docs/guide/integrations/gpt.md
@@ -53,6 +53,7 @@ Add GPT configuration to `trusted-server.toml`:
 ```toml
 [integrations.gpt]
 enabled = true
+gam_attribution_enabled = false
 script_url = "https://securepubads.g.doubleclick.net/tag/js/gpt.js"
 cache_ttl_seconds = 3600
 rewrite_script = true
@@ -60,12 +61,18 @@ rewrite_script = true
 
 ### Configuration Options
 
-| Field               | Type    | Required | Default                                                | Description                                |
-| ------------------- | ------- | -------- | ------------------------------------------------------ | ------------------------------------------ |
-| `enabled`           | boolean | No       | `true`                                                 | Enable/disable the integration             |
-| `script_url`        | string  | No       | `https://securepubads.g.doubleclick.net/tag/js/gpt.js` | URL for the GPT bootstrap script           |
-| `cache_ttl_seconds` | integer | No       | `3600`                                                 | Cache TTL for proxied scripts (60--86400s) |
-| `rewrite_script`    | boolean | No       | `true`                                                 | Whether to rewrite GPT script URLs in HTML |
+| Field                     | Type    | Required | Default                                                | Description                                                       |
+| ------------------------- | ------- | -------- | ------------------------------------------------------ | ----------------------------------------------------------------- |
+| `enabled`                 | boolean | No       | `true`                                                 | Enable/disable the integration                                    |
+| `gam_attribution_enabled` | boolean | No       | `false`                                                | Add fixed page-level `ts=true` targeting for GAM cohort reporting |
+| `script_url`              | string  | No       | `https://securepubads.g.doubleclick.net/tag/js/gpt.js` | URL for the GPT bootstrap script                                  |
+| `cache_ttl_seconds`       | integer | No       | `3600`                                                 | Cache TTL for proxied scripts (60--86400s)                        |
+| `rewrite_script`          | boolean | No       | `true`                                                 | Whether to rewrite GPT script URLs in HTML                        |
+
+The environment override
+`TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED` works only when
+`gam_attribution_enabled` is already present under `[integrations.gpt]` in the
+TOML file. EdgeZero v0.0.4 cannot create a missing configuration leaf.
 
 ## Endpoints
 
@@ -108,6 +115,65 @@ Takes over `googletag.cmd` so every queued callback is wrapped before GPT execut
 - EC ID injection as page-level key-value targeting
 - Consent gating of ad requests
 - Ad-unit path rewriting for A/B testing
+
+### GAM Treatment Attribution
+
+Setting `gam_attribution_enabled = true` adds the fixed page-level GPT targeting
+value `ts=true`. It is applied before publisher GPT initialization and remains
+for the browser document's lifetime, so initial, lazy, refresh, publisher-owned,
+and SPA-route requests inherit it unless another targeting consumer clears or
+overrides the key. The attribution switch is independently controlled and
+defaults to `false`, but the GPT integration's `enabled` master switch must also
+be `true`.
+
+This key is distinct from the existing slot-level `ts_initial=1` value.
+`ts_initial` retains its current cleanup lifecycle; Trusted Server does not
+clear the page-level `ts` value during Prebid refresh or SPA cleanup.
+
+For an eligible publisher document whose activation script was not cloned,
+`ts=true` means Trusted Server emitted the rewritten document head before the
+GPT request. It does not prove that the response body completed, that a Trusted
+Server bid won, or that an impression was caused by treatment. A publisher can
+copy the activation script with `srcdoc` or `document.write`; treat any marker
+on an unrewritten nested document as contamination, not attribution proof.
+
+Before enabling attribution in a cohort:
+
+1. Complete privacy and CSP review, create the reportable predefined `true`
+   value in the target GAM network, and verify the chosen GAM reporting surface
+   and billing approval.
+2. Audit the short `ts` key across publisher GPT code, effective Prebid
+   `bidderSettings[*].adserverTargeting` output (including
+   `setTargetingForGPTAsync`), the effective creative-opportunity targeting map,
+   and every GAM consumer that can affect eligibility, pricing, protection, or
+   routing. Trusted Server accepts and forwards operator targeting verbatim; it
+   does not reserve, filter, or intercept a slot-level `ts` key at runtime.
+3. With treatment routing stopped, deploy attribution enabled and validate
+   initial, lazy, refresh, publisher-owned, and SPA requests. Confirm every
+   excluded path reports zero marked requests, then save a short paired-report
+   dry run that satisfies the invariants below before starting the cohort.
+
+For reporting, save one exact eligible universe: GAM network, inventory units,
+routes, formats, time zone, date window, metrics, and all exclusions. Report A
+is the nonduplicated total for that universe. Report B uses identical filters
+and metrics plus exactly `ts=true`. If Enhanced Key-Value reporting is
+unavailable, unapproved, or incompatible, use an exactly filtered legacy
+key-value report and never sum its repeated key-value rows. Derive control as
+`A - B`, and require `0 <= B <= A` for every metric. A violation invalidates the
+whole report pair; never clamp a negative result. Use the same reporting-latency
+and invalid-traffic maturation window for both reports.
+
+GAM results are descriptive delivery attribution, not a causal treatment
+effect. Aggregate monitoring and synthetic/manual samples can detect obvious
+failures but cannot prove marker completeness on every production request
+without request-correlated telemetry.
+
+For a normal rollback, first stop and verify new treatment assignment at the
+router, record a clean reporting boundary, and let already-open documents drain.
+Exclude the drain interval, then set `gam_attribution_enabled = false` after
+marked traffic reaches zero for the agreed interval. An emergency kill may flip
+the setting immediately, but the affected interval and subsequent drain must be
+treated as invalid for experiment reporting.
 
 ## Use Cases
 

--- a/docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md
+++ b/docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md
@@ -905,8 +905,9 @@ This task must not add buffering or adapter logic.
   - saved report pairs are exported after the same reporting-latency and
     invalid-traffic window, and monitoring/synthetic samples do not prove
     per-response marker completeness;
-  - normal rollback stops and verifies routing before flipping the setting,
-    then excludes the open-document drain interval;
+  - normal rollback stops and verifies routing, records the boundary, keeps
+    attribution enabled through the excluded open-document drain, and flips the
+    setting only after marked traffic reaches zero;
   - an emergency kill flips immediately and invalidates the affected/drain
     interval.
 
@@ -1018,7 +1019,7 @@ This task must not add buffering or adapter logic.
   git log --oneline --decorate -8
   ```
 
-  Expected: a clean worktree, seven focused implementation commits, and no
+  Expected: a clean worktree, focused implementation commits, and no
   production changes to creative-opportunity filtering, Prebid interception,
   streaming buffering, or adapter behavior.
 
@@ -1052,10 +1053,11 @@ remain separate from Tasks 1-8 because they require publisher/router/GAM access.
       `0 <= Report B <= Report A` for every selected metric.
 - [ ] Start the sticky treatment cohort only after every gate passes; use GAM
       share versus router allocation only as a diagnostic.
-- [ ] For normal rollback, close the clean report boundary, stop and verify new
-      treatment routing, disable attribution, and exclude the marked-document
-      drain interval. For an emergency kill, disable immediately and invalidate
-      the affected plus drain intervals.
+- [ ] For normal rollback, stop and verify new treatment routing, close the
+      clean report boundary, keep attribution enabled while marked documents
+      drain through the excluded interval, and disable only after marked traffic
+      reaches zero for the agreed interval. For an emergency kill, disable
+      immediately and invalidate the affected plus drain intervals.
 
 ## Definition of done
 

--- a/docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md
+++ b/docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md
@@ -1,0 +1,1076 @@
+# GAM Page-Delivery Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a disabled-by-default `gam_attribution_enabled` GPT option that marks every eligible request from a Trusted Server head-emitted publisher document with the fixed page-level GAM value `ts=true`.
+
+**Architecture:** One parsed `GptConfig` instance controls both delivery paths. The raw head bootstrap is the primary, earliest queue insertion; integration-owned publisher-tag metadata adds `data-ts-gam-attribution="true"` to the synchronous bundle for a `document.currentScript`-gated fallback. Existing slot targeting, Prebid refresh cleanup, creative-opportunity forwarding, and Fastly streaming behavior remain unchanged.
+
+**Tech Stack:** Rust 1.95, Serde, `validator`, `lol_html`, TypeScript, Vitest/jsdom, Playwright, Google Publisher Tag
+
+---
+
+**Issue:** [#1027](https://github.com/IABTechLab/trusted-server/issues/1027)
+
+**Design:** `docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md`
+
+## Fixed contracts
+
+| Concern            | Contract                                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| Marker             | Exactly page-level `ts=true`; no configurable name/value, alias, or dual write                       |
+| Default            | `[integrations.gpt] gam_attribution_enabled = false`                                                 |
+| Kill switch        | Disables only attribution; GPT proxying, shim, `adInit`, and `ts_initial` remain active              |
+| Primary path       | Raw GPT bootstrap queues targeting before `if (ts.adInit) return;`                                   |
+| Fallback           | Existing synchronous publisher bundle, authorized only by its own `document.currentScript` attribute |
+| Publisher tag      | One tag; `data-ts-gam-attribution="true"` only for enabled GPT attribution                           |
+| Streaming meaning  | Rewritten head emitted before the request, not complete response success; no new buffering           |
+| Slot targeting     | `ts_initial=1` lifecycle unchanged; page-level `ts` is never added to cleanup arrays                 |
+| Operator targeting | Forwarded verbatim; characterize collisions but add no validator, filter, or interception            |
+| Analysis           | Descriptive GAM delivery attribution, not a causal treatment effect                                  |
+
+Run every command block from the repository root unless that block begins with
+an explicit `cd`. Treat separate command blocks as separate shell sessions.
+
+## File map
+
+| File                                                                                       | Responsibility                                                                         |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `crates/trusted-server-core/src/integrations/gpt.rs`                                       | Parse the option, emit the inline activation flag, and expose publisher-tag metadata   |
+| `crates/trusted-server-core/src/integrations/registry.rs`                                  | Define the default-empty tag-attribute hook and aggregate enabled integration metadata |
+| `crates/trusted-server-core/src/tsjs.rs`                                                   | Render an attributed publisher bundle tag without changing generic/creative tag output |
+| `crates/trusted-server-core/src/html_processor.rs`                                         | Pass registry-owned attributes to the single synchronous publisher bundle tag          |
+| `crates/trusted-server-core/src/integrations/gpt_bootstrap.js`                             | Queue the primary `setConfig({ targeting: { ts: "true" } })` callback                  |
+| `crates/trusted-server-js/lib/src/integrations/gpt/index.ts`                               | Queue the `document.currentScript`-authorized fallback                                 |
+| `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`                 | Execute the raw bootstrap and prove ordering/failure isolation                         |
+| `crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts`                         | Prove exact executing-tag activation and fail-closed cases                             |
+| `crates/trusted-server-core/src/creative_opportunities.rs`                                 | Characterize verbatim operator `ts` targeting; production code remains unchanged       |
+| `crates/trusted-server-core/src/publisher.rs`                                              | Characterize wire forwarding and marked-head-before-EOF streaming                      |
+| `crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts`                       | Freeze GPT slot cleanup behavior                                                       |
+| `crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts`                      | Characterize Prebid-produced slot-level collisions and cleanup behavior                |
+| `crates/trusted-server-cli/tests/config_env_overlay.rs`                                    | Prove the typed CLI environment override updates an existing TOML leaf                 |
+| `trusted-server.example.toml`                                                              | Publish the disabled default                                                           |
+| `crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml` | Keep the browser fixture explicitly default-off                                        |
+| `crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts`    | Smoke-test absence of the activation attribute in the default-off deployment           |
+| `docs/guide/integrations/gpt.md`                                                           | Document configuration, semantics, audit, reporting, and rollback prerequisites        |
+
+## Task 1: Add the GPT attribution option and integration-owned metadata
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/gpt.rs:64-94`
+- Modify: `crates/trusted-server-core/src/integrations/gpt.rs:467-510`
+- Modify: `crates/trusted-server-core/src/integrations/gpt.rs:549-559`
+- Modify: `crates/trusted-server-core/src/integrations/registry.rs:572-579`
+- Test: `crates/trusted-server-core/src/integrations/gpt.rs`
+
+- [ ] **Step 1: Write failing configuration and head-injector tests.**
+
+  Add tests that deserialize omitted, explicit-false, and explicit-true values,
+  then exercise both activation outputs. Use behavior-oriented assertions like:
+
+  ```rust
+  #[test]
+  fn gam_attribution_defaults_to_disabled() {
+      let config: GptConfig =
+          serde_json::from_value(serde_json::json!({})).expect("should parse defaults");
+      assert!(!config.gam_attribution_enabled);
+  }
+
+  #[test]
+  fn gam_attribution_true_adds_both_activation_signals_without_a_new_insert() {
+      let integration = GptIntegration::new(GptConfig {
+          gam_attribution_enabled: true,
+          ..test_config()
+      });
+      let document_state = IntegrationDocumentState::default();
+      let context = IntegrationHtmlContext {
+          request_host: "edge.example.com",
+          request_scheme: "https",
+          origin_host: "origin.example.com",
+          document_state: &document_state,
+      };
+      let inserts = integration.head_inserts(&context);
+
+      assert_eq!(inserts.len(), 2);
+      assert!(inserts[0].contains("window.__tsjs_gam_attribution_enabled=true;"));
+      assert_eq!(
+          integration.tsjs_script_tag_attributes(),
+          vec![("data-ts-gam-attribution", "true")]
+      );
+  }
+  ```
+
+  Retain the current exact-string assertion for the false first insert. Add
+  `gam_attribution_enabled: false` to `test_config()` and any other full
+  `GptConfig` literals.
+
+- [ ] **Step 2: Run the focused tests and confirm RED.**
+
+  Run:
+
+  ```bash
+  cargo test-fastly gam_attribution
+  ```
+
+  Expected: compilation fails because `GptConfig::gam_attribution_enabled` and
+  `IntegrationHeadInjector::tsjs_script_tag_attributes` do not exist.
+
+- [ ] **Step 3: Add the default-empty trait hook and parsed field.**
+
+  Add an object-safe default method beside `head_inserts`:
+
+  ```rust
+  pub trait IntegrationHeadInjector: Send + Sync {
+      fn integration_id(&self) -> &'static str;
+      fn head_inserts(&self, ctx: &IntegrationHtmlContext<'_>) -> Vec<String>;
+
+      fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+          Vec::new()
+      }
+  }
+  ```
+
+  Add the flat field to `GptConfig`:
+
+  ```rust
+  /// Enable page-level `ts=true` delivery attribution in GAM.
+  #[serde(default)]
+  pub gam_attribution_enabled: bool,
+  ```
+
+  Do not add a configurable key or value.
+
+- [ ] **Step 4: Emit the true-only inline flag without changing false bytes.**
+
+  Build the first insert with an empty-or-fixed fragment:
+
+  ```rust
+  let gam_attribution_flag = self
+      .config
+      .gam_attribution_enabled
+      .then_some("window.__tsjs_gam_attribution_enabled=true;")
+      .unwrap_or_default();
+
+  let mut scripts = vec![
+      format!(
+          "<script>window.__tsjs_gpt_enabled=true;{gam_attribution_flag}\
+           window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>"
+      ),
+      format!("<script>{}</script>", GPT_BOOTSTRAP_JS),
+  ];
+  ```
+
+  Verify the false string remains exactly:
+
+  ```text
+  <script>window.__tsjs_gpt_enabled=true;window.__tsjs_installGptShim&&window.__tsjs_installGptShim();</script>
+  ```
+
+- [ ] **Step 5: Override the metadata hook from the same `GptConfig`.**
+
+  ```rust
+  fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+      if self.config.gam_attribution_enabled {
+          vec![("data-ts-gam-attribution", "true")]
+      } else {
+          Vec::new()
+      }
+  }
+  ```
+
+  Do not store this state in `HtmlProcessorConfig` or
+  `IntegrationDocumentState`.
+
+- [ ] **Step 6: Run focused and neighboring GPT tests.**
+
+  ```bash
+  cargo test-fastly gam_attribution
+  cargo test-fastly head_injector
+  ```
+
+  Expected: PASS; false preserves two current inserts, true adds the flag and
+  metadata while still emitting two inserts when `slim_prebid_url` is absent.
+
+- [ ] **Step 7: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/integrations/gpt.rs crates/trusted-server-core/src/integrations/registry.rs
+  git commit -m "Add GPT GAM attribution option"
+  ```
+
+## Task 2: Put activation metadata on only the publisher bundle tag
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/registry.rs:1043-1054`
+- Modify: `crates/trusted-server-core/src/tsjs.rs:11-39`
+- Modify: `crates/trusted-server-core/src/html_processor.rs:324-360`
+- Test: `crates/trusted-server-core/src/integrations/registry.rs`
+- Test: `crates/trusted-server-core/src/tsjs.rs:161-187`
+- Test: `crates/trusted-server-core/src/html_processor.rs:768-820`
+- Test: `crates/trusted-server-core/src/html_processor.rs:1637-1671`
+
+- [ ] **Step 1: Write failing registry and tag-rendering tests.**
+
+  Add a test head injector whose metadata method returns the attribution pair.
+  Assert registry aggregation is deterministic and preserves the default-empty
+  behavior of injectors that implement only `head_inserts`.
+
+  Add exact tag tests:
+
+  ```rust
+  #[test]
+  fn publisher_script_tag_renders_static_attributes() {
+      let ids = ["gpt"];
+      let src = tsjs_script_src(&ids);
+
+      assert_eq!(
+          tsjs_script_tag_with_attributes(
+              &ids,
+              &[("data-ts-gam-attribution", "true")]
+          ),
+          format!(
+              "<script src=\"{src}\" id=\"trustedserver-js\" \
+               data-ts-gam-attribution=\"true\"></script>"
+          )
+      );
+      assert_eq!(
+          tsjs_script_tag(&ids),
+          format!("<script src=\"{src}\" id=\"trustedserver-js\"></script>")
+      );
+  }
+  ```
+
+  The final string must contain no formatting whitespace introduced only by the
+  multiline example.
+
+- [ ] **Step 2: Write a failing HTML matrix test.**
+
+  Process `<html><head></head><body></body></html>` with:
+  1. a real enabled GPT registry with attribution true;
+  2. enabled GPT with attribution false; and
+  3. no GPT integration.
+
+  Assert exactly one `#trustedserver-js` tag in every case, the attribute only
+  in case 1, and integration head inserts remain before the external bundle.
+  Also retain the generic `tsjs_unified_script_tag()` exact-output test so
+  creative/all-modules callers stay unmarked.
+
+- [ ] **Step 3: Run the tests and confirm RED.**
+
+  ```bash
+  cargo test-fastly tsjs_script_tag
+  cargo test-fastly integration_head_injector
+  ```
+
+  Expected: FAIL because the registry aggregator and attributed publisher
+  helper are not implemented.
+
+- [ ] **Step 4: Aggregate integration-owned static attributes.**
+
+  Add beside `IntegrationRegistry::head_inserts`:
+
+  ```rust
+  #[must_use]
+  pub fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+      self.inner
+          .head_injectors
+          .iter()
+          .flat_map(|injector| injector.tsjs_script_tag_attributes())
+          .collect()
+  }
+  ```
+
+  Keep the hook default-empty so existing integration injectors and test doubles
+  compile without changes.
+
+- [ ] **Step 5: Add the publisher-only tag helper.**
+
+  Render only trusted, compile-time static attribute pairs:
+
+  ```rust
+  #[must_use]
+  pub fn tsjs_script_tag_with_attributes(
+      module_ids: &[&str],
+      attributes: &[(&'static str, &'static str)],
+  ) -> String {
+      let attributes = attributes
+          .iter()
+          .map(|(name, value)| format!(" {name}=\"{value}\""))
+          .collect::<String>();
+      format!(
+          "<script src=\"{}\" id=\"trustedserver-js\"{attributes}></script>",
+          tsjs_script_src(module_ids)
+      )
+  }
+  ```
+
+  Have `tsjs_script_tag(module_ids)` retain its exact output, either directly or
+  by delegating with an empty slice. Do not change
+  `tsjs_unified_script_tag()` or either creative call site.
+
+- [ ] **Step 6: Wire only the publisher HTML path.**
+
+  Replace the single `html_processor.rs` call with:
+
+  ```rust
+  let immediate_ids = integrations.js_module_ids_immediate();
+  let script_attributes = integrations.tsjs_script_tag_attributes();
+  snippet.push_str(&tsjs::tsjs_script_tag_with_attributes(
+      &immediate_ids,
+      &script_attributes,
+  ));
+  ```
+
+  Preserve source order: ad slots, integration head inserts, diagnostics
+  bootstrap, one synchronous bundle, diagnostics module, deferred bundles.
+
+- [ ] **Step 7: Run focused tests.**
+
+  ```bash
+  cargo test-fastly tsjs_script_tag
+  cargo test-fastly integration_head_injector
+  cargo test-fastly golden_script_tag
+  ```
+
+  Expected: PASS; false/non-GPT/generic output is unmarked and true output has
+  one attributed publisher tag.
+
+- [ ] **Step 8: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/integrations/registry.rs crates/trusted-server-core/src/tsjs.rs crates/trusted-server-core/src/html_processor.rs
+  git commit -m "Authorize GAM attribution bundle"
+  ```
+
+## Task 3: Queue the primary marker before the bootstrap guard
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/gpt_bootstrap.js:17-45`
+- Modify: `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts:8-220`
+- Test: `crates/trusted-server-core/src/integrations/gpt.rs:1131-1454`
+
+- [ ] **Step 1: Extend the raw-source test harness.**
+
+  Add the optional page flag and `setConfig` surface:
+
+  ```typescript
+  interface MockGoogleTag {
+    cmd: MockCommandQueue
+    setConfig?: (config: Record<string, unknown>) => void
+    // retain the existing members
+  }
+
+  type TestWindow = Omit<Window, 'tsjs'> & {
+    googletag?: MockGoogleTag
+    tsjs?: Partial<TsjsApi>
+    __tsjs_gam_attribution_enabled?: boolean
+  }
+
+  function makeGoogleTag(
+    overrides: Partial<MockGoogleTag> = {}
+  ): MockGoogleTag {
+    return {
+      cmd: [],
+      defineSlot: vi.fn(),
+      pubads: vi.fn(() => ({})),
+      enableServices: vi.fn(),
+      display: vi.fn(),
+      ...overrides,
+    }
+  }
+  ```
+
+  Delete the flag in both `beforeEach` and `afterEach`.
+
+- [ ] **Step 2: Write failing behavioral tests.**
+
+  Cover all of these independently:
+  - default/false plus a preinstalled `ts.adInit` returns without creating
+    `window.googletag`;
+  - true queues the exact string-valued targeting callback before a publisher
+    callback appended after `runBootstrap()`;
+  - true plus preinstalled `ts.adInit` still queues and applies targeting but
+    does not replace `adInit` or install the fallback scheduler;
+  - missing `setConfig` is a no-op and the initial-load detector and `adInit`
+    still install;
+  - throwing `setConfig` is caught inside the marker callback, and a later
+    publisher callback still executes;
+  - the wrapped `disableInitialLoad` path still records
+    `ts.gptInitialLoadDisabled`.
+
+  Use a real array queue, append a publisher spy after bootstrap execution, and
+  drain a snapshot in order:
+
+  ```typescript
+  const queue: Array<() => void> = []
+  const setConfig = vi.fn()
+  ;(window as TestWindow).googletag = makeGoogleTag({ cmd: queue, setConfig })
+  ;(window as TestWindow).__tsjs_gam_attribution_enabled = true
+
+  runBootstrap()
+  const publisherCommand = vi.fn()
+  queue.push(publisherCommand)
+  ;[...queue].forEach((command) => command())
+
+  expect(setConfig).toHaveBeenCalledWith({ targeting: { ts: 'true' } })
+  expect(setConfig.mock.invocationCallOrder[0]).toBeLessThan(
+    publisherCommand.mock.invocationCallOrder[0]
+  )
+  ```
+
+- [ ] **Step 3: Run the raw bootstrap tests and confirm RED.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  npx vitest run test/integrations/gpt/gpt_bootstrap.test.ts
+  ```
+
+  Expected: targeting assertions fail because the raw bootstrap returns before
+  any marker enqueue.
+
+- [ ] **Step 4: Implement one flag-gated queue initialization before the guard.**
+
+  Preserve the local `ts` namespace and reuse `tag` in the existing detector:
+
+  ```javascript
+  var ts = (window.tsjs = window.tsjs || {})
+  var tag
+
+  if (window.__tsjs_gam_attribution_enabled === true) {
+    tag = window.googletag = window.googletag || { cmd: [] }
+    tag.cmd = tag.cmd || []
+    tag.cmd.push(function () {
+      try {
+        var gpt = window.googletag
+        if (gpt && typeof gpt.setConfig === 'function') {
+          // "ts" is the fixed GAM key, not the local window.tsjs alias.
+          gpt.setConfig({ targeting: { ts: 'true' } })
+        }
+      } catch (_) {
+        // Attribution must not interrupt the existing bootstrap queue.
+      }
+    })
+  }
+
+  if (ts.adInit) return
+
+  tag = tag || (window.googletag = window.googletag || { cmd: [] })
+  tag.cmd = tag.cmd || []
+  tag.cmd.push(function () {
+    // existing initial-load detector body, unchanged
+  })
+  ```
+
+  Do not add a global deduplication state machine, network call, beacon, cookie
+  read, slot-level key, or third head insert.
+
+- [ ] **Step 5: Add/retain Rust source-order assertions.**
+
+  In `gpt.rs`, assert the embedded bootstrap's attribution enqueue occurs before
+  `if (ts.adInit) return;` and before the executable
+  `googletag.display(` and `googletag.pubads().refresh(` tokens. Do not compare
+  against comment-only `display()`/`refresh()` text. Retain `ts_initial`
+  assertions and the two-insert count.
+
+- [ ] **Step 6: Run focused JS and Rust tests.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  npx vitest run test/integrations/gpt/gpt_bootstrap.test.ts
+  cd ../../..
+  cargo test-fastly head_inserts
+  ```
+
+  Expected: PASS; default behavior is unchanged and every failure mode is
+  isolated from the existing bootstrap.
+
+- [ ] **Step 7: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/integrations/gpt_bootstrap.js crates/trusted-server-core/src/integrations/gpt.rs crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+  git commit -m "Queue page-level GAM attribution"
+  ```
+
+## Task 4: Add the exact-executing-tag bundle fallback
+
+**Files:**
+
+- Modify: `crates/trusted-server-js/lib/src/integrations/gpt/index.ts:259-307`
+- Modify: `crates/trusted-server-js/lib/src/integrations/gpt/index.ts:1878-1898`
+- Modify: `crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts:350-421`
+
+- [ ] **Step 1: Add a test helper that controls `document.currentScript`.**
+
+  In the runtime-gating suite, install a configurable getter before a fresh
+  dynamic import and restore it afterward:
+
+  ```typescript
+  let executingScript: HTMLScriptElement | null
+
+  Object.defineProperty(document, 'currentScript', {
+    configurable: true,
+    get: () => executingScript,
+  })
+  ```
+
+  Use actual `<script>` elements. Do not authorize tests through
+  `querySelector('#trustedserver-js')`.
+
+- [ ] **Step 2: Write failing activation and fail-closed tests.**
+
+  Prove:
+  - the executing tag with exact `data-ts-gam-attribution="true"` reuses the
+    existing `cmd` array and queues `{ targeting: { ts: 'true' } }`;
+  - missing, empty, `"false"`, or non-exact attribute values do not activate;
+  - `document.currentScript === null` fails closed;
+  - a marked duplicate-ID decoy does not activate when the executing tag is
+    unmarked;
+  - a marked executing tag can activate even if its ID was copied via
+    `srcdoc`/`document.write`, documenting contamination rather than asserting
+    an untrue rewrite guarantee;
+  - the marker queue push occurs while `window.tsjs.adInit` is still absent;
+  - missing or throwing `setConfig` does not prevent `adInit`, SPA, loader, or
+    render-bridge installation;
+  - GPT-enabled but attribution-disabled imports retain current shim/stub
+    behavior while queuing no marker;
+  - with neither the old enable flag nor the new attribute, a plain import still
+    leaves `window.googletag` undefined.
+
+- [ ] **Step 3: Run the suite and confirm RED.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  npx vitest run test/integrations/gpt/index.test.ts
+  ```
+
+  Expected: activation cases fail because the bundle does not inspect its
+  executing tag.
+
+- [ ] **Step 4: Capture the executing tag during module evaluation.**
+
+  Add one module-local capture, not a global lookup:
+
+  ```typescript
+  const executingPublisherScript =
+    typeof document === 'undefined' ? null : document.currentScript
+  ```
+
+  Preserve the `HTMLOrSVGScriptElement | null` type returned by the DOM API or
+  narrow safely by capability; do not use an unchecked ID query.
+
+- [ ] **Step 5: Add a defensive helper using existing GPT types.**
+
+  ```typescript
+  function installTrustedServerPageTargeting(): void {
+    if (
+      executingPublisherScript?.getAttribute('data-ts-gam-attribution') !==
+      'true'
+    ) {
+      return
+    }
+
+    const win = window as GptWindow
+    const tag = ensureGoogleTagStub(win)
+    tag.cmd!.push(() => {
+      try {
+        const gpt = win.googletag
+        if (typeof gpt?.setConfig === 'function') {
+          gpt.setConfig({ targeting: { ts: 'true' } })
+        }
+      } catch (error) {
+        log.warn('[tsjs-gpt] GAM attribution targeting failed', error)
+      }
+    })
+  }
+  ```
+
+  Reuse `GoogleTagConfig` and optional `GoogleTag.setConfig` exactly as they
+  exist. Do not add a new type surface or throw from the callback.
+
+- [ ] **Step 6: Call it in the approved initialization order.**
+
+  ```typescript
+  if (win.__tsjs_gpt_enabled === true) {
+    installGptShim()
+  }
+
+  installTrustedServerPageTargeting()
+  installTsAdInit()
+  installSpaAuctionHook()
+  installSlimPrebidLoader()
+  installTsRenderBridge()
+  ```
+
+  The bootstrap remains primary; duplicate same-value page targeting is
+  intentional and idempotent.
+
+- [ ] **Step 7: Run focused and neighboring GPT suites.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  npx vitest run \
+    test/integrations/gpt/index.test.ts \
+    test/integrations/gpt/gpt_bootstrap.test.ts \
+    test/integrations/gpt/ad_init.test.ts
+  ```
+
+  Expected: PASS with no new script element, request, or slot targeting.
+
+- [ ] **Step 8: Commit.**
+
+  ```bash
+  git add crates/trusted-server-js/lib/src/integrations/gpt/index.ts crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts
+  git commit -m "Add GAM attribution bundle fallback"
+  ```
+
+## Task 5: Characterize targeting collisions and preserve cleanup boundaries
+
+**Files:**
+
+- Test: `crates/trusted-server-core/src/creative_opportunities.rs:1710-1760`
+- Test: `crates/trusted-server-core/src/publisher.rs:8737-8756`
+- Test: `crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts:1870`
+- Test: `crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts:1851`
+- Test: `crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts` publisher-settings coverage
+
+This task adds characterization only. Do not change
+`CreativeOpportunitySlot` parsing, `to_ad_slot`, `build_slot_json`,
+`TS_BASE_TARGETING_KEYS`, `TS_REFRESH_TARGETING_KEYS`, or Prebid interception
+code.
+
+- [ ] **Step 1: Freeze verbatim operator targeting in Rust tests.**
+
+  Add `"ts": "operator-value"` to a test `CreativeOpportunitySlot.targeting`.
+  Assert both:
+
+  ```rust
+  assert_eq!(
+      ad_slot.targeting.get("ts"),
+      Some(&serde_json::Value::String("operator-value".to_owned()))
+  );
+  assert_eq!(
+      build_slot_json(&slot, &config, "example")["targeting"]["ts"],
+      "operator-value"
+  );
+  ```
+
+  This is evidence for the external launch audit, not authorization to filter
+  the key.
+
+- [ ] **Step 2: Freeze GPT slot-cleanup behavior.**
+
+  Extend the existing stale-targeting route test with a slot-level `ts` value.
+  Assert:
+
+  ```typescript
+  expect(clearTargeting).not.toHaveBeenCalledWith('ts')
+  expect(clearTargeting).toHaveBeenCalledWith('ts_initial')
+  ```
+
+  The page-level marker is not a member of the slot cleanup list.
+
+- [ ] **Step 3: Characterize publisher `bidderSettings` preservation.**
+
+  Seed:
+
+  ```typescript
+  mockPbjs.bidderSettings = {
+    exampleBidder: {
+      adserverTargeting: [{ key: 'ts', val: () => 'publisher-value' }],
+    },
+  }
+  ```
+
+  Run the existing wrapped `requestBids` path and assert that adding
+  `trustedServer.allowAlternateBidderCodes` does not delete or rewrite the
+  publisher's `adserverTargeting` entry. Delete or reset `bidderSettings` in the
+  suite cleanup so this collision fixture cannot leak into unrelated tests.
+
+- [ ] **Step 4: Characterize `setTargetingForGPTAsync` collision behavior.**
+
+  In the existing Prebid refresh test, make the mock
+  `setTargetingForGPTAsync` apply slot-level `ts=prebid-value`. Assert it runs
+  before delegated refresh, `clearTargeting('ts')` was not called, and no
+  Trusted Server wrapper filters the value. Retain the current
+  `ts_initial`/`hb_*` clearing assertions.
+
+- [ ] **Step 5: Run characterization suites.**
+
+  ```bash
+  cargo test-fastly to_ad_slot
+  cargo test-fastly ad_slots_script_contains_slot_data
+  cd crates/trusted-server-js/lib
+  npx vitest run \
+    test/integrations/gpt/ad_init.test.ts \
+    test/integrations/prebid/index.test.ts
+  ```
+
+  Expected: PASS without production-code changes. If a test reveals current
+  filtering, stop and reconcile the spec instead of adding compensating
+  behavior.
+
+- [ ] **Step 6: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/creative_opportunities.rs crates/trusted-server-core/src/publisher.rs crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts
+  git commit -m "Characterize targeting collisions"
+  ```
+
+## Task 6: Characterize marked-head streaming before origin EOF
+
+**Files:**
+
+- Test: `crates/trusted-server-core/src/publisher.rs:7756-7885`
+- Verify unchanged: `crates/trusted-server-core/src/streaming_processor.rs:297-364`
+- Verify unchanged: `crates/trusted-server-adapter-fastly/src/main.rs:322-358`
+
+This task must not add buffering or adapter logic.
+
+- [ ] **Step 1: Add a test-only settings-aware streaming helper.**
+
+  Let the existing `streaming_finalize_response` delegate to a sibling that
+  accepts `Settings`. The helper still builds
+  `IntegrationRegistry::new(&settings)` and polls the same lazy body; do not
+  alter production parameters.
+
+- [ ] **Step 2: Add the before-EOF regression.**
+
+  Configure enabled GPT attribution in test settings, send an HTML origin chunk
+  followed by permanent `Pending`, and poll exactly one client chunk:
+
+  ```rust
+  #[test]
+  fn streaming_finalize_emits_gam_attribution_head_before_origin_eof() {
+      let mut settings = create_test_settings();
+      settings
+          .integrations
+          .insert_config(
+              "gpt",
+              &serde_json::json!({
+                  "enabled": true,
+                  "gam_attribution_enabled": true
+              }),
+          )
+          .expect("should insert GPT config");
+
+      let body = streaming_finalize_response_with_settings(
+          html_stream_params("", None),
+          origin_chunk_then_pending(bytes::Bytes::from_static(
+              b"<html><head></head><body><p>origin remains pending</p>"
+          )),
+          settings,
+      );
+      let html = String::from_utf8(first_lazy_body_chunk(body).to_vec())
+          .expect("should emit UTF-8 HTML");
+
+      assert!(html.contains("__tsjs_gam_attribution_enabled=true"));
+      assert!(html.contains("data-ts-gam-attribution=\"true\""));
+  }
+  ```
+
+  If the rewriter needs more input to flush, use the established large-prefix or
+  auction-hold fixture pattern; never complete the origin stream to make the
+  test pass.
+
+- [ ] **Step 3: Run the new and existing streaming/error regressions.**
+
+  ```bash
+  cargo test-fastly streaming_finalize_emits_gam_attribution_head_before_origin_eof
+  cargo test-fastly streaming_finalize_emits_compressed_html_before_origin_eof
+  cargo test-fastly stream_publisher_body_surfaces_mid_stream_decode_error
+  ```
+
+  Expected: PASS. The new marker is in the first rewritten head chunk, and the
+  existing later decoder error still surfaces as truncation rather than
+  reclassification or buffering.
+
+- [ ] **Step 4: Confirm the diff contains test code only for this task.**
+
+  ```bash
+  git diff -- crates/trusted-server-core/src/publisher.rs crates/trusted-server-core/src/streaming_processor.rs crates/trusted-server-adapter-fastly/src/main.rs
+  ```
+
+  Expected: `publisher.rs` test module changes only; no production streaming or
+  Fastly adapter changes.
+
+- [ ] **Step 5: Commit.**
+
+  ```bash
+  git add crates/trusted-server-core/src/publisher.rs
+  git commit -m "Define GAM attribution streaming semantics"
+  ```
+
+## Task 7: Publish configuration, environment, browser-smoke, and operator docs
+
+**Files:**
+
+- Modify: `trusted-server.example.toml:105-109`
+- Modify: `crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml:87-91`
+- Modify: `crates/trusted-server-cli/tests/config_env_overlay.rs`
+- Modify: `crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts:4-12`
+- Modify: `docs/guide/integrations/gpt.md:49-110`
+
+- [ ] **Step 1: Write the failing typed-CLI overlay test.**
+
+  Add:
+
+  ```rust
+  const GAM_ATTRIBUTION_ENV: &str =
+      "TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED";
+  ```
+
+  Use `ts config push` with `GAM_ATTRIBUTION_ENV=true` and inspect the stored
+  blob envelope:
+
+  ```rust
+  assert_eq!(
+      envelope["data"]["integrations"]["gpt"]["gam_attribution_enabled"],
+      serde_json::Value::Bool(true)
+  );
+  ```
+
+  Run before adding the fixture leaf to demonstrate EdgeZero v0.0.4 cannot
+  create the missing leaf.
+
+- [ ] **Step 2: Confirm the overlay test is RED.**
+
+  ```bash
+  ./scripts/test-cli.sh
+  ```
+
+  Expected: the new assertion fails because the base TOML does not yet contain
+  `gam_attribution_enabled`.
+
+- [ ] **Step 3: Add the explicit disabled leaf to both TOML files.**
+
+  ```toml
+  [integrations.gpt]
+  enabled = false
+  gam_attribution_enabled = false
+  ```
+
+  Preserve the surrounding GPT URL/cache/rewrite fields. The comprehensive
+  browser fixture remains GPT-disabled and attribution-disabled.
+
+- [ ] **Step 4: Extend the default-off browser smoke.**
+
+  In `script-injection.spec.ts`, keep the existing one-tag/source assertion and
+  add:
+
+  ```typescript
+  await expect(script).not.toHaveAttribute('data-ts-gam-attribution')
+  ```
+
+  Do not add a second Playwright project or enable GPT globally. Enabled
+  behavior is covered deterministically by Rust/Vitest and later by the external
+  deployment validation.
+
+- [ ] **Step 5: Update the GPT configuration reference.**
+
+  Add `gam_attribution_enabled = false` to the snippet and a table row stating:
+  - type boolean;
+  - optional;
+  - default false;
+  - independently enables fixed page-level GAM `ts=true` attribution.
+
+  State that an environment override works only when this TOML leaf already
+  exists:
+
+  ```text
+  TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED
+  ```
+
+- [ ] **Step 6: Add the operator attribution section.**
+
+  Near “Command Queue Patch,” document:
+  - `ts=true` is page-level and persists for the browser document;
+  - `ts_initial=1` remains slot-level and is cleared on its existing lifecycle;
+  - the marker means an eligible, non-cloned TS publisher pipeline emitted the
+    head, not that a TS bid won or the body completed;
+  - the fixed short key must pass publisher GPT, Prebid
+    `bidderSettings/adserverTargeting/setTargetingForGPTAsync`, effective
+    creative-opportunity map, and GAM-consumer collision audits;
+  - there is no runtime filtering of operator targeting;
+  - privacy/CSP review, reportable predefined value, Enhanced-or-exact-legacy
+    report dry run, and excluded-path zero counts are launch gates;
+  - Report A is the non-duplicated eligible-scope total, Report B uses the same
+    dates/time zone/inventory/metrics plus exactly `ts=true`, and legacy
+    Key-values rows are never summed;
+  - control is `Report A - Report B`; every interpreted metric must satisfy
+    `0 <= Report B <= Report A`, and a violation invalidates the complete pair
+    rather than being clamped;
+  - saved report pairs are exported after the same reporting-latency and
+    invalid-traffic window, and monitoring/synthetic samples do not prove
+    per-response marker completeness;
+  - normal rollback stops and verifies routing before flipping the setting,
+    then excludes the open-document drain interval;
+  - an emergency kill flips immediately and invalidates the affected/drain
+    interval.
+
+  Label GAM results descriptive delivery attribution, not causal analysis. Do
+  not update `docs/guide/integrations/gam.md`, which describes a separate future
+  integration.
+
+- [ ] **Step 7: Run configuration, docs, and browser checks.**
+
+  ```bash
+  ./scripts/test-cli.sh
+  cd docs
+  npm run format
+  npm run build
+  cd ..
+  ./scripts/integration-tests-browser.sh
+  ```
+
+  Expected: CLI overlay PASS; docs format/build PASS; Next.js and WordPress
+  browser suites PASS with an unmarked default-off publisher tag.
+
+- [ ] **Step 8: Commit.**
+
+  ```bash
+  git add trusted-server.example.toml crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml crates/trusted-server-cli/tests/config_env_overlay.rs crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts docs/guide/integrations/gpt.md
+  git commit -m "Document GAM attribution configuration"
+  ```
+
+## Task 8: Run the complete repository verification matrix
+
+**Files:**
+
+- Verify all files changed in Tasks 1-7
+- Follow: `CLAUDE.md`
+
+- [ ] **Step 1: Format and inspect before the expensive matrix.**
+
+  ```bash
+  cargo fmt --all
+  cd crates/trusted-server-js/lib
+  npm run format
+  cd ../../../docs
+  npm run format
+  cd ..
+  git diff --check
+  git status --short
+  ```
+
+  Expected: formatters succeed and only intended feature files are modified. If
+  a formatter changes committed content, inspect and commit that correction
+  before continuing.
+
+- [ ] **Step 2: Run all target-matched Rust lints.**
+
+  ```bash
+  cargo clippy-fastly
+  cargo clippy-axum
+  cargo clippy-cloudflare
+  cargo clippy-cloudflare-wasm
+  cargo clippy-spin-native
+  cargo clippy-spin-wasm
+  ```
+
+  Expected: PASS with `-D warnings`. Do not substitute bare workspace clippy.
+
+- [ ] **Step 3: Run all target-matched Rust suites.**
+
+  ```bash
+  cargo test-fastly
+  cargo test-axum
+  cargo test-cloudflare
+  cargo test-spin
+  cargo test --manifest-path crates/trusted-server-integration-tests/Cargo.toml --test parity
+  ./scripts/test-cli.sh
+  ```
+
+  Expected: PASS. Do not use bare `cargo test --workspace`.
+
+- [ ] **Step 4: Run the full TypeScript build, tests, lint, and format check.**
+
+  ```bash
+  cd crates/trusted-server-js/lib
+  node build-all.mjs
+  npx vitest run
+  npm run lint
+  npm run format
+  ```
+
+  Expected: all bundles build and all tests/lint/format checks pass.
+
+- [ ] **Step 5: Run docs and browser integration gates.**
+
+  ```bash
+  cd docs
+  npm run format
+  npm run build
+  cd ..
+  ./scripts/integration-tests-browser.sh
+  ```
+
+  Expected: docs build and both browser frameworks pass.
+
+- [ ] **Step 6: Recheck the final diff and commits.**
+
+  ```bash
+  cargo fmt --all -- --check
+  git diff --check
+  git status --short
+  git log --oneline --decorate -8
+  ```
+
+  Expected: a clean worktree, seven focused implementation commits, and no
+  production changes to creative-opportunity filtering, Prebid interception,
+  streaming buffering, or adapter behavior.
+
+## External launch gates (not repository implementation)
+
+Do not mark implementation complete as “experiment ready” until an operator
+records these artifacts for the target GAM network. These steps intentionally
+remain separate from Tasks 1-8 because they require publisher/router/GAM access.
+
+- [ ] Create or verify the one predefined reportable key/value `ts=true` and
+      retain the target-network 10-character preflight evidence.
+- [ ] Freeze the exact eligible route/site/ad-unit/format/time-zone/window
+      manifest and derive both saved reports and every exclusion query from it.
+- [ ] Record Enhanced key-value availability, metric compatibility, owner
+      approval, and displayed billing terms; otherwise enable the key for legacy
+      reporting and validate the exact `ts=true` filter without summing
+      Key-values rows.
+- [ ] Retain zero-count evidence or an identical independent filter for every
+      excluded path: non-experiment TS, smoke/direct/operations, IMA/video,
+      direct tags, server-side GAM, and excluded nested inventory.
+- [ ] Complete publisher GPT, Prebid, effective creative-opportunity map, and
+      every GAM targeting-consumer collision audits with owners, queries,
+      timestamps, and re-audit triggers.
+- [ ] Complete privacy/data-governance and CSP eligibility reviews.
+- [ ] With treatment routing stopped, deploy
+      `gam_attribution_enabled = true` to the validation deployment.
+- [ ] Validate initial/lazy/refresh/publisher-owned/SPA requests, control
+      absence, `ts_initial` isolation, CSP execution, fallback incident
+      detection, and the disabled kill switch.
+- [ ] Save a short paired Report A/Report B dry run and verify
+      `0 <= Report B <= Report A` for every selected metric.
+- [ ] Start the sticky treatment cohort only after every gate passes; use GAM
+      share versus router allocation only as a diagnostic.
+- [ ] For normal rollback, close the clean report boundary, stop and verify new
+      treatment routing, disable attribution, and exclude the marked-document
+      drain interval. For an emergency kill, disable immediately and invalidate
+      the affected plus drain intervals.
+
+## Definition of done
+
+- The repository behavior and automated tests satisfy every code-addressable
+  design acceptance criterion; experiment-readiness remains explicitly gated
+  on the external checklist above.
+- `gam_attribution_enabled` is default-off, externally overridable only from an
+  existing TOML leaf, and does not disable any existing GPT behavior.
+- Enabled publisher documents receive both activation signals, and at least one
+  callback successfully applies the single effective page-level `ts=true` value
+  before publisher GPT requests. The same-value fallback callback remains safe.
+- Generic/creative tags, production/control pages, and default-off fixtures are
+  unmarked.
+- `ts_initial`, slot cleanup, arbitrary operator targeting, Prebid behavior,
+  Fastly streaming, and adapters have no production behavior changes.
+- All `CLAUDE.md` target-matched gates pass.
+- External GAM artifacts are explicitly outstanding until an authorized
+  operator completes the launch checklist.

--- a/docs/superpowers/plans/2026-08-19-gam-attribution-review-resolution.md
+++ b/docs/superpowers/plans/2026-08-19-gam-attribution-review-resolution.md
@@ -1,0 +1,346 @@
+# GAM Attribution Review Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve all actionable comments from PR #1034 review 4966544291 without changing the default-off GAM attribution behavior.
+
+**Architecture:** Attribute conflict handling stays at the integration aggregation boundary, while trusted static HTML validation stays at the rendering boundary. GPT attribution errors remain isolated inside the command queue but become observable through the existing guarded logger. Remaining edits are source-style, test-fixture, and documentation consistency changes.
+
+**Tech Stack:** Rust 2024, JavaScript, TypeScript, Vitest, Cargo workspace aliases, Prettier.
+
+---
+
+### Task 1: Enforce safe publisher-tag attributes
+
+**Files:**
+
+- Modify: `crates/trusted-server-core/src/integrations/registry.rs`
+- Modify: `crates/trusted-server-core/src/tsjs.rs`
+
+- [ ] **Step 1: Add a failing duplicate-attribute aggregation test**
+
+Add this second test injector with an explicitly conflicting later value and a
+unique attribute:
+
+```rust
+struct ConflictingMetadataHeadInjector;
+
+impl IntegrationHeadInjector for ConflictingMetadataHeadInjector {
+    fn integration_id(&self) -> &'static str {
+        "conflicting-metadata"
+    }
+
+    fn head_inserts(&self, _ctx: &IntegrationHtmlContext<'_>) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn tsjs_script_tag_attributes(&self) -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("data-ts-gam-attribution", "false"),
+            ("data-third-attribute", "third"),
+        ]
+    }
+}
+```
+
+Register it after `StaticMetadataHeadInjector`. Update
+`tsjs_script_tag_attributes_preserve_registration_order_and_default_empty` to
+expect the original value once and all unique attributes in registration order.
+
+```rust
+assert_eq!(
+    registry.tsjs_script_tag_attributes(),
+    vec![
+        ("data-ts-gam-attribution", "true"),
+        ("data-test-order", "second"),
+        ("data-third-attribute", "third"),
+    ],
+    "should keep the first value for duplicate names and preserve attribute order"
+);
+```
+
+- [ ] **Step 2: Run the registry test and verify RED**
+
+Run `cargo test_details -p trusted-server-core tsjs_script_tag_attributes_preserve_registration_order_and_default_empty`.
+
+Expected: FAIL because the current flat-map returns both duplicate values.
+
+- [ ] **Step 3: Implement first-wins deduplication**
+
+Replace the flat-map with ordered accumulation:
+
+```rust
+let mut attributes = Vec::new();
+for injector in &self.inner.head_injectors {
+    for attribute in injector.tsjs_script_tag_attributes() {
+        if !attributes.iter().any(|(name, _)| *name == attribute.0) {
+            attributes.push(attribute);
+        }
+    }
+}
+attributes
+```
+
+- [ ] **Step 4: Run the registry test and verify GREEN**
+
+Run the Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Add failing invalid-attribute tests**
+
+Add debug assertion tests in `tsjs.rs`:
+
+```rust
+#[test]
+#[should_panic(expected = "should contain only lowercase ASCII letters, digits, and hyphens")]
+fn publisher_tsjs_script_tag_rejects_invalid_attribute_name() {
+    tsjs_script_tag_with_attributes(&["gpt"], &[("data-bad_name", "true")]);
+}
+
+#[test]
+#[should_panic(expected = "should contain only lowercase ASCII letters, digits, and hyphens")]
+fn publisher_tsjs_script_tag_rejects_empty_attribute_name() {
+    tsjs_script_tag_with_attributes(&["gpt"], &[("", "true")]);
+}
+
+#[test]
+fn publisher_tsjs_script_tag_rejects_html_sensitive_attribute_values() {
+    for value in ["bad\"value", "bad&value", "bad<value", "bad>value"] {
+        let result = std::panic::catch_unwind(|| {
+            tsjs_script_tag_with_attributes(&["gpt"], &[("data-safe-name", value)]);
+        });
+        assert!(result.is_err(), "should reject HTML-sensitive value `{value}`");
+    }
+}
+```
+
+- [ ] **Step 6: Run validation tests and verify RED**
+
+Run `cargo test_details -p trusted-server-core publisher_tsjs_script_tag_rejects`.
+
+Expected: FAIL because both `#[should_panic]` tests return normally.
+
+- [ ] **Step 7: Add debug-only validation**
+
+Inside attribute rendering, assert that names are non-empty and contain only
+lowercase ASCII letters, digits, and hyphens, and that values exclude `"`, `&`,
+`<`, and `>`.
+
+```rust
+debug_assert!(
+    !name.is_empty()
+        && name.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'
+        }),
+    "attribute name should contain only lowercase ASCII letters, digits, and hyphens"
+);
+debug_assert!(
+    !value.bytes().any(|byte| matches!(byte, b'"' | b'&' | b'<' | b'>')),
+    "attribute value should not contain HTML-sensitive characters"
+);
+```
+
+- [ ] **Step 8: Run adjacent Rust tests**
+
+Run `cargo test_details -p trusted-server-core publisher_tsjs_script_tag` and
+`cargo test_details -p trusted-server-core tsjs_script_tag_attributes`. Expected:
+PASS.
+
+Then run `cargo fmt --all -- --check` and `cargo clippy-fastly`. Expected: PASS
+before committing.
+
+- [ ] **Step 9: Commit the Rust hardening change**
+
+```bash
+git add crates/trusted-server-core/src/integrations/registry.rs crates/trusted-server-core/src/tsjs.rs
+git commit -m "Harden publisher tag attributes"
+```
+
+### Task 2: Make bootstrap attribution failures observable
+
+**Files:**
+
+- Modify: `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`
+- Modify: `crates/trusted-server-core/src/integrations/gpt_bootstrap.js`
+- Modify: `crates/trusted-server-core/src/integrations/gpt.rs`
+
+- [ ] **Step 1: Extend the throwing-setConfig test and verify RED**
+
+Install a warning spy with a complete test logger on `window.tsjs` before
+running the bootstrap:
+
+```typescript
+const warn = vi.fn()
+;(window as TestWindow).tsjs = {
+  log: {
+    setLevel: vi.fn(),
+    getLevel: vi.fn(() => 'warn'),
+    info: vi.fn(),
+    warn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}
+```
+
+After executing the queue, assert:
+
+```typescript
+expect(warn).toHaveBeenCalledWith(
+  'GAM attribution targeting failed',
+  expect.any(Error)
+)
+```
+
+Run from `crates/trusted-server-js/lib`:
+
+```bash
+npx vitest run test/integrations/gpt/gpt_bootstrap.test.ts
+```
+
+Expected: FAIL because the catch block does not log.
+
+- [ ] **Step 2: Add guarded warning emission**
+
+```javascript
+} catch (error) {
+  // Attribution must not interrupt the existing bootstrap queue.
+  ts.log && ts.log.warn && ts.log.warn("GAM attribution targeting failed", error);
+}
+```
+
+- [ ] **Step 3: Run the focused Vitest and verify GREEN**
+
+Run the Step 1 Vitest command. Expected: PASS.
+
+- [ ] **Step 4: Apply consistency cleanup**
+
+Change the JavaScript targeting value to `ts: "true"`, update the matching Rust
+string in `gpt.rs` exactly as follows, and remove the unused `getConfig` member
+from `MockGoogleTag`.
+
+```rust
+.find("gpt.setConfig({ targeting: { ts: \"true\" } })")
+```
+
+- [ ] **Step 5: Run focused tests and quality checks**
+
+Run:
+
+```bash
+cd crates/trusted-server-js/lib
+npx vitest run test/integrations/gpt/gpt_bootstrap.test.ts
+cd ../../..
+cargo test_details -p trusted-server-core head_inserts_queue_gam_attribution_before_guard_and_ad_requests
+cargo fmt --all -- --check
+cargo clippy-fastly
+```
+
+Then run `npm run format` from `crates/trusted-server-js/lib`. Expected: PASS
+with no unexpected changes.
+
+- [ ] **Step 6: Commit the bootstrap fixes**
+
+```bash
+git add crates/trusted-server-core/src/integrations/gpt_bootstrap.js crates/trusted-server-core/src/integrations/gpt.rs crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+git commit -m "Log GAM attribution bootstrap failures"
+```
+
+### Task 3: Make EdgeZero guidance capability-based
+
+**Files:**
+
+- Modify: `trusted-server.example.toml`
+- Modify: `docs/guide/integrations/gpt.md`
+
+- [ ] **Step 1: Replace version-specific wording**
+
+Use this GPT example wording:
+
+```toml
+# Keep this leaf present when the environment overlay cannot create a missing
+# configuration leaf. Attribution remains off until explicitly enabled.
+```
+
+In the GPT guide, state: `The environment overlay cannot create a missing
+configuration leaf.` Do not modify the integration fixture or unrelated
+EdgeZero version references.
+
+- [ ] **Step 2: Run documentation and diff checks**
+
+Run `cd docs && npm run format`, then run `git diff --check` from the repository
+root. Expected: both exit successfully with no unrelated changes.
+
+- [ ] **Step 3: Commit the documentation cleanup**
+
+```bash
+git add trusted-server.example.toml docs/guide/integrations/gpt.md
+git commit -m "Clarify GAM attribution overlay requirement"
+```
+
+### Task 4: Verify the complete review resolution
+
+**Files:**
+
+- Verify all files modified in Tasks 1-3
+
+- [ ] **Step 1: Run formatting checks**
+
+Run `cargo fmt --all -- --check`, the JS `npm run format`, and the docs
+`npm run format`. Expected: PASS with no unexpected modifications.
+
+- [ ] **Step 2: Run JavaScript tests**
+
+Run `npx vitest run` from `crates/trusted-server-js/lib`. Expected: PASS.
+
+- [ ] **Step 3: Run target-matched Rust tests**
+
+Run `cargo test-fastly`, `cargo test-axum`, `cargo test-cloudflare`, and
+`cargo test-spin`. Expected: PASS.
+
+- [ ] **Step 4: Run integration parity and CLI tests**
+
+Run:
+
+```bash
+cargo test --manifest-path crates/trusted-server-integration-tests/Cargo.toml --test parity
+./scripts/test-cli.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run all clippy gates**
+
+Run `cargo clippy-fastly`, `cargo clippy-axum`, `cargo clippy-cloudflare`,
+`cargo clippy-cloudflare-wasm`, `cargo clippy-spin-native`, and
+`cargo clippy-spin-wasm`. Expected: PASS.
+
+- [ ] **Step 6: Audit the final diff**
+
+Run `git status --short`, `git diff origin/main...HEAD --check`, and
+`git log --oneline origin/main..HEAD`. Also run:
+
+```bash
+git diff --exit-code HEAD~3..HEAD -- crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml
+git diff --name-only HEAD~3..HEAD
+```
+
+The fixture command must produce no output. The name-only command must contain
+exactly these seven implementation files:
+
+```text
+crates/trusted-server-core/src/integrations/gpt.rs
+crates/trusted-server-core/src/integrations/gpt_bootstrap.js
+crates/trusted-server-core/src/integrations/registry.rs
+crates/trusted-server-core/src/tsjs.rs
+crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts
+docs/guide/integrations/gpt.md
+trusted-server.example.toml
+```
+
+Confirm all six actionable comments are addressed and no unrelated files
+changed.
+
+- [ ] **Step 7: Prepare thread replies**
+
+Draft concise replies describing each change and its verification. Do not push
+commits or post replies without explicit user authorization.

--- a/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
@@ -2,6 +2,8 @@
 
 Date: 2026-07-15
 
+Updated: 2026-08-14
+
 Status: Design
 
 ## Problem
@@ -20,16 +22,17 @@ the experiment marker:
 - it is cleared before later client-side refresh auctions; and
 - it is set on matched slots rather than every GPT request on the page.
 
-The experiment needs a document-delivery marker. Every request issued by the
-document-local GPT PubAds service after marker installation in an HTML document
-successfully rewritten by Trusted Server must contain `ts=true`, including
-initial requests, publisher-owned slots, lazy slots, and refreshes. Production
-documents cannot be modified, so the control cohort remains unmarked.
+The experiment needs a document-delivery marker. When attribution is explicitly
+enabled, every request issued by the document-local GPT PubAds service after
+Trusted Server rewrites and emits the document head must contain `ts=true`,
+including initial requests, publisher-owned slots, lazy slots, and refreshes.
+Production documents cannot be modified, so the control cohort remains
+unmarked.
 
 ## Goals
 
-1. Add `ts=true` to every in-scope GPT PubAds request made during the lifetime
-   of an HTML document successfully rewritten by Trusted Server.
+1. Add `ts=true` to every in-scope GPT PubAds request made after Trusted Server
+   rewrites and emits the document head.
 2. Leave production/control pages unchanged.
 3. Preserve the existing `ts_initial=1` slot-ownership and refresh lifecycle.
 4. Support GAM reports that count treatment impressions and clicks and derive
@@ -38,22 +41,26 @@ documents cannot be modified, so the control cohort remains unmarked.
    performance.
 6. Define the data-quality checks needed when an unmarked request is used as the
    control baseline.
+7. Keep attribution disabled by default and independently reversible without
+   disabling the GPT integration.
 
 ## Non-goals
 
 - Implement or change the cookie-based A/B router. The experiment infrastructure
   owns sticky cohort assignment and routes only the treatment cohort through
   Trusted Server.
-- Prove that a Trusted Server server-side bid won the GAM auction. `ts=true`
-  means that the page was delivered through Trusted Server, regardless of
-  whether the winning demand was a server-side bid, a direct GAM line item, Ad
-  Exchange, or backfill.
-- Mark GAM traffic outside a successfully rewritten document's local GPT PubAds
-  service. IMA/video SDK requests, direct tags, and server-side GAM requests
-  require separate instrumentation and are outside this design. A nested
-  document's GPT instance is in scope only when that nested HTML response is
-  independently routed through Trusted Server and satisfies the same rewrite,
-  ordering, CSP, and audit prerequisites.
+- Prove that a Trusted Server server-side bid won the GAM auction. For an
+  in-scope document satisfying the non-cloned activation prerequisite, `ts=true`
+  means that Trusted Server emitted the document head through its publisher
+  pipeline, regardless of whether the winning demand was a server-side bid, a
+  direct GAM line item, Ad Exchange, or backfill.
+- Mark GAM traffic outside a document-local GPT PubAds service whose head was
+  processed by the enabled publisher attribution pipeline. IMA/video SDK
+  requests, direct tags, and server-side GAM requests require separate
+  instrumentation and are outside this design. Nested inventory is eligible
+  only when its own response is independently routed, rewritten, and validated;
+  the activation attribute is not proof of those facts because publisher code
+  can copy it into `srcdoc` or `document.write` markup.
 - Replace `ts_initial`, `hb_*`, line-item, bidder, or creative reporting.
 - Add a client-side analytics beacon or a Trusted Server telemetry event.
 - Make GAM click tracking more complete. The marker only segments clicks that
@@ -62,14 +69,22 @@ documents cannot be modified, so the control cohort remains unmarked.
 
 ## Assumptions and prerequisites
 
-- The GPT integration is enabled on every page routed into the treatment cohort.
-  A page served through Trusted Server without the GPT integration does not
-  receive the GPT head bootstrap and cannot satisfy this design.
-- The response enters and successfully completes Trusted Server HTML rewriting,
-  contains a literal `<head>` element, and reaches that element before any
-  publisher script issues a GAM request. Pass-through or buffered-unmodified
-  responses, rewrite failures, and origin markup that omits `<head>` cannot
-  satisfy the marker guarantee.
+- The GPT integration and its separate `gam_attribution_enabled` setting are
+  enabled on every Trusted Server deployment receiving treatment traffic. The
+  attribution setting defaults to `false`; enabling GPT alone does not emit the
+  marker or its activation signals.
+- The response enters Trusted Server HTML rewriting, contains a literal `<head>`
+  element, and Trusted Server rewrites and emits that head before any publisher
+  script issues a GAM request. Pass-through or buffered-unmodified responses and
+  origin markup that omits `<head>` cannot satisfy the marker guarantee.
+- On the existing no-post-processor Fastly streaming path, the rewritten head
+  can reach the browser before origin EOF or rewriter finalization. `ts=true`
+  therefore certifies successful head rewrite and emission, not successful
+  completion of the remaining body. A later origin, decode, or rewrite failure
+  can truncate an already marked page; the request remains treatment traffic and
+  the delivery failure is monitored separately. This design adds no response
+  buffering; configurations with HTML post-processors retain their existing
+  buffering behavior.
 - The publisher Content Security Policy allows Trusted Server's bare inline
   scripts to execute. Initial `adSlots`, the GPT enable flag, the GPT bootstrap,
   and the `bids`/`adInit` invocation are all nonce-less inline scripts; Trusted
@@ -77,12 +92,14 @@ documents cannot be modified, so the control cohort remains unmarked.
   policy that blocks those scripts makes the initial TS ad stack inert and is
   ineligible at launch even if it allows the synchronous first-party TSJS
   bundle.
-- Each in-scope HTML document uses one document-local GPT PubAds service. Nested
-  documents are not implicitly covered by a marked parent: each nested HTML
-  response must be independently routed through Trusted Server and rewritten to
-  receive the marker. IMA/video, direct-tag, server-side GAM, and any nested GPT
-  inventory whose document is not independently rewritten must be excluded from
-  the experiment and paired reports.
+- Each in-scope HTML document uses one document-local GPT PubAds service. A
+  marked parent does not mark a nested GPT instance. The publisher-only bundle
+  attribute is deliberately non-secret and can be copied, so the implementation
+  cannot guarantee that an unrewritten nested document never activates the
+  fallback. IMA/video, direct-tag, server-side GAM, and nested inventory not
+  independently routed, rewritten, and validated must be excluded from the
+  experiment and paired reports. A copied activation attribute is a measurement
+  contamination incident, not evidence that the nested document is eligible.
 - Treatment and control traffic use the same GAM network and comparable
   inventory. Report filters can isolate the pages and time window eligible for
   the experiment.
@@ -126,64 +143,103 @@ Add a separate page-level GPT key-value:
 ts=true
 ```
 
+The marker contract is fixed: the target GAM network rejected the longer
+`trusted_server` request name under its enforced 10-character limit. Trusted
+Server therefore emits exactly `ts=true`, with no configurable key or value and
+no alias or dual-write path.
+
+Attribution has a separate, disabled-by-default GPT setting:
+
+```toml
+[integrations.gpt]
+gam_attribution_enabled = false
+```
+
+The equivalent environment override is
+`TRUSTED_SERVER__INTEGRATIONS__GPT__GAM_ATTRIBUTION_ENABLED`. Trusted Server's
+environment overlay only replaces leaves that are present in the TOML source,
+so an operator relying on that override must retain
+`gam_attribution_enabled = false` under `[integrations.gpt]` in the base file.
+When the setting is `false`, enabling GPT preserves current behavior: the dormant
+gated bootstrap code may still be present, but no attribution callback is
+enqueued or executed and no inline attribution flag, bundle activation
+attribute, or fallback is activated. This setting is the attribution kill switch
+and does not disable GPT proxying, script rewriting, the GPT shim, `adInit`, or
+`ts_initial`.
+
+When attribution is enabled, `head_inserts` adds
+`window.__tsjs_gam_attribution_enabled=true` to the integration's existing first
+inline head insert; it does not add a third insert. That inline flag authorizes
+the raw bootstrap's primary marker path. It is deliberately not the bundle
+fallback signal because CSP can block the inline insert that defines it.
+
 The early GPT bootstrap will enqueue page-level targeting before publisher GPT
-commands execute. The enqueue must occur after `window.tsjs` is initialized but
-before the existing `if (ts.adInit) return;` guard:
+commands execute only when the inline attribution flag is exactly `true`. The
+enqueue must occur after `window.tsjs` is initialized but before the existing
+`if (ts.adInit) return;` guard:
 
 ```text
 (function () {
   if (typeof window === "undefined") return;
   var ts = (window.tsjs = window.tsjs || {});
-  var tag = (window.googletag = window.googletag || { cmd: [] });
-  tag.cmd = tag.cmd || [];
-  tag.cmd.push(function () {
-    try {
-      if (typeof googletag.setConfig === "function") {
-        googletag.setConfig({ targeting: { ts: "true" } });
+  var tag;
+  if (window.__tsjs_gam_attribution_enabled === true) {
+    tag = (window.googletag = window.googletag || { cmd: [] });
+    tag.cmd = tag.cmd || [];
+    tag.cmd.push(function () {
+      try {
+        if (typeof googletag.setConfig === "function") {
+          googletag.setConfig({ targeting: { ts: "true" } });
+        }
+      } catch (_) {
+        // Attribution must not interrupt the existing bootstrap.
       }
-    } catch (_) {
-      // Attribution must not interrupt the existing bootstrap.
-    }
-  });
+    });
+  }
 
   if (ts.adInit) return;
-  // Existing initial-load detector and adInit stub follow.
+  // Existing initial-load detector and adInit stub follow, reusing `tag` when
+  // attribution initialized it and preserving their current path otherwise.
 })();
 ```
 
 The exact implementation must follow the repository's JavaScript formatting and
 defensive checks. The important contract is that the page-level targeting
 command is queued by the head bootstrap before the origin page can queue its GPT
-setup or request ads. Page attribution is independent of whether the bootstrap
-needs to install `ts.adInit`, so the existing guard may skip only the ad-init
-stub and detector setup, never the marker enqueue. An unavailable targeting API
-may skip only the marker callback; it must not prevent later queued publisher or
-Trusted Server callbacks from running.
+setup or request ads when attribution is enabled. Page attribution is
+independent of whether the bootstrap needs to install `ts.adInit`, so the
+existing guard may skip only the ad-init stub and detector setup, never an
+enabled marker enqueue. An unavailable targeting API may skip only the marker
+callback; it must not prevent later queued publisher or Trusted Server callbacks
+from running.
 
-The existing initial-load detector immediately below the new marker must reuse
-the initialized `tag.cmd` reference rather than repeat its current
-`(window.googletag = window.googletag || { cmd: [] }).cmd` expression. This
-keeps queue initialization and both bootstrap callbacks on one consistent path.
+The existing initial-load detector immediately below the new marker reuses the
+initialized `tag.cmd` reference when attribution created it and follows its
+current initialization path otherwise. In particular, attribution disabled plus
+a pre-existing `ts.adInit` must still return without creating
+`window.googletag`; the new default-off setting cannot change current runtime
+behavior.
 
 Moving queue initialization above the `ts.adInit` guard intentionally creates a
-standard `window.googletag` command-queue stub on every rewritten, GPT-enabled
-page, including a page where `ts.adInit` already exists and GPT never loads. The
-stub is inert by itself and preserves the marker-before-guard guarantee; it is
-not an accidental behavior to remove during implementation review.
+standard `window.googletag` command-queue stub on every attribution-enabled page,
+including a page where `ts.adInit` already exists and GPT never loads. The stub
+is inert by itself and preserves the marker-before-guard guarantee; it is not an
+accidental behavior to remove during implementation review.
 
 The TypeScript GPT bundle will defensively enqueue the same page-level targeting
 at module initialization after the existing flag-gated shim block and before
-`installTsAdInit()`, only when the existing publisher-page bundle tag carries a
-non-executable GPT activation attribute. The HTML pipeline adds that attribute
-when the GPT integration is enabled. A pre-existing `ts.adInit` is already
-covered by placing the bootstrap marker before the guard and is not a reason for
-the fallback.
+`installTsAdInit()`, only when the executing publisher-page bundle tag carries
+the non-executable `data-ts-gam-attribution="true"` attribute. The HTML pipeline
+adds that attribute only when GPT and `gam_attribution_enabled` are both enabled.
+A pre-existing `ts.adInit` is already covered by placing the bootstrap marker
+before the guard and is not a reason for the fallback.
 
 The fallback exists to preserve delivery-path attribution if the inline
 bootstrap unexpectedly stops executing while the synchronous first-party bundle
 still runs before publisher GPT. It does not recover `adSlots`, bids, the
 `adInit` invocation, or the initial TS auction: those are also nonce-less inline
-scripts. A fallback-only marker therefore still truthfully means "page delivered
+scripts. On an eligible publisher document whose activation tag was not copied,
+a fallback-only marker therefore still truthfully means "document head emitted
 through Trusted Server," but it also indicates a deployment state that was
 ineligible at launch. Synthetic validation must treat that state as a
 measurement incident, pause interpretation, and exclude the affected time window
@@ -228,12 +284,15 @@ An in-scope GAM request is in the treatment cohort when it contains:
 ts=true
 ```
 
-The marker means:
+For an in-scope document that satisfies the non-cloned activation prerequisite,
+the marker means:
 
-> The containing page was delivered through Trusted Server.
+> Trusted Server rewrote and emitted the containing document's `<head>` through
+> the enabled publisher attribution pipeline before the in-scope GPT request.
 
 It does not mean:
 
+- the complete streamed response reached the browser or finished rewriting;
 - a Trusted Server bidder returned a bid;
 - a Trusted Server bid won;
 - Trusted Server rendered the winning creative; or
@@ -251,10 +310,10 @@ with the A/B router's expected cookie cohort share.
 
 ### Relationship to `ts_initial`
 
-| Key            | Scope      | Lifetime                     | Meaning                                   |
-| -------------- | ---------- | ---------------------------- | ----------------------------------------- |
-| `ts=true`      | Page-level | Entire browser page lifetime | Page was delivered through Trusted Server |
-| `ts_initial=1` | Slot-level | Initial TS-managed request   | Initial slot request was prepared by TS   |
+| Key            | Scope      | Lifetime                     | Meaning                                             |
+| -------------- | ---------- | ---------------------------- | --------------------------------------------------- |
+| `ts=true`      | Page-level | Entire browser page lifetime | Eligible, non-cloned TS pipeline emitted page head  |
+| `ts_initial=1` | Slot-level | Initial TS-managed request   | Initial slot request was prepared by Trusted Server |
 
 The two keys answer different questions and coexist. No code or report should
 infer that one is an alias for the other. The value contract is exactly
@@ -268,6 +327,7 @@ Sticky A/B cookie
   -> control: browser receives production page
        -> publisher GPT runs without the `ts` key
   -> treatment: request is routed through Trusted Server
+       -> deployment has `gam_attribution_enabled = true`
        -> GPT head bootstrap queues page-level `ts=true`
        -> GPT bundle defensively queues the same marker
        -> GPT library drains the command queue
@@ -287,23 +347,55 @@ The marker covers:
 
 All bullets refer to slots using the same document-local GPT PubAds service.
 Requests from IMA/video SDKs, direct tags, or server-side GAM integrations are
-not covered merely because the containing document is marked. A nested GPT
-instance is marked only when Trusted Server separately rewrites that nested
-document and injects the attribution paths into its own `<head>`.
+not covered merely because the containing document is marked. Nested inventory
+is eligible only when Trusted Server separately routes and rewrites that
+document and validation proves the same request and report contract. Because a
+publisher can copy the non-secret activation tag into `srcdoc` or
+`document.write` content, marker presence alone does not prove that a nested
+document was independently rewritten.
 
 A full browser navigation creates a new page and repeats cookie-based routing.
-The new page receives the marker only when that navigation is routed through
-Trusted Server.
+The new page receives the marker only when that navigation is routed through a
+Trusted Server deployment with `gam_attribution_enabled = true`, its head is
+rewritten and emitted, and a marker callback successfully applies page-level
+targeting before its first in-scope GPT request.
 
 ## Component changes
+
+### GPT configuration and head activation
+
+`crates/trusted-server-core/src/integrations/gpt.rs` will add
+`gam_attribution_enabled: bool` to `GptConfig` with Serde's ordinary `false`
+default. Configuration tests must cover an omitted field, explicit `false`,
+explicit `true`, and an environment override whose base TOML includes the leaf.
+The example configuration will show the field as disabled.
+
+`GptIntegration::head_inserts` keeps its current number and order of scripts.
+When attribution is enabled, it appends the inline attribution flag to the
+existing GPT enable/shim insert; when disabled, that insert remains byte-for-byte
+equivalent to its current behavior apart from formatting that does not affect
+execution.
+
+The same parsed `GptConfig` instance must authorize the publisher bundle-tag
+attribute without reparsing settings or relying on head-insert side effects.
+Add a default-empty `IntegrationHeadInjector::tsjs_script_tag_attributes()`
+hook, override it in `GptIntegration` to return only
+`data-ts-gam-attribution="true"` when attribution is enabled, and aggregate the
+attributes through `IntegrationRegistry`. `html_processor.rs` passes that
+registry-owned attribute list to a new publisher-only
+`tsjs_script_tag_with_attributes` helper. Keep the existing
+`tsjs_script_tag` and `tsjs_unified_script_tag` output unchanged for creative,
+test, and other generic callers. This makes the bootstrap and fallback derive
+from one integration-owned setting while avoiding a GPT-specific
+`HtmlProcessorConfig` field or order-dependent document-state mutation.
 
 ### Early GPT bootstrap
 
 `crates/trusted-server-core/src/integrations/gpt_bootstrap.js` owns the
 behavior. It will set the page-level key in its earliest GPT command callback,
-before the `ts.adInit` early-return guard. The targeting code stays inside the
-existing raw bootstrap script returned by `head_inserts`; it must not add a
-third head insert.
+before the `ts.adInit` early-return guard, only when the inline attribution flag
+is exactly `true`. The targeting code stays inside the existing raw bootstrap
+script returned by `head_inserts`; it must not add a third head insert.
 
 The operation must be idempotent. Calling
 `googletag.setConfig({ targeting: { ts: 'true' } })` more than once with the
@@ -324,34 +416,38 @@ initialization after the existing flag-gated `installGptShim()` block and before
 `installTsAdInit()` when the publisher-page bundle's activation attribute is
 present. The helper creates or reuses the standard GPT command queue, enqueues
 the same defensive `setConfig({ targeting: { ts: 'true' } })` call, and does not
-read the experiment cookie or wait for an auction. Extend the local `GoogleTag`
-interface with optional `setConfig?(config: Record<string, unknown>): void` so
-the fallback remains defensive when the API is unavailable.
+read the experiment cookie or wait for an auction. The existing optional
+`GoogleTag.setConfig` method and `GoogleTagConfig extends Record<string,
+unknown>` types already cover this call and must be reused rather than extended.
 
 The bootstrap remains the primary path because it is injected first. The bundle
 call is a redundant fallback and must not delay module initialization, create a
-request, or add slot-level targeting. A plain GPT module import without the
-activation attribute must preserve the existing runtime-gating contract and must
-not create `window.googletag`.
+request, or add slot-level targeting. The attribution helper must not create
+`window.googletag` independently when the activation attribute is absent. A
+standalone module import with neither the existing GPT-enable flag nor the new
+attribute must preserve the current runtime-gating contract and leave
+`window.googletag` untouched.
 
 ### Non-executable bundle activation
 
 The publisher HTML pipeline in
 `crates/trusted-server-core/src/html_processor.rs`, using a separate,
 publisher-page-only tag helper in `crates/trusted-server-core/src/tsjs.rs`, will
-add a `data-ts-gpt-enabled="true"` attribute to the existing synchronous
-`#trustedserver-js` bundle tag when GPT is enabled. The attribute is data, not
-an inline executable, so CSP can block the inline GPT head inserts while still
-allowing the external bundle to detect that it owns page attribution.
+add a `data-ts-gam-attribution="true"` attribute to the existing synchronous
+`#trustedserver-js` bundle tag only when GPT and `gam_attribution_enabled` are
+both enabled. The attribute is data, not an inline executable, so CSP can block
+the inline GPT head inserts while still allowing the external bundle to detect
+that it owns page attribution.
 
 At module initialization, the GPT bundle captures `document.currentScript` and
-requires that executing synchronous script to carry `data-ts-gpt-enabled="true"`
-before the fallback may create a GPT stub. It must fail closed when the
-executing script cannot be identified. Do not authorize activation through a
-global `#trustedserver-js` lookup: the generic unified tag uses the same ID in
-creative and test contexts, and duplicate IDs could select the wrong element.
-Binding the signal to the executing tag keeps the activation decision explicit
-and testable without relying on an inline global flag.
+requires that executing synchronous script to carry
+`data-ts-gam-attribution="true"` before the fallback may create a GPT stub. It
+must fail closed when the executing script cannot be identified. Do not
+authorize activation through a global `#trustedserver-js` lookup: the generic
+unified tag uses the same ID in creative and test contexts, and duplicate IDs
+could select the wrong element. Binding the signal to the executing tag keeps
+the activation decision explicit and testable without relying on an inline
+global flag.
 
 The existing `window.__tsjs_gpt_enabled` flag continues to activate
 `installGptShim()` when inline scripts run. It cannot activate the CSP fallback
@@ -368,46 +464,47 @@ bundle outside the publisher GPT integration. Do not add a new script tag or
 change the integration's existing head-insert count.
 
 Extend the `tsjs.rs` and `html_processor.rs` tests to prove that the existing
-publisher-page bundle tag gains the activation attribute only when GPT is in the
-enabled immediate module set, remains a single external tag, and omits the
-attribute for non-GPT publisher bundles and generic all-modules tags. Bundle
-tests must also prove that an unrelated or duplicate element with
-`id="trustedserver-js"` cannot activate the fallback.
+publisher-page bundle tag gains the activation attribute only when GPT and
+`gam_attribution_enabled` are both enabled, remains a single external tag, and
+omits the attribute for attribution-disabled, non-GPT, and generic all-modules
+bundles. Bundle tests must also prove that an unrelated or duplicate element
+with `id="trustedserver-js"` cannot activate the fallback.
 
 ### GPT Rust integration tests
 
 `crates/trusted-server-core/src/integrations/gpt.rs` already tests the embedded
 bootstrap returned by `head_inserts`. Extend those tests to prove that:
 
-- the bootstrap contains page-level `ts=true` targeting;
+- omitted and explicit-false configuration emit neither the inline attribution
+  flag nor publisher-tag attribute metadata;
+- explicit-true configuration emits the inline attribution flag and exposes the
+  publisher-tag attribute metadata;
+- the bootstrap contains the flag-gated page-level `ts=true` targeting;
 - the marker enqueue appears before the `if (ts.adInit) return;` guard;
 - the targeting setup is queued before `ts.adInit` can issue `display` or
   `refresh`;
 - the existing `ts_initial` marker remains present; and
-- the enabled integration without `slim_prebid_url` still emits exactly the
+- the attribution-enabled integration without `slim_prebid_url` still emits
+  exactly the
   existing two head inserts, proving the marker was added to the bootstrap
   instead of a new tag.
 
 ### Bootstrap execution tests
 
-Add `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`
-as a Vitest/jsdom behavioral test for the raw bootstrap. The test reads
-`crates/trusted-server-core/src/integrations/gpt_bootstrap.js` with Node's
-`readFileSync`, resolves the source path relative to `import.meta.url` rather
-than the process working directory, and creates an isolated
-`new JSDOM(html, { runScripts: 'outside-only' })` realm. Before evaluating the
-exact source with that realm's `window.eval`, the test must assert that
-`globalThis === window` and `typeof global === 'undefined'` inside the realm.
-This is required because Vitest's default jsdom `window.eval` runs in Node's
-realm under the current configuration. The harness supplies a minimal mocked GPT
-command queue and `pubads` service. It must not evaluate the source in Node's
-global context, copy the bootstrap into a test fixture, or add a JavaScript
-runtime dependency to Rust.
+Extend the existing
+`crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`
+Vitest/jsdom behavioral test for the raw bootstrap. Preserve its established
+`process.cwd()` source resolution and `new Function(BOOTSTRAP_SOURCE)` execution
+strategy unless a separate test-harness change demonstrates a concrete need to
+replace them. The tests continue to execute the checked-in raw source rather
+than a copied fixture and add no JavaScript runtime dependency to Rust.
 
 The harness must prove that:
 
-- the attribution callback is queued before a publisher callback added after the
-  injected bootstrap;
+- attribution disabled preserves the existing pre-installed-`ts.adInit` behavior
+  without creating `window.googletag`;
+- attribution enabled queues the callback before a publisher callback added
+  after the injected bootstrap;
 - draining the queue calls `googletag.setConfig` with page-level `ts=true`
   before the publisher callback runs;
 - a pre-existing `ts.adInit` does not prevent the attribution callback from
@@ -428,10 +525,14 @@ its existing dynamic-import and `vi.resetModules()` pattern. Prove that module
 initialization with the bundle activation attribute queues page-level `ts=true`
 after any existing flag-gated shim installation and before installing
 `ts.adInit`, that it reuses an existing GPT command queue, and that unavailable
-or throwing `setConfig` does not stop the remaining GPT module installers.
-Retain the existing assertion that a plain module import without an activation
-signal does not create `window.googletag`. A duplicate call after the bootstrap
-must remain safe and must not create another script or network request.
+or throwing `setConfig` does not stop the remaining GPT module installers. The
+attribution helper must not create a stub independently when its attribute is
+absent: a standalone import with neither the existing GPT-enable flag nor the
+new attribute leaves `window.googletag` untouched. An attribution-disabled but
+GPT-enabled deployment preserves today's flag-gated shim and stub behavior; it
+only omits the attribution callback and fallback. A duplicate call after the
+bootstrap must remain safe and must not create another script or network
+request.
 
 ### Slot cleanup constraints
 
@@ -445,11 +546,18 @@ No refresh-lifecycle change is required. In particular:
 Leaving these components unchanged is part of the design: slot cleanup cannot
 remove a page-level key set through `googletag.setConfig`.
 
+No new `CreativeOpportunitySlot` parsing, filtering, or startup validation is
+added. Trusted Server continues accepting and forwarding operator targeting
+maps verbatim. The external launch audit—not runtime code—must reject an
+effective configuration containing slot-level `ts`.
+
 ### Documentation
 
 Document the distinction between page-level `ts=true` and slot-level
 `ts_initial=1` in `docs/guide/integrations/gpt.md`, near the existing command
-queue documentation. Include the GAM setup and reporting preconditions below; do
+queue documentation. Document `gam_attribution_enabled`, its default-off and
+kill-switch behavior, the fixed marker contract, and the GAM setup and reporting
+preconditions below. Add the disabled field to `trusted-server.example.toml`; do
 not add this current integration to a planned-future GAM document.
 
 ## GAM configuration
@@ -457,49 +565,58 @@ not add this current integration to a planned-future GAM document.
 GAM configuration is a deployment prerequisite and must be completed before the
 experiment starts because key-value reporting is not retroactive.
 
-The request contract is `ts=true`: key name `ts`, predefined value `true`. The
-key name is provisional pending a GAM preflight (see issue #1027). The GPT/GAM
-`CustomTargetingKey.name` (the code sent in the ad request) is documented as
-limited to 10 characters in the SOAP/REST API, which would rule out a fuller
-name such as `trusted_server` (14); other Help Center material implies 20, and
-these describe different provisioning surfaces, so the enforced limit must be
-confirmed in the target network before the contract is fixed. If the confirmed
-limit permits a longer name, a more descriptive, less collision-prone key is
-preferred over `ts`. Because `ts` is short, it carries a real collision risk with
-common publisher timestamp or cache-buster keys, which makes the cross-system
-collision audit a hard launch gate, not a formality. If any publisher, Trusted
-Server configuration, or GAM object already uses `ts`, the experiment must stop
-until the collision is removed or the contract is explicitly revised everywhere
-before treatment traffic begins.
+The request contract is finalized as key name `ts`, predefined value `true`.
+The target-network preflight rejected `trusted_server` (14 characters) under
+the enforced 10-character request-name limit, consistent with the SOAP/REST
+`CustomTargetingKey` contract. Because `ts` is short, it carries a real collision
+risk with common publisher timestamp or cache-buster keys, which makes the
+cross-system collision audit a hard launch gate, not a formality. If any
+publisher, Trusted Server configuration, Prebid targeting source, or GAM object
+already uses `ts`, the experiment must stop until the collision is removed.
+Changing the finalized contract or silently filtering established targeting is
+out of scope.
 
-1. In **Inventory > Key-values**, create or verify a key whose request name is
-   the finalized marker key (`ts` pending the preflight in issue #1027). When the
-   key is created, confirm the enforced key-name and value length limits on the
-   provisioning surface actually used: the SOAP/REST
-   [`CustomTargetingKey`](https://developers.google.com/ad-manager/api/reference/v202511/CustomTargetingService.CustomTargetingKey)
-   documents a 10-character key-`name` limit and a 40-character value limit, but
-   the UI surface may differ, so verify against the target network rather than
-   assuming.
+1. In **Inventory > Key-values**, create or verify the `ts` key and retain the
+   target-network preflight result with the experiment runbook. The SOAP/REST
+   [`CustomTargetingKey`](https://developers.google.com/ad-manager/api/reference/v202605/CustomTargetingService.CustomTargetingKey)
+   documents the enforced 10-character request-name limit and a 40-character
+   value limit.
 2. Use a predefined value named `true`.
-3. Enable `ts` as a dedicated reportable Enhanced key-value dimension. If the
-   network does not support Enhanced key-value dimensions, use a report filtered
-   to the single legacy key-value `ts=true`; never sum unfiltered legacy
-   **Key-values** dimension rows.
+3. Preflight whether the target network has Enhanced key-value reporting and
+   confirm the publisher has approved its Premium reporting activation and
+   displayed CPM terms, minimum/maximum charge, and non-prorated monthly billing.
+   Record the result. If approved and compatible with the selected metrics,
+   enable `ts` as a dedicated Enhanced dimension. Otherwise, enable `ts` for
+   legacy reporting and prove with a target-network dry run that the exact
+   legacy `ts=true` filter and chosen metrics are available; never sum unfiltered
+   legacy **Key-values** rows. See
+   [Access Premium reporting](https://support.google.com/admanager/answer/16176700)
+   and [Report on targeting keys](https://support.google.com/admanager/answer/14528835).
 4. Reserve `ts` for Trusted Server page attribution.
 5. Audit existing publisher GPT code and every GAM object that consumes custom
    targeting for an existing `ts` key before deployment. This includes line
    items, proposal line items, rules, protections, yield configuration, and any
    network-specific custom-targeting surface.
-6. Audit every `CreativeOpportunitySlot.targeting` map from all effective
+6. Audit Prebid-generated GPT targeting, including `pbjs.bidderSettings`, each
+   bidder's and standard key's `adserverTargeting`, and every call to
+   `setTargetingForGPTAsync`. Record every path capable of producing a slot-level
+   `ts`; any occurrence is a launch blocker because GPT slot targeting overrides
+   the page-level value.
+7. Audit every `CreativeOpportunitySlot.targeting` map from all effective
    `trusted-server.toml` configuration sources. The arbitrary operator-supplied
    map is copied to GPT slots, where a slot-level `ts` value would override the
    page-level marker. Any occurrence is a launch blocker; do not silently
    discard it because that could change established operator targeting.
-7. Audit publisher code for every operation that can remove or supersede the
+8. Audit publisher code for every operation that can remove or supersede the
    marker after initial GPT setup. Search for `setConfig({ targeting: null })`,
    a `ts: null` or different `ts` value, `pubads().clearTargeting()` with no key
    or with `ts`, and slot-level `ts` targeting. Account for equivalent calls
    assembled dynamically.
+
+The runbook records the audit owner, exact queries or search procedures, result
+artifact, timestamp, and re-audit trigger. A deployment, publisher GPT, Prebid,
+or GAM targeting change affecting the audited surfaces invalidates the prior
+result and blocks attribution until the audit is repeated.
 
 The audit is a hard precondition. If `ts` already has another meaning, or any
 GAM object targets or acts on `ts=true`, the experiment owner must resolve the
@@ -526,12 +643,19 @@ Every comparison must apply identical filters for:
 - geography and device categories, when used; and
 - any consent or traffic-quality exclusions.
 
+Before launch, the experiment owner freezes an authoritative scope manifest
+containing those values, the eligible route/site inventory, exact ad-unit list,
+owner, version, and activation timestamp. Report A, Report B, router/access-log
+queries, synthetic URLs, and any external denominators must all reference that
+same manifest. A scope change closes the current reporting window and requires a
+new manifest version and fresh preflight.
+
 Do not compare the TS cohort with all unmarked network traffic unless all that
 traffic is eligible for the same experiment. Likewise, exclude smoke tests,
 direct hits, operations traffic, and any other TS-served page outside the cookie
 experiment. The marker identifies the delivery path, not the router's cohort
-assignment, so all such requests also carry `ts=true` when the GPT integration
-runs.
+assignment, so all such requests also carry `ts=true` when attribution is
+enabled for their Trusted Server deployment.
 
 The route owner must use router or access logs to prove that non-experiment TS
 traffic is absent from the eligible inventory during the measurement window. If
@@ -540,21 +664,28 @@ dimension, GAM cannot remove it from Report B because its marker is identical to
 the cohort marker; the experiment must not launch. Record the owner, query,
 expected zero threshold, and response procedure in the experiment runbook.
 
+Before treatment routing begins, run and retain a zero-count query for every
+excluded path: non-experiment Trusted Server traffic, smoke/direct/operations
+traffic, IMA/video, direct tags, server-side GAM, and excluded nested inventory.
+Any non-zero result blocks launch unless an independent dimension excludes the
+same traffic from both saved reports.
+
 ### Cohort calculations
 
-Use two reports with identical date boundaries, time zone, inventory filters,
-traffic-quality filters, and metric definitions:
+Create and retain two saved reports with identical date boundaries, time zone,
+inventory filters, traffic-quality filters, and metric definitions:
 
 1. **Report A — experiment total.** Do not include **Placement**, legacy
    **Key-values**, **Targeting**, **Yield group**, or another dimension that can
    represent one event more than once. This report provides one non-duplicated
    total for every metric in the eligible experiment scope.
 2. **Report B — TS treatment.** Use the dedicated Enhanced `ts` dimension
-   filtered to `ts=true`. If Enhanced key-value dimensions are unavailable, use
-   the legacy **Key-values** dimension filtered to exactly `ts=true` and do not
-   sum any other key-value rows. Do not add **Placement**, **Targeting**,
-   **Yield group**, or any unrelated dimension that can represent the filtered
-   treatment event more than once.
+   filtered to `ts=true`. If Enhanced key-value dimensions are unavailable,
+   unapproved, or incompatible with the saved metric pair, use the legacy
+   **Key-values** dimension filtered to exactly `ts=true` and do not sum any
+   other key-value rows. Do not add **Placement**, **Targeting**, **Yield
+   group**, or any unrelated dimension that can represent the filtered treatment
+   event more than once.
 
 The legacy **Key-values** dimension can emit the same impression or click on
 multiple rows when a request contains multiple key-values. It therefore cannot
@@ -582,6 +713,19 @@ Export both reports after the same GAM reporting-latency and invalid-traffic
 adjustment window. If GAM restates one report, rerun the pair before applying
 the subtraction.
 
+For every paired metric and reporting window, validate:
+
+```text
+0 <= Report B <= Report A
+derived_control = Report A - Report B
+```
+
+A negative derived control, Report B greater than Report A, mismatched report
+definition, incompatible metric, missing saved definition, or non-zero excluded
+traffic is a fail-closed reporting incident. Do not publish or interpret that
+window; correct the inputs and rerun the complete pair after the same reporting
+latency and invalid-traffic adjustment window.
+
 Use total metrics when the goal includes all GAM demand sources. GAM's
 `Ad server impressions` and `Ad server clicks` metrics exclude Ad Exchange and
 AdSense, so those narrower metrics should only be used when that exclusion is
@@ -589,30 +733,33 @@ intentional. GAM counts impressions and clicks according to its own tracking
 rules; adding `ts=true` does not create new impression or click trackers. See
 [Counting impressions and clicks](https://support.google.com/admanager/answer/2521337).
 
-Both reports must use the same non-targeted impression and click metric names.
-Do not use targeted-impression or targeted-click metrics for this attribution:
-`ts` is intentionally forbidden from line-item targeting, so metrics limited to
-keys used for targeting do not represent the requested delivery-path cohort.
-Record the exact selected GAM metric names with the saved report definitions
-before launch.
+Both reports must use the same metric names, and the target-network dry run must
+prove that each metric is compatible with the chosen Enhanced or legacy
+dimension and filters. Prefer non-targeted impression and click metrics because
+`ts` is forbidden from line-item targeting; targeted metrics limited to keys
+used for targeting do not represent this delivery-path cohort. If GAM cannot
+produce an identical compatible metric in both reports, omit that metric rather
+than substitute different definitions. Record the exact selected metric names
+and successful dry-run exports before launch.
 
-### Unequal cohort sizes
+### Descriptive rates for unequal cohort sizes
 
 The treatment cohort is intentionally small, so raw TS and production totals are
-not directly comparable. Reports should show the raw counts, but experiment
-conclusions should compare normalized measures where compatible metrics are
-available:
+not directly comparable. GAM may show raw counts and descriptive normalized
+rates where compatible metrics are available:
 
 - impressions per GAM ad request;
 - fill rate;
 - clicks per impression (CTR); and
 - revenue per thousand impressions or requests.
 
-Impressions per routed pageview or per assigned visitor require a denominator
-from the A/B router or site analytics. GAM alone cannot identify unmarked
-production pageviews that made no ad request. Any cross-system experiment
-analysis is outside the implementation but should use the same time and
-eligibility filters.
+These rates describe GAM delivery; they do not estimate a causal treatment
+effect. Impressions per routed pageview or per assigned visitor require a
+denominator from the A/B router or site analytics because GAM cannot identify
+unmarked production pageviews that made no ad request. Any causal analysis is
+outside this implementation and requires a separately approved design defining
+the eligible population, router/site denominators, analysis window, and stopping
+rules.
 
 ### Data-quality checks
 
@@ -631,9 +778,16 @@ A gap between expected and observed treatment share is a measurement incident,
 not evidence of production performance, until missing-marker and request-volume
 differences are ruled out. Because router assignment and GAM delivery normally
 use page or visitor counts versus ad-request or impression counts, this share
-comparison is a diagnostic rather than direct proof of marker coverage. It can
-measure coverage directly only when the router or site analytics supplies a
-matched request- or page-level denominator.
+comparison is a diagnostic rather than direct proof of marker coverage. A
+request-correlated router or site denominator can strengthen the aggregate
+coverage estimate, but without new request-correlated telemetry it still cannot
+prove marker presence on every production request.
+
+Neither aggregate share nor a scheduled synthetic sample proves that every
+production response or ad request carried the expected marker. Automated tests
+establish code-path invariants; production checks provide sampled operational
+evidence. The runbook must not describe either diagnostic as per-response
+coverage telemetry.
 
 Checks 2–3 use a scheduled synthetic browser crawl of representative experiment
 URLs. The crawler supplies known treatment and control cookies, captures GAM
@@ -647,11 +801,11 @@ On treatment URLs with matched creative opportunities, the crawler must also
 detect the fallback-only CSP state: capture CSP violations and verify that the
 injected `adSlots`, `bids`, and initial `adInit` handoff executed. A page that
 has `ts=true` only because the external bundle ran, while those inline scripts
-were blocked, remains correctly marked as TS-delivered but raises a measurement
-incident. Since GAM cannot separate those requests afterward, the incident owner
-must pause interpretation and exclude the affected time range from both reports
-when clean boundaries can be established; otherwise the experiment result is
-invalid.
+were blocked, remains correctly marked as having a TS-emitted head but raises a
+measurement incident. Since GAM cannot separate those requests afterward, the
+incident owner must pause interpretation and exclude the affected time range
+from both reports when clean boundaries can be established; otherwise the
+experiment result is invalid.
 
 ## Failure handling
 
@@ -659,14 +813,24 @@ The marker is best-effort instrumentation and must never block ads or page
 delivery.
 
 - If GPT never loads, there is no GAM request to classify.
-- If a response is not successfully HTML-rewritten, has no literal `<head>`, or
-  issues an in-scope GPT request before the injected head content runs, neither
-  targeting path can mark that request. Such traffic is ineligible for the
-  experiment and must be detected before launch or excluded from analysis.
+- If attribution is disabled, the dormant gated bootstrap source may remain, but
+  no attribution callback is enqueued or executed and no activation flag or
+  attribute is emitted; GPT otherwise keeps its current behavior.
+- If Trusted Server does not rewrite and emit a literal `<head>`, or an in-scope
+  GPT request occurs before the injected head content runs, neither targeting
+  path can mark that request. Such traffic is ineligible for the experiment and
+  must be detected before launch or excluded from analysis.
+- If an origin, decoder, or rewriter failure occurs after Fastly emitted the
+  rewritten head, the browser may already have queued `ts=true`. Any resulting
+  request remains treatment because the marker represents head delivery, not
+  full-response completion. The client may receive a truncated document; the
+  delivery failure is logged and investigated separately rather than being
+  reclassified as control.
 - If CSP blocks Trusted Server's nonce-less inline scripts, the initial TS ad
   stack is inert and the page is ineligible even when the first-party bundle
-  queues the attribution marker. The fallback prevents a TS-delivered page from
-  leaking into the inferred control cohort; it does not make the deployment
+  queues the attribution marker. The fallback prevents a page whose head was
+  emitted through Trusted Server from leaking into the inferred control cohort;
+  it does not make the deployment
   healthy. If CSP blocks both inline scripts and the bundle, attribution also
   fails.
 - If `googletag.setConfig` is unavailable when a queued command runs, the
@@ -677,6 +841,10 @@ delivery.
   applies slot-level `ts`, GPT gives the slot-level value precedence. The
   deployment audit prevents this collision; runtime filtering or interception is
   out of scope because it could silently alter established targeting behavior.
+- If Prebid `bidderSettings`, bidder or standard `adserverTargeting`, or
+  `setTargetingForGPTAsync` applies slot-level `ts`, the slot value can supersede
+  the page marker. The launch audit and characterization tests cover these paths;
+  Trusted Server does not filter or intercept them.
 - If publisher code calls `setConfig({ targeting: null })`, sets `ts: null` or a
   different value, calls legacy `pubads().clearTargeting()` for all keys or for
   `ts`, or applies slot-level `ts`, the effective marker can be removed or
@@ -692,35 +860,39 @@ added by this feature.
 ## Privacy and consent
 
 `ts=true` contains no unique user identifier, cookie value, page URL, or auction
-data. It describes only the delivery path of the current document. Because only
-the cookie-sticky treatment cohort is routed through Trusted Server for this
-experiment, the value also reveals treatment-path membership for that GAM
-request. It is therefore cohort information even though it does not expose the
-assignment cookie or identify a person by itself.
+data. Its intended meaning is the head-delivery path of an eligible document;
+outside that scope, copied activation is contamination rather than proof of
+delivery. Because only the cookie-sticky treatment cohort is routed through
+Trusted Server for this experiment, the value also reveals treatment-path
+membership for that GAM request. It is therefore cohort information even though
+it does not expose the assignment cookie or identify a person by itself.
 
 The implementation does not read the experiment cookie. Routing happens before
 Trusted Server handles the request. Existing consent gates continue to decide
 whether GAM requests or auctions occur. The marker does not create an ad request
-that would otherwise be suppressed. Before enabling the key, the experiment
-owner must complete the publisher's privacy/data-governance review for sending
-this treatment-path attribute to GAM and confirm that existing consent and
-data-use terms cover it.
+that would otherwise be suppressed. Before enabling
+`gam_attribution_enabled`, the experiment owner must complete the publisher's
+privacy/data-governance review for sending this treatment-path attribute to GAM
+and confirm that existing consent and data-use terms cover it.
 
 ## Testing strategy
 
 ### Automated tests
 
-1. Extend Rust GPT head-insert tests to assert page-level `ts=true` targeting is
-   in the existing raw bootstrap, occurs before the `ts.adInit` guard and any
-   bootstrap `display()` or `refresh()` call, and does not change the expected
-   head-insert count.
+1. Extend GPT configuration and head-insert tests for omitted, false, and true
+   `gam_attribution_enabled` values. Assert that the true case authorizes
+   page-level `ts=true` before the `ts.adInit` guard and any bootstrap `display()`
+   or `refresh()` call without changing the expected head-insert count; false
+   must preserve current output and behavior.
 2. Extend the TSJS tag and HTML processor tests to prove the non-executable GPT
-   activation attribute appears only on the enabled publisher-page bundle and
-   adds no script tag.
-3. Add the Vitest/jsdom raw-bootstrap harness described above. Exercise the
+   activation attribute appears only when GPT and attribution are both enabled
+   on the publisher-page bundle and adds no script tag.
+3. Extend the existing Vitest/jsdom raw-bootstrap harness described above.
+   Exercise the
    bootstrap with `googletag.setConfig` available, unavailable, and throwing,
-   and prove a later publisher callback still runs in every case. Set
-   `window.tsjs.adInit` before evaluation and prove the marker still runs.
+   and prove a later publisher callback still runs in every enabled case. Prove
+   the disabled case preserves existing behavior, then set `window.tsjs.adInit`
+   before evaluation and prove only the enabled marker still runs.
 4. Extend the existing GPT bundle tests to prove module initialization queues
    the fallback marker and remains non-blocking when `setConfig` is unavailable
    or throws.
@@ -732,12 +904,30 @@ data-use terms cover it.
    operator targeting map is forwarded verbatim, documenting why the deployment
    audit must reject a configured `ts` key rather than assuming the client
    overwrites or filters it.
-8. Run the project-required target-matched Rust and JavaScript checks for the
-   touched files.
+8. Add Prebid characterization tests covering `bidderSettings`, custom
+   `adserverTargeting`, and `setTargetingForGPTAsync` so a generated slot-level
+   `ts` collision is visible and remains a launch-audit responsibility rather
+   than being silently filtered.
+9. Extend no-post-processor streaming regression coverage to prove an
+   attribution-enabled Fastly response can emit the marked rewritten head before
+   origin EOF. Preserve the existing later-error/truncation behavior,
+   documenting that the marker does not certify complete response delivery and
+   adds no buffering.
+10. Add focused Vitest/jsdom bundle-DOM coverage for the synchronous publisher
+    tag, proving `document.currentScript` is the attributed element and
+    false/non-publisher/duplicate-tag cases fail closed. Characterize a publisher
+    copying the attributed tag through `srcdoc` or `document.write`: the clone can
+    activate the fallback, so tests must not encode the false guarantee that only
+    independently rewritten nested documents can be marked. Manual browser/GAM
+    validation below covers the real deployed bundle without expanding the
+    repository's single-config Playwright harness.
+11. Run the project-required target-matched Rust and JavaScript checks for the
+    touched files.
 
 ### Browser/GAM validation
 
-Before experiment launch:
+Before experiment launch, with `gam_attribution_enabled = true` on the treatment
+deployment:
 
 1. Load a treatment page using a known treatment cookie.
 2. Confirm the initial in-scope GAM request contains `ts=true` using GPT
@@ -746,57 +936,77 @@ Before experiment launch:
    `ts=true`.
 4. Load the equivalent production page with a control cookie and confirm the key
    is absent.
-5. Confirm `ts_initial=1` remains limited to its existing initial-slot
+5. Disable `gam_attribution_enabled` on a Trusted Server validation deployment
+   and confirm GPT still functions while the inline flag, activation attribute,
+   and `ts` request key are absent.
+6. Confirm `ts_initial=1` remains limited to its existing initial-slot
    lifecycle.
-6. Validate the deployed CSP by proving `adSlots`, the GPT bootstrap, `bids`,
+7. Validate the deployed CSP by proving `adSlots`, the GPT bootstrap, `bids`,
    and the initial `adInit` handoff execute on a representative page with
    matched slots. A page that runs only the external bundle is ineligible even
    if the fallback marker appears.
-7. Set an unrelated page-level targeting key after `ts=true` and confirm both
+8. Set an unrelated page-level targeting key after `ts=true` and confirm both
    keys remain on a later request. Treat an explicit page-level or per-key clear
    as a failed publisher-code audit, not supported behavior.
-8. Validate that IMA/video, direct-tag, server-side GAM, and nested GPT
+9. Validate that IMA/video, direct-tag, server-side GAM, and nested GPT
    inventory without an independently TS-rewritten document is absent from the
    experiment and paired report scope. Directly validate any independently
    rewritten nested documents that are intentionally included.
-9. Run a short GAM report and verify treatment totals appear under `ts=true`
-   while overall totals remain unchanged apart from normal reporting latency.
+10. Run a short GAM report and verify treatment totals appear under `ts=true`
+    while overall totals remain unchanged apart from normal reporting latency.
 
 ## Rollout
 
-1. Audit response eligibility, including HTML rewriting, `<head>` ordering, CSP,
+1. Create the fixed reportable `ts=true` GAM key/value and record the intended
+   Enhanced or legacy reporting path, compatibility requirements, and billing
+   decision.
+2. Freeze the eligible-scope manifest and draft the saved Report A/Report B
+   definitions and excluded-path queries from that manifest.
+3. Audit response eligibility, including head rewrite/emission, ordering, CSP,
    and publisher GPT calls that could precede or remove the marker.
-2. Audit the `ts` key across publisher GPT code, effective `trusted-server.toml`
-   creative-opportunity targeting maps, and every GAM custom-targeting consumer.
-3. Prove through router or access logs that non-experiment traffic is excluded
-   from the TS route or independently separable in both paired GAM reports.
-4. Exclude IMA/video, direct-tag, server-side GAM, and nested GPT inventory
-   whose document is not independently rewritten. Inventory in intentionally
-   rewritten nested documents must pass the same request and report validation
-   as the top-level document.
-5. Create and enable the reportable GAM key and predefined value.
-6. Deploy the Trusted Server marker before assigning experiment traffic.
+4. Audit `ts` across publisher GPT code, Prebid-generated targeting, effective
+   `trusted-server.toml` creative-opportunity targeting maps, and every GAM
+   custom-targeting consumer. Retain the owner, evidence, timestamp, and re-audit
+   trigger.
+5. Exclude IMA/video, direct-tag, server-side GAM, and nested GPT inventory not
+   independently routed, rewritten, and validated. Treat copied activation in an
+   excluded nested document as contamination.
+6. Deploy `gam_attribution_enabled = true` while treatment routing remains
+   stopped.
 7. Provision the scheduled synthetic crawl, assign an incident owner, and obtain
-   one successful treatment/control run covering initial, lazy, refreshed, and
-   CSP execution checks.
-8. Validate treatment and control requests manually.
-9. Start the small cookie-sticky cohort.
-10. Compare observed GAM treatment share with the router allocation before using
-    the results for performance decisions.
-11. Monitor normalized metrics over a sufficiently large window; do not infer a
-    treatment effect from unequal raw totals.
+   one successful treatment/control run covering initial, lazy, refreshed, CSP,
+   fallback, and disabled-setting checks.
+8. On the validation deployment, validate treatment and control requests
+   manually, retain zero-count results for every excluded path, and save a short
+   paired-report dry run that proves the selected dimensions, filters, metrics,
+   and `0 <= Report B <= Report A` invariants.
+9. Start the small cookie-sticky treatment cohort only after every configuration,
+   collision, privacy, CSP, synthetic, exclusion, and reporting gate passes.
+10. Compare observed GAM treatment share with router allocation only as a
+    diagnostic before interpreting descriptive delivery results.
 
-Rollback stops adding the page-level key to newly loaded documents. Already-open
-documents—including long-lived SPA sessions—retain page-level targeting and may
-continue issuing marked lazy or refreshed requests after the code rollback.
-Record the rollback timestamp, end the experiment reports at the last clean
-pre-rollback boundary, and exclude the post-rollback drain interval from both
-cohorts. The drain ends only after router/access logs and GAM show no remaining
-`ts=true` traffic for one complete agreed reporting interval and a fresh
-synthetic navigation confirms that new documents are unmarked. If marked traffic
-persists, the interval remains excluded rather than being inferred as control.
-Historical GAM rows recorded while the key was active remain valid, and the GAM
+Rollback is ordered so newly routed treatment traffic cannot become unmarked
+control. First record the last clean reporting boundary and stop new treatment
+assignment/routing. Verify through router or access logs that routing stopped;
+then set `gam_attribution_enabled = false` and deploy the kill switch. Fresh
+Trusted Server documents must keep normal GPT behavior while omitting the
+marker. Already-open documents—including long-lived SPA sessions and any marked
+document restored from a cache—retain page-level targeting and may continue
+issuing marked lazy or refreshed requests. Exclude the entire post-boundary
+drain interval from both cohorts. The drain ends only after router/access logs
+and GAM show no remaining `ts=true` traffic for one complete, runbook-defined
+reporting interval and a fresh synthetic navigation confirms that new documents
+are unmarked. If marked traffic persists, the interval remains excluded rather
+than being inferred as control. Historical GAM rows remain valid, and the GAM
 key may stay defined and reportable for historical analysis.
+
+If an active privacy, targeting-collision, or ad-delivery incident requires an
+immediate kill, deploy `gam_attribution_enabled = false` without waiting for
+router verification. Treat the affected window and subsequent drain interval as
+invalid for both cohorts, then stop and verify treatment routing and follow the
+same drain-completion rule. The emergency path prioritizes serving safety over a
+clean experiment boundary; it must never reinterpret newly unmarked treatment
+traffic as control.
 
 ## Alternatives considered
 
@@ -818,25 +1028,46 @@ Rejected as the sole path. Placing the enqueue before the existing `ts.adInit`
 guard correctly handles a pre-installed ad-init implementation. The bundle is
 not needed for that case. It remains useful when the inline script unexpectedly
 stops executing but the synchronous first-party bundle still runs: without the
-fallback, a TS-delivered treatment page would be silently inferred as control.
+fallback, a treatment page with a TS-emitted head would be silently inferred as
+control.
 The fallback does not rescue the simultaneously blocked TS ad-stack scripts, so
 that state is an incident rather than an eligible deployment mode.
+
+### Enable attribution whenever GPT is enabled
+
+Rejected because an upgrade would begin disclosing cohort/path information and
+reserving the short `ts` key on every existing GPT deployment before its
+collision, privacy, and reporting prerequisites were complete. The independent,
+default-off setting permits deliberate rollout and rollback without removing the
+GPT proxy, shim, or auction behavior.
+
+### Buffer the existing Fastly streaming HTML path until the complete rewrite succeeds
+
+Rejected because the marker must run from the rewritten head before publisher
+GPT requests, while the no-post-processor Fastly path deliberately streams that
+head before origin EOF. Adding full-response buffering to that path would change
+latency, memory use, and first contentful paint. On that in-scope path, the
+marker therefore certifies successful head rewrite and emission; later stream
+completion is a separate delivery concern. Existing configurations that
+register an HTML post-processor retain their current buffering behavior; this
+feature adds none.
 
 ### Use a longer descriptive key name such as `trusted_server`
 
 A descriptive name would lower the collision risk that the short `ts` key
-carries. Rejected because GAM limits a custom-targeting key name to 10
-characters, so `trusted_server` (14) cannot be created as a reportable key. The
-short `ts` name is therefore mandatory, and the cross-system collision audit is
-the compensating control. Do not dual-write `ts` alongside any longer alias: two
-names for one cohort would increase GAM setup and audit surface and permit
+carries. Rejected because the target-network provisioning preflight enforced a
+10-character request-name limit and rejected `trusted_server` (14), even though
+other GAM help surfaces describe a 20-character limit. The short `ts` name is
+therefore mandatory for this deployment, and the cross-system collision audit
+is the compensating control. Do not dual-write `ts` alongside any longer alias:
+two names for one cohort would increase GAM setup and audit surface and permit
 silent drift between reports. Only `ts=true` is valid.
 
 ### Configure `ts=true` in creative-opportunity slot targeting
 
 Rejected because creative-opportunity targeting applies only to matched slots.
-The experiment requirement covers every request from each successfully rewritten
-document's local GPT PubAds service.
+The experiment requirement covers every request after the enabled publisher
+pipeline emits the document head for its local GPT PubAds service.
 
 ### Rewrite `cust_params` on GAM network requests
 
@@ -851,36 +1082,59 @@ baseline limitation and requires coverage checks.
 
 ## Acceptance criteria
 
-1. For a deployment that satisfies the documented GPT-integration, HTML-rewrite,
-   `<head>` ordering, CSP, reserved-key, request-scope, and targeting-cleanup
-   prerequisites—and in which a Trusted Server marker callback runs before the
-   first request—every request from that rewritten document's local GPT PubAds
-   service carries `ts=true`, including initial, lazy, refreshed,
-   publisher-owned, and SPA-route requests. A nested document is covered only
-   when its own HTML response independently satisfies the same prerequisites.
-2. Production/control pages remain unmodified and do not carry `ts` from this
+1. `gam_attribution_enabled` defaults to `false`. With omitted or false
+   configuration, dormant gated bootstrap source may remain present, but no
+   attribution callback is enqueued or executed and no inline attribution flag,
+   bundle activation attribute, or fallback is activated. Current GPT, shim,
+   `adInit`, and `ts_initial` behavior is preserved, and setting the field to
+   `false` independently disables attribution.
+2. For an enabled deployment that satisfies the documented head-rewrite,
+   ordering, CSP, reserved-key, request-scope, and targeting-cleanup
+   prerequisites—and in which at least one callback successfully applies
+   page-level targeting before the first request, with no later clear or
+   override—every request from that document's local GPT PubAds service carries
+   `ts=true`, including initial, lazy, refreshed, publisher-owned, and SPA-route
+   requests.
+3. For an in-scope document satisfying the non-cloned activation prerequisite,
+   the marker means the Trusted Server publisher pipeline rewrote and emitted
+   that document's head before the request. It does not certify complete streamed
+   response delivery. This feature adds no buffering; on the existing streaming
+   Fastly path, a later truncation does not reclassify an already marked request
+   as control.
+4. Production/control pages remain unmodified and do not carry `ts` from this
    feature.
-3. `ts_initial=1` retains its current slot-level initial-request lifecycle.
-4. The new key is not cleared by Prebid refresh or SPA slot cleanup.
-5. No publisher code, effective Trusted Server creative-opportunity targeting
-   map, or GAM custom-targeting consumer changes ad eligibility, pricing,
-   protection, routing, or the marker value because of the measurement key.
-6. The marker adds no unique identifier, cookie value, network request, or
-   blocking work. Its disclosure of treatment-path membership to GAM has passed
-   the publisher's privacy/data-governance review.
-7. GAM can report treatment impressions and clicks under `ts=true`, and the
-   control counts can be derived within the same experiment scope using
-   identical non-targeted metrics.
-8. Known treatment requests are validated directly for marker presence, and the
-   observed GAM treatment share is compared diagnostically with the router's
-   expected cohort allocation before experiment results are interpreted.
-9. Non-experiment TS traffic is absent from the route during the measurement
-   window or excluded from both paired GAM reports with identical filters.
-10. Only `ts=true` is emitted and reported; no other value (for example `ts=1`)
-    and no alternative key name (for example `trusted_server`) alias or
-    dual-write compatibility path exists.
-11. CSP-compatible inline execution is proven before launch. A fallback-only
+5. `ts_initial=1` retains its current slot-level initial-request lifecycle, and
+   `ts` is not cleared by Prebid refresh or SPA slot cleanup.
+6. No publisher code, Prebid-generated targeting, effective Trusted Server
+   creative-opportunity targeting map, or GAM custom-targeting consumer changes
+   ad eligibility, pricing, protection, routing, or the marker value because of
+   the measurement key.
+7. The marker adds no unique identifier, cookie value, network request,
+   response buffering, or blocking work. Its disclosure of treatment-path
+   membership to GAM has passed the publisher's privacy/data-governance review.
+8. The target-network preflight has fixed the only contract as `ts=true`; no
+   other value, alternative key name, alias, configurable marker, or dual-write
+   path exists.
+9. The exact Enhanced or legacy reporting path, billing approval, dimensions,
+   filters, and compatible metrics pass a target-network dry run. Saved Report A
+   and Report B use the same frozen eligible-scope manifest and satisfy
+   `0 <= Report B <= Report A` for every interpreted metric; violations invalidate
+   the pair rather than being clamped or reported.
+10. GAM output is described as delivery attribution, not a causal treatment
+    effect. Known treatment/control requests are sampled directly, while
+    aggregate marker share is compared diagnostically with router allocation;
+    neither check is represented as proof of per-response production coverage.
+11. Every excluded traffic path has a retained zero-count preflight or an
+    independent filter applied identically to both saved reports.
+12. Nested inventory is included only when independently routed, rewritten, and
+    validated. Because the activation tag is clonable, marker presence alone is
+    not proof of eligibility; copied activation in excluded inventory is a
+    contamination incident.
+13. CSP-compatible inline execution is proven before launch. A fallback-only
     page remains attributed to treatment but raises an incident and cannot be
     treated as a healthy experiment page.
-12. Rollback reporting excludes already-open documents until observed marked
-    traffic has drained according to the documented boundary rule.
+14. Normal rollback stops and verifies new treatment routing before deploying
+    the attribution kill switch, and reporting excludes already-open or cached
+    marked documents until observed traffic drains according to the documented
+    boundary rule. An emergency kill invalidates the affected and drain windows
+    instead of treating newly unmarked traffic as control.

--- a/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
@@ -986,19 +986,20 @@ deployment:
     diagnostic before interpreting descriptive delivery results.
 
 Rollback is ordered so newly routed treatment traffic cannot become unmarked
-control. First record the last clean reporting boundary and stop new treatment
-assignment/routing. Verify through router or access logs that routing stopped;
-then set `gam_attribution_enabled = false` and deploy the kill switch. Fresh
-Trusted Server documents must keep normal GPT behavior while omitting the
-marker. Already-open documents—including long-lived SPA sessions and any marked
-document restored from a cache—retain page-level targeting and may continue
-issuing marked lazy or refreshed requests. Exclude the entire post-boundary
-drain interval from both cohorts. The drain ends only after router/access logs
-and GAM show no remaining `ts=true` traffic for one complete, runbook-defined
-reporting interval and a fresh synthetic navigation confirms that new documents
-are unmarked. If marked traffic persists, the interval remains excluded rather
-than being inferred as control. Historical GAM rows remain valid, and the GAM
-key may stay defined and reportable for historical analysis.
+control. First stop new treatment assignment/routing and verify through router
+or access logs that routing stopped, then record the last clean reporting
+boundary. Keep `gam_attribution_enabled = true` while already-open
+documents—including long-lived SPA sessions and any marked document restored
+from a cache—drain; they retain page-level targeting and may continue issuing
+marked lazy or refreshed requests. Exclude the entire post-boundary drain
+interval from both cohorts. The drain ends only after router/access logs and GAM
+show no remaining `ts=true` traffic for one complete, runbook-defined reporting
+interval. Then set `gam_attribution_enabled = false`, deploy the kill switch,
+and use a fresh synthetic Trusted Server navigation to confirm normal GPT
+behavior while the marker is absent. If marked traffic persists, keep
+attribution enabled and the interval excluded rather than inferring it as
+control. Historical GAM rows remain valid, and the GAM key may stay defined and
+reportable for historical analysis.
 
 If an active privacy, targeting-collision, or ad-delivery incident requires an
 immediate kill, deploy `gam_attribution_enabled = false` without waiting for
@@ -1133,8 +1134,8 @@ baseline limitation and requires coverage checks.
 13. CSP-compatible inline execution is proven before launch. A fallback-only
     page remains attributed to treatment but raises an incident and cannot be
     treated as a healthy experiment page.
-14. Normal rollback stops and verifies new treatment routing before deploying
-    the attribution kill switch, and reporting excludes already-open or cached
-    marked documents until observed traffic drains according to the documented
-    boundary rule. An emergency kill invalidates the affected and drain windows
-    instead of treating newly unmarked traffic as control.
+14. Normal rollback stops and verifies new treatment routing, records the clean
+    boundary, and keeps attribution enabled until already-open or cached marked
+    documents drain according to the documented rule. Only then is the kill
+    switch deployed. An emergency kill invalidates the affected and drain
+    windows instead of treating newly unmarked traffic as control.

--- a/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md
@@ -1,0 +1,886 @@
+# GAM `ts=true` attribution for Trusted Server A/B traffic
+
+Date: 2026-07-15
+
+Status: Design
+
+## Problem
+
+A publisher will route a small, cookie-sticky A/B cohort through Trusted Server
+while the control cohort continues through the existing production path. The
+publisher wants Google Ad Manager (GAM) reporting to identify impressions and
+clicks generated on pages served through Trusted Server and compare them with
+the unmodified production cohort.
+
+Trusted Server currently adds the slot-level key-value `ts_initial=1` while it
+prepares initial GPT slots. That key has a different lifecycle and meaning from
+the experiment marker:
+
+- it identifies the initial slot request prepared by Trusted Server;
+- it is cleared before later client-side refresh auctions; and
+- it is set on matched slots rather than every GPT request on the page.
+
+The experiment needs a document-delivery marker. Every request issued by the
+document-local GPT PubAds service after marker installation in an HTML document
+successfully rewritten by Trusted Server must contain `ts=true`, including
+initial requests, publisher-owned slots, lazy slots, and refreshes. Production
+documents cannot be modified, so the control cohort remains unmarked.
+
+## Goals
+
+1. Add `ts=true` to every in-scope GPT PubAds request made during the lifetime
+   of an HTML document successfully rewritten by Trusted Server.
+2. Leave production/control pages unchanged.
+3. Preserve the existing `ts_initial=1` slot-ownership and refresh lifecycle.
+4. Support GAM reports that count treatment impressions and clicks and derive
+   the control counts within the same experiment scope.
+5. Avoid changing auction eligibility, ad delivery, consent behavior, or page
+   performance.
+6. Define the data-quality checks needed when an unmarked request is used as the
+   control baseline.
+
+## Non-goals
+
+- Implement or change the cookie-based A/B router. The experiment infrastructure
+  owns sticky cohort assignment and routes only the treatment cohort through
+  Trusted Server.
+- Prove that a Trusted Server server-side bid won the GAM auction. `ts=true`
+  means that the page was delivered through Trusted Server, regardless of
+  whether the winning demand was a server-side bid, a direct GAM line item, Ad
+  Exchange, or backfill.
+- Mark GAM traffic outside a successfully rewritten document's local GPT PubAds
+  service. IMA/video SDK requests, direct tags, and server-side GAM requests
+  require separate instrumentation and are outside this design. A nested
+  document's GPT instance is in scope only when that nested HTML response is
+  independently routed through Trusted Server and satisfies the same rewrite,
+  ordering, CSP, and audit prerequisites.
+- Replace `ts_initial`, `hb_*`, line-item, bidder, or creative reporting.
+- Add a client-side analytics beacon or a Trusted Server telemetry event.
+- Make GAM click tracking more complete. The marker only segments clicks that
+  GAM already records.
+- Provide billing-grade or causal experiment analysis from GAM alone.
+
+## Assumptions and prerequisites
+
+- The GPT integration is enabled on every page routed into the treatment cohort.
+  A page served through Trusted Server without the GPT integration does not
+  receive the GPT head bootstrap and cannot satisfy this design.
+- The response enters and successfully completes Trusted Server HTML rewriting,
+  contains a literal `<head>` element, and reaches that element before any
+  publisher script issues a GAM request. Pass-through or buffered-unmodified
+  responses, rewrite failures, and origin markup that omits `<head>` cannot
+  satisfy the marker guarantee.
+- The publisher Content Security Policy allows Trusted Server's bare inline
+  scripts to execute. Initial `adSlots`, the GPT enable flag, the GPT bootstrap,
+  and the `bids`/`adInit` invocation are all nonce-less inline scripts; Trusted
+  Server does not currently propagate a publisher nonce or update CSP hashes. A
+  policy that blocks those scripts makes the initial TS ad stack inert and is
+  ineligible at launch even if it allows the synchronous first-party TSJS
+  bundle.
+- Each in-scope HTML document uses one document-local GPT PubAds service. Nested
+  documents are not implicitly covered by a marked parent: each nested HTML
+  response must be independently routed through Trusted Server and rewritten to
+  receive the marker. IMA/video, direct-tag, server-side GAM, and any nested GPT
+  inventory whose document is not independently rewritten must be excluded from
+  the experiment and paired reports.
+- Treatment and control traffic use the same GAM network and comparable
+  inventory. Report filters can isolate the pages and time window eligible for
+  the experiment.
+- The experiment owner can obtain the expected treatment allocation from the
+  cookie router, even though Trusted Server does not read or emit that cookie.
+- Publisher code and Trusted Server creative-opportunity slot configuration do
+  not reuse `ts` for another meaning, set a slot-level `ts` value, or clear
+  page-level targeting after Trusted Server targeting runs. The deployment audit
+  must inspect `trusted-server.toml` targeting maps and search publisher code
+  for `setTargeting`, `setConfig`, and `clearTargeting` uses that could
+  overwrite or remove the reserved key. If such behavior exists, it must be
+  resolved before launch; silently filtering operator targeting or wrapping
+  publisher GPT APIs is out of scope.
+
+## Existing behavior
+
+The GPT integration has two related pieces:
+
+1. `crates/trusted-server-core/src/integrations/gpt_bootstrap.js` is injected at
+   the start of `<head>`. It creates the GPT command queue early and installs
+   the minimal `window.tsjs.adInit` implementation used before the richer bundle
+   is available.
+2. `crates/trusted-server-js/lib/src/integrations/gpt/index.ts` installs the
+   richer GPT integration and applies slot-level auction targeting.
+
+Both initial-render paths set `ts_initial=1` on slots handled by `adInit`. The
+Prebid refresh integration includes `ts_initial` in its list of stale
+slot-targeting keys and clears it before subsequent client-side refresh
+auctions. SPA cleanup also clears stale `ts_initial` targeting before applying
+new route state.
+
+This behavior is correct for `ts_initial` and must not change. It is not
+sufficient for a page-level treatment marker because it does not cover all GPT
+slots and intentionally does not persist across refreshes.
+
+## Decision
+
+Add a separate page-level GPT key-value:
+
+```text
+ts=true
+```
+
+The early GPT bootstrap will enqueue page-level targeting before publisher GPT
+commands execute. The enqueue must occur after `window.tsjs` is initialized but
+before the existing `if (ts.adInit) return;` guard:
+
+```text
+(function () {
+  if (typeof window === "undefined") return;
+  var ts = (window.tsjs = window.tsjs || {});
+  var tag = (window.googletag = window.googletag || { cmd: [] });
+  tag.cmd = tag.cmd || [];
+  tag.cmd.push(function () {
+    try {
+      if (typeof googletag.setConfig === "function") {
+        googletag.setConfig({ targeting: { ts: "true" } });
+      }
+    } catch (_) {
+      // Attribution must not interrupt the existing bootstrap.
+    }
+  });
+
+  if (ts.adInit) return;
+  // Existing initial-load detector and adInit stub follow.
+})();
+```
+
+The exact implementation must follow the repository's JavaScript formatting and
+defensive checks. The important contract is that the page-level targeting
+command is queued by the head bootstrap before the origin page can queue its GPT
+setup or request ads. Page attribution is independent of whether the bootstrap
+needs to install `ts.adInit`, so the existing guard may skip only the ad-init
+stub and detector setup, never the marker enqueue. An unavailable targeting API
+may skip only the marker callback; it must not prevent later queued publisher or
+Trusted Server callbacks from running.
+
+The existing initial-load detector immediately below the new marker must reuse
+the initialized `tag.cmd` reference rather than repeat its current
+`(window.googletag = window.googletag || { cmd: [] }).cmd` expression. This
+keeps queue initialization and both bootstrap callbacks on one consistent path.
+
+Moving queue initialization above the `ts.adInit` guard intentionally creates a
+standard `window.googletag` command-queue stub on every rewritten, GPT-enabled
+page, including a page where `ts.adInit` already exists and GPT never loads. The
+stub is inert by itself and preserves the marker-before-guard guarantee; it is
+not an accidental behavior to remove during implementation review.
+
+The TypeScript GPT bundle will defensively enqueue the same page-level targeting
+at module initialization after the existing flag-gated shim block and before
+`installTsAdInit()`, only when the existing publisher-page bundle tag carries a
+non-executable GPT activation attribute. The HTML pipeline adds that attribute
+when the GPT integration is enabled. A pre-existing `ts.adInit` is already
+covered by placing the bootstrap marker before the guard and is not a reason for
+the fallback.
+
+The fallback exists to preserve delivery-path attribution if the inline
+bootstrap unexpectedly stops executing while the synchronous first-party bundle
+still runs before publisher GPT. It does not recover `adSlots`, bids, the
+`adInit` invocation, or the initial TS auction: those are also nonce-less inline
+scripts. A fallback-only marker therefore still truthfully means "page delivered
+through Trusted Server," but it also indicates a deployment state that was
+ineligible at launch. Synthetic validation must treat that state as a
+measurement incident, pause interpretation, and exclude the affected time window
+from both paired reports if the incident contaminates collected results. GAM
+cannot distinguish fallback-only pages from normally executing treatment pages
+because both intentionally use the same marker.
+
+Neither targeting path can cover a response that was not HTML-rewritten, markup
+without `<head>`, a policy that blocks both injected paths, or a publisher GPT
+request issued before the injected head content runs. Those are deployment
+eligibility and coverage-validation concerns, not runtime conditions the
+targeting code can repair.
+
+The implementation uses GPT's current page-level `googletag.setConfig` API
+rather than the deprecated `pubads().setTargeting()` API. See
+[GPT configuration API migration](https://developers.google.com/publisher-tag/guides/config-migration).
+Page-level targeting is the right scope because GPT applies it to all slots
+associated with the `pubads` service. Once installed, it remains effective for
+initial, lazy, and refreshed requests for the life of the page. Existing slot
+targeting may add or override other keys without requiring Trusted Server to
+discover every publisher slot.
+
+GPT merges page-level targeting per key across `setConfig` calls. Enqueuing
+`ts=true` from both Trusted Server paths is therefore idempotent, and a
+publisher call that sets an unrelated targeting key preserves `ts`. The explicit
+clear operations are a per-key `null`, a whole-targeting `null`, or the
+equivalent legacy `pubads().clearTargeting()` calls. See
+[GPT key-value targeting](https://developers.google.com/publisher-tag/guides/key-value-targeting).
+
+`ts` is intentionally not added to the slot-targeting cleanup arrays. Those
+arrays manage per-auction state. Clearing page-level `ts` during refresh or SPA
+navigation would incorrectly move a treatment page into the unmarked control
+cohort.
+
+## Attribution contract
+
+### Treatment
+
+An in-scope GAM request is in the treatment cohort when it contains:
+
+```text
+ts=true
+```
+
+The marker means:
+
+> The containing page was delivered through Trusted Server.
+
+It does not mean:
+
+- a Trusted Server bidder returned a bid;
+- a Trusted Server bid won;
+- Trusted Server rendered the winning creative; or
+- the request was the first impression for the slot.
+
+### Control
+
+The production path cannot be changed. Within the exact experiment inventory,
+time window, and publisher scope, an unmarked GAM request is treated as control.
+
+This is an inference rather than an explicit `ts=false` assertion. A treatment
+request that loses its marker would be misclassified as control. The rollout
+therefore requires coverage checks that compare the observed GAM treatment share
+with the A/B router's expected cookie cohort share.
+
+### Relationship to `ts_initial`
+
+| Key            | Scope      | Lifetime                     | Meaning                                   |
+| -------------- | ---------- | ---------------------------- | ----------------------------------------- |
+| `ts=true`      | Page-level | Entire browser page lifetime | Page was delivered through Trusted Server |
+| `ts_initial=1` | Slot-level | Initial TS-managed request   | Initial slot request was prepared by TS   |
+
+The two keys answer different questions and coexist. No code or report should
+infer that one is an alias for the other. The value contract is exactly
+`ts=true`: do not emit, accept, or report any other value (for example `ts=1`),
+and do not dual-write an alternative key name such as `trusted_server`.
+
+## Request lifecycle
+
+```text
+Sticky A/B cookie
+  -> control: browser receives production page
+       -> publisher GPT runs without the `ts` key
+  -> treatment: request is routed through Trusted Server
+       -> GPT head bootstrap queues page-level `ts=true`
+       -> GPT bundle defensively queues the same marker
+       -> GPT library drains the command queue
+       -> publisher and TS define/display/refresh slots
+       -> every in-scope PubAds request carries `ts=true`
+```
+
+The marker covers:
+
+- Trusted Server-defined initial slots;
+- publisher-defined slots reused by Trusted Server;
+- publisher slots that are not part of a Trusted Server creative opportunity;
+- slots created lazily after initial page load;
+- publisher-initiated refreshes;
+- Prebid-managed refreshes; and
+- SPA route changes within the same browser document.
+
+All bullets refer to slots using the same document-local GPT PubAds service.
+Requests from IMA/video SDKs, direct tags, or server-side GAM integrations are
+not covered merely because the containing document is marked. A nested GPT
+instance is marked only when Trusted Server separately rewrites that nested
+document and injects the attribution paths into its own `<head>`.
+
+A full browser navigation creates a new page and repeats cookie-based routing.
+The new page receives the marker only when that navigation is routed through
+Trusted Server.
+
+## Component changes
+
+### Early GPT bootstrap
+
+`crates/trusted-server-core/src/integrations/gpt_bootstrap.js` owns the
+behavior. It will set the page-level key in its earliest GPT command callback,
+before the `ts.adInit` early-return guard. The targeting code stays inside the
+existing raw bootstrap script returned by `head_inserts`; it must not add a
+third head insert.
+
+The operation must be idempotent. Calling
+`googletag.setConfig({ targeting: { ts: 'true' } })` more than once with the
+same value is harmless, but the bootstrap should avoid adding a new global state
+machine solely for deduplication.
+
+The bootstrap already binds the local variable `ts` to the `window.tsjs`
+namespace, so the targeting key `ts` and that variable are unrelated names that
+sit only a few lines apart. Add a clarifying comment at the targeting call so a
+maintainer does not read the key as the namespace. The value is the string
+`'true'`, never the boolean `true`: GPT targeting values must be strings.
+
+### TypeScript GPT bundle fallback
+
+`crates/trusted-server-js/lib/src/integrations/gpt/index.ts` will add a small
+`installTrustedServerPageTargeting()` helper and call it during GPT module
+initialization after the existing flag-gated `installGptShim()` block and before
+`installTsAdInit()` when the publisher-page bundle's activation attribute is
+present. The helper creates or reuses the standard GPT command queue, enqueues
+the same defensive `setConfig({ targeting: { ts: 'true' } })` call, and does not
+read the experiment cookie or wait for an auction. Extend the local `GoogleTag`
+interface with optional `setConfig?(config: Record<string, unknown>): void` so
+the fallback remains defensive when the API is unavailable.
+
+The bootstrap remains the primary path because it is injected first. The bundle
+call is a redundant fallback and must not delay module initialization, create a
+request, or add slot-level targeting. A plain GPT module import without the
+activation attribute must preserve the existing runtime-gating contract and must
+not create `window.googletag`.
+
+### Non-executable bundle activation
+
+The publisher HTML pipeline in
+`crates/trusted-server-core/src/html_processor.rs`, using a separate,
+publisher-page-only tag helper in `crates/trusted-server-core/src/tsjs.rs`, will
+add a `data-ts-gpt-enabled="true"` attribute to the existing synchronous
+`#trustedserver-js` bundle tag when GPT is enabled. The attribute is data, not
+an inline executable, so CSP can block the inline GPT head inserts while still
+allowing the external bundle to detect that it owns page attribution.
+
+At module initialization, the GPT bundle captures `document.currentScript` and
+requires that executing synchronous script to carry `data-ts-gpt-enabled="true"`
+before the fallback may create a GPT stub. It must fail closed when the
+executing script cannot be identified. Do not authorize activation through a
+global `#trustedserver-js` lookup: the generic unified tag uses the same ID in
+creative and test contexts, and duplicate IDs could select the wrong element.
+Binding the signal to the executing tag keeps the activation decision explicit
+and testable without relying on an inline global flag.
+
+The existing `window.__tsjs_gpt_enabled` flag continues to activate
+`installGptShim()` when inline scripts run. It cannot activate the CSP fallback
+because the server sets it from an inline head insert—the execution path CSP may
+block. Migrating shim activation to the data attribute is out of scope; module
+initialization preserves the current flag-gated shim installation, then runs the
+attribute-gated page-targeting helper, then installs `ts.adInit` and the
+remaining GPT bundle hooks.
+
+This signal must be limited to the publisher-page bundle generated from the
+enabled integration registry. Do not infer activation merely because the GPT
+module exists in an all-modules bundle: creative and test tooling can load that
+bundle outside the publisher GPT integration. Do not add a new script tag or
+change the integration's existing head-insert count.
+
+Extend the `tsjs.rs` and `html_processor.rs` tests to prove that the existing
+publisher-page bundle tag gains the activation attribute only when GPT is in the
+enabled immediate module set, remains a single external tag, and omits the
+attribute for non-GPT publisher bundles and generic all-modules tags. Bundle
+tests must also prove that an unrelated or duplicate element with
+`id="trustedserver-js"` cannot activate the fallback.
+
+### GPT Rust integration tests
+
+`crates/trusted-server-core/src/integrations/gpt.rs` already tests the embedded
+bootstrap returned by `head_inserts`. Extend those tests to prove that:
+
+- the bootstrap contains page-level `ts=true` targeting;
+- the marker enqueue appears before the `if (ts.adInit) return;` guard;
+- the targeting setup is queued before `ts.adInit` can issue `display` or
+  `refresh`;
+- the existing `ts_initial` marker remains present; and
+- the enabled integration without `slim_prebid_url` still emits exactly the
+  existing two head inserts, proving the marker was added to the bootstrap
+  instead of a new tag.
+
+### Bootstrap execution tests
+
+Add `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts`
+as a Vitest/jsdom behavioral test for the raw bootstrap. The test reads
+`crates/trusted-server-core/src/integrations/gpt_bootstrap.js` with Node's
+`readFileSync`, resolves the source path relative to `import.meta.url` rather
+than the process working directory, and creates an isolated
+`new JSDOM(html, { runScripts: 'outside-only' })` realm. Before evaluating the
+exact source with that realm's `window.eval`, the test must assert that
+`globalThis === window` and `typeof global === 'undefined'` inside the realm.
+This is required because Vitest's default jsdom `window.eval` runs in Node's
+realm under the current configuration. The harness supplies a minimal mocked GPT
+command queue and `pubads` service. It must not evaluate the source in Node's
+global context, copy the bootstrap into a test fixture, or add a JavaScript
+runtime dependency to Rust.
+
+The harness must prove that:
+
+- the attribution callback is queued before a publisher callback added after the
+  injected bootstrap;
+- draining the queue calls `googletag.setConfig` with page-level `ts=true`
+  before the publisher callback runs;
+- a pre-existing `ts.adInit` does not prevent the attribution callback from
+  being queued or executed;
+- a publisher callback queued after the bootstrap still runs when
+  `googletag.setConfig` throws;
+- an unavailable or throwing `googletag.setConfig` does not prevent the existing
+  `disableInitialLoad` wrapper from being installed;
+- `ts.adInit` remains installed when attribution setup is unavailable or throws;
+  and
+- calling the wrapped `disableInitialLoad` still records
+  `ts.gptInitialLoadDisabled`.
+
+### Bundle fallback tests
+
+Extend `crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts` using
+its existing dynamic-import and `vi.resetModules()` pattern. Prove that module
+initialization with the bundle activation attribute queues page-level `ts=true`
+after any existing flag-gated shim installation and before installing
+`ts.adInit`, that it reuses an existing GPT command queue, and that unavailable
+or throwing `setConfig` does not stop the remaining GPT module installers.
+Retain the existing assertion that a plain module import without an activation
+signal does not create `window.googletag`. A duplicate call after the bootstrap
+must remain safe and must not create another script or network request.
+
+### Slot cleanup constraints
+
+No refresh-lifecycle change is required. In particular:
+
+- do not add `ts` to `TS_REFRESH_TARGETING_KEYS`;
+- do not add `ts` to `TS_BASE_TARGETING_KEYS`;
+- do not rename or remove `TS_INITIAL_TARGETING_KEY`; and
+- do not copy `ts` onto individual slots.
+
+Leaving these components unchanged is part of the design: slot cleanup cannot
+remove a page-level key set through `googletag.setConfig`.
+
+### Documentation
+
+Document the distinction between page-level `ts=true` and slot-level
+`ts_initial=1` in `docs/guide/integrations/gpt.md`, near the existing command
+queue documentation. Include the GAM setup and reporting preconditions below; do
+not add this current integration to a planned-future GAM document.
+
+## GAM configuration
+
+GAM configuration is a deployment prerequisite and must be completed before the
+experiment starts because key-value reporting is not retroactive.
+
+The request contract is `ts=true`: key name `ts`, predefined value `true`. The
+key name is provisional pending a GAM preflight (see issue #1027). The GPT/GAM
+`CustomTargetingKey.name` (the code sent in the ad request) is documented as
+limited to 10 characters in the SOAP/REST API, which would rule out a fuller
+name such as `trusted_server` (14); other Help Center material implies 20, and
+these describe different provisioning surfaces, so the enforced limit must be
+confirmed in the target network before the contract is fixed. If the confirmed
+limit permits a longer name, a more descriptive, less collision-prone key is
+preferred over `ts`. Because `ts` is short, it carries a real collision risk with
+common publisher timestamp or cache-buster keys, which makes the cross-system
+collision audit a hard launch gate, not a formality. If any publisher, Trusted
+Server configuration, or GAM object already uses `ts`, the experiment must stop
+until the collision is removed or the contract is explicitly revised everywhere
+before treatment traffic begins.
+
+1. In **Inventory > Key-values**, create or verify a key whose request name is
+   the finalized marker key (`ts` pending the preflight in issue #1027). When the
+   key is created, confirm the enforced key-name and value length limits on the
+   provisioning surface actually used: the SOAP/REST
+   [`CustomTargetingKey`](https://developers.google.com/ad-manager/api/reference/v202511/CustomTargetingService.CustomTargetingKey)
+   documents a 10-character key-`name` limit and a 40-character value limit, but
+   the UI surface may differ, so verify against the target network rather than
+   assuming.
+2. Use a predefined value named `true`.
+3. Enable `ts` as a dedicated reportable Enhanced key-value dimension. If the
+   network does not support Enhanced key-value dimensions, use a report filtered
+   to the single legacy key-value `ts=true`; never sum unfiltered legacy
+   **Key-values** dimension rows.
+4. Reserve `ts` for Trusted Server page attribution.
+5. Audit existing publisher GPT code and every GAM object that consumes custom
+   targeting for an existing `ts` key before deployment. This includes line
+   items, proposal line items, rules, protections, yield configuration, and any
+   network-specific custom-targeting surface.
+6. Audit every `CreativeOpportunitySlot.targeting` map from all effective
+   `trusted-server.toml` configuration sources. The arbitrary operator-supplied
+   map is copied to GPT slots, where a slot-level `ts` value would override the
+   page-level marker. Any occurrence is a launch blocker; do not silently
+   discard it because that could change established operator targeting.
+7. Audit publisher code for every operation that can remove or supersede the
+   marker after initial GPT setup. Search for `setConfig({ targeting: null })`,
+   a `ts: null` or different `ts` value, `pubads().clearTargeting()` with no key
+   or with `ts`, and slot-level `ts` targeting. Account for equivalent calls
+   assembled dynamically.
+
+The audit is a hard precondition. If `ts` already has another meaning, or any
+GAM object targets or acts on `ts=true`, the experiment owner must resolve the
+collision before deployment. The measurement marker is not intended to change ad
+eligibility, pricing, protection, or routing. A pre-existing targeting consumer
+for `ts=true` would make the A/B test measure a traffic or demand change at the
+same time as Trusted Server delivery.
+
+Undefined values do not appear in standard key-value reports even when the key
+is reportable, so value `true` must exist before treatment traffic begins. See
+[Add key-values](https://support.google.com/admanager/answer/9796369) and
+[Report on targeting keys](https://support.google.com/admanager/answer/14528835).
+
+## Reporting and comparison
+
+### Report scope
+
+Every comparison must apply identical filters for:
+
+- publisher/network;
+- experiment start and end time;
+- sites or inventory included in the cookie experiment;
+- ad units and formats;
+- geography and device categories, when used; and
+- any consent or traffic-quality exclusions.
+
+Do not compare the TS cohort with all unmarked network traffic unless all that
+traffic is eligible for the same experiment. Likewise, exclude smoke tests,
+direct hits, operations traffic, and any other TS-served page outside the cookie
+experiment. The marker identifies the delivery path, not the router's cohort
+assignment, so all such requests also carry `ts=true` when the GPT integration
+runs.
+
+The route owner must use router or access logs to prove that non-experiment TS
+traffic is absent from the eligible inventory during the measurement window. If
+such traffic cannot be prevented and has no independent inventory or reportable
+dimension, GAM cannot remove it from Report B because its marker is identical to
+the cohort marker; the experiment must not launch. Record the owner, query,
+expected zero threshold, and response procedure in the experiment runbook.
+
+### Cohort calculations
+
+Use two reports with identical date boundaries, time zone, inventory filters,
+traffic-quality filters, and metric definitions:
+
+1. **Report A — experiment total.** Do not include **Placement**, legacy
+   **Key-values**, **Targeting**, **Yield group**, or another dimension that can
+   represent one event more than once. This report provides one non-duplicated
+   total for every metric in the eligible experiment scope.
+2. **Report B — TS treatment.** Use the dedicated Enhanced `ts` dimension
+   filtered to `ts=true`. If Enhanced key-value dimensions are unavailable, use
+   the legacy **Key-values** dimension filtered to exactly `ts=true` and do not
+   sum any other key-value rows. Do not add **Placement**, **Targeting**,
+   **Yield group**, or any unrelated dimension that can represent the filtered
+   treatment event more than once.
+
+The legacy **Key-values** dimension can emit the same impression or click on
+multiple rows when a request contains multiple key-values. It therefore cannot
+provide Report A or a summable totals row. See
+[Avoid double counting report totals](https://support.google.com/admanager/answer/7642799).
+
+For this paired report scope, define:
+
+```text
+total_impressions = Report A impressions
+ts_impressions = Report B impressions
+prod_impressions = total_impressions - ts_impressions
+
+total_clicks = Report A GAM-recorded clicks
+ts_clicks = Report B GAM-recorded clicks
+prod_clicks = total_clicks - ts_clicks
+```
+
+If the selected GAM report exposes an explicit unassigned or `(not set)` row,
+that row may be used only as a cross-check. The paired Report A minus Report B
+calculation remains the control definition because production cannot send an
+explicit value. The experiment owner must retain both report definitions with
+the results so later analysis can verify that their filters and metrics match.
+Export both reports after the same GAM reporting-latency and invalid-traffic
+adjustment window. If GAM restates one report, rerun the pair before applying
+the subtraction.
+
+Use total metrics when the goal includes all GAM demand sources. GAM's
+`Ad server impressions` and `Ad server clicks` metrics exclude Ad Exchange and
+AdSense, so those narrower metrics should only be used when that exclusion is
+intentional. GAM counts impressions and clicks according to its own tracking
+rules; adding `ts=true` does not create new impression or click trackers. See
+[Counting impressions and clicks](https://support.google.com/admanager/answer/2521337).
+
+Both reports must use the same non-targeted impression and click metric names.
+Do not use targeted-impression or targeted-click metrics for this attribution:
+`ts` is intentionally forbidden from line-item targeting, so metrics limited to
+keys used for targeting do not represent the requested delivery-path cohort.
+Record the exact selected GAM metric names with the saved report definitions
+before launch.
+
+### Unequal cohort sizes
+
+The treatment cohort is intentionally small, so raw TS and production totals are
+not directly comparable. Reports should show the raw counts, but experiment
+conclusions should compare normalized measures where compatible metrics are
+available:
+
+- impressions per GAM ad request;
+- fill rate;
+- clicks per impression (CTR); and
+- revenue per thousand impressions or requests.
+
+Impressions per routed pageview or per assigned visitor require a denominator
+from the A/B router or site analytics. GAM alone cannot identify unmarked
+production pageviews that made no ad request. Any cross-system experiment
+analysis is outside the implementation but should use the same time and
+eligibility filters.
+
+### Data-quality checks
+
+During the experiment, monitor:
+
+1. observed `ts=true` ad-request or impression share versus the router's
+   expected treatment allocation;
+2. scheduled synthetic marker presence on initial, lazy, and refreshed treatment
+   requests;
+3. scheduled synthetic marker absence on production requests;
+4. non-experiment traffic served through Trusted Server;
+5. unexpected `ts` values or line-item targeting;
+6. report freshness and GAM invalid-traffic adjustments.
+
+A gap between expected and observed treatment share is a measurement incident,
+not evidence of production performance, until missing-marker and request-volume
+differences are ruled out. Because router assignment and GAM delivery normally
+use page or visitor counts versus ad-request or impression counts, this share
+comparison is a diagnostic rather than direct proof of marker coverage. It can
+measure coverage directly only when the router or site analytics supplies a
+matched request- or page-level denominator.
+
+Checks 2–3 use a scheduled synthetic browser crawl of representative experiment
+URLs. The crawler supplies known treatment and control cookies, captures GAM
+network requests, and triggers initial, lazy, and refreshed slots. A failed
+marker assertion is an operational measurement incident. This is external
+validation rather than a site beacon or Trusted Server telemetry event; if the
+experiment owner cannot operate the crawl, checks 2–3 become documented manual
+samples and must not be represented as continuous production metrics.
+
+On treatment URLs with matched creative opportunities, the crawler must also
+detect the fallback-only CSP state: capture CSP violations and verify that the
+injected `adSlots`, `bids`, and initial `adInit` handoff executed. A page that
+has `ts=true` only because the external bundle ran, while those inline scripts
+were blocked, remains correctly marked as TS-delivered but raises a measurement
+incident. Since GAM cannot separate those requests afterward, the incident owner
+must pause interpretation and exclude the affected time range from both reports
+when clean boundaries can be established; otherwise the experiment result is
+invalid.
+
+## Failure handling
+
+The marker is best-effort instrumentation and must never block ads or page
+delivery.
+
+- If GPT never loads, there is no GAM request to classify.
+- If a response is not successfully HTML-rewritten, has no literal `<head>`, or
+  issues an in-scope GPT request before the injected head content runs, neither
+  targeting path can mark that request. Such traffic is ineligible for the
+  experiment and must be detected before launch or excluded from analysis.
+- If CSP blocks Trusted Server's nonce-less inline scripts, the initial TS ad
+  stack is inert and the page is ineligible even when the first-party bundle
+  queues the attribution marker. The fallback prevents a TS-delivered page from
+  leaking into the inferred control cohort; it does not make the deployment
+  healthy. If CSP blocks both inline scripts and the bundle, attribution also
+  fails.
+- If `googletag.setConfig` is unavailable when a queued command runs, the
+  targeting step is a defensive no-op and must not throw. Supported treatment
+  deployments must use a GPT version with the configuration API; browser/GAM
+  validation detects an unsupported or missing API before experiment launch.
+- If publisher code or a Trusted Server creative-opportunity targeting map
+  applies slot-level `ts`, GPT gives the slot-level value precedence. The
+  deployment audit prevents this collision; runtime filtering or interception is
+  out of scope because it could silently alter established targeting behavior.
+- If publisher code calls `setConfig({ targeting: null })`, sets `ts: null` or a
+  different value, calls legacy `pubads().clearTargeting()` for all keys or for
+  `ts`, or applies slot-level `ts`, the effective marker can be removed or
+  superseded. The publisher-code audit and refresh validation are required
+  because this design deliberately does not intercept those APIs.
+- If the marker is absent on a treatment request, GAM classifies it with the
+  unmarked baseline. Coverage monitoring is the mitigation.
+- GAM configuration or reporting failures do not affect ad serving.
+
+No retry, beacon, cookie read, backend request, or persistent client state is
+added by this feature.
+
+## Privacy and consent
+
+`ts=true` contains no unique user identifier, cookie value, page URL, or auction
+data. It describes only the delivery path of the current document. Because only
+the cookie-sticky treatment cohort is routed through Trusted Server for this
+experiment, the value also reveals treatment-path membership for that GAM
+request. It is therefore cohort information even though it does not expose the
+assignment cookie or identify a person by itself.
+
+The implementation does not read the experiment cookie. Routing happens before
+Trusted Server handles the request. Existing consent gates continue to decide
+whether GAM requests or auctions occur. The marker does not create an ad request
+that would otherwise be suppressed. Before enabling the key, the experiment
+owner must complete the publisher's privacy/data-governance review for sending
+this treatment-path attribute to GAM and confirm that existing consent and
+data-use terms cover it.
+
+## Testing strategy
+
+### Automated tests
+
+1. Extend Rust GPT head-insert tests to assert page-level `ts=true` targeting is
+   in the existing raw bootstrap, occurs before the `ts.adInit` guard and any
+   bootstrap `display()` or `refresh()` call, and does not change the expected
+   head-insert count.
+2. Extend the TSJS tag and HTML processor tests to prove the non-executable GPT
+   activation attribute appears only on the enabled publisher-page bundle and
+   adds no script tag.
+3. Add the Vitest/jsdom raw-bootstrap harness described above. Exercise the
+   bootstrap with `googletag.setConfig` available, unavailable, and throwing,
+   and prove a later publisher callback still runs in every case. Set
+   `window.tsjs.adInit` before evaluation and prove the marker still runs.
+4. Extend the existing GPT bundle tests to prove module initialization queues
+   the fallback marker and remains non-blocking when `setConfig` is unavailable
+   or throws.
+5. Retain assertions for `ts_initial=1` to prevent accidental replacement.
+6. Retain refresh tests proving stale `ts_initial` and `hb_*` slot targeting is
+   cleared. Add an explicit assertion or source-level invariant that page-level
+   `ts` is not included in slot cleanup lists.
+7. Extend creative-opportunity configuration tests to demonstrate that an
+   operator targeting map is forwarded verbatim, documenting why the deployment
+   audit must reject a configured `ts` key rather than assuming the client
+   overwrites or filters it.
+8. Run the project-required target-matched Rust and JavaScript checks for the
+   touched files.
+
+### Browser/GAM validation
+
+Before experiment launch:
+
+1. Load a treatment page using a known treatment cookie.
+2. Confirm the initial in-scope GAM request contains `ts=true` using GPT
+   Publisher Console, Delivery Inspector, or the browser network panel.
+3. Trigger a lazy slot and a refresh; confirm both requests still contain
+   `ts=true`.
+4. Load the equivalent production page with a control cookie and confirm the key
+   is absent.
+5. Confirm `ts_initial=1` remains limited to its existing initial-slot
+   lifecycle.
+6. Validate the deployed CSP by proving `adSlots`, the GPT bootstrap, `bids`,
+   and the initial `adInit` handoff execute on a representative page with
+   matched slots. A page that runs only the external bundle is ineligible even
+   if the fallback marker appears.
+7. Set an unrelated page-level targeting key after `ts=true` and confirm both
+   keys remain on a later request. Treat an explicit page-level or per-key clear
+   as a failed publisher-code audit, not supported behavior.
+8. Validate that IMA/video, direct-tag, server-side GAM, and nested GPT
+   inventory without an independently TS-rewritten document is absent from the
+   experiment and paired report scope. Directly validate any independently
+   rewritten nested documents that are intentionally included.
+9. Run a short GAM report and verify treatment totals appear under `ts=true`
+   while overall totals remain unchanged apart from normal reporting latency.
+
+## Rollout
+
+1. Audit response eligibility, including HTML rewriting, `<head>` ordering, CSP,
+   and publisher GPT calls that could precede or remove the marker.
+2. Audit the `ts` key across publisher GPT code, effective `trusted-server.toml`
+   creative-opportunity targeting maps, and every GAM custom-targeting consumer.
+3. Prove through router or access logs that non-experiment traffic is excluded
+   from the TS route or independently separable in both paired GAM reports.
+4. Exclude IMA/video, direct-tag, server-side GAM, and nested GPT inventory
+   whose document is not independently rewritten. Inventory in intentionally
+   rewritten nested documents must pass the same request and report validation
+   as the top-level document.
+5. Create and enable the reportable GAM key and predefined value.
+6. Deploy the Trusted Server marker before assigning experiment traffic.
+7. Provision the scheduled synthetic crawl, assign an incident owner, and obtain
+   one successful treatment/control run covering initial, lazy, refreshed, and
+   CSP execution checks.
+8. Validate treatment and control requests manually.
+9. Start the small cookie-sticky cohort.
+10. Compare observed GAM treatment share with the router allocation before using
+    the results for performance decisions.
+11. Monitor normalized metrics over a sufficiently large window; do not infer a
+    treatment effect from unequal raw totals.
+
+Rollback stops adding the page-level key to newly loaded documents. Already-open
+documents—including long-lived SPA sessions—retain page-level targeting and may
+continue issuing marked lazy or refreshed requests after the code rollback.
+Record the rollback timestamp, end the experiment reports at the last clean
+pre-rollback boundary, and exclude the post-rollback drain interval from both
+cohorts. The drain ends only after router/access logs and GAM show no remaining
+`ts=true` traffic for one complete agreed reporting interval and a fresh
+synthetic navigation confirms that new documents are unmarked. If marked traffic
+persists, the interval remains excluded rather than being inferred as control.
+Historical GAM rows recorded while the key was active remain valid, and the GAM
+key may stay defined and reportable for historical analysis.
+
+## Alternatives considered
+
+### Reuse `ts_initial=1`
+
+Rejected because the key is slot-level, covers only TS-managed initial slots,
+and is deliberately cleared on refresh. Changing its lifecycle would also break
+its existing ownership semantics.
+
+### Add slot-level `ts=true` in `adInit`
+
+Rejected because it would miss publisher-owned or lazy slots that do not pass
+through `adInit`, and existing refresh cleanup could remove it. It would measure
+auction participation rather than page delivery.
+
+### Set `ts=true` only in the bootstrap
+
+Rejected as the sole path. Placing the enqueue before the existing `ts.adInit`
+guard correctly handles a pre-installed ad-init implementation. The bundle is
+not needed for that case. It remains useful when the inline script unexpectedly
+stops executing but the synchronous first-party bundle still runs: without the
+fallback, a TS-delivered treatment page would be silently inferred as control.
+The fallback does not rescue the simultaneously blocked TS ad-stack scripts, so
+that state is an incident rather than an eligible deployment mode.
+
+### Use a longer descriptive key name such as `trusted_server`
+
+A descriptive name would lower the collision risk that the short `ts` key
+carries. Rejected because GAM limits a custom-targeting key name to 10
+characters, so `trusted_server` (14) cannot be created as a reportable key. The
+short `ts` name is therefore mandatory, and the cross-system collision audit is
+the compensating control. Do not dual-write `ts` alongside any longer alias: two
+names for one cohort would increase GAM setup and audit surface and permit
+silent drift between reports. Only `ts=true` is valid.
+
+### Configure `ts=true` in creative-opportunity slot targeting
+
+Rejected because creative-opportunity targeting applies only to matched slots.
+The experiment requirement covers every request from each successfully rewritten
+document's local GPT PubAds service.
+
+### Rewrite `cust_params` on GAM network requests
+
+Rejected because it depends on GPT's internal request construction and encoding,
+adds interception risk, and duplicates a supported GPT targeting API.
+
+### Mark production explicitly with `ts=false`
+
+Preferred in a fully controlled experiment, but unavailable because the
+production path cannot be changed. The design documents the resulting unmarked
+baseline limitation and requires coverage checks.
+
+## Acceptance criteria
+
+1. For a deployment that satisfies the documented GPT-integration, HTML-rewrite,
+   `<head>` ordering, CSP, reserved-key, request-scope, and targeting-cleanup
+   prerequisites—and in which a Trusted Server marker callback runs before the
+   first request—every request from that rewritten document's local GPT PubAds
+   service carries `ts=true`, including initial, lazy, refreshed,
+   publisher-owned, and SPA-route requests. A nested document is covered only
+   when its own HTML response independently satisfies the same prerequisites.
+2. Production/control pages remain unmodified and do not carry `ts` from this
+   feature.
+3. `ts_initial=1` retains its current slot-level initial-request lifecycle.
+4. The new key is not cleared by Prebid refresh or SPA slot cleanup.
+5. No publisher code, effective Trusted Server creative-opportunity targeting
+   map, or GAM custom-targeting consumer changes ad eligibility, pricing,
+   protection, routing, or the marker value because of the measurement key.
+6. The marker adds no unique identifier, cookie value, network request, or
+   blocking work. Its disclosure of treatment-path membership to GAM has passed
+   the publisher's privacy/data-governance review.
+7. GAM can report treatment impressions and clicks under `ts=true`, and the
+   control counts can be derived within the same experiment scope using
+   identical non-targeted metrics.
+8. Known treatment requests are validated directly for marker presence, and the
+   observed GAM treatment share is compared diagnostically with the router's
+   expected cohort allocation before experiment results are interpreted.
+9. Non-experiment TS traffic is absent from the route during the measurement
+   window or excluded from both paired GAM reports with identical filters.
+10. Only `ts=true` is emitted and reported; no other value (for example `ts=1`)
+    and no alternative key name (for example `trusted_server`) alias or
+    dual-write compatibility path exists.
+11. CSP-compatible inline execution is proven before launch. A fallback-only
+    page remains attributed to treatment but raises an incident and cannot be
+    treated as a healthy experiment page.
+12. Rollback reporting excludes already-open documents until observed marked
+    traffic has drained according to the documented boundary rule.

--- a/docs/superpowers/specs/2026-08-19-gam-attribution-review-resolution-design.md
+++ b/docs/superpowers/specs/2026-08-19-gam-attribution-review-resolution-design.md
@@ -58,4 +58,3 @@ Changes will be made test-first where behavior changes:
 3. Run focused Rust and JavaScript tests after each implementation step.
 4. Run repository formatting, JavaScript formatting/tests, target-matched Rust tests,
    clippy aliases, parity tests, and CLI tests before handoff.
-

--- a/docs/superpowers/specs/2026-08-19-gam-attribution-review-resolution-design.md
+++ b/docs/superpowers/specs/2026-08-19-gam-attribution-review-resolution-design.md
@@ -1,0 +1,61 @@
+# GAM Attribution Review Resolution Design
+
+## Goal
+
+Resolve every actionable comment from PR #1034 review 4966544291 while preserving
+the existing default-off GAM attribution behavior and avoiding unrelated changes.
+
+## Attribute aggregation
+
+`IntegrationRegistry::tsjs_script_tag_attributes` will remain the boundary that
+combines metadata from enabled head injectors. It will preserve registration order
+and keep the first value emitted for each attribute name. Later duplicate names will
+be ignored. This prevents invalid duplicate HTML attributes without changing the
+precedence implied by the existing ordered aggregation.
+
+The registry test fixtures will include two injectors that emit the same attribute
+name, proving that the first value wins and non-conflicting attributes retain their
+order.
+
+## Trusted static attribute validation
+
+`tsjs_script_tag_with_attributes` will continue rendering trusted, compile-time
+attribute pairs without release-mode escaping overhead. In debug builds and tests,
+it will assert that names are non-empty and contain only lowercase ASCII letters,
+digits, and hyphens, and that values contain none of the characters that could alter
+or ambiguously encode the double-quoted HTML attribute: double quote, ampersand,
+less-than, or greater-than.
+
+Focused panic tests will cover invalid names and values. The existing rendering test
+will continue proving the valid path and the byte-for-byte unchanged unmarked path.
+
+## Bootstrap failure visibility
+
+The early GPT attribution command will continue isolating `setConfig` exceptions so
+later bootstrap and publisher commands run. Its catch block will also call
+`ts.log.warn` when that logger is present, matching the guarded logging style already
+used in the bootstrap. The existing throwing-`setConfig` test will be extended to
+prove both isolation and warning emission.
+
+The attribution literal will use the file's double-quote style, and the Rust source
+ordering test will match the normalized source text.
+
+## Consistency cleanup
+
+The unused `getConfig` member will be removed from the test-only `MockGoogleTag`
+interface. Version-specific EdgeZero wording in the reviewed GPT example and guide
+will be replaced with capability-based wording. The integration fixture identified
+as load-bearing will remain unchanged.
+
+## Verification
+
+Changes will be made test-first where behavior changes:
+
+1. Add duplicate-attribute and invalid-attribute tests and observe their expected
+   failures before implementing the Rust protections.
+2. Extend the throwing-`setConfig` Vitest and observe the missing warning assertion
+   fail before adding guarded logging.
+3. Run focused Rust and JavaScript tests after each implementation step.
+4. Run repository formatting, JavaScript formatting/tests, target-matched Rust tests,
+   clippy aliases, parity tests, and CLI tests before handoff.
+

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -104,6 +104,9 @@ rewrite_sdk = true
 
 [integrations.gpt]
 enabled = false
+# Keep this leaf present when using the corresponding EdgeZero v0.0.4
+# environment override. Attribution remains off until explicitly enabled.
+gam_attribution_enabled = false
 script_url = "https://ads.example.com/gpt.js"
 cache_ttl_seconds = 3600
 rewrite_script = true

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -104,8 +104,8 @@ rewrite_sdk = true
 
 [integrations.gpt]
 enabled = false
-# Keep this leaf present when using the corresponding EdgeZero v0.0.4
-# environment override. Attribution remains off until explicitly enabled.
+# Keep this leaf present when the environment overlay cannot create a missing
+# configuration leaf. Attribution remains off until explicitly enabled.
 gam_attribution_enabled = false
 script_url = "https://ads.example.com/gpt.js"
 cache_ttl_seconds = 3600

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -104,8 +104,8 @@ rewrite_sdk = true
 
 [integrations.gpt]
 enabled = false
-# Keep this leaf present when the environment overlay cannot create a missing
-# configuration leaf. Attribution remains off until explicitly enabled.
+# Keep this leaf present so the environment override can apply; the overlay
+# cannot create a missing configuration leaf. Attribution stays off until enabled.
 gam_attribution_enabled = false
 script_url = "https://ads.example.com/gpt.js"
 cache_ttl_seconds = 3600


### PR DESCRIPTION
## Summary

- Add a default-off `gam_attribution_enabled` GPT option that applies fixed page-level `ts=true` targeting to eligible publisher documents whose rewritten head is emitted by Trusted Server, allowing GAM to describe treatment delivery while the production/control path remains unmarked.
- Apply targeting before publisher GPT initialization through the early bootstrap, with an exact `document.currentScript` attribute-gated TSJS fallback that fails closed and isolates `setConfig` failures.
- Preserve auction behavior, consent, the slot-level `ts_initial` lifecycle, and publisher/Prebid targeting while documenting the collision audit, reporting contract, rollout, monitoring limits, and drain-safe rollback sequence.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-cli/tests/config_env_overlay.rs` | Verify the GAM attribution environment override is applied when the corresponding TOML leaf exists. |
| `crates/trusted-server-core/src/creative_opportunities.rs` | Characterize that operator-provided slot-level `ts` targeting remains forwarded unchanged. |
| `crates/trusted-server-core/src/html_processor.rs` | Add integration-provided attributes to publisher TSJS tags and cover enabled, disabled, and source-order behavior. |
| `crates/trusted-server-core/src/integrations/gpt.rs` | Add the default-off setting and drive both inline activation and fallback authorization from the parsed GPT configuration. |
| `crates/trusted-server-core/src/integrations/gpt_bootstrap.js` | Queue page-level `ts=true` before the existing `adInit` guard and isolate attribution failures from later GPT commands. |
| `crates/trusted-server-core/src/integrations/registry.rs` | Add and test the integration hook that supplies trusted static attributes for publisher bundle tags. |
| `crates/trusted-server-core/src/publisher.rs` | Cover streaming-head attribution semantics and operator-targeting preservation. |
| `crates/trusted-server-core/src/tsjs.rs` | Render trusted static attributes on publisher TSJS tags without changing generic or creative tag output. |
| `crates/trusted-server-integration-tests/browser/tests/shared/script-injection.spec.ts` | Verify attribution metadata is absent from the default-off integration fixture. |
| `crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml` | Keep the new configuration leaf explicit and disabled in integration tests. |
| `crates/trusted-server-js/lib/src/integrations/gpt/index.ts` | Add the executing-script-gated bundle fallback for page-level GAM targeting. |
| `crates/trusted-server-js/lib/test/integrations/gpt/ad_init.test.ts` | Verify SPA cleanup does not clear the page-level `ts` key. |
| `crates/trusted-server-js/lib/test/integrations/gpt/gpt_bootstrap.test.ts` | Exercise activation ordering, disabled behavior, unavailable or throwing `setConfig`, and bootstrap continuity. |
| `crates/trusted-server-js/lib/test/integrations/gpt/index.test.ts` | Cover exact fallback authorization, fail-closed cases, duplicate-ID decoys, cloned tags, and error isolation. |
| `crates/trusted-server-js/lib/test/integrations/prebid/index.test.ts` | Characterize publisher and Prebid-generated `ts` targeting across refreshes. |
| `docs/guide/integrations/gpt.md` | Document configuration, environment-overlay requirements, attribution semantics, collision checks, reporting, rollout, and rollback. |
| `docs/superpowers/plans/2026-07-15-gam-ts-cohort-attribution.md` | Add the reviewed implementation and verification plan. |
| `docs/superpowers/specs/2026-07-15-gam-ts-cohort-attribution-design.md` | Finalize the fixed marker contract, streaming meaning, reporting scope, and operational safeguards. |
| `trusted-server.example.toml` | Add the explicit default-off setting and environment-overlay guidance. |

## Launch gates

This PR completes the repository implementation. Starting the cohort remains gated on target-network GAM provisioning, cross-system collision and privacy/CSP audits, a paired-report dry run, and router-controlled treatment validation described in the design.

GAM results are descriptive delivery attribution, not causal treatment-effect estimates.

## Closes

Closes #1027

## Test plan

- [x] `cargo test-fastly && cargo test-axum`
- [x] `cargo clippy-fastly && cargo clippy-axum`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/trusted-server-js/lib && npx vitest run` (44 files, 847 tests)
- [x] JS format: `cd crates/trusted-server-js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [x] WASM build: `cargo build --package trusted-server-adapter-fastly --release --target wasm32-wasip1`
- [x] Manual testing via `fastly compute serve`: confirmed the inline flag, activation attribute, GPT page targeting, and decoded `cust_params` containing `ts=true` on a real GAM request
- [x] Other: Cloudflare and Spin adapter tests/clippy, cross-adapter parity, native CLI tests, and Next.js/WordPress browser integration suites

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` added to production code
- [x] Logging follows project conventions; no direct stdout/stderr logging was added
- [x] New code has tests
- [x] No secrets or credentials committed
