### PR TITLE
Add native secret-store config resolution

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,7 @@
+# Non-secret development overlays used while generating the Axum config blob.
+# Sourcing this file alone does not configure the Axum server: also export the
+# blob and referenced secret-store values as shown in docs/guide/getting-started.md.
+
 # [publisher]
 TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=http://localhost:9090
 

--- a/.env.dev
+++ b/.env.dev
@@ -3,6 +3,8 @@
 # blob and referenced secret-store values as shown in docs/guide/getting-started.md.
 
 # [publisher]
+TRUSTED_SERVER__PUBLISHER__DOMAIN=localhost
+TRUSTED_SERVER__PUBLISHER__COOKIE_DOMAIN=localhost
 TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=http://localhost:9090
 
 # [synthetic]

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@
 # and export one secret per key name as:
 # TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_<KEY_NAME>=<secret-value>
 # The commented examples below are CLI overlays for ordinary fields only.
+# Fastly example: map logical app-config secrets to physical `ts_secrets`.
+EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME=ts_secrets
 
 # =============================================================================
 # Publisher Settings

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_<KEY_NAME>=<secret-value>
 # The commented examples below are CLI overlays for ordinary fields only.
 # Fastly example: map logical app-config secrets to physical `ts_secrets`.
-EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME=ts_secrets
+# EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME=ts_secrets
 
 # =============================================================================
 # Publisher Settings

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
-# Trusted Server Environment Variables
-# Copy this file to .env.dev, .env.staging, or .env.production and fill in values
-# See docs/guide/configuration.md for details
+# Trusted Server development environment variables
+# Copy this file to .env.dev, .env.staging, or .env.production and fill in
+# non-secret values. App-config secrets are key names in the pushed blob and
+# their values belong in the platform secret store; see the configuration guide.
+# For Axum runtime loading, export the config blob as:
+# TRUSTED_SERVER_CONFIG_TRUSTED_SERVER_CONFIG_TRUSTED_SERVER_CONFIG=<blob-envelope-json>
+# and export one secret per key name as:
+# TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_<KEY_NAME>=<secret-value>
+# The commented examples below are CLI overlays for ordinary fields only.
 
 # =============================================================================
 # Publisher Settings
@@ -8,14 +14,12 @@
 TRUSTED_SERVER__PUBLISHER__DOMAIN=publisher.com
 TRUSTED_SERVER__PUBLISHER__COOKIE_DOMAIN=.publisher.com
 TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.com
-TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=<your-proxy-secret>
 
 # =============================================================================
 # Synthetic ID Settings
 # =============================================================================
 TRUSTED_SERVER__SYNTHETIC__COUNTER_STORE=counter_store
 TRUSTED_SERVER__SYNTHETIC__OPID_STORE=opid_store
-TRUSTED_SERVER__SYNTHETIC__SECRET_KEY=<your-synthetic-secret>
 # Template variables: client_ip, user_agent, first_party_id, auth_user_id, publisher_domain, accept_language
 TRUSTED_SERVER__SYNTHETIC__TEMPLATE={{ client_ip }}:{{ user_agent }}:{{ first_party_id }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5399,6 +5399,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "toml",
  "trusted-server-core",
  "url",
  "urlencoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
+source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
 dependencies = [
  "toml",
 ]
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
+source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
+source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
+source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
+source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
+source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
 dependencies = [
  "chrono",
  "clap",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
+source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
+source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
 dependencies = [
  "log",
  "proc-macro2",
@@ -3676,7 +3676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -3696,7 +3696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3709,7 +3709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.7#5c9886e51d17e6969531356bacdf27f144ac8a2e"
+source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
 dependencies = [
  "toml",
 ]
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.7#5c9886e51d17e6969531356bacdf27f144ac8a2e"
+source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.7#5c9886e51d17e6969531356bacdf27f144ac8a2e"
+source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.7#5c9886e51d17e6969531356bacdf27f144ac8a2e"
+source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.7#5c9886e51d17e6969531356bacdf27f144ac8a2e"
+source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.7#5c9886e51d17e6969531356bacdf27f144ac8a2e"
+source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
 dependencies = [
  "chrono",
  "clap",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.7#5c9886e51d17e6969531356bacdf27f144ac8a2e"
+source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1598,14 +1598,14 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?tag=v0.0.7#5c9886e51d17e6969531356bacdf27f144ac8a2e"
+source = "git+https://github.com/stackpop/edgezero?rev=bb4411625856472b1279a3db49aeeac5e8b1507e#bb4411625856472b1279a3db49aeeac5e8b1507e"
 dependencies = [
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 3.0.4",
+ "syn 2.0.118",
  "toml",
  "validator",
 ]
@@ -4852,17 +4852,6 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
+source = "git+https://github.com/stackpop/edgezero?tag=v0.0.8#567964158e4f8bd0d52321b9801de44966422e1b"
 dependencies = [
  "toml",
 ]
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
+source = "git+https://github.com/stackpop/edgezero?tag=v0.0.8#567964158e4f8bd0d52321b9801de44966422e1b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
+source = "git+https://github.com/stackpop/edgezero?tag=v0.0.8#567964158e4f8bd0d52321b9801de44966422e1b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
+source = "git+https://github.com/stackpop/edgezero?tag=v0.0.8#567964158e4f8bd0d52321b9801de44966422e1b"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
+source = "git+https://github.com/stackpop/edgezero?tag=v0.0.8#567964158e4f8bd0d52321b9801de44966422e1b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
+source = "git+https://github.com/stackpop/edgezero?tag=v0.0.8#567964158e4f8bd0d52321b9801de44966422e1b"
 dependencies = [
  "chrono",
  "clap",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
+source = "git+https://github.com/stackpop/edgezero?tag=v0.0.8#567964158e4f8bd0d52321b9801de44966422e1b"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
+source = "git+https://github.com/stackpop/edgezero?tag=v0.0.8#567964158e4f8bd0d52321b9801de44966422e1b"
 dependencies = [
  "log",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
+source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
 dependencies = [
  "toml",
 ]
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
+source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
+source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
+source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
+source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
+source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
 dependencies = [
  "chrono",
  "clap",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
+source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
+source = "git+https://github.com/stackpop/edgezero?rev=0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34#0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34"
 dependencies = [
  "log",
  "proc-macro2",
@@ -6013,7 +6013,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
+source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
 dependencies = [
  "toml",
 ]
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-axum"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
+source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-cloudflare"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
+source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-fastly"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
+source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "edgezero-adapter-spin"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
+source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "edgezero-cli"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
+source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
 dependencies = [
  "chrono",
  "clap",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "edgezero-core"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
+source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1598,14 +1598,14 @@ dependencies = [
 [[package]]
 name = "edgezero-macros"
 version = "0.1.0"
-source = "git+https://github.com/stackpop/edgezero?rev=a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221#a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221"
+source = "git+https://github.com/stackpop/edgezero?rev=2b249571af53a45c1539a24895ea975edd2bf4d5#2b249571af53a45c1539a24895ea975edd2bf4d5"
 dependencies = [
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.118",
+ "syn 3.0.4",
  "toml",
  "validator",
 ]
@@ -4859,6 +4859,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6002,7 +6013,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 derive_more = { version = "2.0", features = ["display", "error"] }
 directories = "5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
-edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
-edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
-edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
-edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
-edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221" }
-edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
+edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
+edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
+edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
+edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
+edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5" }
+edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
 env_logger = "0.11"
 error-stack = "0.6"
 esi = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 derive_more = { version = "2.0", features = ["display", "error"] }
 directories = "5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
-edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
-edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
-edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
-edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
-edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e" }
-edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
+edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
+edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
+edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
+edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
+edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221" }
+edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "a9bcbf8b29c8e5f7a555fba6ea7c428d5e360221", default-features = false }
 env_logger = "0.11"
 error-stack = "0.6"
 esi = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 derive_more = { version = "2.0", features = ["display", "error"] }
 directories = "5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
-edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
-edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
-edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
-edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
-edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5" }
-edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "2b249571af53a45c1539a24895ea975edd2bf4d5", default-features = false }
+edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
+edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
+edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
+edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
+edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34" }
+edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
 env_logger = "0.11"
 error-stack = "0.6"
 esi = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 derive_more = { version = "2.0", features = ["display", "error"] }
 directories = "5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
-edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.7", default-features = false }
-edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.7", default-features = false }
-edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.7", default-features = false }
-edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.7", default-features = false }
-edgezero-cli = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.7" }
-edgezero-core = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.7", default-features = false }
+edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
+edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
+edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
+edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
+edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e" }
+edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "bb4411625856472b1279a3db49aeeac5e8b1507e", default-features = false }
 env_logger = "0.11"
 error-stack = "0.6"
 esi = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 derive_more = { version = "2.0", features = ["display", "error"] }
 directories = "5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
-edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
-edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
-edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
-edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
-edgezero-cli = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34" }
-edgezero-core = { git = "https://github.com/stackpop/edgezero", rev = "0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34", default-features = false }
+edgezero-adapter-axum = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.8", default-features = false }
+edgezero-adapter-cloudflare = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.8", default-features = false }
+edgezero-adapter-fastly = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.8", default-features = false }
+edgezero-adapter-spin = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.8", default-features = false }
+edgezero-cli = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.8" }
+edgezero-core = { git = "https://github.com/stackpop/edgezero", tag = "v0.0.8", default-features = false }
 env_logger = "0.11"
 error-stack = "0.6"
 esi = "0.7.2"

--- a/crates/trusted-server-adapter-axum/src/app.rs
+++ b/crates/trusted-server-adapter-axum/src/app.rs
@@ -38,7 +38,7 @@ use trusted_server_core::settings_data::{
 use trusted_server_core::platform::RuntimeServices;
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware, SanitizeRequestMiddleware};
-use crate::platform::{AxumPlatformConfigStore, build_runtime_services};
+use crate::platform::{AxumPlatformConfigStore, AxumPlatformSecretStore, build_runtime_services};
 
 // ---------------------------------------------------------------------------
 // AppState
@@ -60,8 +60,13 @@ pub struct AppState {
 fn build_state() -> Result<Arc<AppState>, Report<TrustedServerError>> {
     let store_name = default_config_store_name();
     let config_key = default_config_key();
-    let settings =
-        get_settings_from_config_store(&AxumPlatformConfigStore, &store_name, &config_key)?;
+    let settings = get_settings_from_config_store(
+        &AxumPlatformConfigStore,
+        &AxumPlatformSecretStore,
+        &store_name,
+        &config_key,
+        &trusted_server_core::settings_data::default_secret_store_name(),
+    )?;
     build_state_with_settings(settings)
 }
 

--- a/crates/trusted-server-adapter-cloudflare/src/app.rs
+++ b/crates/trusted-server-adapter-cloudflare/src/app.rs
@@ -35,6 +35,8 @@ use trusted_server_core::request_signing::{
     handle_trusted_server_discovery, handle_verify_signature,
 };
 use trusted_server_core::settings::Settings;
+#[cfg(target_arch = "wasm32")]
+use trusted_server_core::settings_data::default_secret_store_name;
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware, SanitizeRequestMiddleware};
 use crate::platform::build_runtime_services;
@@ -44,11 +46,23 @@ use crate::platform::build_runtime_services;
 // ---------------------------------------------------------------------------
 
 #[cfg(target_arch = "wasm32")]
-static CLOUDFLARE_CONFIG_JSON: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+thread_local! {
+    static CLOUDFLARE_CONFIG_JSON: std::cell::OnceCell<String> = const { std::cell::OnceCell::new() };
+    static CLOUDFLARE_ENV: std::cell::OnceCell<worker::Env> = const { std::cell::OnceCell::new() };
+}
 
 #[cfg(target_arch = "wasm32")]
 pub fn set_cloudflare_config_json(value: String) {
-    let _ = CLOUDFLARE_CONFIG_JSON.set(value);
+    CLOUDFLARE_CONFIG_JSON.with(|slot| {
+        let _ = slot.set(value);
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn set_cloudflare_env(env: worker::Env) {
+    CLOUDFLARE_ENV.with(|slot| {
+        let _ = slot.set(env);
+    });
 }
 
 /// Application state built once at startup and shared across all requests.
@@ -76,18 +90,22 @@ fn load_startup_settings() -> Result<Settings, Report<TrustedServerError>> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn load_startup_settings() -> Result<Settings, Report<TrustedServerError>> {
-    Settings::from_toml(include_str!("../../../trusted-server.example.toml"))
+    Err(Report::new(TrustedServerError::Configuration {
+        message: "Cloudflare startup settings require a Worker config binding".to_string(),
+    })
+    .attach("use TrustedServerApp::routes_with_settings for host tests"))
 }
 
 #[cfg(target_arch = "wasm32")]
 fn settings_from_cloudflare_config_json() -> Result<Settings, Report<TrustedServerError>> {
-    let raw_config = CLOUDFLARE_CONFIG_JSON.get().ok_or_else(|| {
+    let raw_config = CLOUDFLARE_CONFIG_JSON.with(|slot| slot.get().cloned());
+    let raw_config = raw_config.ok_or_else(|| {
         Report::new(TrustedServerError::Configuration {
             message: "Cloudflare TRUSTED_SERVER_CONFIG is required".to_string(),
         })
         .attach("set TRUSTED_SERVER_CONFIG to JSON containing the app_config blob envelope")
     })?;
-    let value: serde_json::Value = serde_json::from_str(raw_config).map_err(|error| {
+    let value: serde_json::Value = serde_json::from_str(&raw_config).map_err(|error| {
         Report::new(TrustedServerError::Configuration {
             message: "invalid Cloudflare TRUSTED_SERVER_CONFIG JSON".to_string(),
         })
@@ -101,7 +119,15 @@ fn settings_from_cloudflare_config_json() -> Result<Settings, Report<TrustedServ
                 message: "Cloudflare TRUSTED_SERVER_CONFIG missing app_config".to_string(),
             })
         })?;
-    settings_from_config_blob(envelope)
+    let env = CLOUDFLARE_ENV
+        .with(|slot| slot.get().cloned())
+        .ok_or_else(|| {
+            Report::new(TrustedServerError::Configuration {
+                message: "Cloudflare Worker environment is unavailable during startup".to_string(),
+            })
+        })?;
+    let secret_store = crate::platform::CloudflareSecretStoreAdapter { env };
+    settings_from_config_blob(envelope, &secret_store, &default_secret_store_name())
 }
 
 /// Build the application state from explicit settings.

--- a/crates/trusted-server-adapter-cloudflare/src/app.rs
+++ b/crates/trusted-server-adapter-cloudflare/src/app.rs
@@ -12,7 +12,7 @@ use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 use trusted_server_core::cache_policy::EdgeCacheHeader;
 #[cfg(target_arch = "wasm32")]
-use trusted_server_core::config_payload::settings_from_config_blob;
+use trusted_server_core::config_payload::{DEFAULT_SECRET_STORE_ID, settings_from_config_blob};
 use trusted_server_core::ec::EcContext;
 use trusted_server_core::ec::admin::{
     admin_ec_lookup_not_supported as core_admin_ec_lookup_not_supported,
@@ -22,6 +22,8 @@ use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::error::{IntoHttpResponse as _, TrustedServerError};
 use trusted_server_core::integrations::{IntegrationRegistry, ProxyDispatchInput};
 use trusted_server_core::platform::RuntimeServices;
+#[cfg(target_arch = "wasm32")]
+use trusted_server_core::platform::StoreName;
 use trusted_server_core::proxy::{
     handle_first_party_click, handle_first_party_proxy, handle_first_party_proxy_rebuild,
     handle_first_party_proxy_sign,
@@ -35,8 +37,6 @@ use trusted_server_core::request_signing::{
     handle_trusted_server_discovery, handle_verify_signature,
 };
 use trusted_server_core::settings::Settings;
-#[cfg(target_arch = "wasm32")]
-use trusted_server_core::settings_data::default_secret_store_name;
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware, SanitizeRequestMiddleware};
 use crate::platform::build_runtime_services;
@@ -127,7 +127,8 @@ fn settings_from_cloudflare_config_json() -> Result<Settings, Report<TrustedServ
             })
         })?;
     let secret_store = crate::platform::CloudflareSecretStoreAdapter { env };
-    settings_from_config_blob(envelope, &secret_store, &default_secret_store_name())
+    let default_secret_store = StoreName::from(DEFAULT_SECRET_STORE_ID);
+    settings_from_config_blob(envelope, &secret_store, &default_secret_store)
 }
 
 /// Build the application state from explicit settings.

--- a/crates/trusted-server-adapter-cloudflare/src/lib.rs
+++ b/crates/trusted-server-adapter-cloudflare/src/lib.rs
@@ -27,6 +27,7 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
     if let Ok(config) = env.var("TRUSTED_SERVER_CONFIG") {
         app::set_cloudflare_config_json(config.to_string());
     }
+    app::set_cloudflare_env(env.clone());
 
     match edgezero_adapter_cloudflare::run_app::<app::TrustedServerApp>(req, env, ctx).await {
         Ok(resp) => Ok(resp),

--- a/crates/trusted-server-adapter-cloudflare/src/platform.rs
+++ b/crates/trusted-server-adapter-cloudflare/src/platform.rs
@@ -547,8 +547,8 @@ impl PlatformHttpClient for CloudflareHttpClient {
 /// Bridges [`worker::Env`] secrets to [`PlatformSecretStore`] by calling
 /// `env.secret(key)` synchronously. Writes and deletes return errors.
 #[cfg(target_arch = "wasm32")]
-struct CloudflareSecretStoreAdapter {
-    env: worker::Env,
+pub(crate) struct CloudflareSecretStoreAdapter {
+    pub(crate) env: worker::Env,
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/trusted-server-adapter-cloudflare/wrangler.ci.toml
+++ b/crates/trusted-server-adapter-cloudflare/wrangler.ci.toml
@@ -14,3 +14,12 @@ id = "ci-local-kv"
 # Placeholder replaced by the integration test harness with a JSON object that
 # contains the runtime Trusted Server app-config blob envelope.
 TRUSTED_SERVER_CONFIG = "{}"
+
+# Fictitious integration-only secret values. `worker::Env::secret` reads these
+# string bindings in local Wrangler runs; production values are provisioned with
+# `wrangler secret put` instead of being committed to a manifest.
+integration_admin_password = "integration-admin-password-32-bytes-ok"
+integration_proxy_secret = "integration-test-proxy-secret-32-bytes-ok"
+integration_ec_passphrase = "integration-test-ec-secret-padded-32"
+integration_partner_token_alpha = "integration-test-token-alpha-32-bytes-ok"
+integration_partner_token_bravo = "integration-test-token-bravo-32-bytes-ok"

--- a/crates/trusted-server-adapter-cloudflare/wrangler.toml
+++ b/crates/trusted-server-adapter-cloudflare/wrangler.toml
@@ -26,3 +26,7 @@ id = "REPLACE_WITH_YOUR_KV_NAMESPACE_ID"
 # invalid placeholder with JSON containing an `app_config` blob envelope before
 # deploying or running `wrangler dev` against real traffic.
 TRUSTED_SERVER_CONFIG = '{"app_config":""}'
+
+# App-config secret values are provisioned as Worker secrets with
+# `wrangler secret put <key-name>`. The pushed blob contains only those key
+# names; never add secret values to this file.

--- a/crates/trusted-server-adapter-fastly/Cargo.toml
+++ b/crates/trusted-server-adapter-fastly/Cargo.toml
@@ -35,4 +35,5 @@ urlencoding = { workspace = true }
 [dev-dependencies]
 bytes = { workspace = true }
 edgezero-core = { workspace = true, features = ["test-utils"] }
+toml = { workspace = true }
 trusted-server-core = { workspace = true, features = ["test-utils"] }

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -90,6 +90,7 @@ use std::sync::Arc;
 
 use crate::rate_limiter::{FastlyRateLimiter, RATE_COUNTER_NAME};
 use edgezero_adapter_fastly::context::FastlyRequestContext;
+use edgezero_adapter_fastly::env_config_from_runtime_dictionary;
 use edgezero_core::app::{App, Hooks, StoreMetadata, StoresMetadata};
 use edgezero_core::context::RequestContext;
 use edgezero_core::env_config::EnvConfig;
@@ -1323,7 +1324,8 @@ impl Hooks for TrustedServerApp {
     }
 
     fn routes() -> RouterService {
-        let stores = RuntimeStoreConfig::from_env(&EnvConfig::from_env());
+        let runtime_env = env_config_from_runtime_dictionary(Self::stores());
+        let stores = RuntimeStoreConfig::from_env(&runtime_env);
         Self::router_with_state(&stores).0
     }
 

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -1391,17 +1391,46 @@ mod tests {
     use trusted_server_core::settings::Settings;
 
     #[test]
-    fn hooks_expose_the_manifest_store_metadata_used_by_fastly_runtime_mapping() {
+    fn hooks_store_metadata_matches_edgezero_manifest() {
+        let manifest: toml::Value = toml::from_str(include_str!("../../../edgezero.toml"))
+            .expect("should parse edgezero manifest");
+        let manifest_stores = manifest
+            .get("stores")
+            .and_then(toml::Value::as_table)
+            .expect("manifest should declare stores");
         let metadata = TrustedServerApp::stores();
 
-        assert_eq!(
-            metadata.config.map(|store| store.default),
-            Some("trusted_server_config")
-        );
-        assert_eq!(
-            metadata.secrets.map(|store| store.default),
-            Some("trusted_server_secrets")
-        );
+        for (kind, runtime_store) in [
+            (
+                "config",
+                metadata.config.expect("should declare config stores"),
+            ),
+            ("kv", metadata.kv.expect("should declare KV stores")),
+            (
+                "secrets",
+                metadata.secrets.expect("should declare secret stores"),
+            ),
+        ] {
+            let manifest_store = manifest_stores
+                .get(kind)
+                .and_then(toml::Value::as_table)
+                .unwrap_or_else(|| panic!("manifest should declare {kind} stores"));
+            let manifest_default = manifest_store
+                .get("default")
+                .and_then(toml::Value::as_str)
+                .unwrap_or_else(|| panic!("manifest {kind} stores should declare a default"));
+            let manifest_ids = manifest_store
+                .get("ids")
+                .and_then(toml::Value::as_array)
+                .unwrap_or_else(|| panic!("manifest {kind} stores should declare ids"))
+                .iter()
+                .map(toml::Value::as_str)
+                .collect::<Option<Vec<_>>>()
+                .unwrap_or_else(|| panic!("manifest {kind} store ids should be strings"));
+
+            assert_eq!(runtime_store.default, manifest_default);
+            assert_eq!(runtime_store.ids, manifest_ids);
+        }
     }
 
     #[test]

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -90,7 +90,7 @@ use std::sync::Arc;
 
 use crate::rate_limiter::{FastlyRateLimiter, RATE_COUNTER_NAME};
 use edgezero_adapter_fastly::context::FastlyRequestContext;
-use edgezero_adapter_fastly::env_config_from_runtime_dictionary;
+use edgezero_adapter_fastly::runtime_env_config;
 use edgezero_core::app::{App, Hooks, StoreMetadata, StoresMetadata};
 use edgezero_core::context::RequestContext;
 use edgezero_core::env_config::EnvConfig;
@@ -1324,7 +1324,7 @@ impl Hooks for TrustedServerApp {
     }
 
     fn routes() -> RouterService {
-        let runtime_env = env_config_from_runtime_dictionary(Self::stores());
+        let runtime_env = runtime_env_config(Self::stores());
         let stores = RuntimeStoreConfig::from_env(&runtime_env);
         Self::router_with_state(&stores).0
     }
@@ -1355,9 +1355,10 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        AppState, NAMED_ROUTES, NamedRouteHandler, PAGE_BIDS_LEGACY_PATH, PAGE_BIDS_PATH,
-        RuntimeStoreConfig, TrustedServerApp, build_per_request_services,
-        build_state_from_settings, startup_error_router,
+        AppState, AuctionDispatch, EcContext, EdgeCacheHeader, HandlerFuture, NAMED_ROUTES,
+        NamedRouteHandler, PAGE_BIDS_LEGACY_PATH, PAGE_BIDS_PATH, RuntimeStoreConfig,
+        TrustedServerApp, build_per_request_services, build_state_from_settings,
+        handle_publisher_request, publisher_response_into_streaming_response, startup_error_router,
     };
     use base64::Engine as _;
     use bytes::Bytes;
@@ -1577,21 +1578,6 @@ mod tests {
     fn test_router() -> RouterService {
         let state = build_state_from_settings(test_settings()).expect("should build test state");
         TrustedServerApp::routes_for_state(&state)
-    }
-
-    #[test]
-    fn trusted_server_app_declares_config_store_metadata() {
-        let stores = TrustedServerApp::stores();
-
-        assert_eq!(
-            stores.config,
-            Some(StoreMetadata {
-                default: "trusted_server_config",
-                ids: &["trusted_server_config"],
-            })
-        );
-        assert_eq!(stores.kv, None);
-        assert_eq!(stores.secrets, None);
     }
 
     #[test]

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -177,7 +177,13 @@ pub(crate) fn load_settings_from_config_store(
 ) -> Result<Settings, Report<TrustedServerError>> {
     let store_name = config_store_name(env);
     let key = config_key(env);
-    get_settings_from_config_store(&FastlyPlatformConfigStore, &store_name, &key)
+    get_settings_from_config_store(
+        &FastlyPlatformConfigStore,
+        &FastlyPlatformSecretStore,
+        &store_name,
+        &key,
+        &trusted_server_core::settings_data::default_secret_store_name(),
+    )
 }
 
 pub(crate) fn build_state_from_settings(

--- a/crates/trusted-server-adapter-fastly/src/app.rs
+++ b/crates/trusted-server-adapter-fastly/src/app.rs
@@ -103,6 +103,7 @@ use trusted_server_core::auction::AuctionTelemetrySink;
 use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 use trusted_server_core::cache_policy::EdgeCacheHeader;
+use trusted_server_core::config_payload::DEFAULT_SECRET_STORE_ID;
 use trusted_server_core::constants::{COOKIE_SHAREDID, COOKIE_TS_EIDS};
 use trusted_server_core::ec::EcContext;
 use trusted_server_core::ec::admin::{
@@ -120,7 +121,9 @@ use trusted_server_core::integrations::{
     IntegrationRegistry, ProxyDispatchInput, RequestFilterEffects, RequestFilterRegistryInput,
     RequestFilterRegistryOutcome,
 };
-use trusted_server_core::platform::{ClientInfo, GeoInfo, PlatformKvStore, RuntimeServices};
+use trusted_server_core::platform::{
+    ClientInfo, GeoInfo, PlatformKvStore, RuntimeServices, StoreName,
+};
 use trusted_server_core::proxy::{
     AssetProxyCachePolicy, handle_asset_proxy_request, handle_first_party_click,
     handle_first_party_proxy, handle_first_party_proxy_rebuild, handle_first_party_proxy_sign,
@@ -135,9 +138,7 @@ use trusted_server_core::request_signing::{
     handle_verify_signature,
 };
 use trusted_server_core::settings::{ProxyAssetRoute, Settings};
-use trusted_server_core::settings_data::{
-    config_key, config_store_name, get_settings_from_config_store,
-};
+use trusted_server_core::settings_data::{DEFAULT_CONFIG_STORE_ID, get_settings_from_config_store};
 use trusted_server_core::tester_cookie::{handle_clear_tester, handle_set_tester};
 
 use crate::middleware::{AuthMiddleware, FinalizeResponseMiddleware};
@@ -149,6 +150,23 @@ use crate::platform::{
 // ---------------------------------------------------------------------------
 // AppState
 // ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeStoreConfig {
+    pub(crate) config_store_name: StoreName,
+    pub(crate) config_key: String,
+    pub(crate) secret_store_name: StoreName,
+}
+
+impl RuntimeStoreConfig {
+    pub(crate) fn from_env(env: &EnvConfig) -> Self {
+        Self {
+            config_store_name: StoreName::from(env.store_name("config", DEFAULT_CONFIG_STORE_ID)),
+            config_key: env.store_key("config", DEFAULT_CONFIG_STORE_ID),
+            secret_store_name: StoreName::from(env.store_name("secrets", DEFAULT_SECRET_STORE_ID)),
+        }
+    }
+}
 
 /// Application state built once per Wasm instance and shared for its lifetime.
 ///
@@ -168,21 +186,21 @@ pub(crate) struct AppState {
 ///
 /// Returns an error when settings, the auction orchestrator, or the integration
 /// registry fail to initialise.
-pub(crate) fn build_state(env: &EnvConfig) -> Result<Arc<AppState>, Report<TrustedServerError>> {
-    build_state_from_settings(load_settings_from_config_store(env)?)
+pub(crate) fn build_state(
+    stores: &RuntimeStoreConfig,
+) -> Result<Arc<AppState>, Report<TrustedServerError>> {
+    build_state_from_settings(load_settings_from_config_store(stores)?)
 }
 
 pub(crate) fn load_settings_from_config_store(
-    env: &EnvConfig,
+    stores: &RuntimeStoreConfig,
 ) -> Result<Settings, Report<TrustedServerError>> {
-    let store_name = config_store_name(env);
-    let key = config_key(env);
     get_settings_from_config_store(
         &FastlyPlatformConfigStore,
         &FastlyPlatformSecretStore,
-        &store_name,
-        &key,
-        &trusted_server_core::settings_data::default_secret_store_name(),
+        &stores.config_store_name,
+        &stores.config_key,
+        &stores.secret_store_name,
     )
 }
 
@@ -1237,15 +1255,17 @@ fn fallback_route_handler(
 pub struct TrustedServerApp;
 
 impl TrustedServerApp {
-    pub(crate) fn build_app_with_state(env: &EnvConfig) -> (App, Option<Arc<AppState>>) {
-        let (router, state) = Self::router_with_state(env);
+    pub(crate) fn build_app_with_state(
+        stores: &RuntimeStoreConfig,
+    ) -> (App, Option<Arc<AppState>>) {
+        let (router, state) = Self::router_with_state(stores);
         let mut app = App::with_name(router, Self::name());
         Self::configure(&mut app);
         (app, state)
     }
 
-    fn router_with_state(env: &EnvConfig) -> (RouterService, Option<Arc<AppState>>) {
-        let state = match build_state(env) {
+    fn router_with_state(stores: &RuntimeStoreConfig) -> (RouterService, Option<Arc<AppState>>) {
+        let state = match build_state(stores) {
             Ok(state) => state,
             Err(ref e) => {
                 log::error!("failed to build application state: {:?}", e);
@@ -1303,16 +1323,24 @@ impl Hooks for TrustedServerApp {
     }
 
     fn routes() -> RouterService {
-        Self::router_with_state(&EnvConfig::from_env()).0
+        let stores = RuntimeStoreConfig::from_env(&EnvConfig::from_env());
+        Self::router_with_state(&stores).0
     }
 
     fn stores() -> StoresMetadata {
         StoresMetadata {
             config: Some(StoreMetadata {
-                default: "trusted_server_config",
-                ids: &["trusted_server_config"],
+                default: DEFAULT_CONFIG_STORE_ID,
+                ids: &[DEFAULT_CONFIG_STORE_ID],
             }),
-            ..StoresMetadata::default()
+            kv: Some(StoreMetadata {
+                default: "trusted_server_kv",
+                ids: &["trusted_server_kv"],
+            }),
+            secrets: Some(StoreMetadata {
+                default: DEFAULT_SECRET_STORE_ID,
+                ids: &[DEFAULT_SECRET_STORE_ID],
+            }),
         }
     }
 }
@@ -1325,16 +1353,16 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        AppState, AuctionDispatch, EcContext, EdgeCacheHeader, HandlerFuture, NAMED_ROUTES,
-        NamedRouteHandler, PAGE_BIDS_LEGACY_PATH, PAGE_BIDS_PATH, TrustedServerApp,
-        build_per_request_services, build_state_from_settings, handle_publisher_request,
-        publisher_response_into_streaming_response, startup_error_router,
+        AppState, NAMED_ROUTES, NamedRouteHandler, PAGE_BIDS_LEGACY_PATH, PAGE_BIDS_PATH,
+        RuntimeStoreConfig, TrustedServerApp, build_per_request_services,
+        build_state_from_settings, startup_error_router,
     };
     use base64::Engine as _;
     use bytes::Bytes;
-    use edgezero_core::app::{Hooks as _, StoreMetadata};
+    use edgezero_core::app::Hooks as _;
     use edgezero_core::body::Body;
     use edgezero_core::context::RequestContext;
+    use edgezero_core::env_config::EnvConfig;
     use edgezero_core::http::{Method, Response, StatusCode, header, request_builder};
     use edgezero_core::key_value_store::NoopKvStore;
     use edgezero_core::params::PathParams;
@@ -1359,6 +1387,53 @@ mod tests {
         TemplateCacheMiss, TemplateCacheReservation, TemplateEntry, TemplateMetadata,
     };
     use trusted_server_core::settings::Settings;
+
+    #[test]
+    fn hooks_expose_the_manifest_store_metadata_used_by_fastly_runtime_mapping() {
+        let metadata = TrustedServerApp::stores();
+
+        assert_eq!(
+            metadata.config.map(|store| store.default),
+            Some("trusted_server_config")
+        );
+        assert_eq!(
+            metadata.secrets.map(|store| store.default),
+            Some("trusted_server_secrets")
+        );
+    }
+
+    #[test]
+    fn runtime_store_config_maps_logical_store_names_and_config_key() {
+        let env = EnvConfig::from_vars([
+            (
+                "EDGEZERO__STORES__CONFIG__TRUSTED_SERVER_CONFIG__NAME",
+                "physical_config",
+            ),
+            (
+                "EDGEZERO__STORES__CONFIG__TRUSTED_SERVER_CONFIG__KEY",
+                "active_config",
+            ),
+            (
+                "EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME",
+                "ts_secrets",
+            ),
+        ]);
+
+        let stores = RuntimeStoreConfig::from_env(&env);
+
+        assert_eq!(stores.config_store_name.as_ref(), "physical_config");
+        assert_eq!(stores.config_key, "active_config");
+        assert_eq!(stores.secret_store_name.as_ref(), "ts_secrets");
+    }
+
+    #[test]
+    fn runtime_store_config_uses_logical_defaults_without_overrides() {
+        let stores = RuntimeStoreConfig::from_env(&EnvConfig::default());
+
+        assert_eq!(stores.config_store_name.as_ref(), "trusted_server_config");
+        assert_eq!(stores.config_key, "trusted_server_config");
+        assert_eq!(stores.secret_store_name.as_ref(), "trusted_server_secrets");
+    }
 
     fn settings_with_missing_consent_store() -> Settings {
         Settings::from_toml(

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use edgezero_adapter_fastly::config_store::FastlyConfigStore as EdgeZeroFastlyConfigStore;
+use edgezero_adapter_fastly::env_config_from_runtime_dictionary;
 use edgezero_adapter_fastly::request::into_core_request;
-use edgezero_adapter_fastly::runtime_env_config;
 use edgezero_core::app::Hooks as _;
 use edgezero_core::body::Body as EdgeBody;
 use edgezero_core::config_store::ConfigStoreHandle;
@@ -44,7 +44,9 @@ mod rate_limiter;
 mod template_cache;
 mod tinybird;
 
-use crate::app::{EcFinalizeState, TrustedServerApp, load_settings_from_config_store};
+use crate::app::{
+    EcFinalizeState, RuntimeStoreConfig, TrustedServerApp, load_settings_from_config_store,
+};
 use crate::ec_kv::FastlyEcKvStore;
 use crate::middleware::{HEADER_X_TS_FINALIZED, apply_finalize_headers, resolve_geo_for_response};
 use crate::platform::{FastlyPlatformGeo, client_info_from_request};
@@ -55,9 +57,8 @@ use crate::rate_limiter::{FastlyRateLimiter, RATE_COUNTER_NAME};
 /// # Errors
 ///
 /// Returns [`fastly::Error`] if the config store cannot be opened.
-fn open_trusted_server_config_store(env: &EnvConfig) -> Result<ConfigStoreHandle, fastly::Error> {
-    let store_name = config_store_name(env);
-    let store = EdgeZeroFastlyConfigStore::try_open(store_name.as_ref()).map_err(|e| {
+fn open_trusted_server_config_store(store_name: &str) -> Result<ConfigStoreHandle, fastly::Error> {
+    let store = EdgeZeroFastlyConfigStore::try_open(store_name).map_err(|e| {
         fastly::Error::msg(format!("failed to open config store `{store_name}`: {e}"))
     })?;
     Ok(ConfigStoreHandle::new(Arc::new(store)))
@@ -86,17 +87,19 @@ fn main() {
     }
 
     logging::init_logger();
-    let env = runtime_env_config(TrustedServerApp::stores());
-    edgezero_main(req, &env);
+    edgezero_main(req);
 }
 
 /// Handles a request through the `EdgeZero` router path.
-fn edgezero_main(mut req: FastlyRequest, env: &EnvConfig) {
+fn edgezero_main(mut req: FastlyRequest) {
+    let runtime_env = env_config_from_runtime_dictionary(TrustedServerApp::stores());
+    let runtime_stores = RuntimeStoreConfig::from_env(&runtime_env);
+
     // Short-circuit the JA4 debug probe before app construction. Must run here
     // because TLS/JA4 accessors are only available on FastlyRequest before
     // conversion to edgezero types.
     if req.get_method() == FastlyMethod::GET && req.get_path() == "/_ts/debug/ja4" {
-        match load_settings_from_config_store(env) {
+        match load_settings_from_config_store(&runtime_stores) {
             Ok(settings) if settings.debug.ja4_endpoint_enabled => {
                 build_ja4_debug_response(&req).send_to_client();
             }
@@ -113,18 +116,19 @@ fn edgezero_main(mut req: FastlyRequest, env: &EnvConfig) {
         return;
     }
 
-    let config_store = match open_trusted_server_config_store(env) {
-        Ok(cs) => cs,
-        Err(e) => {
-            log::error!("failed to open config store: {e}");
-            FastlyResponse::from_status(fastly::http::StatusCode::INTERNAL_SERVER_ERROR)
-                .with_body_text_plain("Internal Server Error")
-                .send_to_client();
-            return;
-        }
-    };
+    let config_store =
+        match open_trusted_server_config_store(runtime_stores.config_store_name.as_ref()) {
+            Ok(cs) => cs,
+            Err(e) => {
+                log::error!("failed to open config store: {e}");
+                FastlyResponse::from_status(fastly::http::StatusCode::INTERNAL_SERVER_ERROR)
+                    .with_body_text_plain("Internal Server Error")
+                    .send_to_client();
+                return;
+            }
+        };
 
-    let (app, app_state) = TrustedServerApp::build_app_with_state(env);
+    let (app, app_state) = TrustedServerApp::build_app_with_state(&runtime_stores);
     let settings_snapshot = app_state.as_ref().map(|state| Arc::clone(&state.settings));
     let trusted_client_ip = settings_snapshot
         .as_deref()
@@ -199,7 +203,7 @@ fn edgezero_main(mut req: FastlyRequest, env: &EnvConfig) {
         if let Some(settings) = settings_snapshot.as_deref() {
             apply_entry_point_finalize_headers(settings, &mut response, client_ip);
         } else {
-            match load_settings_from_config_store(env) {
+            match load_settings_from_config_store(&runtime_stores) {
                 Ok(settings) => {
                     apply_entry_point_finalize_headers(&settings, &mut response, client_ip);
                 }
@@ -229,7 +233,7 @@ fn edgezero_main(mut req: FastlyRequest, env: &EnvConfig) {
                 }
             }
         } else {
-            match load_settings_from_config_store(env) {
+            match load_settings_from_config_store(&runtime_stores) {
                 Ok(settings) => {
                     match apply_edgezero_ec_finalize(&settings, &ec_state, &mut response) {
                         Ok(partner_registry) => {

--- a/crates/trusted-server-adapter-fastly/src/main.rs
+++ b/crates/trusted-server-adapter-fastly/src/main.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use edgezero_adapter_fastly::config_store::FastlyConfigStore as EdgeZeroFastlyConfigStore;
-use edgezero_adapter_fastly::env_config_from_runtime_dictionary;
 use edgezero_adapter_fastly::request::into_core_request;
+use edgezero_adapter_fastly::runtime_env_config;
 use edgezero_core::app::Hooks as _;
 use edgezero_core::body::Body as EdgeBody;
 use edgezero_core::config_store::ConfigStoreHandle;
-use edgezero_core::env_config::EnvConfig;
 use edgezero_core::error::EdgeError;
 use edgezero_core::http::{Request as HttpRequest, Response as HttpResponse};
 use edgezero_core::response::IntoResponse;
@@ -29,7 +28,6 @@ use trusted_server_core::platform::RuntimeServices;
 use trusted_server_core::proxy::{AssetProxyCachePolicy, stream_asset_body};
 use trusted_server_core::response_privacy::TerminalPrivateResponse;
 use trusted_server_core::settings::Settings;
-use trusted_server_core::settings_data::config_store_name;
 
 mod app;
 mod backend;
@@ -92,7 +90,7 @@ fn main() {
 
 /// Handles a request through the `EdgeZero` router path.
 fn edgezero_main(mut req: FastlyRequest) {
-    let runtime_env = env_config_from_runtime_dictionary(TrustedServerApp::stores());
+    let runtime_env = runtime_env_config(TrustedServerApp::stores());
     let runtime_stores = RuntimeStoreConfig::from_env(&runtime_env);
 
     // Short-circuit the JA4 debug probe before app construction. Must run here

--- a/crates/trusted-server-adapter-fastly/src/tinybird.rs
+++ b/crates/trusted-server-adapter-fastly/src/tinybird.rs
@@ -10,9 +10,8 @@ use trusted_server_core::auction::telemetry::{
     AuctionEventBatch, AuctionTelemetrySink, NoopAuctionTelemetrySink,
 };
 use trusted_server_core::error::TrustedServerError;
-use trusted_server_core::platform::{
-    PlatformBackendSpec, PlatformHttpRequest, RuntimeServices, StoreName,
-};
+use trusted_server_core::platform::{PlatformBackendSpec, PlatformHttpRequest, RuntimeServices};
+use trusted_server_core::redacted::Redacted;
 use trusted_server_core::settings::{Settings, TinybirdSettings};
 
 const TINYBIRD_EVENTS_PATH: &str = "/v0/events";
@@ -43,8 +42,7 @@ struct FastlyTinybirdAuctionTelemetrySink {
 struct TinybirdEventsTarget {
     api_host: String,
     dataset: String,
-    secret_store: StoreName,
-    token_secret: String,
+    append_token: Redacted<String>,
     uri: String,
     backend_spec: PlatformBackendSpec,
     max_body_bytes: usize,
@@ -57,8 +55,9 @@ impl TinybirdEventsTarget {
         Self {
             api_host: config.api_host,
             dataset: config.auction_dataset,
-            secret_store: StoreName::from(config.secret_store),
-            token_secret: config.auction_token_secret,
+            append_token: config
+                .auction_token_secret
+                .expect("should contain a resolved Tinybird auction token when enabled"),
             uri,
             backend_spec,
             max_body_bytes: config.max_body_bytes,
@@ -93,25 +92,6 @@ impl FastlyTinybirdAuctionTelemetrySink {
         batch: &AuctionEventBatch,
     ) -> Result<String, Report<TrustedServerError>> {
         batch.to_ndjson(self.target.max_body_bytes)
-    }
-
-    fn load_append_token(
-        &self,
-        services: &RuntimeServices,
-    ) -> Result<String, Report<TrustedServerError>> {
-        let token = services
-            .secret_store()
-            .get_string(&self.target.secret_store, &self.target.token_secret)
-            .change_context(TrustedServerError::Proxy {
-                message: "Tinybird auction append token unavailable".to_owned(),
-            })?;
-        let token = token.trim().to_owned();
-        if token.is_empty() {
-            return Err(Report::new(TrustedServerError::Proxy {
-                message: "Tinybird auction append token is empty".to_owned(),
-            }));
-        }
-        Ok(token)
     }
 
     fn ensure_backend(
@@ -185,8 +165,7 @@ impl AuctionTelemetrySink for FastlyTinybirdAuctionTelemetrySink {
         Self::validate_batch(&batch)?;
         let body = self.serialize_batch(&batch)?;
         let body_len = body.len();
-        let token = self.load_append_token(services)?;
-        let auth_header = Self::authorization_header(&token)?;
+        let auth_header = Self::authorization_header(self.target.append_token.expose())?;
         let backend_name = self.ensure_backend(services)?;
         let request = self.build_events_request(body, auth_header)?;
 
@@ -233,7 +212,7 @@ mod tests {
     use trusted_server_core::platform::{
         ClientInfo, PlatformBackend, PlatformConfigStore, PlatformError, PlatformGeo,
         PlatformHttpClient, PlatformPendingRequest, PlatformResponse, PlatformSecretStore,
-        PlatformSelectResult, RuntimeServices, StoreId,
+        PlatformSelectResult, RuntimeServices, StoreId, StoreName,
     };
 
     use super::*;
@@ -444,12 +423,12 @@ mod tests {
         TinybirdSettings {
             enabled: true,
             api_host: "api.us-east.aws.tinybird.co".to_owned(),
-            secret_store: "ts_secrets".to_owned(),
+            secret_store: None,
             auction_dataset: "auction_events_raw".to_owned(),
-            auction_token_secret: "tinybird_auction_append_token".to_owned(),
+            auction_token_secret: Some(Redacted::new("append-token".to_owned())),
             access_enabled: false,
             access_dataset: "access_logs_raw".to_owned(),
-            access_token_secret: "tinybird_access_append_token".to_owned(),
+            access_token_secret: None,
             access_sample_rate: 0.0,
             max_body_bytes: 1024 * 1024,
         }
@@ -481,16 +460,13 @@ mod tests {
     }
 
     #[test]
-    fn sink_posts_ndjson_with_secret_token_and_does_not_wait() {
+    fn sink_posts_ndjson_with_resolved_token_and_does_not_wait() {
         let backend = Arc::new(RecordingBackend::default());
         let http_client = Arc::new(RecordingHttpClient::default());
         let services = services(
             Arc::clone(&backend),
             Arc::clone(&http_client),
-            HashMap::from([(
-                "tinybird_auction_append_token".to_owned(),
-                b" append-token\n".to_vec(),
-            )]),
+            HashMap::new(),
         );
         let sink = FastlyTinybirdAuctionTelemetrySink::new(enabled_config());
 
@@ -598,31 +574,6 @@ mod tests {
                 .expect("should lock recorded requests")
                 .is_empty(),
             "should not send empty batches"
-        );
-    }
-
-    #[test]
-    fn sink_drops_missing_secret_as_setup_error() {
-        let backend = Arc::new(RecordingBackend::default());
-        let http_client = Arc::new(RecordingHttpClient::default());
-        let services = services(backend, Arc::clone(&http_client), HashMap::new());
-        let sink = FastlyTinybirdAuctionTelemetrySink::new(enabled_config());
-
-        let result = futures::executor::block_on(
-            sink.emit_auction_events(&services, AuctionEventBatch::new(vec![test_row()])),
-        );
-
-        assert!(
-            result.is_err(),
-            "best-effort caller will suppress this error"
-        );
-        assert!(
-            http_client
-                .requests
-                .lock()
-                .expect("should lock recorded requests")
-                .is_empty(),
-            "should not send without a token"
         );
     }
 

--- a/crates/trusted-server-adapter-spin/spin.toml
+++ b/crates/trusted-server-adapter-spin/spin.toml
@@ -25,6 +25,13 @@ version = "0.1.0"
 [variables]
 v_current_x2dkid = { default = "" }
 v_active_x2dkids = { default = "" }
+# Trusted Server app-config secret references. Replace the empty defaults with
+# values supplied by the deployment's secret provider; never commit values here.
+v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret = { default = "" }
+v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase = { default = "" }
+v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken = { default = "" }
+v_trusted_x5fserver_x5fsecrets_v_partner_x5fts_x5fpull_x5ftoken = { default = "" }
+v_trusted_x5fserver_x5fsecrets_v_handler_x5fpassword = { default = "" }
 
 [[trigger.http]]
 route = "/..."
@@ -38,11 +45,16 @@ source = "../../target/wasm32-wasip1/release/trusted_server_adapter_spin.wasm"
 # origins are still served over plaintext http. Follow-up: scope this to the
 # configured origins once they can be enumerated from settings.
 allowed_outbound_hosts = ["https://*:*", "http://*:*"]
-key_value_stores = ["default"]
+key_value_stores = ["default", "trusted_server_config"]
 
 [component.trusted-server.variables]
 v_current_x2dkid = "{{ v_current_x2dkid }}"
 v_active_x2dkids = "{{ v_active_x2dkids }}"
+v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret = "{{ v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret }}"
+v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase = "{{ v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase }}"
+v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken = "{{ v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken }}"
+v_trusted_x5fserver_x5fsecrets_v_partner_x5fts_x5fpull_x5ftoken = "{{ v_trusted_x5fserver_x5fsecrets_v_partner_x5fts_x5fpull_x5ftoken }}"
+v_trusted_x5fserver_x5fsecrets_v_handler_x5fpassword = "{{ v_trusted_x5fserver_x5fsecrets_v_handler_x5fpassword }}"
 
 [component.trusted-server.build]
 command = "cargo build --target wasm32-wasip1 --release -p trusted-server-adapter-spin --features spin"

--- a/crates/trusted-server-adapter-spin/spin.toml
+++ b/crates/trusted-server-adapter-spin/spin.toml
@@ -27,11 +27,11 @@ v_current_x2dkid = { default = "" }
 v_active_x2dkids = { default = "" }
 # Trusted Server app-config secret references. Replace the empty defaults with
 # values supplied by the deployment's secret provider; never commit values here.
-v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret = { default = "" }
-v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase = { default = "" }
-v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken = { default = "" }
-v_trusted_x5fserver_x5fsecrets_v_partner_x5fts_x5fpull_x5ftoken = { default = "" }
-v_trusted_x5fserver_x5fsecrets_v_handler_x5fpassword = { default = "" }
+v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret = { default = "", secret = true }
+v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase = { default = "", secret = true }
+v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken = { default = "", secret = true }
+v_trusted_x5fserver_x5fsecrets_v_partner_x5fts_x5fpull_x5ftoken = { default = "", secret = true }
+v_trusted_x5fserver_x5fsecrets_v_handler_x5fpassword = { default = "", secret = true }
 
 [[trigger.http]]
 route = "/..."
@@ -45,7 +45,7 @@ source = "../../target/wasm32-wasip1/release/trusted_server_adapter_spin.wasm"
 # origins are still served over plaintext http. Follow-up: scope this to the
 # configured origins once they can be enumerated from settings.
 allowed_outbound_hosts = ["https://*:*", "http://*:*"]
-key_value_stores = ["default", "trusted_server_config"]
+key_value_stores = ["default"]
 
 [component.trusted-server.variables]
 v_current_x2dkid = "{{ v_current_x2dkid }}"

--- a/crates/trusted-server-adapter-spin/spin.toml
+++ b/crates/trusted-server-adapter-spin/spin.toml
@@ -25,8 +25,10 @@ version = "0.1.0"
 [variables]
 v_current_x2dkid = { default = "" }
 v_active_x2dkids = { default = "" }
-# Trusted Server app-config secret references. Replace the empty defaults with
-# values supplied by the deployment's secret provider; never commit values here.
+# These declared variables match the example config's secret key names. Regenerate
+# or extend them for deployment-specific keys, including handler key names such as
+# `admin_password` or `api_handler_password`. Replace the empty defaults with values
+# supplied by the deployment's secret provider; never commit values here.
 v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret = { default = "", secret = true }
 v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase = { default = "", secret = true }
 v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken = { default = "", secret = true }

--- a/crates/trusted-server-adapter-spin/spin.toml
+++ b/crates/trusted-server-adapter-spin/spin.toml
@@ -4,32 +4,26 @@ spin_manifest_version = 2
 name = "trusted-server-adapter-spin"
 version = "0.1.0"
 
-# EdgeZero's Spin config and secret stores read from Spin component variables.
-# The adapter encodes Trusted Server store keys into a Spin-safe, collision-resistant
-# variable name. Every generated name starts with "v_"; lowercase ASCII letters
-# and digits are kept as-is, while uppercase letters and punctuation are encoded
-# as "_xhh" lowercase hex bytes.
+# EdgeZero's Spin config stores are KV-backed and read keys verbatim. Request-signing
+# metadata such as `current-kid`, `active-kids`, and public JWK entries therefore
+# belongs directly in the component's `default` key-value store.
 #
-# Request-signing config examples:
-#   "current-kid" -> v_current_x2dkid
-#   "active-kids" -> v_active_x2dkids
-#   "ts-2026-05-25" -> v_ts_x2d2026_x2d05_x2d25
-#
-# Secret variables include the encoded store name to avoid collisions with
-# config variables in Spin's flat variable namespace:
+# Secret stores read Spin component variables. The adapter encodes the store and
+# key into a collision-resistant variable name. Every generated name starts with
+# "v_"; lowercase ASCII letters and digits are kept as-is, while uppercase letters
+# and punctuation are encoded as "_xhh" lowercase hex bytes. For example:
 #   store "signing_keys", key "ts-2026-05-25"
 #   -> v_signing_x5fkeys_v_ts_x2d2026_x2d05_x2d25
 #
-# Operators enabling request_signing must declare and map one config variable
-# for each public JWK kid, plus one secret variable for each signing key.
+# Operators enabling request_signing must declare one encoded secret variable for
+# each private signing key. Public signing metadata remains in the KV store.
 [variables]
-v_current_x2dkid = { default = "" }
-v_active_x2dkids = { default = "" }
 # These declared variables match the example config's secret key names. Regenerate
 # or extend them for deployment-specific keys, including handler key names such as
 # `admin_password` or `api_handler_password`. Replace the empty defaults with values
 # supplied by the deployment's secret provider; never commit values here.
 v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret = { default = "", secret = true }
+v_trusted_x5fserver_x5fsecrets_v_trusted_x5fclient_x5fip_x5fshared_x5fsecret = { default = "", secret = true }
 v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase = { default = "", secret = true }
 v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken = { default = "", secret = true }
 v_trusted_x5fserver_x5fsecrets_v_partner_x5fts_x5fpull_x5ftoken = { default = "", secret = true }
@@ -50,9 +44,8 @@ allowed_outbound_hosts = ["https://*:*", "http://*:*"]
 key_value_stores = ["default"]
 
 [component.trusted-server.variables]
-v_current_x2dkid = "{{ v_current_x2dkid }}"
-v_active_x2dkids = "{{ v_active_x2dkids }}"
 v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret = "{{ v_trusted_x5fserver_x5fsecrets_v_publisher_x5fproxy_x5fsecret }}"
+v_trusted_x5fserver_x5fsecrets_v_trusted_x5fclient_x5fip_x5fshared_x5fsecret = "{{ v_trusted_x5fserver_x5fsecrets_v_trusted_x5fclient_x5fip_x5fshared_x5fsecret }}"
 v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase = "{{ v_trusted_x5fserver_x5fsecrets_v_ec_x5fpassphrase }}"
 v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken = "{{ v_trusted_x5fserver_x5fsecrets_v_partner_x5fapi_x5ftoken }}"
 v_trusted_x5fserver_x5fsecrets_v_partner_x5fts_x5fpull_x5ftoken = "{{ v_trusted_x5fserver_x5fsecrets_v_partner_x5fts_x5fpull_x5ftoken }}"

--- a/crates/trusted-server-adapter-spin/src/app.rs
+++ b/crates/trusted-server-adapter-spin/src/app.rs
@@ -1,8 +1,12 @@
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+use edgezero_adapter_spin::config_store::SpinConfigStore;
 use edgezero_adapter_spin::context::SpinRequestContext;
 use edgezero_core::app::Hooks;
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+use edgezero_core::config_store::ConfigStoreHandle;
 use edgezero_core::context::RequestContext;
 use edgezero_core::error::EdgeError;
 use edgezero_core::http::{HeaderValue, Method, Request, Response, StatusCode, header};
@@ -11,6 +15,8 @@ use error_stack::Report;
 use trusted_server_core::auction::endpoints::handle_auction;
 use trusted_server_core::auction::{AuctionOrchestrator, build_orchestrator};
 use trusted_server_core::cache_policy::EdgeCacheHeader;
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+use trusted_server_core::config_payload::settings_from_config_blob;
 use trusted_server_core::ec::EcContext;
 use trusted_server_core::ec::admin::{
     admin_ec_lookup_not_supported as core_admin_ec_lookup_not_supported,
@@ -20,6 +26,8 @@ use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::error::{IntoHttpResponse as _, TrustedServerError};
 use trusted_server_core::http_util::sanitize_forwarded_headers;
 use trusted_server_core::integrations::{IntegrationRegistry, ProxyDispatchInput};
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+use trusted_server_core::platform::PlatformConfigStore;
 use trusted_server_core::platform::RuntimeServices;
 use trusted_server_core::proxy::{
     handle_first_party_click, handle_first_party_proxy, handle_first_party_proxy_rebuild,
@@ -34,11 +42,17 @@ use trusted_server_core::request_signing::{
     handle_trusted_server_discovery, handle_verify_signature,
 };
 use trusted_server_core::settings::Settings;
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+use trusted_server_core::settings_data::{
+    default_config_key, default_config_store_name, default_secret_store_name,
+};
 
 use crate::middleware::{
     AuthMiddleware, FinalizeResponseMiddleware, NormalizeMiddleware, SanitizeRequestMiddleware,
 };
 use crate::platform::build_runtime_services;
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+use crate::platform::{ConfigStoreHandleAdapter, SpinSecretStoreAdapter};
 
 // ---------------------------------------------------------------------------
 // AppState
@@ -58,8 +72,42 @@ pub struct AppState {
 /// Returns an error when settings, the auction orchestrator, or the integration
 /// registry fail to initialise.
 fn build_state() -> Result<Arc<AppState>, Report<TrustedServerError>> {
-    let settings = Settings::from_toml(include_str!("../../../trusted-server.example.toml"))?;
+    let settings = load_startup_settings()?;
     build_state_with_settings(settings)
+}
+
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+fn load_startup_settings() -> Result<Settings, Report<TrustedServerError>> {
+    let config_store_name = default_config_store_name();
+    let config_key = default_config_key();
+    let config_store =
+        futures::executor::block_on(SpinConfigStore::open(config_store_name.as_ref().to_owned()))
+            .map_err(|error| {
+            Report::new(TrustedServerError::Configuration {
+                message: "failed to open Spin Trusted Server config store".to_string(),
+            })
+            .attach(error.to_string())
+        })?;
+    let config_handle = ConfigStoreHandle::new(Arc::new(config_store));
+    let config_adapter = ConfigStoreHandleAdapter(config_handle);
+    let raw_envelope = config_adapter
+        .get(&config_store_name, &config_key)
+        .map_err(|error| {
+            Report::new(TrustedServerError::Configuration {
+                message: "failed to read Spin Trusted Server app-config blob".to_string(),
+            })
+            .attach(error.to_string())
+        })?;
+    let secret_store = SpinSecretStoreAdapter;
+    settings_from_config_blob(&raw_envelope, &secret_store, &default_secret_store_name())
+}
+
+#[cfg(not(all(feature = "spin", target_arch = "wasm32")))]
+fn load_startup_settings() -> Result<Settings, Report<TrustedServerError>> {
+    Err(Report::new(TrustedServerError::Configuration {
+        message: "Spin startup settings require the production config store".to_string(),
+    })
+    .attach("use TrustedServerApp::routes_with_settings for host tests"))
 }
 
 /// Build the application state from explicit settings.

--- a/crates/trusted-server-adapter-spin/src/app.rs
+++ b/crates/trusted-server-adapter-spin/src/app.rs
@@ -26,9 +26,9 @@ use trusted_server_core::ec::registry::PartnerRegistry;
 use trusted_server_core::error::{IntoHttpResponse as _, TrustedServerError};
 use trusted_server_core::http_util::sanitize_forwarded_headers;
 use trusted_server_core::integrations::{IntegrationRegistry, ProxyDispatchInput};
-#[cfg(all(feature = "spin", target_arch = "wasm32"))]
-use trusted_server_core::platform::PlatformConfigStore;
 use trusted_server_core::platform::RuntimeServices;
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+use trusted_server_core::platform::{PlatformConfigStore, StoreName};
 use trusted_server_core::proxy::{
     handle_first_party_click, handle_first_party_proxy, handle_first_party_proxy_rebuild,
     handle_first_party_proxy_sign,
@@ -43,9 +43,7 @@ use trusted_server_core::request_signing::{
 };
 use trusted_server_core::settings::Settings;
 #[cfg(all(feature = "spin", target_arch = "wasm32"))]
-use trusted_server_core::settings_data::{
-    default_config_key, default_config_store_name, default_secret_store_name,
-};
+use trusted_server_core::settings_data::{default_config_key, default_secret_store_name};
 
 use crate::middleware::{
     AuthMiddleware, FinalizeResponseMiddleware, NormalizeMiddleware, SanitizeRequestMiddleware,
@@ -57,6 +55,10 @@ use crate::platform::{ConfigStoreHandleAdapter, SpinSecretStoreAdapter};
 // ---------------------------------------------------------------------------
 // AppState
 // ---------------------------------------------------------------------------
+
+/// Spin auto-provides this key-value store label without runtime configuration.
+#[cfg(all(feature = "spin", target_arch = "wasm32"))]
+const SPIN_DEFAULT_CONFIG_STORE: &str = "default";
 
 /// Application state built once at startup and shared across all requests.
 pub struct AppState {
@@ -78,7 +80,7 @@ fn build_state() -> Result<Arc<AppState>, Report<TrustedServerError>> {
 
 #[cfg(all(feature = "spin", target_arch = "wasm32"))]
 fn load_startup_settings() -> Result<Settings, Report<TrustedServerError>> {
-    let config_store_name = default_config_store_name();
+    let config_store_name = StoreName::from(SPIN_DEFAULT_CONFIG_STORE);
     let config_key = default_config_key();
     let config_store =
         futures::executor::block_on(SpinConfigStore::open(config_store_name.as_ref().to_owned()))

--- a/crates/trusted-server-adapter-spin/src/platform.rs
+++ b/crates/trusted-server-adapter-spin/src/platform.rs
@@ -39,6 +39,7 @@ type HeaderPairs = Vec<(String, Vec<u8>)>;
 #[cfg(any(test, all(feature = "spin", target_arch = "wasm32")))]
 type BufferedResponseParts = (HeaderPairs, Vec<u8>);
 
+#[cfg(any(test, all(feature = "spin", target_arch = "wasm32")))]
 const SPIN_VARIABLE_HEX: &[u8; 16] = b"0123456789abcdef";
 
 // ---------------------------------------------------------------------------
@@ -116,25 +117,22 @@ impl PlatformBackend for NoopBackend {
 
 /// Bridges edgezero's [`ConfigStoreHandle`] to [`PlatformConfigStore`].
 ///
-/// Reads delegate through the handle after mapping Trusted Server keys to Spin
-/// variable names. Writes are unsupported on current Spin runtime config and
-/// return typed errors.
-struct ConfigStoreHandleAdapter(ConfigStoreHandle);
+/// Spin config stores are KV-backed, so reads preserve the requested key
+/// verbatim. Writes are unsupported on current Spin runtime config and return
+/// typed errors.
+pub(crate) struct ConfigStoreHandleAdapter(pub(crate) ConfigStoreHandle);
 
 impl PlatformConfigStore for ConfigStoreHandleAdapter {
     fn get(&self, _store_name: &StoreName, key: &str) -> Result<String, Report<PlatformError>> {
-        let variable_name = spin_variable_name(key, PlatformError::ConfigStore)?;
-        futures::executor::block_on(self.0.get(&variable_name))
-            .map_err(|e| {
-                Report::new(PlatformError::ConfigStore)
-                    .attach(format!(
-                        "config store lookup failed for key `{key}` as Spin variable `{variable_name}`: {e}"
-                    ))
+        futures::executor::block_on(self.0.get(key))
+            .map_err(|error| {
+                Report::new(PlatformError::ConfigStore).attach(format!(
+                    "config store lookup failed for key `{key}`: {error}"
+                ))
             })?
             .ok_or_else(|| {
-                Report::new(PlatformError::ConfigStore).attach(format!(
-                    "key `{key}` not found as Spin variable `{variable_name}`"
-                ))
+                Report::new(PlatformError::ConfigStore)
+                    .attach(format!("key `{key}` not found in Spin config store"))
             })
     }
 
@@ -149,6 +147,7 @@ impl PlatformConfigStore for ConfigStoreHandleAdapter {
     }
 }
 
+#[cfg(any(test, all(feature = "spin", target_arch = "wasm32")))]
 fn spin_variable_name(
     key: &str,
     error_context: PlatformError,
@@ -187,6 +186,7 @@ fn spin_variable_name(
     Ok(out)
 }
 
+#[cfg(any(test, all(feature = "spin", target_arch = "wasm32")))]
 fn push_spin_variable_escape(out: &mut String, byte: u8) {
     out.push('_');
     out.push('x');
@@ -676,7 +676,7 @@ fn into_spin_method(method: &edgezero_core::http::Method) -> spin_sdk::http::Met
 ///   with a real secret-provider source (e.g. Vault, Azure Key Vault) to avoid
 ///   storing signing keys in plaintext on disk.
 #[cfg(all(feature = "spin", target_arch = "wasm32"))]
-struct SpinSecretStoreAdapter;
+pub(crate) struct SpinSecretStoreAdapter;
 
 #[cfg(all(feature = "spin", target_arch = "wasm32"))]
 impl PlatformSecretStore for SpinSecretStoreAdapter {
@@ -794,12 +794,22 @@ mod tests {
     use super::*;
 
     use edgezero_core::body::Body;
+    use edgezero_core::config_store::{ConfigStore, ConfigStoreError};
     use edgezero_core::context::RequestContext;
     use edgezero_core::http::request_builder;
     use edgezero_core::params::PathParams;
     use flate2::Compression;
     use flate2::write::GzEncoder;
     use std::io::Write as _;
+
+    struct InMemoryConfigStore(std::collections::BTreeMap<String, String>);
+
+    #[async_trait::async_trait(?Send)]
+    impl ConfigStore for InMemoryConfigStore {
+        async fn get(&self, key: &str) -> Result<Option<String>, ConfigStoreError> {
+            Ok(self.0.get(key).cloned())
+        }
+    }
 
     fn make_ctx_without_spin_context() -> RequestContext {
         let req = request_builder()
@@ -891,6 +901,29 @@ mod tests {
                 .expect("should not fail")
                 .is_none(),
             "should return None for any client IP"
+        );
+    }
+
+    #[test]
+    fn config_store_handle_adapter_reads_verbatim_kv_key() {
+        let handle = ConfigStoreHandle::new(Arc::new(InMemoryConfigStore(
+            std::collections::BTreeMap::from([(
+                "trusted_server_config".to_owned(),
+                "blob-envelope".to_owned(),
+            )]),
+        )));
+        let adapter = ConfigStoreHandleAdapter(handle);
+
+        let value = adapter
+            .get(
+                &StoreName::from("trusted_server_config"),
+                "trusted_server_config",
+            )
+            .expect("should read the verbatim config-store key");
+
+        assert_eq!(
+            value, "blob-envelope",
+            "should not translate a KV-backed config key into a Spin variable name"
         );
     }
 

--- a/crates/trusted-server-adapter-spin/src/platform.rs
+++ b/crates/trusted-server-adapter-spin/src/platform.rs
@@ -928,25 +928,15 @@ mod tests {
     }
 
     #[test]
-    fn spin_variable_name_encodes_trusted_server_keys() {
+    fn spin_variable_name_encodes_secret_key_components() {
         assert_eq!(
-            spin_variable_name("current-kid", PlatformError::ConfigStore)
-                .expect("should encode current kid key"),
-            "v_current_x2dkid"
-        );
-        assert_eq!(
-            spin_variable_name("active-kids", PlatformError::ConfigStore)
-                .expect("should encode active kids key"),
-            "v_active_x2dkids"
-        );
-        assert_eq!(
-            spin_variable_name("ts-2026-05-25", PlatformError::ConfigStore)
+            spin_variable_name("ts-2026-05-25", PlatformError::SecretStore)
                 .expect("should encode generated kid"),
             "v_ts_x2d2026_x2d05_x2d25"
         );
         // Digit-leading keys are rejected at the encoder boundary.
         assert!(
-            spin_variable_name("2026-key", PlatformError::ConfigStore).is_err(),
+            spin_variable_name("2026-key", PlatformError::SecretStore).is_err(),
             "should reject digit-leading key"
         );
     }
@@ -954,8 +944,8 @@ mod tests {
     #[test]
     fn spin_encoder_accepts_every_creatable_kid() {
         // Portability contract: core's create/rotate validation (kid_is_creatable)
-        // must never admit a kid the Spin variable encoder rejects — otherwise such
-        // a kid would 400 on create across every adapter yet 5xx at storage on Spin.
+        // must never admit a kid the Spin secret-variable encoder rejects — otherwise
+        // that kid could be created but its private signing key could not be stored.
         // This pins core >= encoder strictness so the duplicated lowercase-leading
         // rule in validate_kid and spin_variable_name cannot silently drift.
         use trusted_server_core::request_signing::kid_is_creatable;
@@ -981,7 +971,7 @@ mod tests {
         for kid in samples {
             if kid_is_creatable(kid) {
                 assert!(
-                    spin_variable_name(kid, PlatformError::ConfigStore).is_ok(),
+                    spin_variable_name(kid, PlatformError::SecretStore).is_ok(),
                     "core accepts kid `{kid}` but the Spin encoder rejects it \
                      (portability contract broken)"
                 );
@@ -1001,7 +991,7 @@ mod tests {
     #[test]
     fn spin_variable_name_rejects_unsupported_characters() {
         assert!(
-            spin_variable_name("kid/name", PlatformError::ConfigStore).is_err(),
+            spin_variable_name("kid/name", PlatformError::SecretStore).is_err(),
             "should reject characters outside the supported Spin variable mapping"
         );
     }

--- a/crates/trusted-server-core/src/auction/endpoints.rs
+++ b/crates/trusted-server-core/src/auction/endpoints.rs
@@ -642,9 +642,9 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: crate::settings::EcPartner::default_openrtb_atype(),
             bidstream_enabled: true,
-            api_token: crate::redacted::Redacted::new(format!(
+            api_token: Some(crate::redacted::Redacted::new(format!(
                 "token-{source_domain}-32-bytes-minimum-value"
-            )),
+            ))),
             batch_rate_limit: crate::settings::EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -248,6 +248,7 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
 pub fn validate_settings_for_deploy(settings: &Settings) -> Result<(), Report<TrustedServerError>> {
     validate_secret_key_references(settings)?;
     validate_non_secret_deploy_placeholders(settings)?;
+    validate_js_asset_proxy_config(settings)?;
 
     let mut structural_settings = settings.clone();
     structural_settings.prepare_runtime()?;

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -33,7 +33,7 @@ use crate::integrations::{
     sourcepoint::SourcepointConfig,
     testlight::TestlightConfig,
 };
-use crate::settings::{IntegrationConfig, Settings};
+use crate::settings::{AssetOriginAuth, IntegrationConfig, Settings};
 
 const DEPLOY_VALIDATION_FIELD: &str = "trusted_server";
 const MIN_PROXY_SECRET_LENGTH: usize = 32;
@@ -141,6 +141,8 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
             path,
         };
         let object = |name: &'static str| SecretPathSegment::Field(Cow::Borrowed(name));
+        let optional_object =
+            |name: &'static str| SecretPathSegment::OptionalField(Cow::Borrowed(name));
 
         vec![
             field(vec![object("publisher"), object("proxy_secret")], false),
@@ -171,6 +173,57 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
                 ],
                 false,
             ),
+            field(
+                vec![optional_object("tinybird"), object("auction_token_secret")],
+                true,
+            ),
+            field(
+                vec![
+                    optional_object("integrations"),
+                    optional_object("datadome"),
+                    object("server_side_key_secret_name"),
+                ],
+                true,
+            ),
+            field(
+                vec![
+                    optional_object("integrations"),
+                    optional_object("datadome"),
+                    optional_object("protection_test_bypass"),
+                    object("credential_secret_name"),
+                ],
+                true,
+            ),
+            field(
+                vec![
+                    optional_object("proxy"),
+                    optional_object("asset_routes"),
+                    SecretPathSegment::ArrayEach,
+                    optional_object("auth"),
+                    object("access_key_id"),
+                ],
+                false,
+            ),
+            field(
+                vec![
+                    optional_object("proxy"),
+                    optional_object("asset_routes"),
+                    SecretPathSegment::ArrayEach,
+                    optional_object("auth"),
+                    object("secret_access_key"),
+                ],
+                false,
+            ),
+            field(
+                vec![
+                    optional_object("proxy"),
+                    optional_object("asset_routes"),
+                    SecretPathSegment::ArrayEach,
+                    optional_object("auth"),
+                    object("session_token"),
+                ],
+                true,
+            ),
         ]
     }
 }
@@ -194,7 +247,7 @@ pub fn validate_settings_for_deploy(settings: &Settings) -> Result<(), Report<Tr
     structural_settings.prepare_runtime()?;
     structural_settings.validate_admin_coverage()?;
 
-    let enabled_auction_providers = validate_enabled_integrations(settings)?;
+    let enabled_auction_providers = validate_enabled_integrations(settings, false)?;
     validate_auction_provider_names(settings, &enabled_auction_providers)?;
     PartnerRegistry::validate_config_for_deploy(&settings.ec.partners)?;
     Ok(())
@@ -213,7 +266,7 @@ pub fn validate_settings_for_runtime(
     validate_js_asset_proxy_config(settings)?;
     validate_proxy_secret_strength(settings)?;
     settings.validate_admin_handler_passwords()?;
-    let enabled_auction_providers = validate_enabled_integrations(settings)?;
+    let enabled_auction_providers = validate_enabled_integrations(settings, true)?;
     validate_auction_provider_names(settings, &enabled_auction_providers)?;
     PartnerRegistry::from_config(&settings.ec.partners).map(|_| ())?;
     Ok(())
@@ -242,6 +295,7 @@ fn validate_js_asset_proxy_config(settings: &Settings) -> Result<(), Report<Trus
 
 fn validate_enabled_integrations(
     settings: &Settings,
+    resolved_secrets: bool,
 ) -> Result<HashSet<&'static str>, Report<TrustedServerError>> {
     let mut enabled_auction_providers = HashSet::new();
 
@@ -263,7 +317,13 @@ fn validate_enabled_integrations(
     validate_integration::<OsanoConfig>(settings, "osano")?;
     validate_integration::<GoogleTagManagerConfig>(settings, "google_tag_manager")?;
     if let Some(config) = settings.integration_config::<DataDomeConfig>("datadome")? {
-        crate::integrations::datadome::DataDomeIntegration::validate_config_for_startup(config)?;
+        if resolved_secrets {
+            crate::integrations::datadome::DataDomeIntegration::validate_config_for_startup(
+                config,
+            )?;
+        } else {
+            crate::integrations::datadome::DataDomeIntegration::validate_config_for_deploy(config)?;
+        }
     }
     validate_integration::<GptConfig>(settings, "gpt")?;
     validate_integration::<GptDiagnosticsConfig>(settings, "gpt_diagnostics")?;
@@ -346,6 +406,67 @@ fn validate_secret_key_references(settings: &Settings) -> Result<(), Report<Trus
         )?;
     }
 
+    if settings.tinybird.enabled {
+        let token = settings
+            .tinybird
+            .auction_token_secret
+            .as_ref()
+            .ok_or_else(|| missing_secret_key_reference("tinybird.auction_token_secret"))?;
+        validate_secret_key_reference("tinybird.auction_token_secret", token.expose())?;
+    }
+
+    if let Some(datadome) = settings.integration_config::<DataDomeConfig>("datadome")? {
+        if datadome.enable_protection {
+            let key = datadome
+                .server_side_key_secret_name
+                .as_ref()
+                .ok_or_else(|| {
+                    missing_secret_key_reference(
+                        "integrations.datadome.server_side_key_secret_name",
+                    )
+                })?;
+            validate_secret_key_reference(
+                "integrations.datadome.server_side_key_secret_name",
+                key.expose(),
+            )?;
+        }
+        if let Some(bypass) = datadome
+            .protection_test_bypass
+            .as_ref()
+            .filter(|bypass| bypass.enabled)
+        {
+            let credential = bypass.credential_secret_name.as_ref().ok_or_else(|| {
+                missing_secret_key_reference(
+                    "integrations.datadome.protection_test_bypass.credential_secret_name",
+                )
+            })?;
+            validate_secret_key_reference(
+                "integrations.datadome.protection_test_bypass.credential_secret_name",
+                credential.expose(),
+            )?;
+        }
+    }
+
+    for (index, route) in settings.proxy.asset_routes.iter().enumerate() {
+        let Some(AssetOriginAuth::S3SigV4(auth)) = route.auth.as_ref() else {
+            continue;
+        };
+        validate_secret_key_reference(
+            &format!("proxy.asset_routes[{index}].auth.access_key_id"),
+            auth.access_key_id.expose(),
+        )?;
+        validate_secret_key_reference(
+            &format!("proxy.asset_routes[{index}].auth.secret_access_key"),
+            auth.secret_access_key.expose(),
+        )?;
+        if let Some(token) = &auth.session_token {
+            validate_secret_key_reference(
+                &format!("proxy.asset_routes[{index}].auth.session_token"),
+                token.expose(),
+            )?;
+        }
+    }
+
     Ok(())
 }
 
@@ -354,11 +475,15 @@ fn validate_secret_key_reference(
     key_name: &str,
 ) -> Result<(), Report<TrustedServerError>> {
     if key_name.is_empty() {
-        return Err(Report::new(TrustedServerError::Configuration {
-            message: format!("secret key reference at `{path}` must not be empty"),
-        }));
+        return Err(missing_secret_key_reference(path));
     }
     Ok(())
+}
+
+fn missing_secret_key_reference(path: &str) -> Report<TrustedServerError> {
+    Report::new(TrustedServerError::Configuration {
+        message: format!("secret key reference at `{path}` must not be empty"),
+    })
 }
 
 fn validate_proxy_secret_strength(settings: &Settings) -> Result<(), Report<TrustedServerError>> {
@@ -411,6 +536,7 @@ fn report_to_validation_error(
 mod tests {
     use super::*;
     use crate::redacted::Redacted;
+    use crate::settings::{ProxyAssetRoute, S3SigV4AuthConfig};
     use crate::test_support::tests::crate_test_settings_str;
     use edgezero_core::app_config::AppConfigMeta;
 
@@ -641,6 +767,22 @@ formats = [{ width = 300, height = 250 }]
                 ("ec.partners[*].api_token".to_owned(), false),
                 ("ec.partners[*].ts_pull_token".to_owned(), true),
                 ("handlers[*].password".to_owned(), false),
+                ("tinybird.auction_token_secret".to_owned(), true),
+                (
+                    "integrations.datadome.server_side_key_secret_name".to_owned(),
+                    true,
+                ),
+                (
+                    "integrations.datadome.protection_test_bypass.credential_secret_name"
+                        .to_owned(),
+                    true,
+                ),
+                ("proxy.asset_routes[*].auth.access_key_id".to_owned(), false),
+                (
+                    "proxy.asset_routes[*].auth.secret_access_key".to_owned(),
+                    false,
+                ),
+                ("proxy.asset_routes[*].auth.session_token".to_owned(), true),
             ],
             "should expose the native EdgeZero secret metadata contract"
         );
@@ -651,6 +793,77 @@ formats = [{ width = 300, height = 250 }]
             )),
             "all Trusted Server app secrets should use the default secret store"
         );
+    }
+
+    #[test]
+    fn legacy_static_secret_store_selectors_are_accepted_but_not_serialized() {
+        let mut settings = valid_settings();
+        settings.tinybird.secret_store = Some("legacy-tinybird-store".to_string());
+        settings
+            .integrations
+            .insert_config(
+                "datadome",
+                &serde_json::json!({
+                    "enabled": true,
+                    "server_side_key_secret_store": "legacy-datadome-store",
+                    "protection_test_bypass": {
+                        "enabled": false,
+                        "credential_secret_store": "legacy-bypass-store",
+                    },
+                }),
+            )
+            .expect("should insert legacy DataDome selectors");
+        let mut route = ProxyAssetRoute::new(
+            "/assets/",
+            "https://examplebucket.s3.us-east-1.amazonaws.com",
+        );
+        route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
+            region: "us-east-1".to_string(),
+            secret_store: Some("legacy-s3-store".to_string()),
+            access_key_id: Redacted::new("s3-access-key".to_string()),
+            secret_access_key: Redacted::new("s3-secret-key".to_string()),
+            session_token: None,
+            origin_query: None,
+        }));
+        settings.proxy.asset_routes.push(route);
+
+        settings.normalize_deserialized();
+        let serialized = serde_json::to_string(&settings).expect("should serialize settings");
+
+        for legacy_store in [
+            "legacy-tinybird-store",
+            "legacy-datadome-store",
+            "legacy-bypass-store",
+            "legacy-s3-store",
+        ] {
+            assert!(
+                !serialized.contains(legacy_store),
+                "serialized config should omit deprecated selector {legacy_store}"
+            );
+        }
+    }
+
+    #[test]
+    fn settings_debug_redacts_resolved_static_credentials() {
+        let mut settings = valid_settings();
+        settings.tinybird.auction_token_secret =
+            Some(Redacted::new("resolved-tinybird-secret".to_string()));
+        settings
+            .integrations
+            .insert_config(
+                "datadome",
+                &serde_json::json!({
+                    "enabled": true,
+                    "server_side_key_secret_name": "resolved-datadome-secret",
+                }),
+            )
+            .expect("should insert resolved DataDome config");
+
+        let debug = format!("{settings:?}");
+
+        assert!(!debug.contains("resolved-tinybird-secret"));
+        assert!(!debug.contains("resolved-datadome-secret"));
+        assert!(debug.contains("datadome"));
     }
 
     #[test]
@@ -1046,15 +1259,9 @@ password = "production-admin-password-32-bytes"
 
     #[test]
     fn deploy_validation_rejects_invalid_datadome_test_bypass() {
-        for (enable_protection, store, name, expected_message) in [
-            (
-                false,
-                "ts_secrets",
-                "datadome_test_bypass",
-                "requires enable_protection",
-            ),
-            (true, "", "datadome_test_bypass", "credential_secret_store"),
-            (true, "ts_secrets", "", "credential_secret_name"),
+        for (enable_protection, name, expected_message) in [
+            (false, "datadome_test_bypass", "requires enable_protection"),
+            (true, "", "credential_secret_name"),
         ] {
             let mut settings = valid_settings();
             settings
@@ -1064,9 +1271,9 @@ password = "production-admin-password-32-bytes"
                     &serde_json::json!({
                         "enabled": true,
                         "enable_protection": enable_protection,
+                        "server_side_key_secret_name": "datadome_server_side_key",
                         "protection_test_bypass": {
                             "enabled": true,
-                            "credential_secret_store": store,
                             "credential_secret_name": name,
                         },
                     }),

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -173,6 +173,13 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
                 false,
             ),
             field(
+                vec![
+                    optional_object("trusted_client_ip"),
+                    object("shared_secret"),
+                ],
+                false,
+            ),
+            field(
                 vec![optional_object("tinybird"), object("auction_token_secret")],
                 true,
             ),
@@ -406,6 +413,13 @@ fn validate_secret_key_references(settings: &Settings) -> Result<(), Report<Trus
         )?;
     }
 
+    if let Some(trusted_client_ip) = &settings.trusted_client_ip {
+        validate_secret_key_reference(
+            "trusted_client_ip.shared_secret",
+            trusted_client_ip.shared_secret.expose(),
+        )?;
+    }
+
     if settings.tinybird.enabled {
         let token = settings
             .tinybird
@@ -474,7 +488,7 @@ fn validate_secret_key_reference(
     path: &str,
     key_name: &str,
 ) -> Result<(), Report<TrustedServerError>> {
-    if key_name.is_empty() {
+    if key_name.trim().is_empty() {
         return Err(missing_secret_key_reference(path));
     }
     Ok(())
@@ -525,7 +539,7 @@ fn report_to_validation_error(
 mod tests {
     use super::*;
     use crate::redacted::Redacted;
-    use crate::settings::{ProxyAssetRoute, S3SigV4AuthConfig};
+    use crate::settings::{ProxyAssetRoute, S3SigV4AuthConfig, TrustedClientIpConfig};
     use crate::test_support::tests::crate_test_settings_str;
     use edgezero_core::app_config::AppConfigMeta;
 
@@ -756,6 +770,7 @@ formats = [{ width = 300, height = 250 }]
                 ("ec.partners[*].api_token".to_owned(), true),
                 ("ec.partners[*].ts_pull_token".to_owned(), true),
                 ("handlers[*].password".to_owned(), false),
+                ("trusted_client_ip.shared_secret".to_owned(), false),
                 ("tinybird.auction_token_secret".to_owned(), true),
                 (
                     "integrations.datadome.server_side_key_secret_name".to_owned(),
@@ -957,6 +972,33 @@ gam_network_id = "99999"
         assert!(
             err.to_string().contains("publisher.proxy_secret"),
             "error should identify the empty secret reference: {err:?}"
+        );
+    }
+
+    #[test]
+    fn app_config_new_accepts_trusted_client_ip_secret_key_reference() {
+        let mut settings = valid_settings();
+        settings.trusted_client_ip = Some(TrustedClientIpConfig {
+            ip_header: "x-ts-client-ip".to_owned(),
+            auth_header: "x-ts-client-ip-auth".to_owned(),
+            shared_secret: Redacted::new("trusted_client_ip_shared_secret".to_owned()),
+        });
+
+        TrustedServerAppConfig::new(settings)
+            .expect("should validate the shared-secret key name without treating it as the value");
+    }
+
+    #[test]
+    fn app_config_new_rejects_whitespace_secret_key_reference() {
+        let mut settings = valid_settings();
+        settings.publisher.proxy_secret = Redacted::new(" \t ".to_owned());
+
+        let err = TrustedServerAppConfig::new(settings)
+            .expect_err("should reject a whitespace-only secret key reference");
+
+        assert!(
+            err.to_string().contains("publisher.proxy_secret"),
+            "error should identify the whitespace-only secret reference: {err:?}"
         );
     }
 

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -9,6 +9,7 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
 
+use edgezero_core::app_config::{SecretField, SecretKind, SecretPathSegment};
 use error_stack::Report;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use validator::{Validate, ValidationError, ValidationErrors};
@@ -35,6 +36,7 @@ use crate::integrations::{
 use crate::settings::{IntegrationConfig, Settings};
 
 const DEPLOY_VALIDATION_FIELD: &str = "trusted_server";
+const MIN_PROXY_SECRET_LENGTH: usize = 32;
 #[cfg(test)]
 const DEPLOY_VALIDATED_INTEGRATION_IDS: &[&str] = &[
     "prebid",
@@ -65,15 +67,20 @@ pub struct TrustedServerAppConfig {
 }
 
 impl TrustedServerAppConfig {
-    /// Creates a validated app-config wrapper from [`Settings`].
+    /// Creates a push-valid app-config wrapper from [`Settings`].
     ///
     /// # Errors
     ///
-    /// Returns [`TrustedServerError::Configuration`] when deploy validation
+    /// Returns [`TrustedServerError::Configuration`] when push-safe validation
     /// fails.
     pub fn new(settings: Settings) -> Result<Self, Report<TrustedServerError>> {
-        validate_settings_for_deploy(&settings)?;
-        Ok(Self { settings })
+        let app_config = Self { settings };
+        edgezero_core::app_config::validate_excluding_secrets(&app_config).map_err(|errors| {
+            Report::new(TrustedServerError::Configuration {
+                message: format!("Configuration validation failed: {errors}"),
+            })
+        })?;
+        Ok(app_config)
     }
 
     /// Consumes the wrapper and returns the inner [`Settings`].
@@ -103,45 +110,109 @@ impl<'de> Deserialize<'de> for TrustedServerAppConfig {
     where
         D: Deserializer<'de>,
     {
-        let settings = Settings::deserialize(deserializer)?;
-        let settings = Settings::finalize_deserialized(settings, "Configuration")
-            .map_err(serde::de::Error::custom)?;
+        let mut settings = Settings::deserialize(deserializer)?;
+        settings.normalize_deserialized();
         Ok(Self { settings })
     }
 }
 
 impl Validate for TrustedServerAppConfig {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_settings_for_deploy(&self.settings)
-            .map_err(|report| report_to_validation_errors(&report))
+        let mut errors = self.settings.validate().err().unwrap_or_default();
+        if let Err(report) = validate_settings_for_deploy(&self.settings) {
+            errors.add(
+                DEPLOY_VALIDATION_FIELD,
+                report_to_validation_error(&report, "trusted_server_deploy_validation"),
+            );
+        }
+        if errors.errors().is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }
 
 impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
-    // Phase 1 intentionally preserves the existing inline-settings model:
-    // `ts config push` publishes the validated Trusted Server config as one
-    // app-config blob. Migrating app-level secrets to `EdgeZero` secret-store
-    // references needs the secret-field paths spelled out here (this
-    // hand-written impl does not inherit the derive's nested/array paths)
-    // plus operator migration work tracked separately.
-    fn secret_fields() -> Vec<edgezero_core::app_config::SecretField> {
-        Vec::new()
+    fn secret_fields() -> Vec<SecretField> {
+        let field = |path: Vec<SecretPathSegment>, optional| SecretField {
+            kind: SecretKind::KeyInDefault,
+            optional,
+            path,
+        };
+        let object = |name: &'static str| SecretPathSegment::Field(Cow::Borrowed(name));
+
+        vec![
+            field(vec![object("publisher"), object("proxy_secret")], false),
+            field(vec![object("ec"), object("passphrase")], false),
+            field(
+                vec![
+                    object("ec"),
+                    object("partners"),
+                    SecretPathSegment::ArrayEach,
+                    object("api_token"),
+                ],
+                false,
+            ),
+            field(
+                vec![
+                    object("ec"),
+                    object("partners"),
+                    SecretPathSegment::ArrayEach,
+                    object("ts_pull_token"),
+                ],
+                true,
+            ),
+            field(
+                vec![
+                    object("handlers"),
+                    SecretPathSegment::ArrayEach,
+                    object("password"),
+                ],
+                false,
+            ),
+        ]
     }
 }
 
-/// Runs Trusted Server deploy-time validation for pushed app config.
+/// Runs Trusted Server push-time validation for app config.
 ///
-/// This supplements [`Settings`] structural validation with checks that should
-/// fail before an operator publishes a config blob: placeholder secrets,
-/// enabled integration startup checks, auction provider references, and EC
-/// partner registry construction.
+/// Secret fields contain secret-store key names at this stage, so this function
+/// deliberately excludes checks that require resolved values. The `EdgeZero` CLI
+/// additionally calls [`edgezero_core::app_config::validate_excluding_secrets`]
+/// to remove validators attached to those leaves.
 ///
 /// # Errors
 ///
-/// Returns [`TrustedServerError`] when the config should not be deployed.
+/// Returns [`TrustedServerError`] when non-secret configuration or a secret key
+/// reference is invalid.
 pub fn validate_settings_for_deploy(settings: &Settings) -> Result<(), Report<TrustedServerError>> {
+    validate_secret_key_references(settings)?;
+    validate_non_secret_deploy_placeholders(settings)?;
+
+    let mut structural_settings = settings.clone();
+    structural_settings.prepare_runtime()?;
+    structural_settings.validate_admin_coverage()?;
+
+    let enabled_auction_providers = validate_enabled_integrations(settings)?;
+    validate_auction_provider_names(settings, &enabled_auction_providers)?;
+    PartnerRegistry::validate_config_for_deploy(&settings.ec.partners)?;
+    Ok(())
+}
+
+/// Runs Trusted Server runtime validation after secret references are resolved.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError`] when resolved secrets or runtime-only
+/// configuration checks are invalid.
+pub fn validate_settings_for_runtime(
+    settings: &Settings,
+) -> Result<(), Report<TrustedServerError>> {
     settings.reject_placeholder_secrets()?;
     validate_js_asset_proxy_config(settings)?;
+    validate_proxy_secret_strength(settings)?;
+    settings.validate_admin_handler_passwords()?;
     let enabled_auction_providers = validate_enabled_integrations(settings)?;
     validate_auction_provider_names(settings, &enabled_auction_providers)?;
     PartnerRegistry::from_config(&settings.ec.partners).map(|_| ())?;
@@ -216,6 +287,91 @@ where
         .map(|config| config.is_some())
 }
 
+fn validate_non_secret_deploy_placeholders(
+    settings: &Settings,
+) -> Result<(), Report<TrustedServerError>> {
+    let mut insecure_fields = Vec::new();
+
+    if crate::settings::Publisher::is_placeholder_domain(&settings.publisher.domain) {
+        insecure_fields.push("publisher.domain");
+    }
+    if crate::settings::Publisher::is_placeholder_cookie_domain(&settings.publisher.cookie_domain) {
+        insecure_fields.push("publisher.cookie_domain");
+    }
+    if crate::settings::Publisher::is_placeholder_origin_url(&settings.publisher.origin_url) {
+        insecure_fields.push("publisher.origin_url");
+    }
+    if let Some(request_signing) = &settings.request_signing {
+        if crate::settings::RequestSigning::is_unusable_store_id(&request_signing.config_store_id) {
+            insecure_fields.push("request_signing.config_store_id");
+        }
+        if crate::settings::RequestSigning::is_unusable_store_id(&request_signing.secret_store_id) {
+            insecure_fields.push("request_signing.secret_store_id");
+        }
+    }
+
+    if insecure_fields.is_empty() {
+        return Ok(());
+    }
+
+    Err(Report::new(TrustedServerError::InsecureDefault {
+        field: insecure_fields.join(", "),
+    }))
+}
+
+fn validate_secret_key_references(settings: &Settings) -> Result<(), Report<TrustedServerError>> {
+    validate_secret_key_reference(
+        "publisher.proxy_secret",
+        settings.publisher.proxy_secret.expose(),
+    )?;
+    validate_secret_key_reference("ec.passphrase", settings.ec.passphrase.expose())?;
+
+    for (index, partner) in settings.ec.partners.iter().enumerate() {
+        validate_secret_key_reference(
+            &format!("ec.partners[{index}].api_token"),
+            partner.api_token.expose(),
+        )?;
+        if let Some(token) = &partner.ts_pull_token {
+            validate_secret_key_reference(
+                &format!("ec.partners[{index}].ts_pull_token"),
+                token.expose(),
+            )?;
+        }
+    }
+
+    for (index, handler) in settings.handlers.iter().enumerate() {
+        validate_secret_key_reference(
+            &format!("handlers[{index}].password"),
+            handler.password.expose(),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn validate_secret_key_reference(
+    path: &str,
+    key_name: &str,
+) -> Result<(), Report<TrustedServerError>> {
+    if key_name.is_empty() {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!("secret key reference at `{path}` must not be empty"),
+        }));
+    }
+    Ok(())
+}
+
+fn validate_proxy_secret_strength(settings: &Settings) -> Result<(), Report<TrustedServerError>> {
+    if settings.publisher.proxy_secret.expose().len() < MIN_PROXY_SECRET_LENGTH {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: format!(
+                "publisher.proxy_secret must be at least {MIN_PROXY_SECRET_LENGTH} bytes after secret resolution"
+            ),
+        }));
+    }
+    Ok(())
+}
+
 fn validate_auction_provider_names(
     settings: &Settings,
     enabled_auction_providers: &HashSet<&'static str>,
@@ -242,19 +398,21 @@ fn validate_auction_provider_names(
     Ok(())
 }
 
-fn report_to_validation_errors(report: &Report<TrustedServerError>) -> ValidationErrors {
-    let mut error = ValidationError::new("trusted_server_deploy_validation");
+fn report_to_validation_error(
+    report: &Report<TrustedServerError>,
+    code: &'static str,
+) -> ValidationError {
+    let mut error = ValidationError::new(code);
     error.message = Some(Cow::Owned(report.to_string()));
-
-    let mut errors = ValidationErrors::new();
-    errors.add(DEPLOY_VALIDATION_FIELD, error);
-    errors
+    error
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::redacted::Redacted;
     use crate::test_support::tests::crate_test_settings_str;
+    use edgezero_core::app_config::AppConfigMeta;
 
     #[derive(Debug, Deserialize)]
     #[serde(deny_unknown_fields)]
@@ -269,7 +427,9 @@ mod tests {
         slot: Vec<serde_json::Value>,
     }
 
-    fn serialized_creative_opportunities(gam_unit_path: Option<&str>) -> serde_json::Value {
+    fn app_config_with_creative_opportunities(
+        gam_unit_path: Option<&str>,
+    ) -> TrustedServerAppConfig {
         let mut toml = crate_test_settings_str();
         toml.push_str(
             r#"
@@ -287,9 +447,15 @@ formats = [{ width = 300, height = 250 }]
             toml.push_str(&format!("gam_unit_path = {gam_unit_path:?}\n"));
         }
 
-        let app_config: TrustedServerAppConfig =
+        let mut app_config: TrustedServerAppConfig =
             toml::from_str(&toml).expect("should deserialize app config wrapper");
-        serde_json::to_value(app_config)
+        app_config.settings.proxy.allowed_domains =
+            vec!["*.example".to_owned(), "*.example.com".to_owned()];
+        app_config
+    }
+
+    fn serialized_creative_opportunities(gam_unit_path: Option<&str>) -> serde_json::Value {
+        serde_json::to_value(app_config_with_creative_opportunities(gam_unit_path))
             .expect("should serialize app config wrapper")
             .get("creative_opportunities")
             .cloned()
@@ -309,14 +475,23 @@ formats = [{ width = 300, height = 250 }]
         "/../../trusted-server.example.toml"
     ));
 
-    /// Returns the template with its deliberately-invalid placeholder admin
-    /// password swapped for a valid one, so parse-time validation succeeds and
-    /// the test can exercise the optional blocks it uncomments.
-    fn template_with_valid_admin_password() -> String {
-        EXAMPLE_TEMPLATE.replace(
-            "password = \"replace-with-admin-password-32-bytes\"",
-            "password = \"unit-test-admin-password-that-is-long-enough\"",
-        )
+    /// Returns the template with required secret-store key references replaced
+    /// by resolved test values, so direct [`Settings`] parsing can exercise the
+    /// optional blocks this module uncomments.
+    fn template_with_resolved_required_secrets() -> String {
+        EXAMPLE_TEMPLATE
+            .replace(
+                "password = \"handler_password\"",
+                "password = \"unit-test-resolved-handler-password-0001\"",
+            )
+            .replace(
+                "proxy_secret = \"publisher_proxy_secret\"",
+                "proxy_secret = \"unit-test-resolved-publisher-proxy-secret-0001\"",
+            )
+            .replace(
+                "passphrase = \"ec_passphrase\"",
+                "passphrase = \"unit-test-resolved-ec-passphrase-secret-0001\"",
+            )
     }
 
     /// Uncomments the contiguous `#`-prefixed block that begins at the line
@@ -350,11 +525,11 @@ formats = [{ width = 300, height = 250 }]
 
     /// Every documented block should be push-ready: uncommenting it and setting
     /// the shown values must parse and pass field validation. Blocks that ship
-    /// a deliberately-invalid placeholder (admin password, `ec.passphrase`, GTM
-    /// `container_id`, `request_signing` store ids) are excluded.
+    /// a deliberately-invalid non-secret placeholder (GTM `container_id` and
+    /// `request_signing` store ids) are excluded.
     #[test]
     fn documented_integration_blocks_validate_when_uncommented() {
-        let base = template_with_valid_admin_password();
+        let base = template_with_resolved_required_secrets();
 
         for (header, id) in [
             ("[integrations.permutive]", "permutive"),
@@ -396,7 +571,7 @@ formats = [{ width = 300, height = 250 }]
     /// uncommenting it with the documented `api_host` must parse cleanly.
     #[test]
     fn documented_tinybird_block_validates_when_uncommented() {
-        let toml = uncomment_block(&template_with_valid_admin_password(), "[tinybird]");
+        let toml = uncomment_block(&template_with_resolved_required_secrets(), "[tinybird]");
         let settings = Settings::from_toml(&toml)
             .expect("uncommented [tinybird] with documented api_host should parse and validate");
         assert!(
@@ -435,18 +610,65 @@ formats = [{ width = 300, height = 250 }]
     }
 
     #[test]
-    fn dynamic_gam_unit_templates_are_rejected_by_legacy_schema() {
-        for gam_unit_path in ["/{network_id}/example", "/example/{slot_id}"] {
-            let creative_opportunities = serialized_creative_opportunities(Some(gam_unit_path));
-            let err =
-                serde_json::from_value::<LegacyCreativeOpportunitiesConfig>(creative_opportunities)
-                    .expect_err("should reject dynamic GAM unit template");
+    fn push_validation_accepts_secret_key_names() {
+        let mut settings = valid_settings();
+        settings.publisher.proxy_secret = Redacted::new("publisher_proxy".to_owned());
+        settings.ec.passphrase = Redacted::new("ec_key".to_owned());
+        settings.handlers[0].password = Redacted::new("handler_password".to_owned());
+        settings.handlers[1].password = Redacted::new("admin_password".to_owned());
+        let app_config = TrustedServerAppConfig::new(settings)
+            .expect("should validate key names without values");
 
-            assert!(
-                err.to_string().contains("section_segment"),
-                "legacy error should name section_segment: {err}"
-            );
-        }
+        let serialized =
+            serde_json::to_string(&app_config).expect("should serialize key-name-only app config");
+        assert!(serialized.contains("publisher_proxy"));
+        assert!(!serialized.contains("unit-test-proxy-secret"));
+    }
+
+    #[test]
+    fn secret_metadata_lists_all_secret_paths_and_optionality() {
+        let fields = TrustedServerAppConfig::secret_fields();
+        let paths = fields
+            .iter()
+            .map(|field| (field.dotted_path(), field.optional))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![
+                ("publisher.proxy_secret".to_owned(), false),
+                ("ec.passphrase".to_owned(), false),
+                ("ec.partners[*].api_token".to_owned(), false),
+                ("ec.partners[*].ts_pull_token".to_owned(), true),
+                ("handlers[*].password".to_owned(), false),
+            ],
+            "should expose the native EdgeZero secret metadata contract"
+        );
+        assert!(
+            fields.iter().all(|field| matches!(
+                field.kind,
+                edgezero_core::app_config::SecretKind::KeyInDefault
+            )),
+            "all Trusted Server app secrets should use the default secret store"
+        );
+    }
+
+    #[test]
+    fn app_config_deserialization_does_not_finalize_runtime_templates() {
+        let creative_opportunities =
+            serialized_creative_opportunities(Some("/{network_id}/example"));
+        let slot = creative_opportunities["slot"][0]
+            .as_object()
+            .expect("should serialize creative opportunity slot");
+
+        assert!(
+            slot.contains_key("gam_unit_path"),
+            "push deserialization should preserve the operator config field"
+        );
+        assert!(
+            !slot.contains_key("section_segment"),
+            "push deserialization should not add runtime-only compiled fields"
+        );
     }
 
     #[test]
@@ -493,7 +715,53 @@ gam_network_id = "99999"
     }
 
     #[test]
-    fn deploy_validation_rejects_placeholders() {
+    fn app_config_new_rejects_empty_secret_key_reference() {
+        let mut settings = valid_settings();
+        settings.publisher.proxy_secret = Redacted::new(String::new());
+
+        let err = TrustedServerAppConfig::new(settings)
+            .expect_err("should reject an empty secret key reference");
+
+        assert!(
+            err.to_string().contains("publisher.proxy_secret"),
+            "error should identify the empty secret reference: {err:?}"
+        );
+    }
+
+    #[test]
+    fn app_config_new_rejects_invalid_non_secret_settings() {
+        let mut settings = valid_settings();
+        settings.publisher.domain = "invalid/domain".to_owned();
+
+        let err = TrustedServerAppConfig::new(settings)
+            .expect_err("should reject invalid publisher domain before creating an app config");
+
+        assert!(
+            err.to_string().contains("invalid_publisher_domain"),
+            "error should identify the structural validation failure: {err:?}"
+        );
+    }
+
+    #[test]
+    fn runtime_validation_rejects_short_proxy_secret() {
+        let mut settings = valid_settings();
+        settings.publisher.proxy_secret = Redacted::new("short".to_owned());
+
+        let err = validate_settings_for_runtime(&settings)
+            .expect_err("should reject a short resolved proxy secret");
+
+        assert!(
+            err.to_string().contains("at least 32 bytes"),
+            "error should identify the required proxy-secret strength: {err:?}"
+        );
+        assert!(
+            !err.to_string().contains("short"),
+            "error should not expose the resolved secret"
+        );
+    }
+
+    #[test]
+    fn runtime_validation_rejects_placeholders() {
         let settings = Settings::from_toml(
             r#"
 [publisher]
@@ -511,10 +779,10 @@ username = "admin"
 password = "production-admin-password-32-bytes"
 "#,
         )
-        .expect("should parse placeholder settings before deploy validation");
+        .expect("should parse placeholder settings before runtime validation");
 
-        let err =
-            validate_settings_for_deploy(&settings).expect_err("should reject placeholder secrets");
+        let err = validate_settings_for_runtime(&settings)
+            .expect_err("should reject placeholder secrets at runtime");
 
         assert!(
             err.to_string().contains("Insecure default"),

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -202,7 +202,7 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
                     optional_object("auth"),
                     object("access_key_id"),
                 ],
-                false,
+                true,
             ),
             field(
                 vec![
@@ -212,7 +212,7 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
                     optional_object("auth"),
                     object("secret_access_key"),
                 ],
-                false,
+                true,
             ),
             field(
                 vec![
@@ -777,10 +777,10 @@ formats = [{ width = 300, height = 250 }]
                         .to_owned(),
                     true,
                 ),
-                ("proxy.asset_routes[*].auth.access_key_id".to_owned(), false),
+                ("proxy.asset_routes[*].auth.access_key_id".to_owned(), true),
                 (
                     "proxy.asset_routes[*].auth.secret_access_key".to_owned(),
-                    false,
+                    true,
                 ),
                 ("proxy.asset_routes[*].auth.session_token".to_owned(), true),
             ],
@@ -793,6 +793,19 @@ formats = [{ width = 300, height = 250 }]
             )),
             "all Trusted Server app secrets should use the default secret store"
         );
+    }
+
+    #[test]
+    fn omitted_s3_secret_references_materialize_as_defaults() {
+        let auth: S3SigV4AuthConfig =
+            toml::from_str("region = \"us-east-1\"").expect("should apply S3 secret defaults");
+
+        assert_eq!(auth.access_key_id.expose(), "access_key_id");
+        assert_eq!(auth.secret_access_key.expose(), "secret_access_key");
+
+        let serialized = serde_json::to_value(auth).expect("should serialize S3 auth");
+        assert_eq!(serialized["access_key_id"], "access_key_id");
+        assert_eq!(serialized["secret_access_key"], "secret_access_key");
     }
 
     #[test]

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -150,7 +150,7 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
             field(
                 vec![
                     object("ec"),
-                    object("partners"),
+                    optional_object("partners"),
                     SecretPathSegment::ArrayEach,
                     object("api_token"),
                 ],
@@ -159,7 +159,7 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
             field(
                 vec![
                     object("ec"),
-                    object("partners"),
+                    optional_object("partners"),
                     SecretPathSegment::ArrayEach,
                     object("ts_pull_token"),
                 ],
@@ -793,6 +793,23 @@ formats = [{ width = 300, height = 250 }]
             )),
             "all Trusted Server app secrets should use the default secret store"
         );
+    }
+
+    #[test]
+    fn partner_secret_metadata_makes_the_defaulted_array_optional() {
+        let fields = TrustedServerAppConfig::secret_fields();
+
+        for field in fields.iter().filter(|field| {
+            matches!(
+                field.dotted_path().as_str(),
+                "ec.partners[*].api_token" | "ec.partners[*].ts_pull_token"
+            )
+        }) {
+            assert!(matches!(
+                &field.path[1],
+                SecretPathSegment::OptionalField(name) if name == "partners"
+            ));
+        }
     }
 
     #[test]

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -154,7 +154,7 @@ impl edgezero_core::app_config::AppConfigMeta for TrustedServerAppConfig {
                     SecretPathSegment::ArrayEach,
                     object("api_token"),
                 ],
-                false,
+                true,
             ),
             field(
                 vec![
@@ -387,10 +387,12 @@ fn validate_secret_key_references(settings: &Settings) -> Result<(), Report<Trus
     validate_secret_key_reference("ec.passphrase", settings.ec.passphrase.expose())?;
 
     for (index, partner) in settings.ec.partners.iter().enumerate() {
-        validate_secret_key_reference(
-            &format!("ec.partners[{index}].api_token"),
-            partner.api_token.expose(),
-        )?;
+        if let Some(token) = &partner.api_token {
+            validate_secret_key_reference(
+                &format!("ec.partners[{index}].api_token"),
+                token.expose(),
+            )?;
+        }
         if let Some(token) = &partner.ts_pull_token {
             validate_secret_key_reference(
                 &format!("ec.partners[{index}].ts_pull_token"),
@@ -764,7 +766,7 @@ formats = [{ width = 300, height = 250 }]
             vec![
                 ("publisher.proxy_secret".to_owned(), false),
                 ("ec.passphrase".to_owned(), false),
-                ("ec.partners[*].api_token".to_owned(), false),
+                ("ec.partners[*].api_token".to_owned(), true),
                 ("ec.partners[*].ts_pull_token".to_owned(), true),
                 ("handlers[*].password".to_owned(), false),
                 ("tinybird.auction_token_secret".to_owned(), true),

--- a/crates/trusted-server-core/src/config.rs
+++ b/crates/trusted-server-core/src/config.rs
@@ -36,7 +36,6 @@ use crate::integrations::{
 use crate::settings::{AssetOriginAuth, IntegrationConfig, Settings};
 
 const DEPLOY_VALIDATION_FIELD: &str = "trusted_server";
-const MIN_PROXY_SECRET_LENGTH: usize = 32;
 #[cfg(test)]
 const DEPLOY_VALIDATED_INTEGRATION_IDS: &[&str] = &[
     "prebid",
@@ -264,7 +263,6 @@ pub fn validate_settings_for_runtime(
 ) -> Result<(), Report<TrustedServerError>> {
     settings.reject_placeholder_secrets()?;
     validate_js_asset_proxy_config(settings)?;
-    validate_proxy_secret_strength(settings)?;
     settings.validate_admin_handler_passwords()?;
     let enabled_auction_providers = validate_enabled_integrations(settings, true)?;
     validate_auction_provider_names(settings, &enabled_auction_providers)?;
@@ -486,17 +484,6 @@ fn missing_secret_key_reference(path: &str) -> Report<TrustedServerError> {
     Report::new(TrustedServerError::Configuration {
         message: format!("secret key reference at `{path}` must not be empty"),
     })
-}
-
-fn validate_proxy_secret_strength(settings: &Settings) -> Result<(), Report<TrustedServerError>> {
-    if settings.publisher.proxy_secret.expose().len() < MIN_PROXY_SECRET_LENGTH {
-        return Err(Report::new(TrustedServerError::Configuration {
-            message: format!(
-                "publisher.proxy_secret must be at least {MIN_PROXY_SECRET_LENGTH} bytes after secret resolution"
-            ),
-        }));
-    }
-    Ok(())
 }
 
 fn validate_auction_provider_names(
@@ -984,24 +971,6 @@ gam_network_id = "99999"
         assert!(
             err.to_string().contains("invalid_publisher_domain"),
             "error should identify the structural validation failure: {err:?}"
-        );
-    }
-
-    #[test]
-    fn runtime_validation_rejects_short_proxy_secret() {
-        let mut settings = valid_settings();
-        settings.publisher.proxy_secret = Redacted::new("short".to_owned());
-
-        let err = validate_settings_for_runtime(&settings)
-            .expect_err("should reject a short resolved proxy secret");
-
-        assert!(
-            err.to_string().contains("at least 32 bytes"),
-            "error should identify the required proxy-secret strength: {err:?}"
-        );
-        assert!(
-            !err.to_string().contains("short"),
-            "error should not expose the resolved secret"
         );
     }
 

--- a/crates/trusted-server-core/src/config_payload.rs
+++ b/crates/trusted-server-core/src/config_payload.rs
@@ -8,20 +8,32 @@
 use edgezero_core::blob_envelope::BlobEnvelope;
 use error_stack::Report;
 
+use crate::config::TrustedServerAppConfig;
 use crate::error::TrustedServerError;
+use crate::platform::{PlatformSecretStore, StoreName};
+use crate::secret_resolution::resolve_secret_references;
 use crate::settings::Settings;
+
+/// Canonical logical secret store used by Trusted Server app-config secrets.
+pub const DEFAULT_SECRET_STORE_ID: &str = "trusted_server_secrets";
 
 /// Default config-store key containing the Trusted Server app-config blob.
 pub const CONFIG_BLOB_KEY: &str = "trusted_server_config";
 
-/// Reconstruct validated [`Settings`] from a serialized config blob envelope.
+/// Reconstruct runtime [`Settings`] from a serialized config blob envelope.
+///
+/// Secret references are resolved after envelope verification and before
+/// deserialization. The envelope data itself is never mutated or rewritten.
 ///
 /// # Errors
 ///
 /// Returns [`TrustedServerError::Configuration`] when the envelope cannot be
-/// parsed, fails integrity verification, or contains invalid settings data.
+/// parsed, fails integrity verification, secret resolution fails, or resolved
+/// settings are invalid.
 pub fn settings_from_config_blob(
     envelope_json: &str,
+    secret_store: &dyn PlatformSecretStore,
+    default_secret_store_name: &StoreName,
 ) -> Result<Settings, Report<TrustedServerError>> {
     let envelope: BlobEnvelope = serde_json::from_str(envelope_json).map_err(|error| {
         Report::new(TrustedServerError::Configuration {
@@ -36,14 +48,21 @@ pub fn settings_from_config_blob(
         .attach(error.to_string())
     })?;
 
-    let settings = Settings::from_json_value(envelope.into_data())?;
-    settings.reject_placeholder_secrets()?;
+    let mut data = envelope.into_data();
+    resolve_secret_references::<TrustedServerAppConfig>(
+        &mut data,
+        secret_store,
+        default_secret_store_name,
+    )?;
+    let settings = Settings::from_json_value(data)?;
+    crate::config::validate_settings_for_runtime(&settings)?;
     Ok(settings)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::{PlatformError, StoreId};
     use crate::redacted::Redacted;
     use crate::test_support::tests::crate_test_settings_str;
     use serde::Deserialize;
@@ -69,7 +88,40 @@ mod tests {
     }
 
     fn test_settings() -> Settings {
-        Settings::from_toml(&crate_test_settings_str()).expect("should parse test settings")
+        let mut settings =
+            Settings::from_toml(&crate_test_settings_str()).expect("should parse test settings");
+        settings.proxy.allowed_domains = vec!["*.example".to_owned(), "*.example.com".to_owned()];
+        settings
+    }
+
+    struct EchoSecretStore;
+
+    impl PlatformSecretStore for EchoSecretStore {
+        fn get_bytes(
+            &self,
+            _store_name: &StoreName,
+            key: &str,
+        ) -> Result<Vec<u8>, Report<PlatformError>> {
+            let value = match key {
+                "placeholder_proxy" => "change-me-proxy-secret",
+                "unit-test-proxy-secret" => "unit-test-proxy-secret-32-bytes-ok",
+                _ => key,
+            };
+            Ok(value.as_bytes().to_vec())
+        }
+
+        fn create(
+            &self,
+            _store_id: &StoreId,
+            _name: &str,
+            _value: &str,
+        ) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+
+        fn delete(&self, _store_id: &StoreId, _name: &str) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
     }
 
     fn envelope_json(settings: &Settings) -> String {
@@ -78,11 +130,19 @@ mod tests {
         serde_json::to_string(&envelope).expect("should serialize envelope")
     }
 
+    fn load_settings(envelope_json: &str) -> Result<Settings, Report<TrustedServerError>> {
+        settings_from_config_blob(
+            envelope_json,
+            &EchoSecretStore,
+            &StoreName::from("trusted_server_secrets"),
+        )
+    }
+
     #[test]
     fn payload_round_trips_through_blob_envelope() {
         let original = test_settings();
-        let reconstructed = settings_from_config_blob(&envelope_json(&original))
-            .expect("should reconstruct settings");
+        let reconstructed =
+            load_settings(&envelope_json(&original)).expect("should reconstruct settings");
 
         assert_eq!(
             reconstructed.publisher.domain, original.publisher.domain,
@@ -115,7 +175,7 @@ mod tests {
         let envelope_json = serde_json::to_string(&envelope).expect("should serialize envelope");
 
         let reconstructed =
-            settings_from_config_blob(&envelope_json).expect("should reconstruct legacy settings");
+            load_settings(&envelope_json).expect("should reconstruct legacy settings");
 
         assert!(
             reconstructed.auction.rewrite_creatives,
@@ -141,7 +201,7 @@ mod tests {
         let mut original = test_settings();
         original.auction.rewrite_creatives = false;
 
-        let reconstructed = settings_from_config_blob(&envelope_json(&original))
+        let reconstructed = load_settings(&envelope_json(&original))
             .expect("should reconstruct disabled rewriting");
 
         assert!(
@@ -153,12 +213,13 @@ mod tests {
     #[test]
     fn strings_that_look_like_json_scalars_round_trip_as_strings() {
         let mut original = test_settings();
-        original.publisher.proxy_secret = Redacted::new("1234567890".to_string());
+        original.publisher.proxy_secret =
+            Redacted::new("12345678901234567890123456789012".to_string());
         original.ec.passphrase = Redacted::new("12345678901234567890123456789012".to_string());
         original.handlers[0].password = Redacted::new("true".to_string());
 
-        let reconstructed = settings_from_config_blob(&envelope_json(&original))
-            .expect("should reconstruct settings");
+        let reconstructed =
+            load_settings(&envelope_json(&original)).expect("should reconstruct settings");
 
         assert_eq!(
             reconstructed.publisher.proxy_secret.expose(),
@@ -178,6 +239,60 @@ mod tests {
     }
 
     #[test]
+    fn runtime_validation_rejects_short_resolved_proxy_secret() {
+        let mut settings = test_settings();
+        settings.publisher.proxy_secret = Redacted::new("short_proxy".to_owned());
+
+        let err = load_settings(&envelope_json(&settings))
+            .expect_err("should reject a short resolved proxy secret");
+
+        assert!(
+            err.to_string().contains("at least 32 bytes"),
+            "error should indicate runtime validation: {err:?}"
+        );
+        assert!(
+            !err.to_string().contains("short_proxy"),
+            "error should not expose the secret value"
+        );
+    }
+
+    #[test]
+    fn runtime_validation_rejects_short_resolved_passphrase() {
+        let mut settings = test_settings();
+        settings.ec.passphrase = Redacted::new("short_key".to_owned());
+
+        let err = load_settings(&envelope_json(&settings))
+            .expect_err("should reject a short resolved passphrase");
+
+        assert!(
+            err.to_string().contains("short_passphrase") || err.to_string().contains("validation"),
+            "error should indicate runtime validation: {err:?}"
+        );
+        assert!(
+            !err.to_string().contains("short_key"),
+            "error should not expose the secret value"
+        );
+    }
+
+    #[test]
+    fn placeholder_rejection_happens_after_secret_resolution() {
+        let mut settings = test_settings();
+        settings.publisher.proxy_secret = Redacted::new("placeholder_proxy".to_owned());
+
+        let err = load_settings(&envelope_json(&settings))
+            .expect_err("should reject a placeholder resolved from the secret store");
+
+        assert!(
+            err.to_string().contains("Insecure default"),
+            "error should identify the insecure default: {err:?}"
+        );
+        assert!(
+            !err.to_string().contains("change-me-proxy-secret"),
+            "error should not expose the resolved secret value"
+        );
+    }
+
+    #[test]
     fn tampered_blob_hash_is_rejected() {
         let mut envelope: BlobEnvelope =
             serde_json::from_str(&envelope_json(&test_settings())).expect("should parse envelope");
@@ -185,7 +300,7 @@ mod tests {
         let tampered =
             serde_json::to_string(&envelope).expect("should serialize tampered envelope");
 
-        let err = settings_from_config_blob(&tampered).expect_err("should reject hash mismatch");
+        let err = load_settings(&tampered).expect_err("should reject hash mismatch");
 
         assert!(
             err.to_string().contains("integrity verification"),

--- a/crates/trusted-server-core/src/config_payload.rs
+++ b/crates/trusted-server-core/src/config_payload.rs
@@ -380,8 +380,12 @@ mod tests {
         );
         assert!(auth.secret_store.is_none());
         assert_eq!(
-            reconstructed.ec.partners[0].api_token.expose(),
-            "resolved-partner-api-token-32-bytes-ok"
+            reconstructed.ec.partners[0]
+                .api_token
+                .as_ref()
+                .map(Redacted::expose)
+                .map(String::as_str),
+            Some("resolved-partner-api-token-32-bytes-ok")
         );
         assert_eq!(
             reconstructed.ec.partners[0]
@@ -420,6 +424,30 @@ mod tests {
         assert_eq!(
             auth.secret_access_key.expose(),
             "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        );
+    }
+
+    #[test]
+    fn partner_without_api_token_loads_without_secret_resolution() {
+        let mut original = test_settings();
+        let partner = serde_json::from_value(serde_json::json!({
+            "name": "Example Partner",
+            "source_domain": "partner.example.com",
+            "bidstream_enabled": true,
+        }))
+        .expect("should build partner without API token");
+        original.ec.partners.push(partner);
+
+        let reconstructed = settings_from_config_blob(
+            &envelope_json(&original),
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect("should load partner without resolving an API token");
+
+        assert!(
+            reconstructed.ec.partners[0].api_token.is_none(),
+            "should preserve omitted API token"
         );
     }
 

--- a/crates/trusted-server-core/src/config_payload.rs
+++ b/crates/trusted-server-core/src/config_payload.rs
@@ -629,20 +629,17 @@ mod tests {
     }
 
     #[test]
-    fn runtime_validation_rejects_short_resolved_proxy_secret() {
+    fn runtime_validation_accepts_short_resolved_proxy_secret() {
         let mut settings = test_settings();
         settings.publisher.proxy_secret = Redacted::new("short_proxy".to_owned());
 
-        let err = load_settings(&envelope_json(&settings))
-            .expect_err("should reject a short resolved proxy secret");
+        let reconstructed = load_settings(&envelope_json(&settings))
+            .expect("should accept an existing short proxy secret");
 
-        assert!(
-            err.to_string().contains("at least 32 bytes"),
-            "error should indicate runtime validation: {err:?}"
-        );
-        assert!(
-            !err.to_string().contains("short_proxy"),
-            "error should not expose the secret value"
+        assert_eq!(
+            reconstructed.publisher.proxy_secret.expose(),
+            "short_proxy",
+            "should preserve the resolved proxy secret"
         );
     }
 

--- a/crates/trusted-server-core/src/config_payload.rs
+++ b/crates/trusted-server-core/src/config_payload.rs
@@ -49,6 +49,7 @@ pub fn settings_from_config_blob(
     })?;
 
     let mut data = envelope.into_data();
+    remove_inactive_secret_references(&mut data);
     resolve_secret_references::<TrustedServerAppConfig>(
         &mut data,
         secret_store,
@@ -59,11 +60,58 @@ pub fn settings_from_config_blob(
     Ok(settings)
 }
 
+fn remove_inactive_secret_references(data: &mut serde_json::Value) {
+    if data
+        .pointer("/tinybird/enabled")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+        && let Some(tinybird) = data
+            .get_mut("tinybird")
+            .and_then(serde_json::Value::as_object_mut)
+    {
+        tinybird.remove("auction_token_secret");
+        tinybird.remove("access_token_secret");
+    }
+
+    let Some(datadome) = data
+        .pointer_mut("/integrations/datadome")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+    let integration_enabled =
+        datadome.get("enabled").and_then(serde_json::Value::as_bool) != Some(false);
+    let protection_enabled = integration_enabled
+        && datadome
+            .get("enable_protection")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true);
+    if !protection_enabled {
+        datadome.remove("server_side_key_secret_name");
+    }
+
+    let bypass_enabled = protection_enabled
+        && datadome
+            .get("protection_test_bypass")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|bypass| bypass.get("enabled"))
+            .and_then(serde_json::Value::as_bool)
+            == Some(true);
+    if !bypass_enabled
+        && let Some(bypass) = datadome
+            .get_mut("protection_test_bypass")
+            .and_then(serde_json::Value::as_object_mut)
+    {
+        bypass.remove("credential_secret_name");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::platform::{PlatformError, StoreId};
     use crate::redacted::Redacted;
+    use crate::settings::{AssetOriginAuth, ProxyAssetRoute, S3SigV4AuthConfig};
     use crate::test_support::tests::crate_test_settings_str;
     use serde::Deserialize;
 
@@ -124,6 +172,44 @@ mod tests {
         }
     }
 
+    struct UnifiedSecretStore;
+
+    impl PlatformSecretStore for UnifiedSecretStore {
+        fn get_bytes(
+            &self,
+            store_name: &StoreName,
+            key: &str,
+        ) -> Result<Vec<u8>, Report<PlatformError>> {
+            if store_name.as_ref() != "ts_secrets" || key.starts_with("unused-") {
+                return Err(Report::new(PlatformError::SecretStore));
+            }
+            let value = match key {
+                "unit-test-proxy-secret" => "unit-test-proxy-secret-32-bytes-ok",
+                "tinybird-token-key" => "resolved-tinybird-token",
+                "datadome-server-key" => "resolved-datadome-server-key",
+                "datadome-bypass-key" => "resolved-datadome-bypass-credential-32-bytes",
+                "s3-access-key" => "AKIAIOSFODNN7EXAMPLE",
+                "s3-secret-key" => "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                "s3-session-key" => "resolved-session-token",
+                _ => key,
+            };
+            Ok(value.as_bytes().to_vec())
+        }
+
+        fn create(
+            &self,
+            _store_id: &StoreId,
+            _name: &str,
+            _value: &str,
+        ) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+
+        fn delete(&self, _store_id: &StoreId, _name: &str) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+    }
+
     fn envelope_json(settings: &Settings) -> String {
         let data = serde_json::to_value(settings).expect("should serialize settings to JSON");
         let envelope = BlobEnvelope::new(data, "2026-01-01T00:00:00Z".to_string());
@@ -156,6 +242,144 @@ mod tests {
             reconstructed.handlers.len(),
             original.handlers.len(),
             "should preserve arrays"
+        );
+    }
+
+    #[test]
+    fn resolves_all_static_credentials_from_the_mapped_default_store() {
+        let mut original = test_settings();
+        original.tinybird.enabled = true;
+        original.tinybird.api_host = "api.example.com".to_string();
+        original.tinybird.auction_token_secret =
+            Some(Redacted::new("tinybird-token-key".to_string()));
+        original
+            .integrations
+            .insert_config(
+                "datadome",
+                &serde_json::json!({
+                    "enabled": true,
+                    "enable_protection": true,
+                    "server_side_key_secret_name": "datadome-server-key",
+                    "protection_test_bypass": {
+                        "enabled": true,
+                        "credential_secret_name": "datadome-bypass-key",
+                    },
+                }),
+            )
+            .expect("should configure DataDome references");
+        let mut route = ProxyAssetRoute::new(
+            "/assets/",
+            "https://examplebucket.s3.us-east-1.amazonaws.com",
+        );
+        route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
+            region: "us-east-1".to_string(),
+            secret_store: Some("legacy-s3-store".to_string()),
+            access_key_id: Redacted::new("s3-access-key".to_string()),
+            secret_access_key: Redacted::new("s3-secret-key".to_string()),
+            session_token: Some(Redacted::new("s3-session-key".to_string())),
+            origin_query: None,
+        }));
+        original.proxy.asset_routes.push(route);
+
+        let reconstructed = settings_from_config_blob(
+            &envelope_json(&original),
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect("should resolve every static credential from the mapped store");
+
+        assert_eq!(
+            reconstructed
+                .tinybird
+                .auction_token_secret
+                .as_ref()
+                .map(Redacted::expose)
+                .map(String::as_str),
+            Some("resolved-tinybird-token")
+        );
+        let datadome = reconstructed
+            .integration_config::<crate::integrations::datadome::DataDomeConfig>("datadome")
+            .expect("should parse DataDome config")
+            .expect("should enable DataDome");
+        assert_eq!(
+            datadome
+                .server_side_key_secret_name
+                .as_ref()
+                .map(Redacted::expose)
+                .map(String::as_str),
+            Some("resolved-datadome-server-key")
+        );
+        let bypass = datadome
+            .protection_test_bypass
+            .as_ref()
+            .expect("should configure bypass");
+        assert_eq!(
+            bypass
+                .credential_secret_name
+                .as_ref()
+                .map(Redacted::expose)
+                .map(String::as_str),
+            Some("resolved-datadome-bypass-credential-32-bytes")
+        );
+        let auth = reconstructed.proxy.asset_routes[0]
+            .auth
+            .as_ref()
+            .expect("should preserve S3 auth");
+        let AssetOriginAuth::S3SigV4(auth) = auth;
+        assert_eq!(auth.access_key_id.expose(), "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(
+            auth.secret_access_key.expose(),
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        );
+        assert_eq!(
+            auth.session_token
+                .as_ref()
+                .map(Redacted::expose)
+                .map(String::as_str),
+            Some("resolved-session-token")
+        );
+        assert!(auth.secret_store.is_none());
+    }
+
+    #[test]
+    fn inactive_optional_features_do_not_resolve_stale_secret_references() {
+        let mut original = test_settings();
+        original.tinybird.auction_token_secret =
+            Some(Redacted::new("unused-tinybird-key".to_string()));
+        original
+            .integrations
+            .insert_config(
+                "datadome",
+                &serde_json::json!({
+                    "enabled": true,
+                    "enable_protection": false,
+                    "server_side_key_secret_name": "unused-datadome-key",
+                    "protection_test_bypass": {
+                        "enabled": false,
+                        "credential_secret_name": "unused-bypass-key",
+                    },
+                }),
+            )
+            .expect("should configure inactive references");
+
+        let reconstructed = settings_from_config_blob(
+            &envelope_json(&original),
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect("should skip inactive optional feature references");
+
+        assert!(reconstructed.tinybird.auction_token_secret.is_none());
+        let datadome = reconstructed
+            .integration_config::<crate::integrations::datadome::DataDomeConfig>("datadome")
+            .expect("should parse inactive DataDome config")
+            .expect("client-side DataDome remains enabled");
+        assert!(datadome.server_side_key_secret_name.is_none());
+        assert!(
+            datadome
+                .protection_test_bypass
+                .as_ref()
+                .is_some_and(|bypass| bypass.credential_secret_name.is_none())
         );
     }
 

--- a/crates/trusted-server-core/src/config_payload.rs
+++ b/crates/trusted-server-core/src/config_payload.rs
@@ -73,6 +73,24 @@ fn remove_inactive_secret_references(data: &mut serde_json::Value) {
         tinybird.remove("access_token_secret");
     }
 
+    if let Some(partners) = data
+        .pointer_mut("/ec/partners")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for partner in partners {
+            let Some(partner) = partner.as_object_mut() else {
+                continue;
+            };
+            if partner
+                .get("pull_sync_enabled")
+                .and_then(serde_json::Value::as_bool)
+                != Some(true)
+            {
+                partner.remove("ts_pull_token");
+            }
+        }
+    }
+
     let Some(datadome) = data
         .pointer_mut("/integrations/datadome")
         .and_then(serde_json::Value::as_object_mut)
@@ -111,7 +129,7 @@ mod tests {
     use super::*;
     use crate::platform::{PlatformError, StoreId};
     use crate::redacted::Redacted;
-    use crate::settings::{AssetOriginAuth, ProxyAssetRoute, S3SigV4AuthConfig};
+    use crate::settings::{AssetOriginAuth, EcPartner, ProxyAssetRoute, S3SigV4AuthConfig};
     use crate::test_support::tests::crate_test_settings_str;
     use serde::Deserialize;
 
@@ -188,9 +206,11 @@ mod tests {
                 "tinybird-token-key" => "resolved-tinybird-token",
                 "datadome-server-key" => "resolved-datadome-server-key",
                 "datadome-bypass-key" => "resolved-datadome-bypass-credential-32-bytes",
-                "s3-access-key" => "AKIAIOSFODNN7EXAMPLE",
-                "s3-secret-key" => "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                "access_key_id" | "s3-access-key" => "AKIAIOSFODNN7EXAMPLE",
+                "secret_access_key" | "s3-secret-key" => "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
                 "s3-session-key" => "resolved-session-token",
+                "partner-api-token-key" => "resolved-partner-api-token-32-bytes-ok",
+                "partner-pull-token-key" => "resolved-partner-pull-token-32-bytes-ok",
                 _ => key,
             };
             Ok(value.as_bytes().to_vec())
@@ -208,6 +228,22 @@ mod tests {
         fn delete(&self, _store_id: &StoreId, _name: &str) -> Result<(), Report<PlatformError>> {
             Ok(())
         }
+    }
+
+    fn partner_with_pull_sync(enabled: bool, token_key: &str) -> EcPartner {
+        let mut value = serde_json::json!({
+            "name": "Example Partner",
+            "source_domain": "partner.example.com",
+            "api_token": "partner-api-token-key",
+            "pull_sync_enabled": enabled,
+            "ts_pull_token": token_key,
+        });
+        if enabled {
+            value["pull_sync_url"] =
+                serde_json::Value::String("https://partner.example.com/sync".to_string());
+            value["pull_sync_allowed_domains"] = serde_json::json!(["partner.example.com"]);
+        }
+        serde_json::from_value(value).expect("should build pull-sync partner")
     }
 
     fn envelope_json(settings: &Settings) -> String {
@@ -280,6 +316,10 @@ mod tests {
             origin_query: None,
         }));
         original.proxy.asset_routes.push(route);
+        original
+            .ec
+            .partners
+            .push(partner_with_pull_sync(true, "partner-pull-token-key"));
 
         let reconstructed = settings_from_config_blob(
             &envelope_json(&original),
@@ -339,6 +379,62 @@ mod tests {
             Some("resolved-session-token")
         );
         assert!(auth.secret_store.is_none());
+        assert_eq!(
+            reconstructed.ec.partners[0]
+                .ts_pull_token
+                .as_ref()
+                .map(Redacted::expose)
+                .map(String::as_str),
+            Some("resolved-partner-pull-token-32-bytes-ok")
+        );
+    }
+
+    #[test]
+    fn omitted_s3_secret_references_resolve_default_store_keys() {
+        let mut original = test_settings();
+        let mut route = ProxyAssetRoute::new(
+            "/default-s3/",
+            "https://examplebucket.s3.us-east-1.amazonaws.com",
+        );
+        route.auth = Some(AssetOriginAuth::S3SigV4(
+            toml::from_str("region = \"us-east-1\"").expect("should apply S3 secret defaults"),
+        ));
+        original.proxy.asset_routes.push(route);
+
+        let reconstructed = settings_from_config_blob(
+            &envelope_json(&original),
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect("should resolve default S3 secret keys");
+
+        let AssetOriginAuth::S3SigV4(auth) = reconstructed.proxy.asset_routes[0]
+            .auth
+            .as_ref()
+            .expect("should preserve S3 auth");
+        assert_eq!(auth.access_key_id.expose(), "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(
+            auth.secret_access_key.expose(),
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        );
+    }
+
+    #[test]
+    fn active_partner_pull_sync_fails_when_its_token_is_missing() {
+        let mut original = test_settings();
+        original
+            .ec
+            .partners
+            .push(partner_with_pull_sync(true, "unused-partner-pull-token"));
+
+        let error = settings_from_config_blob(
+            &envelope_json(&original),
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect_err("should reject a missing active pull-sync token");
+
+        assert!(error.to_string().contains("ec.partners[0].ts_pull_token"));
     }
 
     #[test]
@@ -361,6 +457,10 @@ mod tests {
                 }),
             )
             .expect("should configure inactive references");
+        original
+            .ec
+            .partners
+            .push(partner_with_pull_sync(false, "unused-partner-pull-token"));
 
         let reconstructed = settings_from_config_blob(
             &envelope_json(&original),
@@ -370,6 +470,7 @@ mod tests {
         .expect("should skip inactive optional feature references");
 
         assert!(reconstructed.tinybird.auction_token_secret.is_none());
+        assert!(reconstructed.ec.partners[0].ts_pull_token.is_none());
         let datadome = reconstructed
             .integration_config::<crate::integrations::datadome::DataDomeConfig>("datadome")
             .expect("should parse inactive DataDome config")

--- a/crates/trusted-server-core/src/config_payload.rs
+++ b/crates/trusted-server-core/src/config_payload.rs
@@ -98,7 +98,7 @@ fn remove_inactive_secret_references(data: &mut serde_json::Value) {
         return;
     };
     let integration_enabled =
-        datadome.get("enabled").and_then(serde_json::Value::as_bool) != Some(false);
+        datadome.get("enabled").and_then(serde_json::Value::as_bool) == Some(true);
     let protection_enabled = integration_enabled
         && datadome
             .get("enable_protection")
@@ -380,6 +380,10 @@ mod tests {
         );
         assert!(auth.secret_store.is_none());
         assert_eq!(
+            reconstructed.ec.partners[0].api_token.expose(),
+            "resolved-partner-api-token-32-bytes-ok"
+        );
+        assert_eq!(
             reconstructed.ec.partners[0]
                 .ts_pull_token
                 .as_ref()
@@ -481,6 +485,39 @@ mod tests {
                 .protection_test_bypass
                 .as_ref()
                 .is_some_and(|bypass| bypass.credential_secret_name.is_none())
+        );
+    }
+
+    #[test]
+    fn omitted_datadome_enabled_does_not_resolve_stale_protection_references() {
+        let mut original = test_settings();
+        original
+            .integrations
+            .insert_config(
+                "datadome",
+                &serde_json::json!({
+                    "enable_protection": true,
+                    "server_side_key_secret_name": "unused-datadome-key",
+                    "protection_test_bypass": {
+                        "enabled": true,
+                        "credential_secret_name": "unused-bypass-key",
+                    },
+                }),
+            )
+            .expect("should configure disabled DataDome references");
+
+        let reconstructed = settings_from_config_blob(
+            &envelope_json(&original),
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect("should skip stale DataDome protection references");
+
+        assert!(
+            reconstructed
+                .integration_config::<crate::integrations::datadome::DataDomeConfig>("datadome")
+                .expect("should parse disabled DataDome config")
+                .is_none()
         );
     }
 

--- a/crates/trusted-server-core/src/config_payload.rs
+++ b/crates/trusted-server-core/src/config_payload.rs
@@ -81,11 +81,7 @@ fn remove_inactive_secret_references(data: &mut serde_json::Value) {
             let Some(partner) = partner.as_object_mut() else {
                 continue;
             };
-            if partner
-                .get("pull_sync_enabled")
-                .and_then(serde_json::Value::as_bool)
-                != Some(true)
-            {
+            if !json_bool_or_string_is_true(partner.get("pull_sync_enabled")) {
                 partner.remove("ts_pull_token");
             }
         }
@@ -124,12 +120,19 @@ fn remove_inactive_secret_references(data: &mut serde_json::Value) {
     }
 }
 
+fn json_bool_or_string_is_true(value: Option<&serde_json::Value>) -> bool {
+    matches!(value, Some(serde_json::Value::Bool(true)))
+        || matches!(value, Some(serde_json::Value::String(value)) if value == "true")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::platform::{PlatformError, StoreId};
     use crate::redacted::Redacted;
-    use crate::settings::{AssetOriginAuth, EcPartner, ProxyAssetRoute, S3SigV4AuthConfig};
+    use crate::settings::{
+        AssetOriginAuth, EcPartner, ProxyAssetRoute, S3SigV4AuthConfig, TrustedClientIpConfig,
+    };
     use crate::test_support::tests::crate_test_settings_str;
     use serde::Deserialize;
 
@@ -211,6 +214,7 @@ mod tests {
                 "s3-session-key" => "resolved-session-token",
                 "partner-api-token-key" => "resolved-partner-api-token-32-bytes-ok",
                 "partner-pull-token-key" => "resolved-partner-pull-token-32-bytes-ok",
+                "trusted-client-ip-key" => "resolved-trusted-client-ip-secret-32-bytes",
                 _ => key,
             };
             Ok(value.as_bytes().to_vec())
@@ -398,6 +402,61 @@ mod tests {
     }
 
     #[test]
+    fn resolves_trusted_client_ip_shared_secret_from_default_store() {
+        let mut original = test_settings();
+        original.trusted_client_ip = Some(TrustedClientIpConfig {
+            ip_header: "x-ts-client-ip".to_owned(),
+            auth_header: "x-ts-client-ip-auth".to_owned(),
+            shared_secret: Redacted::new("trusted-client-ip-key".to_owned()),
+        });
+
+        let reconstructed = settings_from_config_blob(
+            &envelope_json(&original),
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect("should resolve the trusted client IP shared secret");
+
+        assert_eq!(
+            reconstructed
+                .trusted_client_ip
+                .as_ref()
+                .expect("should retain trusted client IP configuration")
+                .shared_secret
+                .expose(),
+            "resolved-trusted-client-ip-secret-32-bytes",
+            "should replace the key reference with the resolved shared secret"
+        );
+    }
+
+    #[test]
+    fn missing_trusted_client_ip_shared_secret_fails_resolution() {
+        let mut original = test_settings();
+        original.trusted_client_ip = Some(TrustedClientIpConfig {
+            ip_header: "x-ts-client-ip".to_owned(),
+            auth_header: "x-ts-client-ip-auth".to_owned(),
+            shared_secret: Redacted::new("unused-trusted-client-ip-key".to_owned()),
+        });
+
+        let error = settings_from_config_blob(
+            &envelope_json(&original),
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect_err("should reject a missing trusted client IP shared secret");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("trusted_client_ip.shared_secret"),
+            "should identify the unresolved secret field: {error:?}"
+        );
+        assert!(
+            !message.contains("unused-trusted-client-ip-key"),
+            "should not expose the secret key reference: {error:?}"
+        );
+    }
+
+    #[test]
     fn omitted_s3_secret_references_resolve_default_store_keys() {
         let mut original = test_settings();
         let mut route = ProxyAssetRoute::new(
@@ -448,6 +507,63 @@ mod tests {
         assert!(
             reconstructed.ec.partners[0].api_token.is_none(),
             "should preserve omitted API token"
+        );
+    }
+
+    #[test]
+    fn string_true_pull_sync_flag_retains_and_resolves_its_token() {
+        let mut original = test_settings();
+        original
+            .ec
+            .partners
+            .push(partner_with_pull_sync(true, "partner-pull-token-key"));
+        let mut data = serde_json::to_value(original).expect("should serialize settings");
+        data["ec"]["partners"][0]["pull_sync_enabled"] =
+            serde_json::Value::String("true".to_owned());
+        let envelope = BlobEnvelope::new(data, "2026-01-01T00:00:00Z".to_owned());
+        let envelope_json = serde_json::to_string(&envelope).expect("should serialize envelope");
+
+        let reconstructed = settings_from_config_blob(
+            &envelope_json,
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect("should resolve a pull token enabled by a string boolean");
+
+        assert_eq!(
+            reconstructed.ec.partners[0]
+                .ts_pull_token
+                .as_ref()
+                .map(Redacted::expose)
+                .map(String::as_str),
+            Some("resolved-partner-pull-token-32-bytes-ok"),
+            "should retain and resolve the active pull token"
+        );
+    }
+
+    #[test]
+    fn string_false_pull_sync_flag_removes_a_stale_token() {
+        let mut original = test_settings();
+        original
+            .ec
+            .partners
+            .push(partner_with_pull_sync(false, "unused-partner-pull-token"));
+        let mut data = serde_json::to_value(original).expect("should serialize settings");
+        data["ec"]["partners"][0]["pull_sync_enabled"] =
+            serde_json::Value::String("false".to_owned());
+        let envelope = BlobEnvelope::new(data, "2026-01-01T00:00:00Z".to_owned());
+        let envelope_json = serde_json::to_string(&envelope).expect("should serialize envelope");
+
+        let reconstructed = settings_from_config_blob(
+            &envelope_json,
+            &UnifiedSecretStore,
+            &StoreName::from("ts_secrets"),
+        )
+        .expect("should skip a pull token disabled by a string boolean");
+
+        assert!(
+            reconstructed.ec.partners[0].ts_pull_token.is_none(),
+            "should remove the inactive pull token"
         );
     }
 

--- a/crates/trusted-server-core/src/ec/admin.rs
+++ b/crates/trusted-server-core/src/ec/admin.rs
@@ -694,7 +694,7 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled,
-            api_token: Redacted::new(format!("test-token-{source_domain:-<32}")),
+            api_token: Some(Redacted::new(format!("test-token-{source_domain:-<32}"))),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,

--- a/crates/trusted-server-core/src/ec/auth.rs
+++ b/crates/trusted-server-core/src/ec/auth.rs
@@ -52,7 +52,7 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled: true,
-            api_token: Redacted::new(api_token.to_owned()),
+            api_token: Some(Redacted::new(api_token.to_owned())),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,
@@ -123,6 +123,25 @@ mod tests {
         assert_eq!(
             result.source_domain, "ssp.example.com",
             "should return the matching partner"
+        );
+    }
+
+    #[test]
+    fn authenticate_bearer_rejects_token_for_partner_without_api_access() {
+        let mut partner = make_test_partner("ssp.example.com", VALID_API_TOKEN);
+        partner.api_token = None;
+        let registry =
+            PartnerRegistry::from_config(&[partner]).expect("should build registry without token");
+        let req = Request::builder()
+            .method("GET")
+            .uri("https://edge.example.com/_ts/api/v1/identify")
+            .header("authorization", format!("Bearer {VALID_API_TOKEN}"))
+            .body(EdgeBody::empty())
+            .expect("should build test request");
+
+        assert!(
+            authenticate_bearer(&registry, &req).is_none(),
+            "should reject authentication when API access is not configured"
         );
     }
 }

--- a/crates/trusted-server-core/src/ec/batch_sync.rs
+++ b/crates/trusted-server-core/src/ec/batch_sync.rs
@@ -341,7 +341,7 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled: true,
-            api_token: Redacted::new(api_token.to_owned()),
+            api_token: Some(Redacted::new(api_token.to_owned())),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,

--- a/crates/trusted-server-core/src/ec/eids.rs
+++ b/crates/trusted-server-core/src/ec/eids.rs
@@ -154,7 +154,9 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled: true,
-            api_token: Redacted::new(format!("token-{source_domain}-32-bytes-minimum-value")),
+            api_token: Some(Redacted::new(format!(
+                "token-{source_domain}-32-bytes-minimum-value"
+            ))),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,

--- a/crates/trusted-server-core/src/ec/finalize.rs
+++ b/crates/trusted-server-core/src/ec/finalize.rs
@@ -261,7 +261,9 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled: true,
-            api_token: Redacted::new(format!("token-{source_domain}-32-bytes-minimum-value")),
+            api_token: Some(Redacted::new(format!(
+                "token-{source_domain}-32-bytes-minimum-value"
+            ))),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,

--- a/crates/trusted-server-core/src/ec/identify.rs
+++ b/crates/trusted-server-core/src/ec/identify.rs
@@ -367,7 +367,7 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled: true,
-            api_token: Redacted::new(api_token.to_owned()),
+            api_token: Some(Redacted::new(api_token.to_owned())),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,

--- a/crates/trusted-server-core/src/ec/prebid_eids.rs
+++ b/crates/trusted-server-core/src/ec/prebid_eids.rs
@@ -451,7 +451,9 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled: true,
-            api_token: Redacted::new(format!("token-{source_domain}-32-bytes-minimum-value")),
+            api_token: Some(Redacted::new(format!(
+                "token-{source_domain}-32-bytes-minimum-value"
+            ))),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,

--- a/crates/trusted-server-core/src/ec/pull_sync.rs
+++ b/crates/trusted-server-core/src/ec/pull_sync.rs
@@ -467,7 +467,7 @@ mod tests {
     fn pull_partner(ttl_sec: u64) -> PartnerConfig {
         PartnerConfig {
             name: "SSP X".to_owned(),
-            api_key_hash: "deadbeef".to_owned(),
+            api_key_hash: Some("deadbeef".to_owned()),
             bidstream_enabled: true,
             source_domain: "ssp.example.com".to_owned(),
             openrtb_atype: 3,

--- a/crates/trusted-server-core/src/ec/pull_sync.rs
+++ b/crates/trusted-server-core/src/ec/pull_sync.rs
@@ -792,7 +792,9 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled: true,
-            api_token: Redacted::new(format!("{source_domain}-api-token-32-bytes-minimum")),
+            api_token: Some(Redacted::new(format!(
+                "{source_domain}-api-token-32-bytes-minimum"
+            ))),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: true,
             pull_sync_url: Some(format!("https://{source_domain}/sync")),

--- a/crates/trusted-server-core/src/ec/registry.rs
+++ b/crates/trusted-server-core/src/ec/registry.rs
@@ -75,6 +75,7 @@ impl PartnerRegistry {
         partners: &[EcPartner],
     ) -> Result<(), Report<TrustedServerError>> {
         let mut source_domains = HashMap::with_capacity(partners.len());
+        let mut api_token_key_references = HashMap::with_capacity(partners.len());
 
         for partner in partners {
             let normalized_source = normalize_partner_source_domain(&partner.source_domain)
@@ -90,6 +91,17 @@ impl PartnerRegistry {
             {
                 return Err(Report::new(TrustedServerError::Configuration {
                     message: format!("ec.partners: duplicate source_domain '{normalized_source}'"),
+                }));
+            }
+
+            if let Some(previous_source) = api_token_key_references
+                .insert(partner.api_token.expose(), normalized_source.clone())
+            {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!(
+                        "ec.partners: API token key reference is shared by source_domain \
+                         '{previous_source}' and '{normalized_source}'"
+                    ),
                 }));
             }
 
@@ -485,6 +497,40 @@ mod tests {
         ];
         let result = PartnerRegistry::from_config(&partners);
         assert!(result.is_err(), "should reject duplicate source domain");
+    }
+
+    #[test]
+    fn deploy_validation_rejects_duplicate_api_token_key_references() {
+        let shared_key = "partner_api_token";
+        let partners = vec![
+            make_partner("first.example.com", shared_key),
+            make_partner("second.example.com", shared_key),
+        ];
+
+        let error = PartnerRegistry::validate_config_for_deploy(&partners)
+            .expect_err("should reject duplicate API token key references");
+        let message = error.to_string();
+
+        assert!(message.contains("first.example.com"));
+        assert!(message.contains("second.example.com"));
+    }
+
+    #[test]
+    fn deploy_validation_allows_distinct_api_tokens_and_shared_pull_token_references() {
+        let mut first = make_partner("first.example.com", "first_partner_api_token");
+        first.pull_sync_enabled = true;
+        first.pull_sync_url = Some("https://first.example.com/sync".to_owned());
+        first.pull_sync_allowed_domains = vec!["first.example.com".to_owned()];
+        first.ts_pull_token = Some(Redacted::new("shared_pull_token".to_owned()));
+
+        let mut second = make_partner("second.example.com", "second_partner_api_token");
+        second.pull_sync_enabled = true;
+        second.pull_sync_url = Some("https://second.example.com/sync".to_owned());
+        second.pull_sync_allowed_domains = vec!["second.example.com".to_owned()];
+        second.ts_pull_token = Some(Redacted::new("shared_pull_token".to_owned()));
+
+        PartnerRegistry::validate_config_for_deploy(&[first, second])
+            .expect("should allow distinct API token and shared pull-token key references");
     }
 
     #[test]

--- a/crates/trusted-server-core/src/ec/registry.rs
+++ b/crates/trusted-server-core/src/ec/registry.rs
@@ -28,8 +28,8 @@ pub struct PartnerConfig {
     pub openrtb_atype: i32,
     /// Whether this partner's UIDs appear in auction `user.eids`.
     pub bidstream_enabled: bool,
-    /// SHA-256 hex of the partner's API token (precomputed at startup).
-    pub api_key_hash: String,
+    /// SHA-256 hex of the partner's API token, when inbound API access is enabled.
+    pub api_key_hash: Option<String>,
     /// Max batch sync API requests per partner per minute.
     pub batch_rate_limit: u32,
     /// Whether server-to-server pull sync is enabled.
@@ -94,8 +94,9 @@ impl PartnerRegistry {
                 }));
             }
 
-            if let Some(previous_source) = api_token_key_references
-                .insert(partner.api_token.expose(), normalized_source.clone())
+            if let Some(api_token) = &partner.api_token
+                && let Some(previous_source) =
+                    api_token_key_references.insert(api_token.expose(), normalized_source.clone())
             {
                 return Err(Report::new(TrustedServerError::Configuration {
                     message: format!(
@@ -160,20 +161,24 @@ impl PartnerRegistry {
                 }));
             }
 
-            validate_api_token(&normalized_source, partner.api_token.expose())?;
+            let api_key_hash = if let Some(api_token) = &partner.api_token {
+                validate_api_token(&normalized_source, api_token.expose())?;
 
-            let api_key_hash = hash_api_key(partner.api_token.expose());
+                let api_key_hash = hash_api_key(api_token.expose());
+                if by_api_key_hash.contains_key(&api_key_hash) {
+                    return Err(Report::new(TrustedServerError::Configuration {
+                        message: format!(
+                            "ec.partners: source_domain '{normalized_source}' has an API token that collides \
+                             with another partner's token hash"
+                        ),
+                    }));
+                }
+                Some(api_key_hash)
+            } else {
+                None
+            };
 
-            if by_api_key_hash.contains_key(&api_key_hash) {
-                return Err(Report::new(TrustedServerError::Configuration {
-                    message: format!(
-                        "ec.partners: source_domain '{normalized_source}' has an API token that collides \
-                         with another partner's token hash"
-                    ),
-                }));
-            }
-
-            let config = build_partner_config(partner, &normalized_source, &api_key_hash);
+            let config = build_partner_config(partner, &normalized_source, api_key_hash.as_deref());
 
             validate_rate_limits(&config).change_context(TrustedServerError::Configuration {
                 message: format!(
@@ -191,7 +196,9 @@ impl PartnerRegistry {
                 })?;
             }
 
-            by_api_key_hash.insert(api_key_hash, normalized_source.clone());
+            if let Some(api_key_hash) = api_key_hash {
+                by_api_key_hash.insert(api_key_hash, normalized_source.clone());
+            }
             by_source_domain.insert(normalized_source, config);
         }
 
@@ -286,14 +293,14 @@ fn validate_api_token(
 fn build_partner_config(
     partner: &EcPartner,
     normalized_source: &str,
-    api_key_hash: &str,
+    api_key_hash: Option<&str>,
 ) -> PartnerConfig {
     PartnerConfig {
         name: partner.name.clone(),
         source_domain: normalized_source.to_owned(),
         openrtb_atype: partner.openrtb_atype,
         bidstream_enabled: partner.bidstream_enabled,
-        api_key_hash: api_key_hash.to_owned(),
+        api_key_hash: api_key_hash.map(ToOwned::to_owned),
         batch_rate_limit: partner.batch_rate_limit,
         pull_sync_enabled: partner.pull_sync_enabled,
         pull_sync_url: partner.pull_sync_url.clone(),
@@ -420,7 +427,7 @@ mod tests {
             source_domain: source_domain.to_owned(),
             openrtb_atype: EcPartner::default_openrtb_atype(),
             bidstream_enabled: false,
-            api_token: Redacted::new(api_token.to_owned()),
+            api_token: Some(Redacted::new(api_token.to_owned())),
             batch_rate_limit: EcPartner::default_batch_rate_limit(),
             pull_sync_enabled: false,
             pull_sync_url: None,
@@ -466,6 +473,28 @@ mod tests {
             found.expect("should exist").source_domain,
             "ssp.example.com",
             "should match source domain"
+        );
+    }
+
+    #[test]
+    fn partner_without_api_token_is_only_indexed_by_source_domain() {
+        let mut partner = make_partner("ssp.example.com", &valid_api_token("unused"));
+        partner.api_token = None;
+        let registry =
+            PartnerRegistry::from_config(&[partner]).expect("should build registry without token");
+
+        let found = registry
+            .find_by_source_domain("ssp.example.com")
+            .expect("should find partner by source domain");
+        assert!(
+            found.api_key_hash.is_none(),
+            "should not assign an API key hash"
+        );
+        assert!(
+            registry
+                .find_by_api_key_hash(&hash_api_key(&valid_api_token("unused")))
+                .is_none(),
+            "should not authenticate omitted API token"
         );
     }
 
@@ -546,6 +575,7 @@ mod tests {
     #[test]
     fn pull_enabled_partners_filters_correctly() {
         let mut pull_partner = make_partner("pull.example.com", &valid_api_token("token-p"));
+        pull_partner.api_token = None;
         pull_partner.pull_sync_enabled = true;
         pull_partner.pull_sync_url = Some("https://pull.example.com/sync".to_owned());
         pull_partner.pull_sync_allowed_domains = vec!["pull.example.com".to_owned()];
@@ -566,6 +596,10 @@ mod tests {
         assert_eq!(
             pull_enabled[0].source_domain, "pull.example.com",
             "should be the correct partner"
+        );
+        assert!(
+            pull_enabled[0].api_key_hash.is_none(),
+            "should allow pull sync without an inbound API token"
         );
         assert_eq!(
             pull_enabled[0]

--- a/crates/trusted-server-core/src/ec/registry.rs
+++ b/crates/trusted-server-core/src/ec/registry.rs
@@ -61,6 +61,68 @@ pub struct PartnerRegistry {
 }
 
 impl PartnerRegistry {
+    /// Validates partner structure without inspecting secret values.
+    ///
+    /// This is the push-time half of partner validation. API-token length,
+    /// placeholder, and collision checks remain in [`Self::from_config`],
+    /// after secret references have been resolved.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrustedServerError::Configuration`] when non-secret partner
+    /// structure is invalid.
+    pub fn validate_config_for_deploy(
+        partners: &[EcPartner],
+    ) -> Result<(), Report<TrustedServerError>> {
+        let mut source_domains = HashMap::with_capacity(partners.len());
+
+        for partner in partners {
+            let normalized_source = normalize_partner_source_domain(&partner.source_domain)
+                .map_err(|msg| {
+                    Report::new(TrustedServerError::Configuration {
+                        message: format!("ec.partners: {msg}"),
+                    })
+                })?;
+
+            if source_domains
+                .insert(normalized_source.clone(), ())
+                .is_some()
+            {
+                return Err(Report::new(TrustedServerError::Configuration {
+                    message: format!("ec.partners: duplicate source_domain '{normalized_source}'"),
+                }));
+            }
+
+            validate_rate_limits_values(partner.batch_rate_limit, partner.pull_sync_rate_limit)
+                .map_err(|error| {
+                    Report::new(TrustedServerError::Configuration {
+                        message: format!(
+                            "ec.partners: invalid rate limits for '{normalized_source}': {error}"
+                        ),
+                    })
+                })?;
+
+            if partner.pull_sync_enabled {
+                validate_pull_sync_fields(
+                    partner.pull_sync_url.as_deref(),
+                    &partner.pull_sync_allowed_domains,
+                    partner
+                        .ts_pull_token
+                        .as_ref()
+                        .map(|token| token.expose().as_str()),
+                    false,
+                )
+                .change_context(TrustedServerError::Configuration {
+                    message: format!(
+                        "ec.partners: pull sync config invalid for '{normalized_source}'"
+                    ),
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Builds a registry from the config-defined partner list.
     ///
     /// # Errors
@@ -231,34 +293,56 @@ fn build_partner_config(
 }
 
 fn validate_rate_limits(config: &PartnerConfig) -> Result<(), Report<TrustedServerError>> {
-    if config.batch_rate_limit == 0 {
-        return Err(Report::new(TrustedServerError::Configuration {
-            message: "batch_rate_limit must be greater than 0".to_owned(),
-        }));
+    validate_rate_limits_values(config.batch_rate_limit, config.pull_sync_rate_limit).map_err(
+        |message| {
+            Report::new(TrustedServerError::Configuration {
+                message: message.to_owned(),
+            })
+        },
+    )
+}
+
+fn validate_rate_limits_values(
+    batch_rate_limit: u32,
+    pull_sync_rate_limit: u32,
+) -> Result<(), &'static str> {
+    if batch_rate_limit == 0 {
+        return Err("batch_rate_limit must be greater than 0");
     }
 
-    if config.pull_sync_rate_limit == 0 {
-        return Err(Report::new(TrustedServerError::Configuration {
-            message: "pull_sync_rate_limit must be greater than 0".to_owned(),
-        }));
+    if pull_sync_rate_limit == 0 {
+        return Err("pull_sync_rate_limit must be greater than 0");
     }
 
     Ok(())
 }
 
 fn validate_pull_sync(config: &PartnerConfig) -> Result<(), Report<TrustedServerError>> {
-    let url_str = config.pull_sync_url.as_deref().unwrap_or("");
+    validate_pull_sync_fields(
+        config.pull_sync_url.as_deref(),
+        &config.pull_sync_allowed_domains,
+        config
+            .ts_pull_token
+            .as_ref()
+            .map(|token| token.expose().as_str()),
+        true,
+    )
+}
+
+fn validate_pull_sync_fields(
+    url: Option<&str>,
+    allowed_domains: &[String],
+    token_value: Option<&str>,
+    require_nonempty_token: bool,
+) -> Result<(), Report<TrustedServerError>> {
+    let url_str = url.unwrap_or("");
     if url_str.is_empty() {
         return Err(Report::new(TrustedServerError::Configuration {
             message: "pull_sync_url is required when pull_sync_enabled is true".to_owned(),
         }));
     }
 
-    if config
-        .ts_pull_token
-        .as_ref()
-        .is_none_or(|token| token.expose().trim().is_empty())
-    {
+    if token_value.is_none() {
         return Err(Report::new(TrustedServerError::Configuration {
             message: "ts_pull_token is required when pull_sync_enabled is true".to_owned(),
         }));
@@ -289,7 +373,7 @@ fn validate_pull_sync(config: &PartnerConfig) -> Result<(), Report<TrustedServer
         .trim_end_matches('.')
         .to_ascii_lowercase();
 
-    let domain_match = config.pull_sync_allowed_domains.iter().any(|d| {
+    let domain_match = allowed_domains.iter().any(|d| {
         let normalized = d.trim_end_matches('.').to_ascii_lowercase();
         host == normalized
     });
@@ -297,6 +381,12 @@ fn validate_pull_sync(config: &PartnerConfig) -> Result<(), Report<TrustedServer
     if !domain_match {
         return Err(Report::new(TrustedServerError::Configuration {
             message: format!("pull_sync_url hostname '{host}' not in pull_sync_allowed_domains"),
+        }));
+    }
+
+    if require_nonempty_token && token_value.is_some_and(|value| value.trim().is_empty()) {
+        return Err(Report::new(TrustedServerError::Configuration {
+            message: "ts_pull_token must not be empty when pull sync is enabled".to_owned(),
         }));
     }
 

--- a/crates/trusted-server-core/src/ec/registry.rs
+++ b/crates/trusted-server-core/src/ec/registry.rs
@@ -4,7 +4,7 @@
 //! in-memory registry. `HashMap` indexes provide O(1)
 //! lookup by source domain and API key hash.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use error_stack::{Report, ResultExt as _};
 
@@ -74,7 +74,7 @@ impl PartnerRegistry {
     pub fn validate_config_for_deploy(
         partners: &[EcPartner],
     ) -> Result<(), Report<TrustedServerError>> {
-        let mut source_domains = HashMap::with_capacity(partners.len());
+        let mut source_domains = HashSet::with_capacity(partners.len());
         let mut api_token_key_references = HashMap::with_capacity(partners.len());
 
         for partner in partners {
@@ -85,10 +85,7 @@ impl PartnerRegistry {
                     })
                 })?;
 
-            if source_domains
-                .insert(normalized_source.clone(), ())
-                .is_some()
-            {
+            if !source_domains.insert(normalized_source.clone()) {
                 return Err(Report::new(TrustedServerError::Configuration {
                     message: format!("ec.partners: duplicate source_domain '{normalized_source}'"),
                 }));

--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -78,6 +78,7 @@ use crate::integrations::{
     collect_body_bounded, collect_response_bounded, ensure_integration_backend,
 };
 use crate::platform::{PlatformHttpRequest, RuntimeServices};
+use crate::redacted::Redacted;
 use crate::settings::{IntegrationConfig, Settings};
 
 mod protection;
@@ -90,6 +91,7 @@ pub use protection_scope::{
 use protection_scope::ProtectionScope;
 
 pub(crate) const DATADOME_INTEGRATION_ID: &str = "datadome";
+pub(super) const MIN_TEST_BYPASS_CREDENTIAL_BYTES: usize = 32;
 /// Fixed request header used by the staging-only protection test bypass.
 pub(crate) const HEADER_DATADOME_TEST_BYPASS: &str = "x-ts-datadome-bypass";
 
@@ -133,13 +135,13 @@ pub struct ProtectionTestBypassConfig {
     #[serde(default)]
     pub enabled: bool,
 
-    /// Secret Store containing the temporary bypass credential.
-    #[serde(default = "default_protection_test_bypass_secret_store")]
-    pub credential_secret_store: String,
+    /// Deprecated feature-specific store selector accepted for migration only.
+    #[serde(default)]
+    pub credential_secret_store: Option<String>,
 
-    /// Secret name containing at least 32 bytes of high-entropy bypass material.
-    #[serde(default = "default_protection_test_bypass_secret_name")]
-    pub credential_secret_name: String,
+    /// Secret reference containing at least 32 bytes of high-entropy bypass material.
+    #[serde(default)]
+    pub credential_secret_name: Option<Redacted<String>>,
 }
 
 /// Configuration for `DataDome` integration.
@@ -175,13 +177,13 @@ pub struct DataDomeConfig {
     #[serde(default)]
     pub enable_protection: bool,
 
-    /// Runtime secret store containing the `DataDome` server-side key.
-    #[serde(default = "default_server_side_key_secret_store")]
-    pub server_side_key_secret_store: String,
+    /// Deprecated feature-specific store selector accepted for migration only.
+    #[serde(default)]
+    pub server_side_key_secret_store: Option<String>,
 
-    /// Secret name containing the `DataDome` server-side key.
-    #[serde(default = "default_server_side_key_secret_name")]
-    pub server_side_key_secret_name: String,
+    /// Secret reference containing the `DataDome` server-side key.
+    #[serde(default)]
+    pub server_side_key_secret_name: Option<Redacted<String>>,
 
     /// Base URL for the `DataDome` Protection API.
     #[serde(default = "default_protection_api_origin")]
@@ -273,22 +275,6 @@ fn default_protection_api_origin() -> String {
     "https://api-fastly.datadome.co".to_string()
 }
 
-fn default_server_side_key_secret_store() -> String {
-    "ts_secrets".to_string()
-}
-
-fn default_server_side_key_secret_name() -> String {
-    "datadome_server_side_key".to_string()
-}
-
-fn default_protection_test_bypass_secret_store() -> String {
-    "ts_secrets".to_string()
-}
-
-fn default_protection_test_bypass_secret_name() -> String {
-    "datadome_test_bypass".to_string()
-}
-
 fn default_timeout_ms() -> u32 {
     1500
 }
@@ -356,8 +342,8 @@ impl Default for DataDomeConfig {
             cache_ttl_seconds: default_cache_ttl(),
             rewrite_sdk: default_rewrite_sdk(),
             enable_protection: false,
-            server_side_key_secret_store: default_server_side_key_secret_store(),
-            server_side_key_secret_name: default_server_side_key_secret_name(),
+            server_side_key_secret_store: None,
+            server_side_key_secret_name: None,
             protection_api_origin: default_protection_api_origin(),
             timeout_ms: default_timeout_ms(),
             protection_excluded_methods: default_protection_excluded_methods(),
@@ -394,28 +380,48 @@ impl DataDomeIntegration {
         Self::try_new(config).expect("should create DataDome integration")
     }
 
-    fn try_new(mut config: DataDomeConfig) -> Result<Arc<Self>, Report<TrustedServerError>> {
-        config.server_side_key_secret_store =
-            config.server_side_key_secret_store.trim().to_string();
-        config.server_side_key_secret_name = config.server_side_key_secret_name.trim().to_string();
+    fn try_new(config: DataDomeConfig) -> Result<Arc<Self>, Report<TrustedServerError>> {
+        Self::try_new_with_secret_validation(config, true)
+    }
+
+    fn try_new_with_secret_validation(
+        mut config: DataDomeConfig,
+        validate_resolved_secrets: bool,
+    ) -> Result<Arc<Self>, Report<TrustedServerError>> {
+        if config.server_side_key_secret_store.take().is_some() {
+            log::warn!(
+                "DataDome server_side_key_secret_store is deprecated and ignored; static credentials resolve through the default app-config secret store"
+            );
+        }
+        config.server_side_key_secret_name =
+            config.server_side_key_secret_name.take().and_then(|value| {
+                let value = value.expose().trim().to_string();
+                (!value.is_empty()).then(|| Redacted::new(value))
+            });
         config.protection_api_origin = config.protection_api_origin.trim().to_string();
         config.client_side_tag_url = config.client_side_tag_url.trim().to_string();
         if let Some(bypass) = &mut config.protection_test_bypass {
-            bypass.credential_secret_store = bypass.credential_secret_store.trim().to_string();
-            bypass.credential_secret_name = bypass.credential_secret_name.trim().to_string();
+            if bypass.credential_secret_store.take().is_some() {
+                log::warn!(
+                    "DataDome credential_secret_store is deprecated and ignored; static credentials resolve through the default app-config secret store"
+                );
+            }
+            bypass.credential_secret_name =
+                bypass.credential_secret_name.take().and_then(|value| {
+                    let value = value.expose().trim().to_string();
+                    (!value.is_empty()).then(|| Redacted::new(value))
+                });
         }
 
         if config.enable_protection {
-            if config.server_side_key_secret_store.is_empty()
-                || config.server_side_key_secret_name.is_empty()
-            {
+            if config.server_side_key_secret_name.is_none() {
                 return Err(Report::new(Self::error(
-                    "server_side_key_secret_store and server_side_key_secret_name are required when enable_protection is true",
+                    "server_side_key_secret_name is required when enable_protection is true",
                 )));
             }
             Self::validate_protection_api_origin(&config.protection_api_origin)?;
         }
-        Self::validate_protection_test_bypass(&config)?;
+        Self::validate_protection_test_bypass(&config, validate_resolved_secrets)?;
 
         if config.inject_client_side_tag {
             Self::validate_client_side_tag_url(&config.client_side_tag_url)?;
@@ -477,6 +483,12 @@ impl DataDomeIntegration {
         Self::try_new(config).map(|_| ())
     }
 
+    pub(crate) fn validate_config_for_deploy(
+        config: DataDomeConfig,
+    ) -> Result<(), Report<TrustedServerError>> {
+        Self::try_new_with_secret_validation(config, false).map(|_| ())
+    }
+
     fn active_protection_test_bypass(&self) -> Option<&ProtectionTestBypassConfig> {
         if std::env::var(ENV_FASTLY_IS_STAGING).as_deref() != Ok("1") {
             return None;
@@ -490,6 +502,7 @@ impl DataDomeIntegration {
 
     fn validate_protection_test_bypass(
         config: &DataDomeConfig,
+        validate_resolved_secret: bool,
     ) -> Result<(), Report<TrustedServerError>> {
         let Some(bypass) = config
             .protection_test_bypass
@@ -504,10 +517,16 @@ impl DataDomeIntegration {
                 "protection_test_bypass requires enable_protection to be true",
             )));
         }
-        if bypass.credential_secret_store.is_empty() || bypass.credential_secret_name.is_empty() {
+        let Some(credential) = bypass.credential_secret_name.as_ref() else {
             return Err(Report::new(Self::error(
-                "protection_test_bypass credential_secret_store and credential_secret_name must not be empty when enabled",
+                "protection_test_bypass credential_secret_name is required when enabled",
             )));
+        };
+        if validate_resolved_secret && credential.expose().len() < MIN_TEST_BYPASS_CREDENTIAL_BYTES
+        {
+            return Err(Report::new(Self::error(format!(
+                "protection_test_bypass credential_secret_name must resolve to at least {MIN_TEST_BYPASS_CREDENTIAL_BYTES} bytes"
+            ))));
         }
 
         Ok(())
@@ -1013,6 +1032,7 @@ mod tests {
             api_origin: "https://api-js.datadome.co".to_string(),
             cache_ttl_seconds: 3600,
             rewrite_sdk: true,
+            server_side_key_secret_name: Some(Redacted::new("server-side-key".to_string())),
             ..DataDomeConfig::default()
         }
     }
@@ -1200,14 +1220,11 @@ mod tests {
     }
 
     #[test]
-    fn protection_secret_defaults_match_sample_config() {
+    fn protection_secrets_are_absent_by_default() {
         let config = DataDomeConfig::default();
 
-        assert_eq!(config.server_side_key_secret_store, "ts_secrets");
-        assert_eq!(
-            config.server_side_key_secret_name,
-            "datadome_server_side_key"
-        );
+        assert!(config.server_side_key_secret_store.is_none());
+        assert!(config.server_side_key_secret_name.is_none());
         assert!(
             config.protection_test_bypass.is_none(),
             "the temporary test bypass should be disabled by default"
@@ -1234,33 +1251,40 @@ mod tests {
 
         assert!(bypass.enabled, "should retain the enabled flag");
         assert_eq!(
-            bypass.credential_secret_store, "ts_secrets",
-            "should retain the configured credential Secret Store"
+            bypass.credential_secret_store.as_deref(),
+            Some("ts_secrets"),
+            "should accept the deprecated credential Secret Store"
         );
         assert_eq!(
-            bypass.credential_secret_name, "datadome_test_bypass",
-            "should retain the configured credential secret name"
+            bypass
+                .credential_secret_name
+                .as_ref()
+                .map(Redacted::expose)
+                .map(String::as_str),
+            Some("datadome_test_bypass"),
+            "should retain the configured credential secret reference"
         );
     }
 
     #[test]
-    fn protection_test_bypass_requires_protection_and_secret_references() {
-        for (enable_protection, store, name, expected_message) in [
+    fn protection_test_bypass_requires_protection_and_resolved_credential() {
+        for (enable_protection, credential, expected_message) in [
             (
                 false,
-                "ts_secrets",
-                "datadome_test_bypass",
+                Some("test-bypass-credential-at-least-32-bytes"),
                 "requires enable_protection",
             ),
-            (true, "", "datadome_test_bypass", "credential_secret_store"),
-            (true, "ts_secrets", "", "credential_secret_name"),
+            (true, None, "credential_secret_name"),
+            (true, Some("short"), "at least 32 bytes"),
         ] {
             let mut config = test_config();
             config.enable_protection = enable_protection;
+            config.server_side_key_secret_name =
+                Some(Redacted::new("resolved-server-key".to_string()));
             config.protection_test_bypass = Some(ProtectionTestBypassConfig {
                 enabled: true,
-                credential_secret_store: store.to_string(),
-                credential_secret_name: name.to_string(),
+                credential_secret_store: None,
+                credential_secret_name: credential.map(|value| Redacted::new(value.to_string())),
             });
 
             let err = match DataDomeIntegration::try_new(config) {
@@ -1275,26 +1299,10 @@ mod tests {
     }
 
     #[test]
-    fn protection_enabled_requires_server_side_key_secret_store() {
-        let mut config = test_config();
-        config.enable_protection = true;
-        config.server_side_key_secret_store = " ".to_string();
-
-        let err = match DataDomeIntegration::try_new(config) {
-            Ok(_) => panic!("should reject empty store"),
-            Err(err) => err,
-        };
-        assert!(
-            format!("{err:?}").contains("server_side_key_secret_store"),
-            "should mention secret store config"
-        );
-    }
-
-    #[test]
     fn protection_enabled_requires_server_side_key_secret_name() {
         let mut config = test_config();
         config.enable_protection = true;
-        config.server_side_key_secret_name = " ".to_string();
+        config.server_side_key_secret_name = Some(Redacted::new(" ".to_string()));
 
         let err = match DataDomeIntegration::try_new(config) {
             Ok(_) => panic!("should reject empty name"),

--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -139,7 +139,10 @@ pub struct ProtectionTestBypassConfig {
     #[serde(default)]
     pub credential_secret_store: Option<String>,
 
-    /// Secret reference containing at least 32 bytes of high-entropy bypass material.
+    /// Secret reference containing the bypass credential.
+    ///
+    /// Holds the store key name in app config and the resolved credential at
+    /// runtime. Treat it as secret material after settings are built.
     #[serde(default)]
     pub credential_secret_name: Option<Redacted<String>>,
 }
@@ -182,6 +185,9 @@ pub struct DataDomeConfig {
     pub server_side_key_secret_store: Option<String>,
 
     /// Secret reference containing the `DataDome` server-side key.
+    ///
+    /// Holds the store key name in app config and the resolved key at runtime.
+    /// Treat it as secret material after settings are built.
     #[serde(default)]
     pub server_side_key_secret_name: Option<Redacted<String>>,
 
@@ -380,14 +386,7 @@ impl DataDomeIntegration {
         Self::try_new(config).expect("should create DataDome integration")
     }
 
-    fn try_new(config: DataDomeConfig) -> Result<Arc<Self>, Report<TrustedServerError>> {
-        Self::try_new_with_secret_validation(config, true)
-    }
-
-    fn try_new_with_secret_validation(
-        mut config: DataDomeConfig,
-        validate_resolved_secrets: bool,
-    ) -> Result<Arc<Self>, Report<TrustedServerError>> {
+    fn try_new(mut config: DataDomeConfig) -> Result<Arc<Self>, Report<TrustedServerError>> {
         if config.server_side_key_secret_store.take().is_some() {
             log::warn!(
                 "DataDome server_side_key_secret_store is deprecated and ignored; static credentials resolve through the default app-config secret store"
@@ -421,7 +420,7 @@ impl DataDomeIntegration {
             }
             Self::validate_protection_api_origin(&config.protection_api_origin)?;
         }
-        Self::validate_protection_test_bypass(&config, validate_resolved_secrets)?;
+        Self::validate_protection_test_bypass(&config)?;
 
         if config.inject_client_side_tag {
             Self::validate_client_side_tag_url(&config.client_side_tag_url)?;
@@ -486,7 +485,7 @@ impl DataDomeIntegration {
     pub(crate) fn validate_config_for_deploy(
         config: DataDomeConfig,
     ) -> Result<(), Report<TrustedServerError>> {
-        Self::try_new_with_secret_validation(config, false).map(|_| ())
+        Self::try_new(config).map(|_| ())
     }
 
     fn active_protection_test_bypass(&self) -> Option<&ProtectionTestBypassConfig> {
@@ -502,7 +501,6 @@ impl DataDomeIntegration {
 
     fn validate_protection_test_bypass(
         config: &DataDomeConfig,
-        validate_resolved_secret: bool,
     ) -> Result<(), Report<TrustedServerError>> {
         let Some(bypass) = config
             .protection_test_bypass
@@ -517,16 +515,10 @@ impl DataDomeIntegration {
                 "protection_test_bypass requires enable_protection to be true",
             )));
         }
-        let Some(credential) = bypass.credential_secret_name.as_ref() else {
+        if bypass.credential_secret_name.is_none() {
             return Err(Report::new(Self::error(
                 "protection_test_bypass credential_secret_name is required when enabled",
             )));
-        };
-        if validate_resolved_secret && credential.expose().len() < MIN_TEST_BYPASS_CREDENTIAL_BYTES
-        {
-            return Err(Report::new(Self::error(format!(
-                "protection_test_bypass credential_secret_name must resolve to at least {MIN_TEST_BYPASS_CREDENTIAL_BYTES} bytes"
-            ))));
         }
 
         Ok(())
@@ -1267,15 +1259,14 @@ mod tests {
     }
 
     #[test]
-    fn protection_test_bypass_requires_protection_and_resolved_credential() {
+    fn protection_test_bypass_requires_protection_and_credential_reference() {
         for (enable_protection, credential, expected_message) in [
             (
                 false,
-                Some("test-bypass-credential-at-least-32-bytes"),
+                Some("test-bypass-credential"),
                 "requires enable_protection",
             ),
             (true, None, "credential_secret_name"),
-            (true, Some("short"), "at least 32 bytes"),
         ] {
             let mut config = test_config();
             config.enable_protection = enable_protection;
@@ -1296,6 +1287,21 @@ mod tests {
                 "should explain the invalid protection test bypass configuration"
             );
         }
+    }
+
+    #[test]
+    fn protection_test_bypass_accepts_short_resolved_credential() {
+        let mut config = test_config();
+        config.enable_protection = true;
+        config.server_side_key_secret_name = Some(Redacted::new("resolved-server-key".to_string()));
+        config.protection_test_bypass = Some(ProtectionTestBypassConfig {
+            enabled: true,
+            credential_secret_store: None,
+            credential_secret_name: Some(Redacted::new("short".to_string())),
+        });
+
+        DataDomeIntegration::try_new(config)
+            .expect("should defer bypass credential strength enforcement to requests");
     }
 
     #[test]

--- a/crates/trusted-server-core/src/integrations/datadome.rs
+++ b/crates/trusted-server-core/src/integrations/datadome.rs
@@ -399,17 +399,12 @@ impl DataDomeIntegration {
             });
         config.protection_api_origin = config.protection_api_origin.trim().to_string();
         config.client_side_tag_url = config.client_side_tag_url.trim().to_string();
-        if let Some(bypass) = &mut config.protection_test_bypass {
-            if bypass.credential_secret_store.take().is_some() {
-                log::warn!(
-                    "DataDome credential_secret_store is deprecated and ignored; static credentials resolve through the default app-config secret store"
-                );
-            }
-            bypass.credential_secret_name =
-                bypass.credential_secret_name.take().and_then(|value| {
-                    let value = value.expose().trim().to_string();
-                    (!value.is_empty()).then(|| Redacted::new(value))
-                });
+        if let Some(bypass) = &mut config.protection_test_bypass
+            && bypass.credential_secret_store.take().is_some()
+        {
+            log::warn!(
+                "DataDome credential_secret_store is deprecated and ignored; static credentials resolve through the default app-config secret store"
+            );
         }
 
         if config.enable_protection {
@@ -515,7 +510,11 @@ impl DataDomeIntegration {
                 "protection_test_bypass requires enable_protection to be true",
             )));
         }
-        if bypass.credential_secret_name.is_none() {
+        if bypass
+            .credential_secret_name
+            .as_ref()
+            .is_none_or(|credential| credential.expose().is_empty())
+        {
             return Err(Report::new(Self::error(
                 "protection_test_bypass credential_secret_name is required when enabled",
             )));
@@ -1302,6 +1301,34 @@ mod tests {
 
         DataDomeIntegration::try_new(config)
             .expect("should defer bypass credential strength enforcement to requests");
+    }
+
+    #[test]
+    fn protection_test_bypass_preserves_resolved_credential() {
+        let credential = " resolved-test-bypass-credential-32-bytes ";
+        let mut config = test_config();
+        config.enable_protection = true;
+        config.server_side_key_secret_name = Some(Redacted::new("resolved-server-key".to_string()));
+        config.protection_test_bypass = Some(ProtectionTestBypassConfig {
+            enabled: true,
+            credential_secret_store: None,
+            credential_secret_name: Some(Redacted::new(credential.to_owned())),
+        });
+
+        let integration =
+            DataDomeIntegration::try_new(config).expect("should create DataDome integration");
+        let resolved = integration
+            .config
+            .protection_test_bypass
+            .as_ref()
+            .and_then(|bypass| bypass.credential_secret_name.as_ref())
+            .expect("should retain the resolved bypass credential");
+
+        assert_eq!(
+            resolved.expose(),
+            credential,
+            "should not normalize resolved secret material"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/integrations/datadome/protection.rs
+++ b/crates/trusted-server-core/src/integrations/datadome/protection.rs
@@ -13,15 +13,13 @@ use crate::http_util::is_navigation_request;
 use crate::integrations::{
     HeaderMutation, RequestFilterDecision, RequestFilterEffects, RequestFilterInput,
 };
-use crate::platform::{PlatformBackendSpec, PlatformHttpRequest, RuntimeServices, StoreName};
+use crate::platform::{PlatformBackendSpec, PlatformHttpRequest, RuntimeServices};
 use crate::redacted::Redacted;
 
 use super::DataDomeIntegration;
 use super::protection_scope::{
     ProtectionRequestFacts, ProtectionScopeDecision, ProtectionSkipReason,
 };
-
-const MIN_TEST_BYPASS_CREDENTIAL_BYTES: usize = 32;
 
 const VALIDATE_REQUEST_PATH: &str = "/validate-request";
 const REQUEST_MODULE_NAME: &str = "Trusted-Server-Rust";
@@ -43,8 +41,7 @@ impl DataDomeIntegration {
         &self,
         mut input: RequestFilterInput<'_>,
     ) -> RequestFilterDecision {
-        let test_bypass_matched =
-            self.take_protection_test_bypass_header(input.request, input.services);
+        let test_bypass_matched = self.take_protection_test_bypass_header(input.request);
         if test_bypass_matched {
             input
                 .request
@@ -87,9 +84,9 @@ impl DataDomeIntegration {
             .ensure_protection_backend(input.services, &api_url)
             .map_err(ProtectionRequestError::Setup)?;
         let server_side_key = self
-            .load_server_side_key(input.services)
+            .server_side_key()
             .map_err(ProtectionRequestError::Setup)?;
-        let payload = self.build_protection_payload(&input, &server_side_key);
+        let payload = self.build_protection_payload(&input, server_side_key);
         let encoded_body = form_encode(&payload.fields);
 
         let mut builder = request_builder()
@@ -175,11 +172,7 @@ impl DataDomeIntegration {
         true
     }
 
-    fn take_protection_test_bypass_header(
-        &self,
-        req: &mut Request<EdgeBody>,
-        services: &RuntimeServices,
-    ) -> bool {
+    fn take_protection_test_bypass_header(&self, req: &mut Request<EdgeBody>) -> bool {
         let supplied_values = req
             .headers()
             .get_all(super::HEADER_DATADOME_TEST_BYPASS)
@@ -200,28 +193,21 @@ impl DataDomeIntegration {
             return false;
         }
 
-        let store_name = StoreName::from(bypass.credential_secret_store.as_str());
-        let credential = match services
-            .secret_store()
-            .get_string(&store_name, &bypass.credential_secret_name)
-        {
-            Ok(credential) if credential.len() >= MIN_TEST_BYPASS_CREDENTIAL_BYTES => credential,
-            Ok(_) => {
-                log::warn!(
-                    "[datadome] DataDome test bypass credential does not meet security requirements; ignoring bypass header"
-                );
-                return false;
-            }
-            Err(err) => {
-                log::warn!(
-                    "[datadome] Failed to load DataDome test bypass credential; ignoring bypass header: {err:?}"
-                );
-                return false;
-            }
+        let Some(credential) = bypass.credential_secret_name.as_ref() else {
+            log::warn!(
+                "[datadome] DataDome test bypass credential is unavailable; ignoring bypass header"
+            );
+            return false;
         };
+        if credential.expose().len() < super::MIN_TEST_BYPASS_CREDENTIAL_BYTES {
+            log::warn!(
+                "[datadome] DataDome test bypass credential does not meet security requirements; ignoring bypass header"
+            );
+            return false;
+        }
 
         let actual = Sha256::digest(supplied_values[0].as_bytes());
-        let expected = Sha256::digest(credential.as_bytes());
+        let expected = Sha256::digest(credential.expose().as_bytes());
         bool::from(actual.ct_eq(&expected))
     }
 
@@ -259,25 +245,15 @@ impl DataDomeIntegration {
         ))
     }
 
-    fn load_server_side_key(
-        &self,
-        services: &RuntimeServices,
-    ) -> Result<Redacted<String>, Report<TrustedServerError>> {
-        let store_name = StoreName::from(self.config.server_side_key_secret_store.as_str());
-        let key = services
-            .secret_store()
-            .get_string(&store_name, &self.config.server_side_key_secret_name)
-            .change_context(Self::error(
-                "Failed to read DataDome server-side key from secret store",
-            ))?;
-        let key = key.trim().to_string();
-        if key.is_empty() {
-            return Err(Report::new(Self::error(
-                "DataDome server-side key secret must not be empty",
-            )));
-        }
-
-        Ok(Redacted::new(key))
+    fn server_side_key(&self) -> Result<&Redacted<String>, Report<TrustedServerError>> {
+        self.config
+            .server_side_key_secret_name
+            .as_ref()
+            .ok_or_else(|| {
+                Report::new(Self::error(
+                    "DataDome server-side key is unavailable after secret resolution",
+                ))
+            })
     }
 
     fn build_protection_payload(
@@ -854,13 +830,17 @@ mod tests {
 
     static FASTLY_IS_STAGING_ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    fn protection_integration() -> Arc<DataDomeIntegration> {
-        let config = DataDomeConfig {
+    fn protection_config() -> DataDomeConfig {
+        DataDomeConfig {
             enabled: true,
             enable_protection: true,
+            server_side_key_secret_name: Some(Redacted::new("server-side-key".to_string())),
             ..DataDomeConfig::default()
-        };
-        DataDomeIntegration::try_new(config).expect("should create integration")
+        }
+    }
+
+    fn protection_integration() -> Arc<DataDomeIntegration> {
+        DataDomeIntegration::try_new(protection_config()).expect("should create integration")
     }
 
     fn request_for_filter() -> Request<EdgeBody> {
@@ -950,10 +930,12 @@ mod tests {
             enable_protection: true,
             protection_test_bypass: Some(ProtectionTestBypassConfig {
                 enabled: true,
-                credential_secret_store: "ts_secrets".to_string(),
-                credential_secret_name: "datadome_test_bypass".to_string(),
+                credential_secret_store: None,
+                credential_secret_name: Some(Redacted::new(
+                    "temporary-test-credential-32-bytes!".to_string(),
+                )),
             }),
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let integration = DataDomeIntegration::try_new(config).expect("should create integration");
         let mut secrets = HashMap::new();
@@ -1002,15 +984,17 @@ mod tests {
             None,
             Some(ProtectionTestBypassConfig {
                 enabled: false,
-                credential_secret_store: "ts_secrets".to_string(),
-                credential_secret_name: "datadome_test_bypass".to_string(),
+                credential_secret_store: None,
+                credential_secret_name: Some(Redacted::new(
+                    "temporary-test-credential-32-bytes!".to_string(),
+                )),
             }),
         ] {
             let config = DataDomeConfig {
                 enabled: true,
                 enable_protection: true,
                 protection_test_bypass,
-                ..DataDomeConfig::default()
+                ..protection_config()
             };
             let integration =
                 DataDomeIntegration::try_new(config).expect("should create integration");
@@ -1068,10 +1052,12 @@ mod tests {
             enable_protection: true,
             protection_test_bypass: Some(ProtectionTestBypassConfig {
                 enabled: true,
-                credential_secret_store: "ts_secrets".to_string(),
-                credential_secret_name: "datadome_test_bypass".to_string(),
+                credential_secret_store: None,
+                credential_secret_name: Some(Redacted::new(
+                    "temporary-test-credential-32-bytes!".to_string(),
+                )),
             }),
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let integration = DataDomeIntegration::try_new(config).expect("should create integration");
         let mut secrets = HashMap::new();
@@ -1156,10 +1142,12 @@ mod tests {
             }],
             protection_test_bypass: Some(ProtectionTestBypassConfig {
                 enabled: true,
-                credential_secret_store: "ts_secrets".to_string(),
-                credential_secret_name: "datadome_test_bypass".to_string(),
+                credential_secret_store: None,
+                credential_secret_name: Some(Redacted::new(
+                    "temporary-test-credential-32-bytes!".to_string(),
+                )),
             }),
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let integration = DataDomeIntegration::try_new(config).expect("should create integration");
         let mut secrets = HashMap::new();
@@ -1202,10 +1190,12 @@ mod tests {
             enable_protection: true,
             protection_test_bypass: Some(ProtectionTestBypassConfig {
                 enabled: true,
-                credential_secret_store: "ts_secrets".to_string(),
-                credential_secret_name: "datadome_test_bypass".to_string(),
+                credential_secret_store: None,
+                credential_secret_name: Some(Redacted::new(
+                    "temporary-test-credential-32-bytes!".to_string(),
+                )),
             }),
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let integration = DataDomeIntegration::try_new(config).expect("should create integration");
         let mut secrets = HashMap::new();
@@ -1265,10 +1255,12 @@ mod tests {
             enable_protection: true,
             protection_test_bypass: Some(ProtectionTestBypassConfig {
                 enabled: true,
-                credential_secret_store: "ts_secrets".to_string(),
-                credential_secret_name: "datadome_test_bypass".to_string(),
+                credential_secret_store: None,
+                credential_secret_name: Some(Redacted::new(
+                    "temporary-test-credential-32-bytes!".to_string(),
+                )),
             }),
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let integration = DataDomeIntegration::try_new(config).expect("should create integration");
         let mut secrets = HashMap::new();
@@ -1318,64 +1310,26 @@ mod tests {
 
     #[test]
     fn test_bypass_credential_requires_at_least_32_bytes() {
-        for (credential, should_match) in [
+        for (credential, should_succeed) in [
             (Some("1234567890123456789012345678901"), false),
             (Some("12345678901234567890123456789012"), true),
             (Some(""), false),
             (None, false),
         ] {
             let config = DataDomeConfig {
-                enabled: true,
-                enable_protection: true,
                 protection_test_bypass: Some(ProtectionTestBypassConfig {
                     enabled: true,
-                    credential_secret_store: "ts_secrets".to_string(),
-                    credential_secret_name: "datadome_test_bypass".to_string(),
+                    credential_secret_store: None,
+                    credential_secret_name: credential
+                        .map(|value| Redacted::new(value.to_string())),
                 }),
-                ..DataDomeConfig::default()
+                ..protection_config()
             };
-            let integration =
-                DataDomeIntegration::try_new(config).expect("should create integration");
-            let mut secrets = HashMap::new();
-            secrets.insert(
-                "datadome_server_side_key".to_string(),
-                b"server-side-key".to_vec(),
-            );
-            if let Some(credential) = credential {
-                secrets.insert(
-                    "datadome_test_bypass".to_string(),
-                    credential.as_bytes().to_vec(),
-                );
-            }
-            let http_client = Arc::new(StubHttpClient::new());
-            if !should_match {
-                http_client.push_response_with_headers(
-                    200,
-                    Vec::new(),
-                    vec![(HEADER_DATADOME_RESPONSE, "200")],
-                );
-            }
-            let services = build_services_with_secret_and_http_client(
-                HashMapSecretStore::new(secrets),
-                http_client.clone(),
-            );
-            let settings = Settings::default();
-            let mut request = request_for_filter();
-            let supplied = credential.unwrap_or("12345678901234567890123456789012");
-            request.headers_mut().insert(
-                super::super::HEADER_DATADOME_TEST_BYPASS,
-                edgezero_core::http::HeaderValue::from_str(supplied)
-                    .expect("should build bypass header"),
-            );
 
-            let decision = filter_with_staging(&integration, &settings, &services, &mut request);
-
-            assert!(matches!(decision, RequestFilterDecision::Continue(_)));
-            assert_eq!(has_client_tag_suppression_marker(&request), should_match);
             assert_eq!(
-                http_client.recorded_backend_names().is_empty(),
-                should_match,
-                "only a credential meeting the minimum should skip the API"
+                DataDomeIntegration::try_new(config).is_ok(),
+                should_succeed,
+                "startup validation should enforce the resolved bypass credential length"
             );
         }
     }
@@ -1417,7 +1371,7 @@ mod tests {
             enabled: true,
             enable_protection: true,
             protection_excluded_ip_cidrs: vec!["192.0.2.0/24".to_string()],
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let inline_request =
             filter_marks_request(inline.clone(), &noop_services_with_client_ip(ip));
@@ -1456,7 +1410,7 @@ mod tests {
                     cidrs: vec!["192.0.2.0/24".to_string()],
                 },
             }],
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let structured_request =
             filter_marks_request(structured_ip, &noop_services_with_client_ip(ip));
@@ -1477,7 +1431,7 @@ mod tests {
                     key: "structured-source".to_string(),
                 },
             }],
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let mut structured_values = HashMap::new();
         structured_values.insert("structured-source".to_string(), "192.0.2.0/24".to_string());
@@ -1534,7 +1488,7 @@ mod tests {
                     methods: Vec::new(),
                     matcher,
                 }],
-                ..DataDomeConfig::default()
+                ..protection_config()
             };
             let request =
                 filter_marks_request_for_uri(config, &noop_services_with_client_ip(ip), None, uri);
@@ -1569,7 +1523,7 @@ mod tests {
                     },
                 },
             ],
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
 
         let request = filter_marks_request(config, &noop_services_with_client_ip(ip));
@@ -1586,7 +1540,7 @@ mod tests {
             enabled: true,
             enable_protection: true,
             protection_excluded_asns: vec![64500],
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let geo_info = GeoInfo {
             city: String::new(),
@@ -1615,7 +1569,7 @@ mod tests {
             enabled: true,
             enable_protection: true,
             protection_excluded_ip_cidrs: vec!["192.0.2.0/24".to_string()],
-            ..DataDomeConfig::default()
+            ..protection_config()
         };
         let request = filter_marks_request(
             config,
@@ -1628,39 +1582,27 @@ mod tests {
     }
 
     #[test]
-    fn load_server_side_key_reads_secret_store() {
-        let mut secrets = HashMap::new();
-        secrets.insert(
-            "datadome_server_side_key".to_string(),
-            b"secret-from-store".to_vec(),
-        );
-        let services = build_services_with_config_and_secret(
-            NoopConfigStore,
-            HashMapSecretStore::new(secrets),
-        );
+    fn server_side_key_uses_resolved_config_value() {
         let integration = protection_integration();
 
         let key = integration
-            .load_server_side_key(&services)
-            .expect("should load server-side key");
+            .server_side_key()
+            .expect("should contain resolved server-side key");
 
-        assert_eq!(key.expose(), "secret-from-store");
+        assert_eq!(key.expose(), "server-side-key");
     }
 
     #[test]
-    fn load_server_side_key_errors_when_secret_missing() {
-        let services = build_services_with_config_and_secret(NoopConfigStore, NoopSecretStore);
+    fn protection_startup_rejects_missing_resolved_server_side_key() {
         let config = DataDomeConfig {
-            enabled: true,
-            enable_protection: true,
-            server_side_key_secret_name: "missing_server_side_key".to_string(),
-            ..DataDomeConfig::default()
+            server_side_key_secret_name: None,
+            ..protection_config()
         };
-        let integration = DataDomeIntegration::try_new(config).expect("should create integration");
 
-        let result = integration.load_server_side_key(&services);
-
-        assert!(result.is_err(), "should error when secret is missing");
+        assert!(
+            DataDomeIntegration::try_new(config).is_err(),
+            "should reject a missing resolved server-side key"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/integrations/datadome/protection.rs
+++ b/crates/trusted-server-core/src/integrations/datadome/protection.rs
@@ -1309,29 +1309,48 @@ mod tests {
     }
 
     #[test]
-    fn test_bypass_credential_requires_at_least_32_bytes() {
-        for (credential, should_succeed) in [
-            (Some("1234567890123456789012345678901"), false),
-            (Some("12345678901234567890123456789012"), true),
-            (Some(""), false),
-            (None, false),
-        ] {
-            let config = DataDomeConfig {
-                protection_test_bypass: Some(ProtectionTestBypassConfig {
-                    enabled: true,
-                    credential_secret_store: None,
-                    credential_secret_name: credential
-                        .map(|value| Redacted::new(value.to_string())),
-                }),
-                ..protection_config()
-            };
+    fn short_test_bypass_credential_is_ignored_without_failing_startup() {
+        let config = DataDomeConfig {
+            protection_test_bypass: Some(ProtectionTestBypassConfig {
+                enabled: true,
+                credential_secret_store: None,
+                credential_secret_name: Some(Redacted::new("short".to_string())),
+            }),
+            ..protection_config()
+        };
+        let integration =
+            DataDomeIntegration::try_new(config).expect("should accept short bypass credential");
+        let http_client = Arc::new(StubHttpClient::new());
+        http_client.push_response_with_headers(
+            200,
+            Vec::new(),
+            vec![(HEADER_DATADOME_RESPONSE, "200")],
+        );
+        let services =
+            build_services_with_secret_and_http_client(NoopSecretStore, http_client.clone());
+        let settings = Settings::default();
+        let mut request = request_for_filter();
+        request.headers_mut().insert(
+            super::super::HEADER_DATADOME_TEST_BYPASS,
+            edgezero_core::http::HeaderValue::from_static("short"),
+        );
 
-            assert_eq!(
-                DataDomeIntegration::try_new(config).is_ok(),
-                should_succeed,
-                "startup validation should enforce the resolved bypass credential length"
-            );
-        }
+        let decision = filter_with_staging(&integration, &settings, &services, &mut request);
+
+        assert!(matches!(decision, RequestFilterDecision::Continue(_)));
+        assert!(
+            request
+                .headers()
+                .get(super::super::HEADER_DATADOME_TEST_BYPASS)
+                .is_none(),
+            "the invalid bypass credential should not reach the publisher origin"
+        );
+        assert!(!has_client_tag_suppression_marker(&request));
+        assert_eq!(
+            http_client.recorded_backend_names().len(),
+            1,
+            "a short credential should not bypass the Protection API"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-core/src/lib.rs
+++ b/crates/trusted-server-core/src/lib.rs
@@ -64,6 +64,7 @@ pub mod request_signing;
 pub mod response_privacy;
 pub mod rsc_flight;
 pub(crate) mod s3_sigv4;
+pub mod secret_resolution;
 pub mod settings;
 pub mod settings_data;
 pub mod storage;

--- a/crates/trusted-server-core/src/proxy.rs
+++ b/crates/trusted-server-core/src/proxy.rs
@@ -7,9 +7,7 @@ use error_stack::{Report, ResultExt};
 use futures::StreamExt as _;
 use http::{HeaderValue, Method, Request, Response, StatusCode, header};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::io::{Cursor, Write};
-use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 use web_time::{SystemTime, UNIX_EPOCH};
 
@@ -27,13 +25,10 @@ use crate::edge_cookie::get_ec_id;
 use crate::error::TrustedServerError;
 use crate::platform::{
     DEFAULT_FIRST_BYTE_TIMEOUT, PlatformBackendSpec, PlatformHttpRequest, PlatformResponse,
-    RuntimeServices, StoreName,
+    RuntimeServices,
 };
-use crate::redacted::Redacted;
 use crate::s3_sigv4::{self, S3Credentials};
-use crate::settings::{
-    AssetOriginAuth, OriginQueryPolicy, ProxyAssetRoute, S3SigV4AuthConfig, Settings,
-};
+use crate::settings::{AssetOriginAuth, OriginQueryPolicy, ProxyAssetRoute, Settings};
 use crate::streaming_processor::{Compression, PipelineConfig, StreamProcessor, StreamingPipeline};
 
 /// Chunk size used for streaming content through the rewrite pipeline.
@@ -228,17 +223,6 @@ impl AssetProxyResponse {
         (self.response, self.stream_body)
     }
 }
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct S3CredentialsCacheKey {
-    secret_store: String,
-    access_key_id: String,
-    secret_access_key: String,
-    session_token: Option<String>,
-}
-
-static S3_CREDENTIALS_CACHE: LazyLock<Mutex<HashMap<S3CredentialsCacheKey, Arc<S3Credentials>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Convert a platform-neutral response into a buffered [`Response`] for downstream processing.
 ///
@@ -897,76 +881,7 @@ fn asset_origin_host_header(
     })
 }
 
-fn s3_credentials_cache_key(config: &S3SigV4AuthConfig) -> S3CredentialsCacheKey {
-    S3CredentialsCacheKey {
-        secret_store: config.secret_store.clone(),
-        access_key_id: config.access_key_id.clone(),
-        secret_access_key: config.secret_access_key.clone(),
-        session_token: config.session_token.clone(),
-    }
-}
-
-fn load_s3_credentials(
-    services: &RuntimeServices,
-    config: &S3SigV4AuthConfig,
-) -> Result<Arc<S3Credentials>, Report<TrustedServerError>> {
-    let cache_key = s3_credentials_cache_key(config);
-    if let Some(credentials) = S3_CREDENTIALS_CACHE
-        .lock()
-        .expect("should lock S3 credentials cache")
-        .get(&cache_key)
-        .cloned()
-    {
-        return Ok(credentials);
-    }
-
-    let store_name = StoreName::from(config.secret_store.as_str());
-    let access_key_id = services
-        .secret_store()
-        .get_string(&store_name, &config.access_key_id)
-        .change_context(TrustedServerError::Proxy {
-            message: "failed to read S3 access key ID from secret store".to_string(),
-        })?;
-    let secret_access_key = services
-        .secret_store()
-        .get_string(&store_name, &config.secret_access_key)
-        .change_context(TrustedServerError::Proxy {
-            message: "failed to read S3 secret access key from secret store".to_string(),
-        })?;
-    let session_token = config
-        .session_token
-        .as_deref()
-        .map(|key| {
-            services
-                .secret_store()
-                .get_string(&store_name, key)
-                .change_context(TrustedServerError::Proxy {
-                    message: "failed to read S3 session token from secret store".to_string(),
-                })
-        })
-        .transpose()?;
-    let credentials = Arc::new(S3Credentials {
-        access_key_id,
-        secret_access_key: Redacted::new(secret_access_key),
-        session_token: session_token.map(Redacted::new),
-    });
-
-    let mut cache = S3_CREDENTIALS_CACHE
-        .lock()
-        .expect("should lock S3 credentials cache");
-    Ok(Arc::clone(cache.entry(cache_key).or_insert(credentials)))
-}
-
-#[cfg(test)]
-fn clear_s3_credentials_cache_for_tests() {
-    S3_CREDENTIALS_CACHE
-        .lock()
-        .expect("should lock S3 credentials cache")
-        .clear();
-}
-
 fn apply_asset_origin_auth(
-    services: &RuntimeServices,
     method: &Method,
     target_url: &url::Url,
     headers: &mut http::HeaderMap,
@@ -974,13 +889,17 @@ fn apply_asset_origin_auth(
 ) -> Result<(), Report<TrustedServerError>> {
     match auth {
         AssetOriginAuth::S3SigV4(config) => {
-            let credentials = load_s3_credentials(services, config)?;
+            let credentials = S3Credentials {
+                access_key_id: config.access_key_id.expose().clone(),
+                secret_access_key: config.secret_access_key.clone(),
+                session_token: config.session_token.clone(),
+            };
             s3_sigv4::sign_headers(
                 method,
                 target_url,
                 headers,
                 &config.region,
-                credentials.as_ref(),
+                &credentials,
                 // s3_sigv4 converts this via chrono's `DateTime::<Utc>::from`, which
                 // only accepts `std::time::SystemTime`. `std::time::SystemTime::now()`
                 // panics on `wasm32-unknown-unknown` (Cloudflare Workers), so derive an
@@ -1093,7 +1012,7 @@ async fn preflight_s3_origin_for_image_optimizer(
     // HEAD preflight lets missing or unauthorized objects return raw S3 errors
     // without invoking IO on the failure path.
     let mut head_headers = unsigned_headers.clone();
-    apply_asset_origin_auth(services, &Method::HEAD, target_url, &mut head_headers, auth)?;
+    apply_asset_origin_auth(&Method::HEAD, target_url, &mut head_headers, auth)?;
     let head_response = send_asset_origin_request(
         services,
         backend_name,
@@ -1116,7 +1035,7 @@ async fn preflight_s3_origin_for_image_optimizer(
     }
 
     let mut get_headers = unsigned_headers.clone();
-    apply_asset_origin_auth(services, &Method::GET, target_url, &mut get_headers, auth)?;
+    apply_asset_origin_auth(&Method::GET, target_url, &mut get_headers, auth)?;
     let mut response = send_asset_origin_request(
         services,
         backend_name,
@@ -1220,13 +1139,7 @@ pub async fn handle_asset_proxy_request(
     }
 
     if let Some(auth) = &route.auth {
-        apply_asset_origin_auth(
-            services,
-            req.method(),
-            &target_url,
-            &mut outbound_headers,
-            auth,
-        )?;
+        apply_asset_origin_auth(req.method(), &target_url, &mut outbound_headers, auth)?;
     }
 
     let mut platform_req =
@@ -2249,10 +2162,9 @@ mod tests {
     use super::{
         AssetProxyCachePolicy, IMAGE_FALLBACK_CONTENT_TYPE, ProxyRequestConfig,
         SUPPORTED_ENCODINGS, asset_origin_host_header, asset_path_skips_image_optimizer,
-        build_asset_proxy_target_url, clear_s3_credentials_cache_for_tests,
-        handle_asset_proxy_request, handle_first_party_click, handle_first_party_proxy,
-        handle_first_party_proxy_rebuild, handle_first_party_proxy_sign, is_host_allowed,
-        is_host_permitted, proxy_request, rebuild_response_with_body,
+        build_asset_proxy_target_url, handle_asset_proxy_request, handle_first_party_click,
+        handle_first_party_proxy, handle_first_party_proxy_rebuild, handle_first_party_proxy_sign,
+        is_host_allowed, is_host_permitted, proxy_request, rebuild_response_with_body,
         reconstruct_and_validate_signed_target, stream_asset_body,
     };
     use crate::cache_policy::{CachePolicy, EdgeCacheHeader};
@@ -2267,6 +2179,7 @@ mod tests {
         PlatformError, PlatformHttpClient, PlatformHttpRequest, PlatformPendingRequest,
         PlatformResponse, PlatformSecretStore, PlatformSelectResult, StoreId, StoreName,
     };
+    use crate::redacted::Redacted;
     use crate::settings::{
         AssetImageOptimizerConfig, AssetOriginAuth, ImageOptimizerAspectRatioConfig,
         ImageOptimizerCropOffsetsConfig, ImageOptimizerProfileSet, ImageOptimizerSettings,
@@ -4823,9 +4736,11 @@ mod tests {
         );
         route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
             region: "us-east-1".to_string(),
-            secret_store: "s3-auth".to_string(),
-            access_key_id: "access_key_id".to_string(),
-            secret_access_key: "secret_access_key".to_string(),
+            secret_store: None,
+            access_key_id: Redacted::new("AKIAIOSFODNN7EXAMPLE".to_string()),
+            secret_access_key: Redacted::new(
+                "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            ),
             session_token: None,
             origin_query: None,
         }));
@@ -4867,9 +4782,11 @@ mod tests {
             );
             route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
                 region: "us-east-1".to_string(),
-                secret_store: "s3-auth".to_string(),
-                access_key_id: "access_key_id".to_string(),
-                secret_access_key: "secret_access_key".to_string(),
+                secret_store: None,
+                access_key_id: Redacted::new("AKIAIOSFODNN7EXAMPLE".to_string()),
+                secret_access_key: Redacted::new(
+                    "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+                ),
                 session_token: None,
                 origin_query: Some(OriginQueryPolicy::Strip),
             }));
@@ -4909,23 +4826,12 @@ mod tests {
     }
 
     #[test]
-    fn handle_asset_proxy_request_caches_s3_credentials_for_repeated_signing() {
+    fn handle_asset_proxy_request_uses_resolved_s3_credentials_without_store_reads() {
         futures::executor::block_on(async {
-            clear_s3_credentials_cache_for_tests();
             let stub = Arc::new(StubHttpClient::new());
             stub.push_response(200, Vec::new());
             stub.push_response(200, b"optimized".to_vec());
-            let secret_store = CountingSecretStore::new(HashMap::from([
-                (
-                    "cache_access_key_id".to_string(),
-                    b"AKIAIOSFODNN7EXAMPLE".to_vec(),
-                ),
-                (
-                    "cache_secret_access_key".to_string(),
-                    b"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_vec(),
-                ),
-                ("cache_session_token".to_string(), b"session-token".to_vec()),
-            ]));
+            let secret_store = CountingSecretStore::new(HashMap::new());
             let observed_secret_store = secret_store.clone();
             let services = build_services_with_secret_and_http_client(
                 secret_store,
@@ -4942,10 +4848,12 @@ mod tests {
             let mut route = test_s3_image_optimizer_route();
             route.auth = Some(AssetOriginAuth::S3SigV4(S3SigV4AuthConfig {
                 region: "us-east-1".to_string(),
-                secret_store: "s3-auth-cache".to_string(),
-                access_key_id: "cache_access_key_id".to_string(),
-                secret_access_key: "cache_secret_access_key".to_string(),
-                session_token: Some("cache_session_token".to_string()),
+                secret_store: None,
+                access_key_id: Redacted::new("AKIAIOSFODNN7EXAMPLE".to_string()),
+                secret_access_key: Redacted::new(
+                    "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+                ),
+                session_token: Some(Redacted::new("session-token".to_string())),
                 origin_query: None,
             }));
 
@@ -4959,19 +4867,9 @@ mod tests {
                 "should sign both the S3 preflight and final request"
             );
             assert_eq!(
-                observed_secret_store.read_count("cache_access_key_id"),
-                1,
-                "should read S3 access key ID once despite repeated signing"
-            );
-            assert_eq!(
-                observed_secret_store.read_count("cache_secret_access_key"),
-                1,
-                "should read S3 secret access key once despite repeated signing"
-            );
-            assert_eq!(
-                observed_secret_store.read_count("cache_session_token"),
-                1,
-                "should read S3 session token once despite repeated signing"
+                observed_secret_store.read_count("AKIAIOSFODNN7EXAMPLE"),
+                0,
+                "should not read S3 credentials from the runtime secret store"
             );
             let headers = stub.recorded_request_headers();
             assert!(

--- a/crates/trusted-server-core/src/publisher.rs
+++ b/crates/trusted-server-core/src/publisher.rs
@@ -14232,6 +14232,7 @@ mod tests {
                 &serde_json::json!({
                     "enabled": true,
                     "enable_protection": true,
+                    "server_side_key_secret_name": "server-side-key",
                     "protection_excluded_ip_cidrs": ["192.0.2.0/24"],
                     "client_side_key": "test-client-key",
                 }),

--- a/crates/trusted-server-core/src/secret_resolution.rs
+++ b/crates/trusted-server-core/src/secret_resolution.rs
@@ -5,7 +5,7 @@
 //! in-memory value used to build runtime [`crate::settings::Settings`].
 
 use edgezero_core::app_config::{AppConfigMeta, SecretField, SecretKind, SecretPathSegment};
-use error_stack::{Report, ResultExt as _};
+use error_stack::Report;
 use serde_json::Value;
 
 use crate::error::TrustedServerError;
@@ -149,6 +149,7 @@ fn resolve_leaf(
     let key_name = match object.get(key) {
         Some(Value::String(value)) if !value.is_empty() => value.clone(),
         Some(Value::Null) | None if field.optional => return Ok(()),
+        Some(Value::Null) | None => return Err(missing_path(&leaf_path)),
         Some(Value::String(_)) => {
             return Err(configuration_error(format!(
                 "secret key reference at `{leaf_path}` must not be empty"
@@ -163,11 +164,11 @@ fn resolve_leaf(
 
     let resolved = secret_store
         .get_string(default_store_name, &key_name)
-        .change_context(TrustedServerError::Configuration {
-            message: format!(
+        .map_err(|_| {
+            configuration_error(format!(
                 "failed to resolve secret reference at `{leaf_path}` from secret store \
-                 `{default_store_name}` key `{key_name}`"
-            ),
+                 `{default_store_name}`"
+            ))
         })?;
     if resolved.is_empty() {
         return Err(configuration_error(format!(
@@ -212,7 +213,8 @@ mod tests {
             key: &str,
         ) -> Result<Vec<u8>, Report<PlatformError>> {
             self.values.get(key).cloned().ok_or_else(|| {
-                Report::new(PlatformError::SecretStore).attach("missing test secret")
+                Report::new(PlatformError::SecretStore)
+                    .attach(format!("missing test secret for key `{key}`"))
             })
         }
 
@@ -312,18 +314,38 @@ mod tests {
 
     #[test]
     fn rejects_missing_required_path_without_secret_values() {
-        let mut data = serde_json::json!({"outer": [{}]});
+        for mut data in [
+            serde_json::json!({"outer": [{}]}),
+            serde_json::json!({"outer": [{"token": null}]}),
+        ] {
+            let err = resolve_secret_references::<Fixture>(
+                &mut data,
+                &store(),
+                &StoreName::from("secrets"),
+            )
+            .expect_err("should reject missing required secret path");
+
+            assert!(err.to_string().contains("missing required secret path"));
+            assert!(err.to_string().contains("outer[0].token"));
+            assert!(!err.to_string().contains("resolved-a"));
+        }
+    }
+
+    #[test]
+    fn rejects_non_string_required_leaf() {
+        let mut data = serde_json::json!({"outer": [{"token": true}]});
         let err =
             resolve_secret_references::<Fixture>(&mut data, &store(), &StoreName::from("secrets"))
-                .expect_err("should reject missing required secret path");
+                .expect_err("should reject non-string secret reference");
 
+        assert!(err.to_string().contains("must be a string"));
         assert!(err.to_string().contains("outer[0].token"));
-        assert!(!err.to_string().contains("resolved-a"));
     }
 
     #[test]
     fn failed_lookup_reports_safe_reference_context_without_secret_values() {
-        let mut data = serde_json::json!({"outer": [{"token": "missing-secret-key"}]});
+        let plaintext_blob_value = "legacy-plaintext-credential";
+        let mut data = serde_json::json!({"outer": [{"token": plaintext_blob_value}]});
         let store = MemorySecretStore {
             values: BTreeMap::from([(
                 "fixture-secret-key".to_owned(),
@@ -338,8 +360,8 @@ mod tests {
 
         assert!(diagnostic.contains("outer[0].token"));
         assert!(diagnostic.contains("secrets"));
-        assert!(diagnostic.contains("missing-secret-key"));
-        assert!(diagnostic.contains("missing test secret"));
+        assert!(!diagnostic.contains(plaintext_blob_value));
+        assert!(!diagnostic.contains("missing test secret"));
         assert!(!diagnostic.contains("fixture-secret-value"));
     }
 

--- a/crates/trusted-server-core/src/secret_resolution.rs
+++ b/crates/trusted-server-core/src/secret_resolution.rs
@@ -26,12 +26,13 @@ pub fn resolve_secret_references<C: AppConfigMeta>(
     secret_store: &dyn PlatformSecretStore,
     default_store_name: &StoreName,
 ) -> Result<(), Report<TrustedServerError>> {
+    let mut resolved_data = data.clone();
     for field in C::secret_fields() {
         if matches!(field.kind, SecretKind::StoreRef) {
             continue;
         }
         resolve_field(
-            data,
+            &mut resolved_data,
             &field,
             &field.path,
             "",
@@ -39,6 +40,7 @@ pub fn resolve_secret_references<C: AppConfigMeta>(
             default_store_name,
         )?;
     }
+    *data = resolved_data;
     Ok(())
 }
 
@@ -59,6 +61,19 @@ fn resolve_field(
             secret_store,
             default_store_name,
         ),
+        Some((SecretPathSegment::OptionalField(name), [])) => {
+            if matches!(node.get(name.as_ref()), None | Some(Value::Null)) {
+                return Ok(());
+            }
+            resolve_leaf(
+                node,
+                field,
+                name.as_ref(),
+                rendered_path,
+                secret_store,
+                default_store_name,
+            )
+        }
         Some((SecretPathSegment::Field(name), rest)) => {
             let next_path = join_field(rendered_path, name.as_ref());
             let child = node
@@ -67,6 +82,26 @@ fn resolve_field(
                 .ok_or_else(|| missing_path(&next_path))?;
             if child.is_null() {
                 return Err(missing_path(&next_path));
+            }
+            resolve_field(
+                child,
+                field,
+                rest,
+                &next_path,
+                secret_store,
+                default_store_name,
+            )
+        }
+        Some((SecretPathSegment::OptionalField(name), rest)) => {
+            let next_path = join_field(rendered_path, name.as_ref());
+            let Some(child) = node
+                .as_object_mut()
+                .and_then(|object| object.get_mut(name.as_ref()))
+            else {
+                return Ok(());
+            };
+            if child.is_null() {
+                return Ok(());
             }
             resolve_field(
                 child,
@@ -217,6 +252,14 @@ mod tests {
                         SecretPathSegment::Field("optional".into()),
                     ],
                 },
+                SecretField {
+                    kind: SecretKind::KeyInDefault,
+                    optional: false,
+                    path: vec![
+                        SecretPathSegment::OptionalField("feature".into()),
+                        SecretPathSegment::Field("credential".into()),
+                    ],
+                },
             ]
         }
     }
@@ -226,6 +269,7 @@ mod tests {
             values: BTreeMap::from([
                 ("token-a".to_owned(), b"resolved-a".to_vec()),
                 ("token-b".to_owned(), b"resolved-b".to_vec()),
+                ("feature-key".to_owned(), b"resolved-feature".to_vec()),
             ]),
         }
     }
@@ -245,6 +289,24 @@ mod tests {
         assert_eq!(data["outer"][0]["token"], "resolved-a");
         assert_eq!(data["outer"][1]["token"], "resolved-b");
         assert!(data["outer"][0]["optional"].is_null());
+    }
+
+    #[test]
+    fn resolves_present_and_skips_absent_optional_intermediate() {
+        let mut absent = serde_json::json!({
+            "outer": [{"token": "token-a"}]
+        });
+        resolve_secret_references::<Fixture>(&mut absent, &store(), &StoreName::from("secrets"))
+            .expect("should skip absent optional intermediate");
+
+        let mut present = serde_json::json!({
+            "outer": [{"token": "token-a"}],
+            "feature": {"credential": "feature-key"}
+        });
+        resolve_secret_references::<Fixture>(&mut present, &store(), &StoreName::from("secrets"))
+            .expect("should resolve present optional intermediate");
+
+        assert_eq!(present["feature"]["credential"], "resolved-feature");
     }
 
     #[test]

--- a/crates/trusted-server-core/src/secret_resolution.rs
+++ b/crates/trusted-server-core/src/secret_resolution.rs
@@ -5,7 +5,7 @@
 //! in-memory value used to build runtime [`crate::settings::Settings`].
 
 use edgezero_core::app_config::{AppConfigMeta, SecretField, SecretKind, SecretPathSegment};
-use error_stack::Report;
+use error_stack::{Report, ResultExt as _};
 use serde_json::Value;
 
 use crate::error::TrustedServerError;
@@ -163,10 +163,11 @@ fn resolve_leaf(
 
     let resolved = secret_store
         .get_string(default_store_name, &key_name)
-        .map_err(|_| {
-            configuration_error(format!(
-                "failed to resolve secret reference at `{leaf_path}`"
-            ))
+        .change_context(TrustedServerError::Configuration {
+            message: format!(
+                "failed to resolve secret reference at `{leaf_path}` from secret store \
+                 `{default_store_name}` key `{key_name}`"
+            ),
         })?;
     if resolved.is_empty() {
         return Err(configuration_error(format!(
@@ -318,6 +319,28 @@ mod tests {
 
         assert!(err.to_string().contains("outer[0].token"));
         assert!(!err.to_string().contains("resolved-a"));
+    }
+
+    #[test]
+    fn failed_lookup_reports_safe_reference_context_without_secret_values() {
+        let mut data = serde_json::json!({"outer": [{"token": "missing-secret-key"}]});
+        let store = MemorySecretStore {
+            values: BTreeMap::from([(
+                "fixture-secret-key".to_owned(),
+                b"fixture-secret-value".to_vec(),
+            )]),
+        };
+
+        let err =
+            resolve_secret_references::<Fixture>(&mut data, &store, &StoreName::from("secrets"))
+                .expect_err("should reject a missing secret key");
+        let diagnostic = format!("{err:?}");
+
+        assert!(diagnostic.contains("outer[0].token"));
+        assert!(diagnostic.contains("secrets"));
+        assert!(diagnostic.contains("missing-secret-key"));
+        assert!(diagnostic.contains("missing test secret"));
+        assert!(!diagnostic.contains("fixture-secret-value"));
     }
 
     #[test]

--- a/crates/trusted-server-core/src/secret_resolution.rs
+++ b/crates/trusted-server-core/src/secret_resolution.rs
@@ -1,0 +1,301 @@
+//! Runtime resolution of `EdgeZero` app-config secret references.
+//!
+//! Config blobs carry secret-store key names at rest. This module walks the
+//! public `EdgeZero` metadata contract and replaces those names only in the
+//! in-memory value used to build runtime [`crate::settings::Settings`].
+
+use edgezero_core::app_config::{AppConfigMeta, SecretField, SecretKind, SecretPathSegment};
+use error_stack::Report;
+use serde_json::Value;
+
+use crate::error::TrustedServerError;
+use crate::platform::{PlatformSecretStore, StoreName};
+
+/// Resolve all secret references in a serialized Trusted Server app config.
+///
+/// The input is mutated in memory; the verified envelope is never rewritten.
+/// Secret values are not included in structural or platform errors.
+///
+/// # Errors
+///
+/// Returns [`TrustedServerError::Configuration`] when a required path or key
+/// is malformed, a secret is unavailable, is not valid UTF-8, or resolves to an
+/// empty value.
+pub fn resolve_secret_references<C: AppConfigMeta>(
+    data: &mut Value,
+    secret_store: &dyn PlatformSecretStore,
+    default_store_name: &StoreName,
+) -> Result<(), Report<TrustedServerError>> {
+    for field in C::secret_fields() {
+        if matches!(field.kind, SecretKind::StoreRef) {
+            continue;
+        }
+        resolve_field(
+            data,
+            &field,
+            &field.path,
+            "",
+            secret_store,
+            default_store_name,
+        )?;
+    }
+    Ok(())
+}
+
+fn resolve_field(
+    node: &mut Value,
+    field: &SecretField,
+    remaining: &[SecretPathSegment],
+    rendered_path: &str,
+    secret_store: &dyn PlatformSecretStore,
+    default_store_name: &StoreName,
+) -> Result<(), Report<TrustedServerError>> {
+    match remaining.split_first() {
+        Some((SecretPathSegment::Field(name), [])) => resolve_leaf(
+            node,
+            field,
+            name.as_ref(),
+            rendered_path,
+            secret_store,
+            default_store_name,
+        ),
+        Some((SecretPathSegment::Field(name), rest)) => {
+            let next_path = join_field(rendered_path, name.as_ref());
+            let child = node
+                .as_object_mut()
+                .and_then(|object| object.get_mut(name.as_ref()))
+                .ok_or_else(|| missing_path(&next_path))?;
+            if child.is_null() {
+                return Err(missing_path(&next_path));
+            }
+            resolve_field(
+                child,
+                field,
+                rest,
+                &next_path,
+                secret_store,
+                default_store_name,
+            )
+        }
+        Some((SecretPathSegment::ArrayEach, rest)) => {
+            let items = node.as_array_mut().ok_or_else(|| {
+                configuration_error(format!("expected an array at `{rendered_path}`"))
+            })?;
+            for (index, item) in items.iter_mut().enumerate() {
+                let indexed_path = format!("{rendered_path}[{index}]");
+                resolve_field(
+                    item,
+                    field,
+                    rest,
+                    &indexed_path,
+                    secret_store,
+                    default_store_name,
+                )?;
+            }
+            Ok(())
+        }
+        None => Ok(()),
+    }
+}
+
+fn resolve_leaf(
+    parent: &mut Value,
+    field: &SecretField,
+    key: &str,
+    rendered_parent: &str,
+    secret_store: &dyn PlatformSecretStore,
+    default_store_name: &StoreName,
+) -> Result<(), Report<TrustedServerError>> {
+    let leaf_path = join_field(rendered_parent, key);
+    let object = parent.as_object_mut().ok_or_else(|| {
+        configuration_error(format!("expected an object containing `{leaf_path}`"))
+    })?;
+
+    let key_name = match object.get(key) {
+        Some(Value::String(value)) if !value.is_empty() => value.clone(),
+        Some(Value::Null) | None if field.optional => return Ok(()),
+        Some(Value::String(_)) => {
+            return Err(configuration_error(format!(
+                "secret key reference at `{leaf_path}` must not be empty"
+            )));
+        }
+        _ => {
+            return Err(configuration_error(format!(
+                "secret key reference at `{leaf_path}` must be a string"
+            )));
+        }
+    };
+
+    let resolved = secret_store
+        .get_string(default_store_name, &key_name)
+        .map_err(|_| {
+            configuration_error(format!(
+                "failed to resolve secret reference at `{leaf_path}`"
+            ))
+        })?;
+    if resolved.is_empty() {
+        return Err(configuration_error(format!(
+            "resolved secret at `{leaf_path}` must not be empty"
+        )));
+    }
+
+    object.insert(key.to_owned(), Value::String(resolved));
+    Ok(())
+}
+
+fn join_field(prefix: &str, field: &str) -> String {
+    if prefix.is_empty() {
+        field.to_owned()
+    } else {
+        format!("{prefix}.{field}")
+    }
+}
+
+fn missing_path(path: &str) -> Report<TrustedServerError> {
+    configuration_error(format!("missing required secret path `{path}`"))
+}
+
+fn configuration_error(message: String) -> Report<TrustedServerError> {
+    Report::new(TrustedServerError::Configuration { message })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::{PlatformError, StoreId};
+    use std::collections::BTreeMap;
+
+    struct MemorySecretStore {
+        values: BTreeMap<String, Vec<u8>>,
+    }
+
+    impl PlatformSecretStore for MemorySecretStore {
+        fn get_bytes(
+            &self,
+            _store_name: &StoreName,
+            key: &str,
+        ) -> Result<Vec<u8>, Report<PlatformError>> {
+            self.values.get(key).cloned().ok_or_else(|| {
+                Report::new(PlatformError::SecretStore).attach("missing test secret")
+            })
+        }
+
+        fn create(
+            &self,
+            _store_id: &StoreId,
+            _name: &str,
+            _value: &str,
+        ) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+
+        fn delete(&self, _store_id: &StoreId, _name: &str) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+    }
+
+    struct Fixture;
+
+    impl AppConfigMeta for Fixture {
+        fn secret_fields() -> Vec<SecretField> {
+            vec![
+                SecretField {
+                    kind: SecretKind::KeyInDefault,
+                    optional: false,
+                    path: vec![
+                        SecretPathSegment::Field("outer".into()),
+                        SecretPathSegment::ArrayEach,
+                        SecretPathSegment::Field("token".into()),
+                    ],
+                },
+                SecretField {
+                    kind: SecretKind::KeyInDefault,
+                    optional: true,
+                    path: vec![
+                        SecretPathSegment::Field("outer".into()),
+                        SecretPathSegment::ArrayEach,
+                        SecretPathSegment::Field("optional".into()),
+                    ],
+                },
+            ]
+        }
+    }
+
+    fn store() -> MemorySecretStore {
+        MemorySecretStore {
+            values: BTreeMap::from([
+                ("token-a".to_owned(), b"resolved-a".to_vec()),
+                ("token-b".to_owned(), b"resolved-b".to_vec()),
+            ]),
+        }
+    }
+
+    #[test]
+    fn resolves_nested_array_values_and_skips_optional_nulls() {
+        let mut data = serde_json::json!({
+            "outer": [
+                {"token": "token-a", "optional": null},
+                {"token": "token-b"}
+            ]
+        });
+
+        resolve_secret_references::<Fixture>(&mut data, &store(), &StoreName::from("secrets"))
+            .expect("should resolve nested array secrets");
+
+        assert_eq!(data["outer"][0]["token"], "resolved-a");
+        assert_eq!(data["outer"][1]["token"], "resolved-b");
+        assert!(data["outer"][0]["optional"].is_null());
+    }
+
+    #[test]
+    fn rejects_missing_required_path_without_secret_values() {
+        let mut data = serde_json::json!({"outer": [{}]});
+        let err =
+            resolve_secret_references::<Fixture>(&mut data, &store(), &StoreName::from("secrets"))
+                .expect_err("should reject missing required secret path");
+
+        assert!(err.to_string().contains("outer[0].token"));
+        assert!(!err.to_string().contains("resolved-a"));
+    }
+
+    #[test]
+    fn rejects_malformed_array_path_without_resolving_values() {
+        let mut data = serde_json::json!({"outer": {"token": "token-a"}});
+        let err =
+            resolve_secret_references::<Fixture>(&mut data, &store(), &StoreName::from("secrets"))
+                .expect_err("should reject a non-array intermediate path");
+
+        assert!(err.to_string().contains("expected an array"));
+        assert!(!err.to_string().contains("resolved-a"));
+    }
+
+    #[test]
+    fn rejects_invalid_utf8_and_empty_resolved_values() {
+        let mut invalid = store();
+        invalid.values.insert("token-a".to_owned(), vec![0xff]);
+        let mut data = serde_json::json!({"outer": [{"token": "token-a"}]});
+        let err =
+            resolve_secret_references::<Fixture>(&mut data, &invalid, &StoreName::from("secrets"))
+                .expect_err("should reject invalid UTF-8");
+        assert!(err.to_string().contains("outer[0].token"));
+
+        let empty = MemorySecretStore {
+            values: BTreeMap::from([("token-a".to_owned(), Vec::new())]),
+        };
+        let mut data = serde_json::json!({"outer": [{"token": "token-a"}]});
+        let err =
+            resolve_secret_references::<Fixture>(&mut data, &empty, &StoreName::from("secrets"))
+                .expect_err("should reject empty resolved value");
+        assert!(err.to_string().contains("outer[0].token"));
+    }
+
+    #[test]
+    fn does_not_mutate_data_when_resolution_fails() {
+        let mut data = serde_json::json!({"outer": [{"token": "missing"}]});
+        let original = data.clone();
+        let result =
+            resolve_secret_references::<Fixture>(&mut data, &store(), &StoreName::from("secrets"));
+        assert!(result.is_err(), "should fail for missing secret key");
+        assert_eq!(data, original, "should preserve unresolved data on failure");
+    }
+}

--- a/crates/trusted-server-core/src/secret_resolution.rs
+++ b/crates/trusted-server-core/src/secret_resolution.rs
@@ -129,6 +129,10 @@ fn resolve_field(
             }
             Ok(())
         }
+        Some(_) => Err(configuration_error(format!(
+            "unsupported secret path segment in `{}`",
+            field.dotted_path()
+        ))),
         None => Ok(()),
     }
 }

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -2714,7 +2714,7 @@ pub struct TrustedClientIpConfig {
     /// Header containing the shared-secret authentication value.
     pub auth_header: String,
     /// Shared secret required before accepting the forwarded client IP address.
-    #[validate(custom(function = validate_redacted_not_empty))]
+    #[validate(custom(function = validate_trusted_client_ip_shared_secret))]
     pub shared_secret: Redacted<String>,
 }
 
@@ -2788,7 +2788,13 @@ fn validate_trusted_client_ip(config: &TrustedClientIpConfig) -> Result<(), Vali
         return Err(ValidationError::new("unsafe_trusted_client_ip_auth_header"));
     }
 
-    let shared_secret = config.shared_secret.expose();
+    Ok(())
+}
+
+fn validate_trusted_client_ip_shared_secret(
+    shared_secret: &Redacted<String>,
+) -> Result<(), ValidationError> {
+    let shared_secret = shared_secret.expose();
     if shared_secret.len() < TrustedClientIpConfig::MIN_SHARED_SECRET_LENGTH {
         return Err(ValidationError::new(
             "short_trusted_client_ip_shared_secret",

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -2899,21 +2899,27 @@ impl Settings {
         Self::finalize_deserialized(settings, "Build-time configuration")
     }
 
+    pub(crate) fn normalize_deserialized(&mut self) {
+        self.cache.normalize();
+        self.proxy.normalize();
+        self.image_optimizer.normalize();
+        self.debug.auction_html_comment_options.normalize();
+        self.consent.validate();
+    }
+
     pub(crate) fn finalize_deserialized(
         mut settings: Self,
         validation_label: &str,
     ) -> Result<Self, Report<TrustedServerError>> {
-        settings.cache.normalize();
-        settings.proxy.normalize();
-        settings.image_optimizer.normalize();
-        settings.debug.auction_html_comment_options.normalize();
-        settings.consent.validate();
-
+        settings.normalize_deserialized();
         settings.prepare_runtime()?;
 
         settings.validate().map_err(|err| {
             Report::new(TrustedServerError::Configuration {
-                message: format!("{validation_label} validation failed: {err}"),
+                message: format!(
+                    "{validation_label} validation failed: {}",
+                    validation_error_summary(&err)
+                ),
             })
         })?;
 
@@ -3216,7 +3222,7 @@ impl Settings {
     ///
     /// Returns [`TrustedServerError::Configuration`] listing any uncovered
     /// admin endpoints.
-    fn validate_admin_coverage(&self) -> Result<(), Report<TrustedServerError>> {
+    pub(crate) fn validate_admin_coverage(&self) -> Result<(), Report<TrustedServerError>> {
         let uncovered = self.uncovered_admin_endpoints()?;
         if uncovered.is_empty() {
             return Ok(());
@@ -3238,7 +3244,9 @@ impl Settings {
     /// regexes, so a narrow handler can shadow the admin namespace for paths no
     /// probe enumerates. Handlers are Trusted Server's own basic-auth gates, so
     /// a placeholder password is never valid on any of them.
-    fn validate_admin_handler_passwords(&self) -> Result<(), Report<TrustedServerError>> {
+    pub(crate) fn validate_admin_handler_passwords(
+        &self,
+    ) -> Result<(), Report<TrustedServerError>> {
         for handler in &self.handlers {
             if is_admin_placeholder_password(handler.password.expose()) {
                 return Err(Report::new(TrustedServerError::Configuration {
@@ -3331,6 +3339,47 @@ fn validate_host_header_override(value: &str) -> Result<(), ValidationError> {
     }
 
     Ok(())
+}
+
+fn validation_error_summary(errors: &validator::ValidationErrors) -> String {
+    fn walk(errors: &validator::ValidationErrors, prefix: &str, messages: &mut Vec<String>) {
+        let mut fields = errors
+            .errors()
+            .keys()
+            .map(AsRef::as_ref)
+            .collect::<Vec<_>>();
+        fields.sort_unstable();
+
+        for field in fields {
+            let path = if prefix.is_empty() {
+                field.to_owned()
+            } else {
+                format!("{prefix}.{field}")
+            };
+            let Some(kind) = errors.errors().get(field) else {
+                continue;
+            };
+            match kind {
+                validator::ValidationErrorsKind::Field(validations) => {
+                    for validation in validations {
+                        messages.push(format!("{path}: {}", validation.code));
+                    }
+                }
+                validator::ValidationErrorsKind::Struct(inner) => {
+                    walk(inner, &path, messages);
+                }
+                validator::ValidationErrorsKind::List(items) => {
+                    for (index, inner) in items {
+                        walk(inner, &format!("{path}[{index}]"), messages);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut messages = Vec::new();
+    walk(errors, "", &mut messages);
+    messages.join(", ")
 }
 
 fn validate_redacted_not_empty(value: &Redacted<String>) -> Result<(), ValidationError> {

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -352,7 +352,7 @@ impl DerefMut for IntegrationSettings {
 /// A partner (SSP, DSP, identity vendor) configured in `[[ec.partners]]`.
 ///
 /// Partners are defined statically in `trusted-server.toml` rather than
-/// registered via API. At startup, each partner's `api_token` is hashed
+/// registered via API. At startup, each configured `api_token` is hashed
 /// (SHA-256) for O(1) auth lookups; the plaintext is never stored at runtime.
 #[derive(Debug, Clone, Deserialize, Serialize, Validate)]
 #[serde(deny_unknown_fields)]
@@ -374,9 +374,12 @@ pub struct EcPartner {
     /// Whether this partner's UIDs appear in auction `user.eids`.
     #[serde(default, deserialize_with = "from_value_or_str")]
     pub bidstream_enabled: bool,
-    /// Plaintext API token. Hashed at startup for auth lookups.
-    /// Used by batch sync (inbound) and identify (inbound).
-    pub api_token: Redacted<String>,
+    /// Plaintext API token used by inbound batch sync and identify requests.
+    ///
+    /// When present, the token is hashed at startup for auth lookups. Omitting
+    /// it disables inbound partner API authentication for this partner.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_token: Option<Redacted<String>>,
     /// Max batch sync API requests per partner per minute.
     #[serde(
         default = "EcPartner::default_batch_rate_limit",
@@ -3046,7 +3049,11 @@ impl Settings {
             insecure_fields.push("trusted_client_ip.shared_secret".to_owned());
         }
         for partner in &self.ec.partners {
-            if EcPartner::is_placeholder_api_token(partner.api_token.expose()) {
+            if partner
+                .api_token
+                .as_ref()
+                .is_some_and(|token| EcPartner::is_placeholder_api_token(token.expose()))
+            {
                 insecure_fields.push(format!("ec.partners[{}].api_token", partner.source_domain));
             }
         }
@@ -5164,6 +5171,24 @@ origin_host_header_overide = "www.example.com""#,
     }
 
     #[test]
+    fn ec_partner_api_token_can_be_omitted() {
+        let partner: EcPartner = toml::from_str(
+            r#"
+name = "Example Partner"
+source_domain = "partner.example.com"
+"#,
+        )
+        .expect("should deserialize partner without API token");
+
+        assert!(partner.api_token.is_none(), "should omit API token");
+        let serialized = serde_json::to_value(partner).expect("should serialize partner");
+        assert!(
+            serialized.get("api_token").is_none(),
+            "should not serialize an omitted API token"
+        );
+    }
+
+    #[test]
     fn validate_passphrase_rejects_under_32_characters() {
         let passphrase = Redacted::new("a".repeat(31));
 
@@ -5645,7 +5670,14 @@ origin_host_header_overide = "www.example.com""#,
                 );
                 assert_eq!(settings.ec.partners[0].openrtb_atype, 571187);
                 assert!(settings.ec.partners[0].bidstream_enabled);
-                assert_eq!(settings.ec.partners[0].api_token.expose(), "env-token-0");
+                assert_eq!(
+                    settings.ec.partners[0]
+                        .api_token
+                        .as_ref()
+                        .map(Redacted::expose)
+                        .map(String::as_str),
+                    Some("env-token-0")
+                );
                 assert_eq!(settings.ec.partners[1].name, "Env Partner 1");
                 assert_eq!(
                     settings.ec.partners[1].source_domain,
@@ -5653,7 +5685,14 @@ origin_host_header_overide = "www.example.com""#,
                 );
                 assert_eq!(settings.ec.partners[1].openrtb_atype, 3);
                 assert!(!settings.ec.partners[1].bidstream_enabled);
-                assert_eq!(settings.ec.partners[1].api_token.expose(), "env-token-1");
+                assert_eq!(
+                    settings.ec.partners[1]
+                        .api_token
+                        .as_ref()
+                        .map(Redacted::expose)
+                        .map(String::as_str),
+                    Some("env-token-1")
+                );
             },
         );
     }

--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -211,10 +211,21 @@ impl Publisher {
     }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[derive(Default, Clone, Deserialize, Serialize)]
 pub struct IntegrationSettings {
     #[serde(flatten)]
     entries: HashMap<String, JsonValue>,
+}
+
+impl std::fmt::Debug for IntegrationSettings {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut integration_ids = self.entries.keys().collect::<Vec<_>>();
+        integration_ids.sort_unstable();
+        formatter
+            .debug_struct("IntegrationSettings")
+            .field("integration_ids", &integration_ids)
+            .finish()
+    }
 }
 
 pub trait IntegrationConfig: DeserializeOwned + Validate {
@@ -249,6 +260,29 @@ impl IntegrationSettings {
             .and_then(|map| map.get("enabled"))
             .and_then(JsonValue::as_bool)
             == Some(false)
+    }
+
+    fn remove_legacy_static_secret_store_selectors(&mut self) {
+        let Some(datadome) = self
+            .entries
+            .get_mut("datadome")
+            .and_then(JsonValue::as_object_mut)
+        else {
+            return;
+        };
+
+        let mut removed = datadome.remove("server_side_key_secret_store").is_some();
+        if let Some(bypass) = datadome
+            .get_mut("protection_test_bypass")
+            .and_then(JsonValue::as_object_mut)
+        {
+            removed |= bypass.remove("credential_secret_store").is_some();
+        }
+        if removed {
+            log::warn!(
+                "DataDome secret-store selectors are deprecated and ignored; static credentials resolve through the default app-config secret store"
+            );
+        }
     }
 
     /// Retrieves and validates a typed configuration for an integration.
@@ -712,16 +746,12 @@ fn default_request_signing_enabled() -> bool {
     false
 }
 
-fn default_s3_secret_store() -> String {
-    "s3-auth".to_string()
+fn default_s3_access_key_id() -> Redacted<String> {
+    Redacted::new("access_key_id".to_string())
 }
 
-fn default_s3_access_key_id() -> String {
-    "access_key_id".to_string()
-}
-
-fn default_s3_secret_access_key() -> String {
-    "secret_access_key".to_string()
+fn default_s3_secret_access_key() -> Redacted<String> {
+    Redacted::new("secret_access_key".to_string())
 }
 
 fn default_asset_image_optimizer_enabled() -> bool {
@@ -808,25 +838,25 @@ impl AssetOriginAuth {
 /// AWS Signature Version 4 configuration for `S3` asset origins.
 ///
 /// The route `origin_url` must use the same `S3` host that `AWS` validates in
-/// the `SigV4` canonical request. Credentials are read from the named runtime
-/// secret store and cached per process by configured secret names.
+/// the `SigV4` canonical request. Credential fields hold secret-store key names
+/// in app config and resolved values at runtime.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct S3SigV4AuthConfig {
     /// `AWS` region used in the credential scope.
     pub region: String,
-    /// Runtime secret store containing `S3` credentials.
-    #[serde(default = "default_s3_secret_store")]
-    pub secret_store: String,
-    /// Secret name containing the `AWS` access key ID.
+    /// Deprecated per-route store selector accepted for migration only.
+    #[serde(default, skip_serializing)]
+    pub secret_store: Option<String>,
+    /// Secret reference containing the `AWS` access key ID.
     #[serde(default = "default_s3_access_key_id")]
-    pub access_key_id: String,
-    /// Secret name containing the `AWS` secret access key.
+    pub access_key_id: Redacted<String>,
+    /// Secret reference containing the `AWS` secret access key.
     #[serde(default = "default_s3_secret_access_key")]
-    pub secret_access_key: String,
-    /// Optional secret name containing an `AWS` session token.
+    pub secret_access_key: Redacted<String>,
+    /// Optional secret reference containing an `AWS` session token.
     #[serde(default)]
-    pub session_token: Option<String>,
+    pub session_token: Option<Redacted<String>>,
     /// Query-string handling policy for the signed `S3` origin request.
     ///
     /// Set this to `strip` when request query parameters are transformation
@@ -845,14 +875,17 @@ fn s3_region_is_valid(region: &str) -> bool {
 impl S3SigV4AuthConfig {
     fn normalize(&mut self) {
         self.region = self.region.trim().to_string();
-        self.secret_store = self.secret_store.trim().to_string();
-        self.access_key_id = self.access_key_id.trim().to_string();
-        self.secret_access_key = self.secret_access_key.trim().to_string();
-        self.session_token = self
-            .session_token
-            .take()
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty());
+        if self.secret_store.take().is_some() {
+            log::warn!(
+                "S3 secret_store is deprecated and ignored; static credentials resolve through the default app-config secret store"
+            );
+        }
+        self.access_key_id = Redacted::new(self.access_key_id.expose().trim().to_string());
+        self.secret_access_key = Redacted::new(self.secret_access_key.expose().trim().to_string());
+        self.session_token = self.session_token.take().and_then(|value| {
+            let value = value.expose().trim().to_string();
+            (!value.is_empty()).then(|| Redacted::new(value))
+        });
     }
 
     fn prepare_runtime(&self) -> Result<(), Report<TrustedServerError>> {
@@ -868,12 +901,9 @@ impl S3SigV4AuthConfig {
                         .to_string(),
             }));
         }
-        if self.secret_store.is_empty()
-            || self.access_key_id.is_empty()
-            || self.secret_access_key.is_empty()
-        {
+        if self.access_key_id.expose().is_empty() || self.secret_access_key.expose().is_empty() {
             return Err(Report::new(TrustedServerError::Configuration {
-                message: "proxy.asset_routes auth s3_sigv4 secret names must not be empty"
+                message: "proxy.asset_routes auth s3_sigv4 credentials must not be empty after secret resolution"
                     .to_string(),
             }));
         }
@@ -1793,15 +1823,15 @@ pub struct TinybirdSettings {
     /// Regional Tinybird API host, without scheme or path.
     #[serde(default)]
     pub api_host: String,
-    /// Fastly Secret Store name containing Tinybird append tokens.
-    #[serde(default = "default_tinybird_secret_store")]
-    pub secret_store: String,
+    /// Deprecated feature-specific store selector accepted for migration only.
+    #[serde(default, skip_serializing)]
+    pub secret_store: Option<String>,
     /// Auction Events API datasource name.
     #[serde(default = "default_tinybird_auction_dataset")]
     pub auction_dataset: String,
-    /// Secret key containing the auction datasource APPEND token.
-    #[serde(default = "default_tinybird_auction_token_secret")]
-    pub auction_token_secret: String,
+    /// Secret reference containing the auction datasource APPEND token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auction_token_secret: Option<Redacted<String>>,
     /// Reserved for future access-log telemetry.
     ///
     /// `true` is rejected until an access-log emitter is wired, so operators
@@ -1811,9 +1841,9 @@ pub struct TinybirdSettings {
     /// Future access-log Events API datasource name.
     #[serde(default = "default_tinybird_access_dataset")]
     pub access_dataset: String,
-    /// Future Secret Store key containing the access-log datasource APPEND token.
-    #[serde(default = "default_tinybird_access_token_secret")]
-    pub access_token_secret: String,
+    /// Deprecated placeholder for the unwired access-log APPEND token.
+    #[serde(default, skip_serializing)]
+    pub access_token_secret: Option<Redacted<String>>,
     /// Future fraction of requests to emit for optional access telemetry.
     #[serde(default)]
     pub access_sample_rate: f64,
@@ -1822,24 +1852,12 @@ pub struct TinybirdSettings {
     pub max_body_bytes: usize,
 }
 
-fn default_tinybird_secret_store() -> String {
-    "ts_secrets".to_owned()
-}
-
 fn default_tinybird_auction_dataset() -> String {
     "auction_events_raw".to_owned()
 }
 
-fn default_tinybird_auction_token_secret() -> String {
-    "tinybird_auction_append_token".to_owned()
-}
-
 fn default_tinybird_access_dataset() -> String {
     "access_logs_raw".to_owned()
-}
-
-fn default_tinybird_access_token_secret() -> String {
-    "tinybird_access_append_token".to_owned()
 }
 
 fn default_tinybird_max_body_bytes() -> usize {
@@ -1851,12 +1869,12 @@ impl Default for TinybirdSettings {
         Self {
             enabled: false,
             api_host: String::new(),
-            secret_store: default_tinybird_secret_store(),
+            secret_store: None,
             auction_dataset: default_tinybird_auction_dataset(),
-            auction_token_secret: default_tinybird_auction_token_secret(),
+            auction_token_secret: None,
             access_enabled: false,
             access_dataset: default_tinybird_access_dataset(),
-            access_token_secret: default_tinybird_access_token_secret(),
+            access_token_secret: None,
             access_sample_rate: 0.0,
             max_body_bytes: default_tinybird_max_body_bytes(),
         }
@@ -1866,11 +1884,18 @@ impl Default for TinybirdSettings {
 impl TinybirdSettings {
     fn normalize(&mut self) {
         self.api_host = self.api_host.trim().to_ascii_lowercase();
-        self.secret_store = self.secret_store.trim().to_owned();
+        if self.secret_store.take().is_some() {
+            log::warn!(
+                "tinybird.secret_store is deprecated and ignored; static credentials resolve through the default app-config secret store"
+            );
+        }
         self.auction_dataset = self.auction_dataset.trim().to_owned();
-        self.auction_token_secret = self.auction_token_secret.trim().to_owned();
+        self.auction_token_secret = self.auction_token_secret.take().and_then(|value| {
+            let value = value.expose().trim().to_owned();
+            (!value.is_empty()).then(|| Redacted::new(value))
+        });
         self.access_dataset = self.access_dataset.trim().to_owned();
-        self.access_token_secret = self.access_token_secret.trim().to_owned();
+        self.access_token_secret = None;
     }
 
     fn prepare_runtime(&mut self) -> Result<(), Report<TrustedServerError>> {
@@ -1894,18 +1919,15 @@ impl TinybirdSettings {
             return Ok(());
         }
         validate_tinybird_api_host(&self.api_host)?;
-        if self.secret_store.is_empty() {
-            return Err(Report::new(TrustedServerError::Configuration {
+        validate_tinybird_dataset(&self.auction_dataset, "tinybird.auction_dataset")?;
+        let token = self.auction_token_secret.as_ref().ok_or_else(|| {
+            Report::new(TrustedServerError::Configuration {
                 message:
-                    "tinybird.secret_store must not be empty when Tinybird telemetry is enabled"
+                    "tinybird.auction_token_secret is required when Tinybird telemetry is enabled"
                         .to_owned(),
-            }));
-        }
-        if self.enabled {
-            validate_tinybird_dataset(&self.auction_dataset, "tinybird.auction_dataset")?;
-            validate_tinybird_secret(&self.auction_token_secret, "tinybird.auction_token_secret")?;
-        }
-        Ok(())
+            })
+        })?;
+        validate_tinybird_secret(token.expose(), "tinybird.auction_token_secret")
     }
 }
 
@@ -1946,7 +1968,7 @@ fn validate_tinybird_dataset(value: &str, setting: &str) -> Result<(), Report<Tr
 fn validate_tinybird_secret(value: &str, setting: &str) -> Result<(), Report<TrustedServerError>> {
     if value.is_empty() || value.chars().any(char::is_control) {
         return Err(Report::new(TrustedServerError::Configuration {
-            message: format!("{setting} must be a non-empty Secret Store key"),
+            message: format!("{setting} must be non-empty after secret resolution"),
         }));
     }
     Ok(())
@@ -2904,6 +2926,9 @@ impl Settings {
         self.proxy.normalize();
         self.image_optimizer.normalize();
         self.debug.auction_html_comment_options.normalize();
+        self.tinybird.normalize();
+        self.integrations
+            .remove_legacy_static_secret_store_selectors();
         self.consent.validate();
     }
 
@@ -4315,12 +4340,9 @@ mod tests {
             !settings.tinybird.enabled,
             "Tinybird should default disabled"
         );
-        assert_eq!(settings.tinybird.secret_store, "ts_secrets");
+        assert_eq!(settings.tinybird.secret_store, None);
         assert_eq!(settings.tinybird.auction_dataset, "auction_events_raw");
-        assert_eq!(
-            settings.tinybird.auction_token_secret,
-            "tinybird_auction_append_token"
-        );
+        assert!(settings.tinybird.auction_token_secret.is_none());
     }
 
     #[test]
@@ -4340,7 +4362,7 @@ mod tests {
     #[test]
     fn tinybird_accepts_region_host_without_scheme() {
         let toml = format!(
-            "{}\n[tinybird]\nenabled = true\napi_host = \"api.us-east.aws.tinybird.co\"\n",
+            "{}\n[tinybird]\nenabled = true\napi_host = \"api.us-east.aws.tinybird.co\"\nauction_token_secret = \"test-auction-token\"\n",
             crate_test_settings_str()
         );
 
@@ -6453,9 +6475,9 @@ origin_host_header_overide = "www.example.com""#,
         match route.auth.as_ref().expect("should configure route auth") {
             AssetOriginAuth::S3SigV4(config) => {
                 assert_eq!(config.region, "us-east-1");
-                assert_eq!(config.secret_store, "s3-auth");
-                assert_eq!(config.access_key_id, "access_key_id");
-                assert_eq!(config.secret_access_key, "secret_access_key");
+                assert_eq!(config.secret_store, None);
+                assert_eq!(config.access_key_id.expose(), "access_key_id");
+                assert_eq!(config.secret_access_key.expose(), "secret_access_key");
             }
         }
     }

--- a/crates/trusted-server-core/src/settings_data.rs
+++ b/crates/trusted-server-core/src/settings_data.rs
@@ -9,7 +9,8 @@ use crate::error::TrustedServerError;
 use crate::platform::{PlatformConfigStore, PlatformSecretStore, StoreName};
 use crate::settings::Settings;
 
-const DEFAULT_CONFIG_STORE_ID: &str = "trusted_server_config";
+/// Canonical logical config store used by Trusted Server app config.
+pub const DEFAULT_CONFIG_STORE_ID: &str = "trusted_server_config";
 const FASTLY_CHUNK_POINTER_KIND: &str = "fastly_config_chunks";
 const FASTLY_CONFIG_ENTRY_LIMIT: usize = 8_000;
 

--- a/crates/trusted-server-core/src/settings_data.rs
+++ b/crates/trusted-server-core/src/settings_data.rs
@@ -3,9 +3,10 @@ use error_stack::{Report, ResultExt};
 use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
 
+use crate::config_payload::DEFAULT_SECRET_STORE_ID;
 use crate::config_payload::settings_from_config_blob;
 use crate::error::TrustedServerError;
-use crate::platform::{PlatformConfigStore, StoreName};
+use crate::platform::{PlatformConfigStore, PlatformSecretStore, StoreName};
 use crate::settings::Settings;
 
 const DEFAULT_CONFIG_STORE_ID: &str = "trusted_server_config";
@@ -52,21 +53,29 @@ pub fn default_config_key() -> String {
     config_key(&EnvConfig::from_env())
 }
 
+/// Returns the default `EdgeZero` secret-store name for Trusted Server secrets.
+#[must_use]
+pub fn default_secret_store_name() -> StoreName {
+    StoreName::from(EnvConfig::from_env().store_name("secrets", DEFAULT_SECRET_STORE_ID))
+}
+
 /// Loads [`Settings`] from a platform config store and key.
 ///
 /// # Errors
 ///
 /// Returns [`TrustedServerError::Configuration`] when the config blob is
-/// missing, cannot be read, fails envelope verification, or fails Trusted
-/// Server settings validation.
+/// missing, cannot be read, fails envelope verification, secret resolution,
+/// or Trusted Server settings validation.
 pub fn get_settings_from_config_store(
     config_store: &dyn PlatformConfigStore,
+    secret_store: &dyn PlatformSecretStore,
     store_name: &StoreName,
     key: &str,
+    default_secret_store_name: &StoreName,
 ) -> Result<Settings, Report<TrustedServerError>> {
     let raw_value = read_config_entry(config_store, store_name, key)?;
     let envelope_json = resolve_fastly_chunk_pointer(config_store, store_name, &raw_value)?;
-    settings_from_config_blob(&envelope_json)
+    settings_from_config_blob(&envelope_json, secret_store, default_secret_store_name)
 }
 
 fn read_config_entry(
@@ -189,7 +198,7 @@ fn configuration_error<T>(message: String) -> Result<T, Report<TrustedServerErro
 mod tests {
     use super::*;
     use crate::config_payload::CONFIG_BLOB_KEY;
-    use crate::platform::PlatformError;
+    use crate::platform::{PlatformError, StoreId};
     use crate::settings::Settings;
     use crate::test_support::tests::crate_test_settings_str;
     use edgezero_core::blob_envelope::BlobEnvelope;
@@ -209,18 +218,43 @@ mod tests {
 
         fn put(
             &self,
-            _store_id: &crate::platform::StoreId,
+            _store_id: &StoreId,
             _key: &str,
             _value: &str,
         ) -> Result<(), Report<PlatformError>> {
             Ok(())
         }
 
-        fn delete(
+        fn delete(&self, _store_id: &StoreId, _key: &str) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+    }
+
+    struct EchoSecretStore;
+
+    impl PlatformSecretStore for EchoSecretStore {
+        fn get_bytes(
             &self,
-            _store_id: &crate::platform::StoreId,
-            _key: &str,
+            _store_name: &StoreName,
+            key: &str,
+        ) -> Result<Vec<u8>, Report<PlatformError>> {
+            let value = match key {
+                "unit-test-proxy-secret" => "unit-test-proxy-secret-32-bytes-ok",
+                _ => key,
+            };
+            Ok(value.as_bytes().to_vec())
+        }
+
+        fn create(
+            &self,
+            _store_id: &StoreId,
+            _name: &str,
+            _value: &str,
         ) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+
+        fn delete(&self, _store_id: &StoreId, _name: &str) -> Result<(), Report<PlatformError>> {
             Ok(())
         }
     }
@@ -229,6 +263,20 @@ mod tests {
         let data = serde_json::to_value(settings).expect("should serialize settings to JSON");
         let envelope = BlobEnvelope::new(data, "2026-01-01T00:00:00Z".to_string());
         serde_json::to_string(&envelope).expect("should serialize envelope")
+    }
+
+    fn load_settings(
+        config_store: &dyn PlatformConfigStore,
+        store_name: &StoreName,
+        key: &str,
+    ) -> Result<Settings, Report<TrustedServerError>> {
+        get_settings_from_config_store(
+            config_store,
+            &EchoSecretStore,
+            store_name,
+            key,
+            &StoreName::from("trusted_server_secrets"),
+        )
     }
 
     #[test]
@@ -274,16 +322,16 @@ mod tests {
 
     #[test]
     fn loads_settings_from_config_blob_entry() {
-        let settings =
+        let mut settings =
             Settings::from_toml(&crate_test_settings_str()).expect("should parse test settings");
+        settings.proxy.allowed_domains = vec!["*.example".to_owned(), "*.example.com".to_owned()];
         let envelope_json = envelope_json(&settings);
         let store = MemoryConfigStore {
             entries: BTreeMap::from([(CONFIG_BLOB_KEY.to_string(), envelope_json)]),
         };
 
-        let loaded =
-            get_settings_from_config_store(&store, &StoreName::from("app_config"), CONFIG_BLOB_KEY)
-                .expect("should load settings");
+        let loaded = load_settings(&store, &StoreName::from("app_config"), CONFIG_BLOB_KEY)
+            .expect("should load settings");
 
         assert_eq!(
             loaded.publisher.domain, settings.publisher.domain,
@@ -293,8 +341,9 @@ mod tests {
 
     #[test]
     fn loads_settings_from_fastly_chunk_pointer() {
-        let settings =
+        let mut settings =
             Settings::from_toml(&crate_test_settings_str()).expect("should parse test settings");
+        settings.proxy.allowed_domains = vec!["*.example".to_owned(), "*.example.com".to_owned()];
         let envelope_json = envelope_json(&settings);
         let midpoint = envelope_json.len() / 2;
         let first_chunk = envelope_json[..midpoint].to_string();
@@ -328,9 +377,8 @@ mod tests {
             ]),
         };
 
-        let loaded =
-            get_settings_from_config_store(&store, &StoreName::from("app_config"), CONFIG_BLOB_KEY)
-                .expect("should load settings");
+        let loaded = load_settings(&store, &StoreName::from("app_config"), CONFIG_BLOB_KEY)
+            .expect("should load settings");
 
         assert_eq!(
             loaded.publisher.domain, settings.publisher.domain,
@@ -359,9 +407,8 @@ mod tests {
             entries: BTreeMap::from([(CONFIG_BLOB_KEY.to_string(), pointer)]),
         };
 
-        let err =
-            get_settings_from_config_store(&store, &StoreName::from("app_config"), CONFIG_BLOB_KEY)
-                .expect_err("should reject malformed chunk length metadata");
+        let err = load_settings(&store, &StoreName::from("app_config"), CONFIG_BLOB_KEY)
+            .expect_err("should reject malformed chunk length metadata");
 
         assert!(
             err.to_string().contains("chunk lengths total mismatch"),
@@ -375,9 +422,8 @@ mod tests {
             entries: BTreeMap::new(),
         };
 
-        let err =
-            get_settings_from_config_store(&store, &StoreName::from("app_config"), CONFIG_BLOB_KEY)
-                .expect_err("should fail when blob is missing");
+        let err = load_settings(&store, &StoreName::from("app_config"), CONFIG_BLOB_KEY)
+            .expect_err("should fail when blob is missing");
 
         assert!(
             err.to_string().contains(CONFIG_BLOB_KEY),

--- a/crates/trusted-server-integration-tests/Cargo.toml
+++ b/crates/trusted-server-integration-tests/Cargo.toml
@@ -23,6 +23,7 @@ workspace = true
 [dependencies]
 edgezero-core = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 trusted-server-core = { workspace = true }
 
 [dev-dependencies]
@@ -40,7 +41,6 @@ reqwest = { workspace = true, features = ["blocking", "cookies"] }
 scraper = { workspace = true }
 testcontainers = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-toml = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 trusted-server-adapter-axum = { path = "../trusted-server-adapter-axum" }
 trusted-server-adapter-cloudflare = { path = "../trusted-server-adapter-cloudflare" }

--- a/crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml
+++ b/crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml
@@ -1,16 +1,16 @@
 [[handlers]]
 path = "^/_ts/admin"
 username = "admin"
-password = "integration-admin-password-32-bytes-ok"
+password = "integration_admin_password"
 
 [publisher]
 domain = "localhost"
 cookie_domain = "localhost"
 origin_url = "http://127.0.0.1:8888"
-proxy_secret = "integration-test-proxy-secret"
+proxy_secret = "integration_proxy_secret"
 
 [ec]
-passphrase = "integration-test-ec-secret-padded-32"
+passphrase = "integration_ec_passphrase"
 ec_store = "ec_identity_store"
 pull_sync_concurrency = 3
 
@@ -18,13 +18,13 @@ pull_sync_concurrency = 3
 name = "Integration Test Partner"
 source_domain = "inttest.example.com"
 bidstream_enabled = true
-api_token = "integration-test-token-alpha-32-bytes-ok"
+api_token = "integration_partner_token_alpha"
 
 [[ec.partners]]
 name = "Integration Test Partner 2"
 source_domain = "inttest2.example.com"
 bidstream_enabled = true
-api_token = "integration-test-token-bravo-32-bytes-ok"
+api_token = "integration_partner_token_bravo"
 
 [request_signing]
 enabled = false

--- a/crates/trusted-server-integration-tests/fixtures/configs/viceroy-template.toml
+++ b/crates/trusted-server-integration-tests/fixtures/configs/viceroy-template.toml
@@ -66,23 +66,28 @@
             key = "api_key"
             data = "test-api-key"
 
-        [[local_server.secret_stores.trusted_server_secrets]]
+        [[local_server.secret_stores.ts_secrets]]
             key = "integration_admin_password"
             data = "integration-admin-password-32-bytes-ok"
-        [[local_server.secret_stores.trusted_server_secrets]]
+        [[local_server.secret_stores.ts_secrets]]
             key = "integration_proxy_secret"
             data = "integration-test-proxy-secret-32-bytes-ok"
-        [[local_server.secret_stores.trusted_server_secrets]]
+        [[local_server.secret_stores.ts_secrets]]
             key = "integration_ec_passphrase"
             data = "integration-test-ec-secret-padded-32"
-        [[local_server.secret_stores.trusted_server_secrets]]
+        [[local_server.secret_stores.ts_secrets]]
             key = "integration_partner_token_alpha"
             data = "integration-test-token-alpha-32-bytes-ok"
-        [[local_server.secret_stores.trusted_server_secrets]]
+        [[local_server.secret_stores.ts_secrets]]
             key = "integration_partner_token_bravo"
             data = "integration-test-token-bravo-32-bytes-ok"
 
     [local_server.config_stores]
+        [local_server.config_stores.edgezero_runtime_env]
+            format = "inline-toml"
+        [local_server.config_stores.edgezero_runtime_env.contents]
+            EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME = "ts_secrets"
+
         # Generated integration configs inject the trusted_server_config blob
         # into the store required by the Fastly entry point.
         # GENERATED_TRUSTED_SERVER_CONFIG_STORES

--- a/crates/trusted-server-integration-tests/fixtures/configs/viceroy-template.toml
+++ b/crates/trusted-server-integration-tests/fixtures/configs/viceroy-template.toml
@@ -66,6 +66,22 @@
             key = "api_key"
             data = "test-api-key"
 
+        [[local_server.secret_stores.trusted_server_secrets]]
+            key = "integration_admin_password"
+            data = "integration-admin-password-32-bytes-ok"
+        [[local_server.secret_stores.trusted_server_secrets]]
+            key = "integration_proxy_secret"
+            data = "integration-test-proxy-secret-32-bytes-ok"
+        [[local_server.secret_stores.trusted_server_secrets]]
+            key = "integration_ec_passphrase"
+            data = "integration-test-ec-secret-padded-32"
+        [[local_server.secret_stores.trusted_server_secrets]]
+            key = "integration_partner_token_alpha"
+            data = "integration-test-token-alpha-32-bytes-ok"
+        [[local_server.secret_stores.trusted_server_secrets]]
+            key = "integration_partner_token_bravo"
+            data = "integration-test-token-bravo-32-bytes-ok"
+
     [local_server.config_stores]
         # Generated integration configs inject the trusted_server_config blob
         # into the store required by the Fastly entry point.

--- a/crates/trusted-server-integration-tests/fixtures/configs/viceroy-template.toml
+++ b/crates/trusted-server-integration-tests/fixtures/configs/viceroy-template.toml
@@ -86,7 +86,7 @@
         [local_server.config_stores.edgezero_runtime_env]
             format = "inline-toml"
         [local_server.config_stores.edgezero_runtime_env.contents]
-            EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME = "ts_secrets"
+            EDGEZERO__SERVICES__0000000000000000000000__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME = "ts_secrets"
 
         # Generated integration configs inject the trusted_server_config blob
         # into the store required by the Fastly entry point.

--- a/crates/trusted-server-integration-tests/src/bin/generate-viceroy-config.rs
+++ b/crates/trusted-server-integration-tests/src/bin/generate-viceroy-config.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use edgezero_core::blob_envelope::BlobEnvelope;
-use trusted_server_core::{config::validate_settings_for_deploy, settings::Settings};
+use trusted_server_core::config::TrustedServerAppConfig;
 
 const GENERATED_AT: &str = "2026-06-23T00:00:00Z";
 const GENERATED_STORES_MARKER: &str = "        # GENERATED_TRUSTED_SERVER_CONFIG_STORES";
@@ -114,15 +114,16 @@ fn build_app_config_envelope(
     app_config_toml: &str,
     origin_url: Option<&str>,
 ) -> Result<String, DynError> {
-    let mut settings = Settings::from_toml(app_config_toml)
-        .map_err(|report| error_box(format!("invalid Trusted Server app config: {report:?}")))?;
+    let app_config: TrustedServerAppConfig = toml::from_str(app_config_toml)
+        .map_err(|error| error_box(format!("invalid Trusted Server app config: {error}")))?;
+    let mut settings = app_config.into_settings();
     if let Some(origin_url) = origin_url {
         settings.publisher.origin_url = origin_url.to_string();
     }
-    validate_settings_for_deploy(&settings)
+    let app_config = TrustedServerAppConfig::new(settings)
         .map_err(|report| error_box(format!("invalid Trusted Server app config: {report:?}")))?;
 
-    let data = serde_json::to_value(&settings).map_err(|error| {
+    let data = serde_json::to_value(&app_config).map_err(|error| {
         error_box(format!(
             "failed to serialize Trusted Server app config to JSON: {error}"
         ))
@@ -161,10 +162,70 @@ fn error_box(message: impl Into<String>) -> DynError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use error_stack::Report;
+    use std::collections::HashMap;
     use trusted_server_core::config_payload::settings_from_config_blob;
+    use trusted_server_core::platform::{PlatformError, PlatformSecretStore, StoreId, StoreName};
 
     const TEMPLATE: &str = include_str!("../../fixtures/configs/viceroy-template.toml");
     const APP_CONFIG: &str = include_str!("../../fixtures/configs/trusted-server.integration.toml");
+
+    struct IntegrationSecretStore {
+        values: HashMap<String, Vec<u8>>,
+    }
+
+    impl PlatformSecretStore for IntegrationSecretStore {
+        fn get_bytes(
+            &self,
+            _store_name: &StoreName,
+            key: &str,
+        ) -> Result<Vec<u8>, Report<PlatformError>> {
+            self.values
+                .get(key)
+                .cloned()
+                .ok_or_else(|| Report::new(PlatformError::SecretStore))
+        }
+
+        fn create(
+            &self,
+            _store_id: &StoreId,
+            _name: &str,
+            _value: &str,
+        ) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+
+        fn delete(&self, _store_id: &StoreId, _name: &str) -> Result<(), Report<PlatformError>> {
+            Ok(())
+        }
+    }
+
+    fn integration_secret_store() -> IntegrationSecretStore {
+        IntegrationSecretStore {
+            values: HashMap::from([
+                (
+                    "integration_admin_password".to_owned(),
+                    b"integration-admin-password-32-bytes-ok".to_vec(),
+                ),
+                (
+                    "integration_proxy_secret".to_owned(),
+                    b"integration-test-proxy-secret-32-bytes-ok".to_vec(),
+                ),
+                (
+                    "integration_ec_passphrase".to_owned(),
+                    b"integration-test-ec-secret-padded-32".to_vec(),
+                ),
+                (
+                    "integration_partner_token_alpha".to_owned(),
+                    b"integration-test-token-alpha-32-bytes-ok".to_vec(),
+                ),
+                (
+                    "integration_partner_token_bravo".to_owned(),
+                    b"integration-test-token-bravo-32-bytes-ok".to_vec(),
+                ),
+            ]),
+        }
+    }
 
     #[test]
     fn parse_args_does_not_require_removed_rollout_switch() {
@@ -253,7 +314,12 @@ mod tests {
     fn generated_blob_verifies_and_applies_origin_override() {
         let envelope = build_app_config_envelope(APP_CONFIG, Some("http://127.0.0.1:9999"))
             .expect("should build envelope");
-        let settings = settings_from_config_blob(&envelope).expect("should verify blob");
+        let settings = settings_from_config_blob(
+            &envelope,
+            &integration_secret_store(),
+            &StoreName::from("trusted_server_secrets"),
+        )
+        .expect("should verify blob");
 
         assert_eq!(
             settings.publisher.origin_url, "http://127.0.0.1:9999",
@@ -266,6 +332,19 @@ mod tests {
         let result = build_app_config_envelope("not valid toml", None);
 
         assert!(result.is_err(), "should reject invalid app config");
+    }
+
+    #[test]
+    fn invalid_non_secret_app_config_fails_before_envelope_generation() {
+        let invalid = APP_CONFIG.replace("domain = \"localhost\"", "domain = \"invalid/domain\"");
+
+        let err = build_app_config_envelope(&invalid, None)
+            .expect_err("should reject invalid non-secret config before creating an envelope");
+
+        assert!(
+            err.to_string().contains("invalid_publisher_domain"),
+            "error should identify the structural validation failure: {err}"
+        );
     }
 
     #[test]

--- a/crates/trusted-server-integration-tests/tests/common/config.rs
+++ b/crates/trusted-server-integration-tests/tests/common/config.rs
@@ -1,7 +1,6 @@
 use edgezero_core::blob_envelope::BlobEnvelope;
 use error_stack::Report;
-use trusted_server_core::config::validate_settings_for_deploy;
-use trusted_server_core::settings::Settings;
+use trusted_server_core::config::TrustedServerAppConfig;
 
 use crate::common::runtime::{TestError, TestResult};
 
@@ -10,18 +9,19 @@ const APP_CONFIG: &str = include_str!("../../fixtures/configs/trusted-server.int
 
 pub fn integration_app_config_envelope(origin_port: u16) -> TestResult<String> {
     let origin_url = format!("http://127.0.0.1:{origin_port}");
-    let mut settings = Settings::from_toml(APP_CONFIG).map_err(|report| {
+    let app_config: TrustedServerAppConfig = toml::from_str(APP_CONFIG).map_err(|error| {
         Report::new(TestError::ConfigGeneration).attach(format!(
-            "invalid Trusted Server integration config: {report:?}"
+            "invalid Trusted Server integration config: {error}"
         ))
     })?;
+    let mut settings = app_config.into_settings();
     settings.publisher.origin_url = origin_url;
-    validate_settings_for_deploy(&settings).map_err(|report| {
+    let app_config = TrustedServerAppConfig::new(settings).map_err(|report| {
         Report::new(TestError::ConfigGeneration)
             .attach(format!("invalid generated integration config: {report:?}"))
     })?;
 
-    let data = serde_json::to_value(&settings).map_err(|error| {
+    let data = serde_json::to_value(&app_config).map_err(|error| {
         Report::new(TestError::ConfigGeneration)
             .attach(format!("failed to serialize integration settings: {error}"))
     })?;

--- a/crates/trusted-server-integration-tests/tests/common/config.rs
+++ b/crates/trusted-server-integration-tests/tests/common/config.rs
@@ -69,4 +69,26 @@ mod tests {
             "fastly.toml should preserve the pre-seeded local EC test row"
         );
     }
+
+    #[test]
+    fn local_fastly_config_defines_starter_secret_references() {
+        let parsed: toml::Value =
+            toml::from_str(FASTLY_CONFIG).expect("should parse root fastly.toml");
+        let entries = parsed["local_server"]["secret_stores"]["ts_secrets"]
+            .as_array()
+            .expect("fastly.toml should define ts_secrets");
+
+        for key in [
+            "publisher_proxy_secret",
+            "ec_passphrase",
+            "handler_password",
+        ] {
+            assert!(
+                entries
+                    .iter()
+                    .any(|entry| entry["key"].as_str() == Some(key)),
+                "fastly.toml should define local value for starter secret `{key}`"
+            );
+        }
+    }
 }

--- a/crates/trusted-server-integration-tests/tests/common/config.rs
+++ b/crates/trusted-server-integration-tests/tests/common/config.rs
@@ -45,6 +45,9 @@ pub fn cloudflare_config_json(origin_port: u16) -> TestResult<String> {
 #[cfg(test)]
 mod tests {
     const FASTLY_CONFIG: &str = include_str!("../../../../fastly.toml");
+    const VICEROY_TEMPLATE: &str = include_str!("../../fixtures/configs/viceroy-template.toml");
+    const VICEROY_SECRET_STORE_MAPPING_KEY: &str =
+        "EDGEZERO__SERVICES__0000000000000000000000__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME";
 
     #[test]
     fn local_fastly_config_defines_runtime_kv_stores() {
@@ -68,6 +71,31 @@ mod tests {
             }),
             "fastly.toml should preserve the pre-seeded local EC test row"
         );
+    }
+
+    #[test]
+    fn local_fastly_secret_store_mapping_is_service_scoped() {
+        for (name, config) in [
+            ("fastly.toml", FASTLY_CONFIG),
+            ("Viceroy integration template", VICEROY_TEMPLATE),
+        ] {
+            let parsed: toml::Value =
+                toml::from_str(config).expect("should parse Fastly configuration");
+            let runtime_env =
+                &parsed["local_server"]["config_stores"]["edgezero_runtime_env"]["contents"];
+
+            assert_eq!(
+                runtime_env[VICEROY_SECRET_STORE_MAPPING_KEY].as_str(),
+                Some("ts_secrets"),
+                "{name} should scope the secret-store mapping to Viceroy's service ID"
+            );
+            assert!(
+                runtime_env
+                    .get("EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME")
+                    .is_none(),
+                "{name} should not define the ignored unscoped secret-store mapping"
+            );
+        }
     }
 
     #[test]

--- a/crates/trusted-server-integration-tests/tests/environments/axum.rs
+++ b/crates/trusted-server-integration-tests/tests/environments/axum.rs
@@ -10,6 +10,30 @@ use std::process::{Child, Command, Stdio};
 /// Default port the Axum dev server binds to when no `PORT` env var is supplied.
 const AXUM_DEFAULT_PORT: u16 = 8787;
 
+/// Secret-store entries referenced by the integration app-config fixture.
+const INTEGRATION_SECRET_ENV: &[(&str, &str)] = &[
+    (
+        "TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_INTEGRATION_ADMIN_PASSWORD",
+        "integration-admin-password-32-bytes-ok",
+    ),
+    (
+        "TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_INTEGRATION_PROXY_SECRET",
+        "integration-test-proxy-secret-32-bytes-ok",
+    ),
+    (
+        "TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_INTEGRATION_EC_PASSPHRASE",
+        "integration-test-ec-secret-padded-32",
+    ),
+    (
+        "TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_INTEGRATION_PARTNER_TOKEN_ALPHA",
+        "integration-test-token-alpha-32-bytes-ok",
+    ),
+    (
+        "TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_INTEGRATION_PARTNER_TOKEN_BRAVO",
+        "integration-test-token-bravo-32-bytes-ok",
+    ),
+];
+
 /// Axum native dev-server runtime environment.
 ///
 /// Spawns the pre-built `trusted-server-axum` binary directly (no WASM, no
@@ -40,6 +64,7 @@ impl RuntimeEnvironment for AxumDevServer {
                 "TRUSTED_SERVER_CONFIG_TRUSTED_SERVER_CONFIG_TRUSTED_SERVER_CONFIG",
                 app_config,
             )
+            .envs(INTEGRATION_SECRET_ENV.iter().copied())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -626,10 +626,10 @@ The auction preview validates the stored record and partner configuration, but c
 | `5xx`  | Unexpected configuration or KV failure (plaintext)          |
 
 ```bash
-curl -u admin:secure-password \
+curl -u 'admin:<resolved-admin-password>' \
   "https://edge.example.com/_ts/admin/ec/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.abc123"
 
-curl -u admin:secure-password \
+curl -u 'admin:<resolved-admin-password>' \
   --cookie "ts-ec=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.abc123" \
   "https://edge.example.com/_ts/admin/ec"
 ```
@@ -660,7 +660,7 @@ After successful authentication this endpoint always returns `200 OK`; missing o
 ```
 
 ```bash
-curl -u admin:secure-password \
+curl -u 'admin:<resolved-admin-password>' \
   --cookie "sharedId=fictional-shared-id" \
   "https://edge.example.com/_ts/admin/eids"
 ```
@@ -844,13 +844,16 @@ Endpoints under protected paths require HTTP Basic Authentication:
 [[handlers]]
 path = "^/_ts/admin"
 username = "admin"
-password = "secure-password"
+password = "admin_password"
 ```
+
+`password` is a key in the Trusted Server secret store. Provision the actual
+Basic Authentication password under `admin_password`.
 
 **Usage:**
 
 ```bash
-curl -u admin:secure-password https://edge.example.com/_ts/admin/keys/rotate
+curl -u 'admin:<resolved-admin-password>' https://edge.example.com/_ts/admin/keys/rotate
 ```
 
 **Protected Endpoints:**

--- a/docs/guide/asset-routes.md
+++ b/docs/guide/asset-routes.md
@@ -64,10 +64,9 @@ origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
 type = "s3_sigv4"
 region = "us-east-1"
 origin_query = "strip"
-secret_store = "s3-auth"
-access_key_id = "access_key_id"
-secret_access_key = "secret_access_key"
-# session_token = "session_token"
+access_key_id = "s3_access_key_id"
+secret_access_key = "s3_secret_access_key"
+# session_token = "s3_session_token"
 ```
 
 ### S3 requirements
@@ -77,22 +76,21 @@ secret_access_key = "secret_access_key"
 - S3 support is for `GET` and `HEAD` asset reads.
 - Signing uses header-based AWS SigV4, not presigned URLs.
 - The signer uses `x-amz-content-sha256: UNSIGNED-PAYLOAD`.
-- Credentials are loaded from the configured runtime secret store and cached per process by configured secret names.
+- Credential references resolve from the logical `trusted_server_secrets` store while runtime settings are built. Signing performs no request-time secret-store reads.
 - Successful authenticated S3 responses preserve the origin `Cache-Control`; configure object cache headers intentionally.
 - Existing client `Authorization` and `x-amz-*` signing headers are replaced before signing.
 
 ### Secret store values
 
-The default secret store and key names are:
+Credential fields contain secret key references:
 
-| Config field        | Default value       | Secret value                         |
+| Config field        | Default key         | Resolved value                       |
 | ------------------- | ------------------- | ------------------------------------ |
-| `secret_store`      | `s3-auth`           | Secret store name                    |
 | `access_key_id`     | `access_key_id`     | AWS access key ID                    |
 | `secret_access_key` | `secret_access_key` | AWS secret access key                |
 | `session_token`     | unset               | Optional AWS temporary session token |
 
-Use private deployment configuration for environment-specific store names or profile tables.
+Place those values in the logical `trusted_server_secrets` store. Adapter configuration maps that logical ID to an environment-specific physical store such as Fastly `ts_secrets`. The legacy `secret_store` field is accepted for one migration release but ignored and omitted from newly pushed config.
 
 ## Origin query policy
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -58,15 +58,28 @@ Migrate an existing deployment in this order:
 1. Create/populate `trusted_server_secrets` with the existing credential values
    without printing them in shell history, logs, or CI output.
 2. Replace the five config values with stable key names.
-3. Run `ts config validate`, then `ts config push --adapter fastly`.
+3. Run `ts config validate`, then `ts config push --adapter fastly --no-diff`.
 4. Restart/redeploy instances as needed to load the new values. Rotation is
    startup-scoped; changing a store value does not alter already-built state.
 
+`--no-diff` prevents `config push` from rendering the previous plaintext
+configuration during this migration.
+
 Keep `publisher.proxy_secret` and `ec.passphrase` stable unless intentionally
-rotating signed URLs or EC identifiers. On Spin, declare a component variable
-for each chosen key name using the encoder documented in `spin.toml`. Missing
-stores, keys, invalid UTF-8, and empty values fail closed; inline plaintext
-fallback is not supported.
+rotating signed URLs or EC identifiers. On Spin, the app-config blob is stored
+under the `trusted_server_config` key in Spin's built-in `default` key-value
+store. Set the corresponding CLI store mapping before pushing so the write
+matches the runtime lookup:
+
+```bash
+export EDGEZERO__STORES__CONFIG__TRUSTED_SERVER_CONFIG__NAME=default
+ts config push --adapter spin
+```
+
+For local Spin development, add `--local` to the push command. Also declare a
+component variable for each chosen secret key name using the encoder documented
+in `spin.toml`. Missing stores, keys, invalid UTF-8, and empty values fail
+closed; inline plaintext fallback is not supported.
 
 ### Generate Secure Secrets
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -45,12 +45,13 @@ ts config validate
 ts config push --adapter fastly
 ```
 
-### Secret-store migration
+### Static secret references
 
 Static app-config credentials contain stable key names only. This includes
-publisher, EC, handler, Tinybird, DataDome, and S3 credential fields:
+publisher, trusted-client-IP, EC, handler, Tinybird, DataDome, and S3 fields:
 
 - `publisher.proxy_secret`
+- `trusted_client_ip.shared_secret`, when trusted client-IP forwarding is configured
 - `ec.passphrase`
 - `ec.partners[*].api_token`, when inbound identify or batch sync is used
 - `ec.partners[*].ts_pull_token`, when pull sync is enabled
@@ -65,19 +66,17 @@ resolved only while an instance builds runtime settings. An adapter can map the
 logical ID to a different physical name. For example, Fastly commonly maps
 `trusted_server_secrets` to physical store `ts_secrets`.
 
-Migrate an existing deployment in this order:
+Prepare an initial reference-based deployment in this order:
 
-1. Populate the physical store mapped from `trusted_server_secrets` with the
-   existing credential values without printing them in shell history, logs, or
-   CI output.
-2. Replace each active credential value with a stable key name and remove the
-   legacy Tinybird, DataDome, and S3 `secret_store` selectors.
-3. Run `ts config validate`, then `ts config push --adapter fastly --no-diff`.
-4. Restart/redeploy instances as needed to load the new values. Rotation is
-   startup-scoped; changing a store value does not alter already-built state.
+1. Create the physical store and configure its `trusted_server_secrets` mapping.
+2. Choose a stable key name for each active credential field in the app config.
+3. Write each credential value under its referenced key without exposing it in
+   command arguments, shell history, logs, or CI output.
+4. Run `ts config validate`, then `ts config push --adapter fastly`.
+5. Start or deploy instances after the store and pushed config are both ready.
 
-`--no-diff` prevents `config push` from rendering the previous plaintext
-configuration during this migration.
+Changing a store value does not alter already-built state. Restart or redeploy
+instances when rotating static credentials.
 
 Keep `publisher.proxy_secret` and `ec.passphrase` stable unless intentionally
 rotating signed URLs or EC identifiers. On Spin, the app-config blob is stored
@@ -429,11 +428,11 @@ it but keep using their own runtime client address.
 
 ### `[trusted_client_ip]`
 
-| Field           | Type   | Required | Description                                                                       |
-| --------------- | ------ | -------- | --------------------------------------------------------------------------------- |
-| `ip_header`     | String | Yes      | Header containing exactly one reader IP address                                   |
-| `auth_header`   | String | Yes      | Header containing exactly one shared-secret value                                 |
-| `shared_secret` | String | Yes      | Secret shared with the trusted front door, 32+ ASCII graphic bytes, no whitespace |
+| Field           | Type   | Required | Description                                                      |
+| --------------- | ------ | -------- | ---------------------------------------------------------------- |
+| `ip_header`     | String | Yes      | Header containing exactly one reader IP address                  |
+| `auth_header`   | String | Yes      | Header containing exactly one shared-secret value                |
+| `shared_secret` | String | Yes      | Key in `trusted_server_secrets` for the front-door shared secret |
 
 All three fields are required when the section exists. When the section is
 absent, Trusted Server continues to use the immediate peer address, and
@@ -453,7 +452,7 @@ this order wrong takes the service down rather than degrading it.
 [trusted_client_ip]
 ip_header = "x-ts-client-ip"
 auth_header = "x-ts-client-ip-auth"
-shared_secret = "replace-with-a-random-shared-secret"
+shared_secret = "trusted_client_ip_shared_secret"
 ```
 
 Prefer a dedicated `x-` name for `ip_header`, as shown. `fastly-client-ip` is
@@ -465,8 +464,9 @@ front-door configuration this section depends on.
 
 The front door must overwrite both headers on every request it forwards to
 Trusted Server, and must remove client-supplied copies on its other routes.
-Trusted Server accepts the forwarded address only when the request has exactly
-one `auth_header` value that matches `shared_secret` byte-for-byte and exactly
+Trusted Server resolves `shared_secret` from `trusted_server_secrets` at startup.
+It accepts the forwarded address only when the request has exactly one
+`auth_header` value that matches the resolved secret byte-for-byte and exactly
 one `ip_header` value that parses directly as IPv4 or IPv6. Values are not
 trimmed or normalized. Missing, empty, duplicate, non-UTF-8, mismatched, or malformed
 values do not reject the request; Trusted Server safely falls back to the
@@ -484,12 +484,12 @@ sensitive headers such as `Host`, `Content-Length`, `Cookie`, and
 dedicated `x-` names that no other application or routing logic uses, because
 Trusted Server removes the configured headers before routing.
 
-Generate `shared_secret` with a cryptographically secure random generator,
-encode it as hex or base64url, store the same value only in the front door and
-Trusted Server configuration, and never commit it. The value is redacted from
-configuration debug output. Configuration requires at least 32 ASCII graphic
-bytes (`!` through `~`) with no whitespace, controls, DEL, or non-ASCII bytes,
-and startup fails when the value is still the documented placeholder.
+Generate the referenced secret value with a cryptographically secure random
+generator, encode it as hex or base64url, and store the same value only in the
+front door and the physical store mapped from `trusted_server_secrets`. Put only
+the key name in Trusted Server configuration. The resolved value must contain at
+least 32 ASCII graphic bytes (`!` through `~`) with no whitespace, controls, DEL,
+or non-ASCII bytes.
 
 Independently of this section, the Fastly adapter treats `fastly-client-ip` as
 client-spoofable and strips it at request entry, so Trusted Server no longer
@@ -497,18 +497,17 @@ forwards an inbound `Fastly-Client-IP` to the publisher origin. This applies
 even when `[trusted_client_ip]` is absent. Check whether the origin reads that
 header before deploying.
 
-Redaction protects debug output and validation errors; it does not move the
-value into a platform secret store. `ts config push` serializes the value in the
-Trusted Server application-config blob, so restrict access to that configuration
-store. Every adapter removes the configured IP and authentication headers before
-routing, although only Fastly uses them for client-IP resolution.
+Startup fails closed if the configured key is missing, empty, invalid UTF-8, or
+resolves to an invalid shared-secret value. Every adapter removes the configured
+IP and authentication headers before routing, although only Fastly uses them for
+client-IP resolution.
 
 **Environment Overrides**:
 
 ```bash
 TRUSTED_SERVER__TRUSTED_CLIENT_IP__IP_HEADER=x-ts-client-ip
 TRUSTED_SERVER__TRUSTED_CLIENT_IP__AUTH_HEADER=x-ts-client-ip-auth
-TRUSTED_SERVER__TRUSTED_CLIENT_IP__SHARED_SECRET=replace-with-a-random-shared-secret
+TRUSTED_SERVER__TRUSTED_CLIENT_IP__SHARED_SECRET=trusted_client_ip_shared_secret
 ```
 
 Because the typed environment overlay cannot create a missing section, add

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -47,17 +47,31 @@ ts config push --adapter fastly
 
 ### Secret-store migration
 
-The five app-config secret fields contain stable key names only:
-`publisher.proxy_secret`, `ec.passphrase`, `ec.partners[*].api_token`,
-`ec.partners[*].ts_pull_token` (when used), and `handlers[*].password`.
+Static app-config credentials contain stable key names only. This includes
+publisher, EC, handler, Tinybird, DataDome, and S3 credential fields:
+
+- `publisher.proxy_secret`
+- `ec.passphrase`
+- `ec.partners[*].api_token`
+- `ec.partners[*].ts_pull_token`, when used
+- `handlers[*].password`
+- `tinybird.auction_token_secret`, when Tinybird auction telemetry is enabled
+- `integrations.datadome.server_side_key_secret_name`, when protection is enabled
+- `integrations.datadome.protection_test_bypass.credential_secret_name`, when the bypass is enabled
+- `proxy.asset_routes[*].auth.access_key_id`, `secret_access_key`, and optional `session_token`
+
 Their values belong in the logical `trusted_server_secrets` store and are
-resolved only while an instance builds runtime settings.
+resolved only while an instance builds runtime settings. An adapter can map the
+logical ID to a different physical name. For example, Fastly commonly maps
+`trusted_server_secrets` to physical store `ts_secrets`.
 
 Migrate an existing deployment in this order:
 
-1. Create/populate `trusted_server_secrets` with the existing credential values
-   without printing them in shell history, logs, or CI output.
-2. Replace the five config values with stable key names.
+1. Populate the physical store mapped from `trusted_server_secrets` with the
+   existing credential values without printing them in shell history, logs, or
+   CI output.
+2. Replace each active credential value with a stable key name and remove the
+   legacy Tinybird, DataDome, and S3 `secret_store` selectors.
 3. Run `ts config validate`, then `ts config push --adapter fastly --no-diff`.
 4. Restart/redeploy instances as needed to load the new values. Rotation is
    startup-scoped; changing a store value does not alter already-built state.
@@ -80,6 +94,25 @@ For local Spin development, add `--local` to the push command. Also declare a
 component variable for each chosen secret key name using the encoder documented
 in `spin.toml`. Missing stores, keys, invalid UTF-8, and empty values fail
 closed; inline plaintext fallback is not supported.
+
+### Tinybird auction telemetry
+
+Tinybird uses the same typed secret-reference path as the other static
+credentials. Do not configure a feature-specific store:
+
+```toml
+[tinybird]
+enabled = true
+api_host = "api.example.com"
+auction_dataset = "auction_events_raw"
+auction_token_secret = "tinybird_auction_append_token"
+```
+
+Store the APPEND token value under `tinybird_auction_append_token` in the
+physical store mapped from `trusted_server_secrets`. The token is resolved once
+at startup. Disabled Tinybird telemetry does not require or resolve the token.
+The legacy `tinybird.secret_store` field is accepted for one migration release,
+but it is ignored and omitted from newly pushed config.
 
 ### Generate Secure Secrets
 
@@ -1056,15 +1089,14 @@ target_path = "/image/upload/$1.$2"
 
 The first supported origin auth type is `s3_sigv4`.
 
-| Field               | Type   | Required | Default             | Description                                     |
-| ------------------- | ------ | -------- | ------------------- | ----------------------------------------------- |
-| `type`              | String | Yes      | none                | Must be `s3_sigv4`                              |
-| `region`            | String | Yes      | none                | AWS region used in the SigV4 credential scope   |
-| `secret_store`      | String | No       | `s3-auth`           | Runtime secret store containing AWS credentials |
-| `access_key_id`     | String | No       | `access_key_id`     | Secret key containing the AWS access key ID     |
-| `secret_access_key` | String | No       | `secret_access_key` | Secret key containing the AWS secret access key |
-| `session_token`     | String | No       | unset               | Optional secret key containing a session token  |
-| `origin_query`      | String | No       | route default       | `preserve` or `strip`                           |
+| Field               | Type   | Required | Default             | Description                                                  |
+| ------------------- | ------ | -------- | ------------------- | ------------------------------------------------------------ |
+| `type`              | String | Yes      | none                | Must be `s3_sigv4`                                           |
+| `region`            | String | Yes      | none                | AWS region used in the SigV4 credential scope                |
+| `access_key_id`     | String | No       | `access_key_id`     | Default-store secret reference for the AWS access key ID     |
+| `secret_access_key` | String | No       | `secret_access_key` | Default-store secret reference for the AWS secret access key |
+| `session_token`     | String | No       | unset               | Optional secret key containing a session token               |
+| `origin_query`      | String | No       | route default       | `preserve` or `strip`                                        |
 
 **Example**:
 
@@ -1077,13 +1109,12 @@ origin_url = "https://bucket.s3.us-east-1.amazonaws.com"
 type = "s3_sigv4"
 region = "us-east-1"
 origin_query = "strip"
-secret_store = "s3-auth"
-access_key_id = "access_key_id"
-secret_access_key = "secret_access_key"
-# session_token = "session_token"
+access_key_id = "s3_access_key_id"
+secret_access_key = "s3_secret_access_key"
+# session_token = "s3_session_token"
 ```
 
-S3 auth uses header-based AWS SigV4 with `UNSIGNED-PAYLOAD`. It is scoped to read-only asset requests and expects `origin_url` to use the S3 host that AWS validates. Credentials are cached per process by configured secret names after the first successful read.
+S3 auth uses header-based AWS SigV4 with `UNSIGNED-PAYLOAD`. It is scoped to read-only asset requests and expects `origin_url` to use the S3 host that AWS validates. Credential references resolve from `trusted_server_secrets` at startup, and request signing performs no secret-store reads.
 
 Effective `origin_query` precedence is auth-level `origin_query`, then enabled Image Optimizer `origin_query`, then the route default.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -52,8 +52,8 @@ publisher, EC, handler, Tinybird, DataDome, and S3 credential fields:
 
 - `publisher.proxy_secret`
 - `ec.passphrase`
-- `ec.partners[*].api_token`
-- `ec.partners[*].ts_pull_token`, when used
+- `ec.partners[*].api_token`, when inbound identify or batch sync is used
+- `ec.partners[*].ts_pull_token`, when pull sync is enabled
 - `handlers[*].password`
 - `tinybird.auction_token_secret`, when Tinybird auction telemetry is enabled
 - `integrations.datadome.server_side_key_secret_name`, when protection is enabled
@@ -583,6 +583,11 @@ be at least 32 bytes. Keep it stable to preserve EC identifier continuity.
 `source_domain` is the canonical partner key. It matches incoming OpenRTB EID `source` values and is also used as the EC KV `ids` map key.
 :::
 
+`api_token` is optional. Set it to a key in `trusted_server_secrets` only when
+the partner calls the inbound identify or batch-sync APIs. A partner without
+`api_token` remains available for source-domain lookup, bidstream EIDs, and
+outbound pull sync, but cannot authenticate to those inbound APIs.
+
 **Example**:
 
 ```toml
@@ -593,9 +598,9 @@ ec_store = "ec_identity_store"
 [[ec.partners]]
 name = "Mocktioneer SSP"
 source_domain = "mocktioneer.example"
-api_token = "partner_api_token"
 bidstream_enabled = true
-# ts_pull_token = "partner_ts_pull_token"  # only when pull sync is enabled
+# api_token = "partner_api_token"  # only for inbound identify or batch sync
+# ts_pull_token = "partner_ts_pull_token"  # required when pull sync is enabled
 ```
 
 **Environment Override**:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -6,9 +6,9 @@ Learn how to configure Trusted Server for your deployment.
 
 Trusted Server uses a flexible configuration system based on:
 
-1. **TOML Files** - `trusted-server.toml` for base configuration
+1. **TOML Files** - `trusted-server.toml` for ordinary configuration and secret key names
 2. **Environment Variables** - Typed CLI overrides with the `TRUSTED_SERVER__` prefix
-3. **Fastly Stores** - KV/Config/Secret stores for runtime data
+3. **EdgeZero Stores** - Config and secret stores for the pushed blob and runtime secret values
 
 ## Quick Start
 
@@ -21,10 +21,10 @@ Create `trusted-server.toml` in your project root:
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
-proxy_secret = "your-secure-secret-here"
+proxy_secret = "publisher_proxy_secret"
 
 [ec]
-passphrase = "replace-with-32-plus-byte-random-secret"
+passphrase = "ec_passphrase"
 ```
 
 ### Environment Variable Overrides
@@ -37,16 +37,43 @@ read by the deployed application at request time.
 # Format: TRUSTED_SERVER__SECTION__FIELD
 export TRUSTED_SERVER__PUBLISHER__DOMAIN=publisher.com
 export TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.com
-export TRUSTED_SERVER__EC__PASSPHRASE=replace-with-32-plus-byte-random-secret
+# Secret overrides, when needed, are key names—not secret values.
+export TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=publisher_proxy_secret
+export TRUSTED_SERVER__EC__PASSPHRASE=ec_passphrase
 
 ts config validate
 ts config push --adapter fastly
 ```
 
+### Secret-store migration
+
+The five app-config secret fields contain stable key names only:
+`publisher.proxy_secret`, `ec.passphrase`, `ec.partners[*].api_token`,
+`ec.partners[*].ts_pull_token` (when used), and `handlers[*].password`.
+Their values belong in the logical `trusted_server_secrets` store and are
+resolved only while an instance builds runtime settings.
+
+Migrate an existing deployment in this order:
+
+1. Create/populate `trusted_server_secrets` with the existing credential values
+   without printing them in shell history, logs, or CI output.
+2. Replace the five config values with stable key names.
+3. Run `ts config validate`, then `ts config push --adapter fastly`.
+4. Restart/redeploy instances as needed to load the new values. Rotation is
+   startup-scoped; changing a store value does not alter already-built state.
+
+Keep `publisher.proxy_secret` and `ec.passphrase` stable unless intentionally
+rotating signed URLs or EC identifiers. On Spin, declare a component variable
+for each chosen key name using the encoder documented in `spin.toml`. Missing
+stores, keys, invalid UTF-8, and empty values fail closed; inline plaintext
+fallback is not supported.
+
 ### Generate Secure Secrets
 
+Generate values locally and write them directly to the platform secret store;
+do not put the generated output in `trusted-server.toml` or the app-config blob.
+
 ```bash
-# Generate cryptographically random secrets
 openssl rand -base64 32
 ```
 
@@ -86,10 +113,10 @@ fail and the service will return its startup-error response.
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
-proxy_secret = "change-me-to-secure-value"
+proxy_secret = "publisher_proxy_secret"
 
 [ec]
-passphrase = "replace-with-32-plus-byte-random-secret"
+passphrase = "ec_passphrase"
 
 [request_signing]
 enabled = true
@@ -116,9 +143,10 @@ base TOML configuration by `ts config validate`, `ts config diff`, and
 stored in the app-config blob. Changing an environment variable requires
 rerunning validation and pushing the resolved config, not rebuilding the binary.
 
-EdgeZero's env overlay only overrides leaves that already exist in the parsed TOML; it
-does not create missing fields. Add newly introduced defaulted fields to an
-existing config before relying on their environment overrides. Pass `--no-env`
+The pinned EdgeZero loader only overrides leaves that already exist in the
+parsed TOML; it does not create missing fields. Add newly introduced defaulted
+fields to an existing config before relying on their environment overrides.
+Secret overlays still contain key names, never secret values. Pass `--no-env`
 to use file values without the overlay.
 
 ### Format
@@ -179,7 +207,7 @@ Core publisher settings for domain, origin, and proxy configuration.
 | `cookie_domain`               | String  | Yes      | Domain for non-EC cookies (typically with leading dot)                      |
 | `origin_url`                  | String  | Yes      | Full URL of publisher origin server                                         |
 | `origin_host_header_override` | String  | No       | Outbound Host header to send while connecting to `origin_url`               |
-| `proxy_secret`                | String  | Yes      | Secret key for encrypting/signing proxy URLs                                |
+| `proxy_secret`                | String  | Yes      | Secret-store key name for the proxy URL secret                              |
 | `max_buffered_body_bytes`     | Integer | No       | Buffered-body cap / Fastly stream raw+decoded byte ceiling (default 16 MiB) |
 
 > **Note:** EC cookies (`ts-ec`) derive their domain automatically as `.{domain}` and
@@ -194,7 +222,7 @@ cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
 # Optional: connect to origin_url but send this outbound Host header.
 # origin_host_header_override = "www.publisher.com"
-proxy_secret = "change-me-to-secure-random-value"
+proxy_secret = "publisher_proxy_secret"
 ```
 
 **Environment Override**:
@@ -204,7 +232,7 @@ TRUSTED_SERVER__PUBLISHER__DOMAIN=publisher.com
 TRUSTED_SERVER__PUBLISHER__COOKIE_DOMAIN=.publisher.com
 TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://origin.publisher.com
 TRUSTED_SERVER__PUBLISHER__ORIGIN_HOST_HEADER_OVERRIDE=www.publisher.com
-TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=your-secret-here
+TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=publisher_proxy_secret
 TRUSTED_SERVER__PUBLISHER__MAX_BUFFERED_BODY_BYTES=16777216
 ```
 
@@ -283,21 +311,12 @@ connecting to the host in `origin_url`.
 
 #### `proxy_secret`
 
-**Purpose**: Secret key for HMAC-SHA256 signing of proxy URLs.
+**Purpose**: Secret-store key name for the HMAC-SHA256 value used to sign proxy URLs.
 
-**Security**:
-
-- Keep confidential and secure
-- Rotate periodically (90 days recommended)
-- Use cryptographically random values (32+ bytes)
-- Never commit to version control
-
-**Generation**:
-
-```bash
-# Generate secure random secret
-openssl rand -base64 32
-```
+The referenced value is resolved from `trusted_server_secrets` at startup. It
+must be at least 32 bytes, so generate it with a cryptographically secure random
+source. Keep that value confidential, rotate it only intentionally, and never
+put it in the TOML file or pushed app-config blob.
 
 **Usage**:
 
@@ -502,6 +521,9 @@ Settings for Edge Cookie identifier generation. The `ec_store` KV store is the o
 
 ### `[ec]`
 
+`passphrase` is a key name in `trusted_server_secrets`; the resolved value must
+be at least 32 bytes. Keep it stable to preserve EC identifier continuity.
+
 | Field                     | Type           | Required | Description                                                             |
 | ------------------------- | -------------- | -------- | ----------------------------------------------------------------------- |
 | `passphrase`              | String         | Yes      | Publisher passphrase used as HMAC key                                   |
@@ -519,20 +541,21 @@ Settings for Edge Cookie identifier generation. The `ec_store` KV store is the o
 
 ```toml
 [ec]
-passphrase = "replace-with-32-plus-byte-random-secret"
+passphrase = "ec_passphrase"
 ec_store = "ec_identity_store"
 
 [[ec.partners]]
 name = "Mocktioneer SSP"
 source_domain = "mocktioneer.example"
-api_token = "partner-api-token-32-bytes-minimum"
+api_token = "partner_api_token"
 bidstream_enabled = true
+# ts_pull_token = "partner_ts_pull_token"  # only when pull sync is enabled
 ```
 
 **Environment Override**:
 
 ```bash
-TRUSTED_SERVER__EC__PASSPHRASE=your-secret
+TRUSTED_SERVER__EC__PASSPHRASE=ec_passphrase
 TRUSTED_SERVER__EC__EC_STORE=ec_identity_store
 ```
 
@@ -540,20 +563,13 @@ TRUSTED_SERVER__EC__EC_STORE=ec_identity_store
 
 #### `passphrase`
 
-**Purpose**: Publisher passphrase used as HMAC key for EC ID generation.
+**Purpose**: Secret-store key name whose resolved value is the HMAC key for EC ID generation.
 
 **Security**:
 
-- Must be non-empty
-- Rotate periodically for security
-- Store securely (environment variable recommended)
-
-**Generation**:
-
-```bash
-# Generate secure random key
-openssl rand -hex 32
-```
+- The key name is stored in app config; the value is stored in `trusted_server_secrets`
+- Keep the value stable unless intentionally rotating EC identifiers
+- Do not place the value in environment overlays or the pushed blob
 
 **Validation**: Application startup fails if:
 
@@ -690,18 +706,18 @@ Path-based HTTP Basic Authentication.
 [[handlers]]
 path = "^/_ts/admin"
 username = "admin"
-password = "secure-password"
+password = "admin_password"
 
 # Multiple handlers
 [[handlers]]
 path = "^/secure"
 username = "user1"
-password = "pass1"
+password = "secure_handler_password"
 
 [[handlers]]
 path = "^/api/private"
 username = "api-user"
-password = "api-pass"
+password = "api_handler_password"
 ```
 
 **Environment Override**:
@@ -710,12 +726,12 @@ password = "api-pass"
 # Handler 0
 TRUSTED_SERVER__HANDLERS__0__PATH="^/_ts/admin"
 TRUSTED_SERVER__HANDLERS__0__USERNAME="admin"
-TRUSTED_SERVER__HANDLERS__0__PASSWORD="secure-password"
+TRUSTED_SERVER__HANDLERS__0__PASSWORD="admin_password"
 
 # Handler 1
 TRUSTED_SERVER__HANDLERS__1__PATH="^/api/private"
 TRUSTED_SERVER__HANDLERS__1__USERNAME="api-user"
-TRUSTED_SERVER__HANDLERS__1__PASSWORD="api-pass"
+TRUSTED_SERVER__HANDLERS__1__PASSWORD="api_handler_password"
 ```
 
 ### Path Patterns
@@ -794,10 +810,9 @@ scheduled for removal
 
 **Password Storage**:
 
-- Stored in plain text in config
-- Use environment variables in production
-- Rotate passwords regularly
-- Consider using Fastly Secret Store
+- `handlers[*].password` is a key name in `trusted_server_secrets`
+- Store the resolved password only in the platform secret store
+- Rotate passwords through the store and restart/redeploy instances
 
 **Limitations**:
 
@@ -807,12 +822,9 @@ scheduled for removal
 - No rate limiting (add at edge)
 
 ::: warning Production Use
-For production, store credentials in environment variables:
-
-```bash
-TRUSTED_SERVER__HANDLERS__0__PASSWORD=$(cat /run/secrets/admin_password)
-```
-
+Do not put handler passwords in `trusted-server.toml`, environment overlays, or
+app-config blobs. Provision the referenced key in `trusted_server_secrets`
+before pushing the config.
 :::
 
 ## URL Rewrite Configuration
@@ -1530,7 +1542,7 @@ remove that field's non-default value (and any environment override), run
 `ts config validate`, push the resulting default-compatible blob, and only then
 roll back the binary.
 
-**Environment overlays:** EdgeZero's env overlays cannot create missing TOML
+**Environment overlays:** The pinned EdgeZero loader cannot create missing TOML
 leaves. Existing configs must add **both** leaves under `[auction]`
 (`rewrite_creatives` and `sanitize_creatives`) before
 `TRUSTED_SERVER__AUCTION__REWRITE_CREATIVES` /
@@ -1929,14 +1941,15 @@ Configuration is validated at startup:
 
 **EC Validation**:
 
-- `passphrase` ≥ 1 character
-- `passphrase` ≠ known placeholders (`"secret-key"`, `"secret_key"`, `"trusted-server"` — case-insensitive)
+- The `passphrase` key name is non-empty at push time
+- The resolved passphrase is at least 32 bytes at runtime
+- Known placeholder values are rejected after resolution
 
 **Handler Validation**:
 
 - `path` is valid regex
-- `username` non-empty
-- `password` non-empty
+- `username` is ordinary configuration and non-empty
+- The resolved `password` is non-empty and is checked for placeholders at runtime
 
 **Integration Validation**:
 
@@ -1971,37 +1984,29 @@ server_url: must not be empty
 [publisher]
 domain = "localhost"
 origin_url = "http://localhost:3000"
-proxy_secret = "dev-secret"
+proxy_secret = "publisher_proxy_secret"
 ```
 
-**Staging**:
+**Staging and production**:
 
-```bash
-# .env.staging
-TRUSTED_SERVER__PUBLISHER__ORIGIN_URL=https://staging.publisher.com
-TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=$(cat /run/secrets/proxy_secret_staging)
-```
-
-**Production**:
-
-```bash
-# All secrets from environment
-TRUSTED_SERVER__PUBLISHER__PROXY_SECRET=$(cat /run/secrets/proxy_secret)
-TRUSTED_SERVER__EC__PASSPHRASE=$(cat /run/secrets/ec_secret)
-TRUSTED_SERVER__HANDLERS__0__PASSWORD=$(cat /run/secrets/admin_password)
-```
+- Provision the same key names in the target `trusted_server_secrets` store.
+- Keep only the key names in `trusted-server.toml` and environment overlays.
+- Push the config after provisioning and restart/redeploy after rotation.
 
 ### Secret Management
 
 **Do**:
-✅ Use environment variables for secrets  
-✅ Rotate secrets periodically  
-✅ Generate cryptographically random values  
-✅ Store in secure secret management (Fastly Secret Store, Vault)  
-✅ Use different secrets per environment
+✅ Store values in the platform secret store
+✅ Rotate values deliberately and restart/redeploy instances
+✅ Generate values locally without printing them to logs
+✅ Use different values per environment when appropriate
+✅ Keep stable key names for rotation
 
 **Don't**:
-❌ Commit secrets to version control  
+❌ Commit secret values to version control
+❌ Put secret values in environment overlays
+❌ Put secret values in config diff output or app-config blobs
+❌ Treat missing secret-store keys as inline values
 ❌ Use default/placeholder values  
 ❌ Share secrets across environments  
 ❌ Log secret values  
@@ -2041,10 +2046,10 @@ trusted-server.dev.toml      # Development overrides
 
 **"Configuration field '...' is set to a known placeholder value"**:
 
-- `ec.passphrase` cannot be `"secret-key"`, `"secret_key"`, or `"trusted-server"` (case-insensitive)
-- `publisher.proxy_secret` cannot be `"change-me-proxy-secret"` (case-insensitive)
-- Must be non-empty
-- Change to a secure random value (see generation commands above)
+- Confirm the referenced key exists in `trusted_server_secrets`
+- Ensure the resolved value is non-empty and not a known placeholder
+- Do not replace the key name with a plaintext value in the app config
+- Rotate the value in the platform secret store, then restart/redeploy
 
 **"Invalid regex"**:
 
@@ -2061,7 +2066,7 @@ trusted-server.dev.toml      # Development overrides
 **Environment Variables Not Applied**:
 
 - Run the override through `ts config validate`, `ts config diff`, or `ts config push`
-- Verify the target leaf already exists in `trusted-server.toml`; the env overlay does not create missing fields
+- Verify the target leaf already exists in `trusted-server.toml`; the pinned EdgeZero loader does not create missing fields
 - Verify prefix: `TRUSTED_SERVER__`
 - Check separator: `__` (double underscore)
 - Confirm the variable is exported: `echo $VARIABLE_NAME`

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -2040,21 +2040,23 @@ proxy_secret = "publisher_proxy_secret"
 ### Secret Management
 
 **Do**:
-✅ Store values in the platform secret store
-✅ Rotate values deliberately and restart/redeploy instances
-✅ Generate values locally without printing them to logs
-✅ Use different values per environment when appropriate
-✅ Keep stable key names for rotation
+
+- ✅ Store values in the platform secret store
+- ✅ Rotate values deliberately and restart/redeploy instances
+- ✅ Generate values locally without printing them to logs
+- ✅ Use different values per environment when appropriate
+- ✅ Keep stable key names for rotation
 
 **Don't**:
-❌ Commit secret values to version control
-❌ Put secret values in environment overlays
-❌ Put secret values in config diff output or app-config blobs
-❌ Treat missing secret-store keys as inline values
-❌ Use default/placeholder values  
-❌ Share secrets across environments  
-❌ Log secret values  
-❌ Expose in error messages
+
+- ❌ Commit secret values to version control
+- ❌ Put secret values in environment overlays
+- ❌ Put secret values in config diff output or app-config blobs
+- ❌ Treat missing secret-store keys as inline values
+- ❌ Use default/placeholder values
+- ❌ Share secrets across environments
+- ❌ Log secret values
+- ❌ Expose in error messages
 
 ### File Organization
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -359,10 +359,10 @@ connecting to the host in `origin_url`.
 
 **Purpose**: Secret-store key name for the HMAC-SHA256 value used to sign proxy URLs.
 
-The referenced value is resolved from `trusted_server_secrets` at startup. It
-must be at least 32 bytes, so generate it with a cryptographically secure random
-source. Keep that value confidential, rotate it only intentionally, and never
-put it in the TOML file or pushed app-config blob.
+The referenced value is resolved from `trusted_server_secrets` at startup.
+Generate it with a cryptographically secure random source; at least 32 random
+bytes are recommended. Keep that value confidential, rotate it only
+intentionally, and never put it in the TOML file or pushed app-config blob.
 
 **Usage**:
 

--- a/docs/guide/ec-setup-guide.md
+++ b/docs/guide/ec-setup-guide.md
@@ -34,7 +34,9 @@ bidstream_enabled = true
 ```
 
 The `passphrase` and `api_token` fields contain keys in the Trusted Server
-secret store, not the credential values. Provision high-entropy values under
+secret store, not the credential values. This workflow calls the inbound
+identify and batch-sync APIs, so its partner needs `api_token`. Partners that
+do not call either API may omit it. Provision high-entropy values under
 `ec_passphrase` and `partner_api_token`; see
 [Configuration](/guide/configuration#secret-store-migration).
 
@@ -79,7 +81,8 @@ bidstream_enabled = true
 ```
 
 Provision the bearer token value under `partner_api_token`, then deploy or
-restart after changing partner configuration.
+restart after changing partner configuration. The token is required for this
+demo because it exercises the inbound partner APIs.
 
 ## 4) Acquire or Reuse EC Cookie
 

--- a/docs/guide/ec-setup-guide.md
+++ b/docs/guide/ec-setup-guide.md
@@ -23,19 +23,24 @@ Set EC configuration in `trusted-server.toml`:
 
 ```toml
 [ec]
-passphrase = "replace-with-32-plus-byte-random-secret"
+passphrase = "ec_passphrase"
 ec_store = "ec_identity_store"
 
 [[ec.partners]]
 name = "Mocktioneer SSP"
 source_domain = "formally-vital-lion.edgecompute.app"
-api_token = "test-batch-sync-key-2026"
+api_token = "partner_api_token"
 bidstream_enabled = true
 ```
 
+The `passphrase` and `api_token` fields contain keys in the Trusted Server
+secret store, not the credential values. Provision high-entropy values under
+`ec_passphrase` and `partner_api_token`; see
+[Configuration](/guide/configuration#secret-store-migration).
+
 Required behavior assumptions:
 
-- `passphrase` is long-lived HMAC-SHA256 keying material for EC ID derivation; use a high-entropy random value of at least 32 characters
+- The value stored under `ec_passphrase` is long-lived HMAC-SHA256 keying material for EC ID derivation; use a high-entropy random value of at least 32 characters
 - `ec_store` is linked to the active Fastly service version
 - `ec_store` is the only KV-backed EC lifecycle store; it contains identity graph state, minimal consent metadata, source-domain keyed partner UIDs, and withdrawal tombstones
 - Live consent is interpreted from request cookies, headers, geolocation, and policy defaults rather than a separate consent KV store
@@ -51,7 +56,8 @@ MOCK_SSP_URL="https://formally-vital-lion.edgecompute.app"
 
 PARTNER_SOURCE_DOMAIN="formally-vital-lion.edgecompute.app"
 PARTNER_NAME="Mocktioneer SSP"
-PARTNER_API_KEY="test-batch-sync-key-2026"
+# Use the value provisioned under the partner_api_token secret-store key.
+PARTNER_API_KEY="<resolved-partner-api-token>"
 
 # Optional: use a real browser EC if already present
 EC_ID="<64hex.6chars>"
@@ -68,11 +74,12 @@ Partners are configured in `trusted-server.toml` and loaded at startup:
 [[ec.partners]]
 name = "Mocktioneer SSP"
 source_domain = "formally-vital-lion.edgecompute.app"
-api_token = "test-batch-sync-key-2026"
+api_token = "partner_api_token"
 bidstream_enabled = true
 ```
 
-Deploy/restart after changing partner configuration.
+Provision the bearer token value under `partner_api_token`, then deploy or
+restart after changing partner configuration.
 
 ## 4) Acquire or Reuse EC Cookie
 

--- a/docs/guide/error-reference.md
+++ b/docs/guide/error-reference.md
@@ -61,8 +61,12 @@ Missing required field: publisher.domain
 [publisher]
 domain = "your-publisher-domain.com"
 origin_url = "https://origin.your-publisher-domain.com"
-proxy_secret = "change-me-to-random-string"
+proxy_secret = "publisher_proxy_secret"
 ```
+
+`proxy_secret` names an entry in the Trusted Server secret store. Provision a
+high-entropy value under `publisher_proxy_secret`; do not put that value in the
+TOML file.
 
 **Required Fields:**
 
@@ -141,18 +145,22 @@ Failed to generate EC ID: HMAC error
 
 **Solution:**
 
-1. Ensure `passphrase` is set in `trusted-server.toml`:
+1. Ensure `passphrase` names a secret-store entry in `trusted-server.toml`:
 
 ```toml
 [ec]
-passphrase = "replace-with-32-plus-byte-random-secret"
+passphrase = "ec_passphrase"
 ```
 
-2. Or set via environment variable:
+2. If using a typed CLI environment override, set the key name rather than the
+   passphrase value:
 
 ```bash
-TRUSTED_SERVER__EC__PASSPHRASE=replace-with-32-plus-byte-random-secret
+TRUSTED_SERVER__EC__PASSPHRASE=ec_passphrase
 ```
+
+3. Provision a high-entropy value of at least 32 characters under
+   `ec_passphrase` in the Trusted Server secret store.
 
 ---
 

--- a/docs/guide/fastly.md
+++ b/docs/guide/fastly.md
@@ -275,16 +275,18 @@ ts provision --adapter fastly
 ```
 
 Provisioning creates or reuses the physical store and persists this runtime
-mapping in Fastly Config Store `edgezero_runtime_env`:
+mapping in Fastly Config Store `edgezero_runtime_env`, scoped to the current
+Fastly service:
 
 ```text
-EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME=ts_secrets
+EDGEZERO__SERVICES__<SERVICE_ID>__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME=ts_secrets
 ```
 
-The Fastly service must link both `ts_secrets` and `edgezero_runtime_env` to the
-active service version. The custom streaming entry point reads the mapping
-before loading app config, so every startup and reload resolves static
-credentials from `ts_secrets` while the portable manifest continues to declare
+The runtime ignores legacy unscoped entries. The Fastly service must link both
+`ts_secrets` and `edgezero_runtime_env` to the active service version. The
+custom streaming entry point reads the service-scoped mapping before loading
+app config, so every startup and reload resolves static credentials from
+`ts_secrets` while the portable manifest continues to declare
 `trusted_server_secrets`.
 
 Create the separate request-signing store when that feature is enabled:

--- a/docs/guide/fastly.md
+++ b/docs/guide/fastly.md
@@ -258,15 +258,41 @@ Used for storing public configuration (e.g., public keys, key metadata):
 fastly config-store create --name jwks_store
 ```
 
-### Secret Store
+### Secret Stores
 
-Used for storing sensitive data (e.g., private signing keys):
+Trusted Server keeps static app-config credentials under logical store ID
+`trusted_server_secrets`. The physical Fastly store can use another name, such
+as `ts_secrets`. Request-signing private keys remain in their separate,
+runtime-managed store.
+
+Set the physical mapping before provisioning:
+
+```bash
+export EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME=ts_secrets
+ts provision --adapter fastly
+```
+
+Provisioning creates or reuses the physical store and persists this runtime
+mapping in Fastly Config Store `edgezero_runtime_env`:
+
+```text
+EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME=ts_secrets
+```
+
+The Fastly service must link both `ts_secrets` and `edgezero_runtime_env` to the
+active service version. The custom streaming entry point reads the mapping
+before loading app config, so every startup and reload resolves static
+credentials from `ts_secrets` while the portable manifest continues to declare
+`trusted_server_secrets`.
+
+Create the separate request-signing store when that feature is enabled:
 
 ```bash
 fastly secret-store create --name signing_keys
 ```
 
-Note the store IDs - you'll need them for your `trusted-server.toml` configuration.
+Do not copy the same app credential store under a second hardcoded
+`trusted_server_secrets` Fastly link. Configure the mapping instead.
 
 ## Create EC KV Store
 

--- a/docs/guide/fastly.md
+++ b/docs/guide/fastly.md
@@ -97,7 +97,7 @@ Prefer header names that nothing else in the fronting service uses:
 [trusted_client_ip]
 ip_header = "x-ts-client-ip"
 auth_header = "x-ts-client-ip-auth"
-shared_secret = "replace-with-a-random-shared-secret"
+shared_secret = "trusted_client_ip_shared_secret"
 ```
 
 `ip_header` may also be
@@ -139,8 +139,11 @@ sub vcl_recv {
 Attach an edge dictionary named `ts_private_config` to the fronting service and
 store the secret under the key `trusted_client_ip_secret`. Create the dictionary
 as write-only so the value cannot be read back through the API or the web
-interface. If the key is absent, the lookup yields no matching value, the
-authentication check fails, and Trusted Server falls back to the peer address.
+interface. Store the identical value in the physical store mapped from
+`trusted_server_secrets`, under the key named by
+`trusted_client_ip.shared_secret` (`trusted_client_ip_shared_secret` above). If
+either key is absent, authentication cannot succeed and Trusted Server falls
+back to the peer address.
 
 Four details in that example carry weight:
 
@@ -166,18 +169,17 @@ Four details in that example carry weight:
   different backend. On the ordinary path the host is unchanged and re-running
   writes the same values.
 
-Configure the identical header names and secret in Trusted Server. The
-`shared_secret` shown above is an intentionally invalid placeholder that
-Trusted Server rejects at startup; replace it with the exact value stored in
-the dictionary. Use a cryptographically random value of at least 32 ASCII
-graphic bytes, encoded as hex or base64url with no whitespace.
+Configure the identical header names and the secret-store key name in Trusted
+Server. Use a cryptographically random value of at least 32 ASCII graphic bytes,
+encoded as hex or base64url with no whitespace, for the two store entries. The
+app-config blob contains only `trusted_client_ip_shared_secret`, not that value.
 
 ### What Trusted Server does with the result
 
 Trusted Server accepts the forwarded address only when the request carries
-exactly one authentication value matching `shared_secret` byte for byte and
-exactly one IP value that parses directly as IPv4 or IPv6. Values are not
-trimmed. Both headers are removed before routing.
+exactly one authentication value matching the resolved shared secret byte for
+byte and exactly one IP value that parses directly as IPv4 or IPv6. Values are
+not trimmed. Both headers are removed before routing.
 
 | Request state                                                     | Address used     |
 | ----------------------------------------------------------------- | ---------------- |
@@ -317,13 +319,14 @@ ec_store = "ec_identity_store"
 ```
 
 Store the high-entropy passphrase under that key in `ts_secrets`. The resolved
-value, rather than the key name, must contain at least 32 characters:
+value, rather than the key name, must contain at least 32 characters. Pipe the
+value over standard input so it never appears in the process argument list:
 
 ```bash
-fastly secret-store-entry create \
+openssl rand -hex 32 | tr -d '\n' | fastly secret-store-entry create \
   --store-id=<ts-secrets-store-id> \
   --name=ec_passphrase \
-  --secret=<high-entropy-32-plus-character-value>
+  --stdin
 ```
 
 Verify stores exist:

--- a/docs/guide/fastly.md
+++ b/docs/guide/fastly.md
@@ -308,12 +308,22 @@ Create it:
 fastly kv-store create --name ec_identity_store
 ```
 
-Configure in `trusted-server.toml`:
+Configure the secret-store key name in `trusted-server.toml`:
 
 ```toml
 [ec]
-passphrase = "replace-with-32-plus-byte-random-secret"
+passphrase = "ec_passphrase"
 ec_store = "ec_identity_store"
+```
+
+Store the high-entropy passphrase under that key in `ts_secrets`. The resolved
+value, rather than the key name, must contain at least 32 characters:
+
+```bash
+fastly secret-store-entry create \
+  --store-id=<ts-secrets-store-id> \
+  --name=ec_passphrase \
+  --secret=<high-entropy-32-plus-character-value>
 ```
 
 Verify stores exist:

--- a/docs/guide/first-party-proxy.md
+++ b/docs/guide/first-party-proxy.md
@@ -443,8 +443,11 @@ Configure proxy behavior in `trusted-server.toml`:
 domain = "publisher.com"
 cookie_domain = ".publisher.com"
 origin_url = "https://origin.publisher.com"
-proxy_secret = "your-secure-random-secret"
+proxy_secret = "publisher_proxy_secret"
 ```
+
+`proxy_secret` is the key name in the Trusted Server secret store. Provision a
+high-entropy value of at least 32 characters under `publisher_proxy_secret`.
 
 ### Asset Routes
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -65,18 +65,29 @@ The server will be available at `http://localhost:7676`.
 
 No Fastly account, CLI, or Viceroy needed. Runs natively on your machine.
 
-The Axum adapter reads configuration from environment variables — it does **not**
-auto-load `.env` files. You must export the variables into your shell before starting
-the server.
+The Axum adapter reads the EdgeZero config blob and secret store from
+environment variables — it does **not** auto-load `.env` files. You must export
+the variables into your shell before starting the server.
 
 ```bash
-# Copy and edit the environment file
+# Create the local app config and apply the non-secret development overlay.
+cp trusted-server.example.toml trusted-server.toml
 cp .env.dev .env
-
-# Export the variables into your current shell session
 set -a && source .env && set +a
 
-# Build and start the dev server
+# Create the local blob-backed config-store entry.
+ts config push --adapter axum --local --yes
+export TRUSTED_SERVER_CONFIG_TRUSTED_SERVER_CONFIG_TRUSTED_SERVER_CONFIG="$(
+  jq -r '.trusted_server_config' .edgezero/local-config-trusted_server_config.json
+)"
+
+# Populate the three secret references from the starter config for this shell.
+# Use stable values only if you need existing proxy URLs or EC IDs to remain valid.
+export TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_PUBLISHER_PROXY_SECRET="$(openssl rand -base64 32)"
+export TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_EC_PASSPHRASE="$(openssl rand -base64 32)"
+export TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_HANDLER_PASSWORD="$(openssl rand -base64 32)"
+
+# Build and start the dev server in the same shell.
 cargo run -p trusted-server-adapter-axum
 ```
 
@@ -85,12 +96,16 @@ The server will be available at `http://localhost:8787`. Set `PORT=<port>` befor
 
 **Environment variable conventions used by the Axum adapter:**
 
-| Purpose            | Pattern                               | Example                                                  |
-| ------------------ | ------------------------------------- | -------------------------------------------------------- |
-| Config store value | `TRUSTED_SERVER_CONFIG_{STORE}_{KEY}` | `TRUSTED_SERVER_CONFIG_SETTINGS_AD_SERVER_URL=https://…` |
-| Secret store value | `TRUSTED_SERVER_SECRET_{STORE}_{KEY}` | `TRUSTED_SERVER_SECRET_KEYS_SIGNING_KEY=abc123`          |
+| Purpose            | Pattern                               | Example                                                               |
+| ------------------ | ------------------------------------- | --------------------------------------------------------------------- |
+| Config store value | `TRUSTED_SERVER_CONFIG_{STORE}_{KEY}` | `TRUSTED_SERVER_CONFIG_TRUSTED_SERVER_CONFIG_TRUSTED_SERVER_CONFIG=…` |
+| Secret store value | `TRUSTED_SERVER_SECRET_{STORE}_{KEY}` | `TRUSTED_SERVER_SECRET_TRUSTED_SERVER_SECRETS_PROXY_KEY=…`            |
 
-Store names and key names are uppercased with hyphens and dots replaced by underscores.
+The config-store value is the verified app-config blob. Secret-store values are
+looked up by the key names in that blob. Store names and key names are uppercased
+with hyphens and dots replaced by underscores. The quick-start exports ephemeral
+secret-store values only into the current shell; do not put secret values in the
+TOML config, config-store blob, or a source-controlled environment file.
 
 > **Dev server limitations:** The Axum adapter does not support KV store,
 > geo lookup, config/secret-store writes, or admin key-management routes.
@@ -132,8 +147,8 @@ ts audit https://publisher.example
 
 The audit command writes `js-assets.toml` plus a draft `trusted-server.toml`.
 The draft includes disabled JS Asset Proxy candidates for detected third-party
-scripts. Review the draft, replace placeholders/secrets, and enable only the asset
-proxy entries you want to serve or block.
+scripts. Review it, replace placeholders with stable secret key names, and enable
+only the asset proxy entries you want to serve or block. Then validate it.
 
 Edit `trusted-server.toml` to configure:
 
@@ -141,14 +156,18 @@ Edit `trusted-server.toml` to configure:
 - KV store mappings
 - EC configuration
 - Consent settings (`[gdpr]`)
+- Stable key names for `trusted_server_secrets`
 
-Validate the config before pushing it to platform storage:
+Provision `trusted_server_secrets` with the existing credential values before
+pushing a migrated config. Then validate and push:
 
 ```bash
 ts config validate
+ts config push --adapter fastly
 ```
 
-See [Configuration](/guide/configuration) and [Trusted Server CLI](/guide/cli) for details.
+Restart or redeploy instances after secret rotation. See
+[Configuration](/guide/configuration) and [Trusted Server CLI](/guide/cli) for details.
 
 ## Deploy to Fastly
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -158,8 +158,9 @@ Edit `trusted-server.toml` to configure:
 - Consent settings (`[gdpr]`)
 - Stable key names for `trusted_server_secrets`
 
-Provision `trusted_server_secrets` with the existing credential values before
-pushing a migrated config. Then validate and push:
+Provision the physical store mapped from logical `trusted_server_secrets` with
+the existing credential values before pushing a migrated config. On Fastly,
+`ts_secrets` is the documented example physical name. Then validate and push:
 
 ```bash
 ts config validate

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -53,12 +53,18 @@ Install and configure the Fastly CLI using the [Fastly setup guide](/guide/fastl
 cargo install viceroy --version 0.17.0 --locked --force
 ```
 
-Start the local Fastly simulator:
+Create and push the starter config, then start the local Fastly simulator:
 
 ```bash
+cp trusted-server.example.toml trusted-server.toml
+set -a && source .env.dev && set +a
+
+ts config push --adapter fastly --local --yes --no-diff
 fastly compute serve
 ```
 
+The local manifest provides public development-only values for the starter
+config's three secret references. Do not reuse them outside local development.
 The server will be available at `http://localhost:7676`.
 
 ### Option B — Axum dev server
@@ -72,8 +78,7 @@ the variables into your shell before starting the server.
 ```bash
 # Create the local app config and apply the non-secret development overlay.
 cp trusted-server.example.toml trusted-server.toml
-cp .env.dev .env
-set -a && source .env && set +a
+set -a && source .env.dev && set +a
 
 # Create the local blob-backed config-store entry.
 ts config push --adapter axum --local --yes
@@ -158,9 +163,10 @@ Edit `trusted-server.toml` to configure:
 - Consent settings (`[gdpr]`)
 - Stable key names for `trusted_server_secrets`
 
-Provision the physical store mapped from logical `trusted_server_secrets` with
-the existing credential values before pushing a migrated config. On Fastly,
-`ts_secrets` is the documented example physical name. Then validate and push:
+Before the first push, provision the physical store mapped from logical
+`trusted_server_secrets` with the credential values referenced by the config.
+On Fastly, `ts_secrets` is the documented example physical name. Then validate
+and push:
 
 ```bash
 ts config validate

--- a/docs/guide/integrations/datadome.md
+++ b/docs/guide/integrations/datadome.md
@@ -43,7 +43,7 @@ rewrite_sdk = true
 
 # Server-side Protection API layer
 enable_protection = false
-server_side_key_secret_store = "ts_secrets"
+# Required only when enable_protection = true.
 server_side_key_secret_name = "datadome_server_side_key"
 protection_api_origin = "https://api-fastly.datadome.co"
 timeout_ms = 1500
@@ -76,8 +76,7 @@ patterns = ["(?i)\\.(avi|flv|mka|mkv|mov|mp4|mpeg|mpg|mp3|flac|ogg|ogm|opus|wav|
 | `cache_ttl_seconds`                    | integer | `3600`                           | Cache TTL for `tags.js`                                                 |
 | `rewrite_sdk`                          | boolean | `true`                           | Rewrite DataDome script URLs in HTML to first-party paths               |
 | `enable_protection`                    | boolean | `false`                          | Call the Protection API before route matching                           |
-| `server_side_key_secret_store`         | string  | `ts_secrets`                     | Runtime secret store containing the DataDome server-side key            |
-| `server_side_key_secret_name`          | string  | `datadome_server_side_key`       | Secret name containing the DataDome server-side key                     |
+| `server_side_key_secret_name`          | string  | none                             | Default-store secret reference required when protection is enabled      |
 | `protection_api_origin`                | string  | `https://api-fastly.datadome.co` | Protection API origin                                                   |
 | `timeout_ms`                           | integer | `1500`                           | Dynamic backend first-byte timeout for Protection API calls             |
 | `protection_excluded_methods`          | array   | `["OPTIONS"]`                    | HTTP methods skipped before the Protection API call                     |
@@ -156,7 +155,7 @@ When `enable_protection = true`, Trusted Server calls DataDome before normal rou
 - **Challenge**: return the DataDome response directly without contacting the publisher origin.
 - **Fail-open condition**: continue routing without DataDome effects when the Protection API times out, returns malformed instructions, or returns an unexpected status.
 
-The configured `server_side_key_secret_store` and `server_side_key_secret_name` must resolve to a non-empty secret when server-side protection is enabled. If the secret cannot be read, DataDome protection fails open for that request.
+`server_side_key_secret_name` is a key reference in the logical `trusted_server_secrets` store. It must resolve to a non-empty value when server-side protection is enabled. Missing or invalid credentials fail startup before requests are served. Protection API transport and response failures continue to fail open per request.
 
 ### Protected traffic
 
@@ -185,7 +184,6 @@ Protection API:
 # Runtime activation also requires FASTLY_IS_STAGING=1.
 [integrations.datadome.protection_test_bypass]
 enabled = true
-credential_secret_store = "ts_secrets"
 credential_secret_name = "datadome_test_bypass"
 ```
 
@@ -197,7 +195,7 @@ staging through the `X-TS-ENV: staging` response signal and the integration
 activation log, and verify production omits that response signal. A retained
 section cannot bypass protection in a production or other non-staging runtime.
 Store a randomly generated credential containing at least 32 bytes of
-high-entropy material in the configured Secret Store, configure this section
+high-entropy material under the referenced key in `trusted_server_secrets`, configure this section
 only while needed, protect the site with an outer access control such as Basic
 Auth, and remove the section when testing finishes.
 
@@ -375,7 +373,6 @@ TRUSTED_SERVER__INTEGRATIONS__DATADOME__API_ORIGIN=https://api-js.datadome.co
 TRUSTED_SERVER__INTEGRATIONS__DATADOME__CACHE_TTL_SECONDS=3600
 TRUSTED_SERVER__INTEGRATIONS__DATADOME__REWRITE_SDK=true
 TRUSTED_SERVER__INTEGRATIONS__DATADOME__ENABLE_PROTECTION=true
-TRUSTED_SERVER__INTEGRATIONS__DATADOME__SERVER_SIDE_KEY_SECRET_STORE=ts_secrets
 TRUSTED_SERVER__INTEGRATIONS__DATADOME__SERVER_SIDE_KEY_SECRET_NAME=datadome_server_side_key
 TRUSTED_SERVER__INTEGRATIONS__DATADOME__CLIENT_SIDE_KEY=your-client-side-key
 ```
@@ -421,7 +418,6 @@ Check that both fields are configured:
 [integrations.datadome]
 enabled = true
 enable_protection = true
-server_side_key_secret_store = "ts_secrets"
 server_side_key_secret_name = "datadome_server_side_key"
 ```
 

--- a/docs/guide/key-rotation.md
+++ b/docs/guide/key-rotation.md
@@ -102,11 +102,13 @@ Key rotation uses the Fastly API to manage store contents. You need to create an
 Store the API token in the `api-keys` secret store:
 
 ```bash
-# Store the API key
-fastly secret-store-entry create \
+# Read without echoing, then send the API key over stdin rather than argv.
+read -rsp 'Fastly API token: ' FASTLY_ROTATION_API_TOKEN && printf '\n'
+printf '%s' "$FASTLY_ROTATION_API_TOKEN" | fastly secret-store-entry create \
   --store-id=<your-api-keys-store-id> \
   --name=api_key \
-  --secret=<your-fastly-api-token>
+  --stdin
+unset FASTLY_ROTATION_API_TOKEN
 ```
 
 ::: warning Keep Your API Token Secure

--- a/docs/guide/proxy-signing.md
+++ b/docs/guide/proxy-signing.md
@@ -22,9 +22,9 @@ Signatures use HMAC-SHA256 with the publisher's `proxy_secret`:
 proxy_secret = "publisher_proxy_secret"
 ```
 
-The config value is a key in the Trusted Server secret store. Provision the
-secure random signing value under `publisher_proxy_secret`; the resolved value
-must contain at least 32 characters.
+The config value is a key in the Trusted Server secret store. Provision a
+secure random signing value under `publisher_proxy_secret`; at least 32 random
+bytes are recommended.
 
 ## Signature Validation
 

--- a/docs/guide/proxy-signing.md
+++ b/docs/guide/proxy-signing.md
@@ -19,8 +19,12 @@ Signatures use HMAC-SHA256 with the publisher's `proxy_secret`:
 
 ```toml
 [publisher]
-proxy_secret = "your-secret-key-here"  # Must be secure random string
+proxy_secret = "publisher_proxy_secret"
 ```
+
+The config value is a key in the Trusted Server secret store. Provision the
+secure random signing value under `publisher_proxy_secret`; the resolved value
+must contain at least 32 characters.
 
 ## Signature Validation
 
@@ -37,7 +41,7 @@ On incoming requests:
 
 ## Security Notes
 
-- Keep `proxy_secret` confidential and secure
-- Rotate secrets periodically
-- Never expose the secret in client-side code
-- Use strong random values (32+ bytes)
+- Keep the resolved signing value confidential
+- Rotate the stored value periodically
+- Never expose the resolved value in client-side code
+- Use a strong random value of at least 32 characters

--- a/fastly.toml
+++ b/fastly.toml
@@ -61,6 +61,12 @@ build = """
             key = "tinybird_access_append_token"
             data = "test-tinybird-access-append-token"
 
+        # App-config secret references resolve from this canonical logical store.
+        # Populate production values through the EdgeZero secret-store workflow.
+        [[local_server.secret_stores.trusted_server_secrets]]
+            key = "placeholder"
+            data = "placeholder"
+
     [local_server.config_stores]
         [local_server.config_stores.trusted_server_config]
             format = "inline-toml"

--- a/fastly.toml
+++ b/fastly.toml
@@ -57,17 +57,18 @@ build = """
             key = "tinybird_auction_append_token"
             data = "test-tinybird-auction-append-token"
 
+        # App-config references use logical `trusted_server_secrets`; the
+        # edgezero_runtime_env mapping below resolves it to physical `ts_secrets`.
         [[local_server.secret_stores.ts_secrets]]
-            key = "tinybird_access_append_token"
-            data = "test-tinybird-access-append-token"
-
-        # App-config secret references resolve from this canonical logical store.
-        # Populate production values through the EdgeZero secret-store workflow.
-        [[local_server.secret_stores.trusted_server_secrets]]
             key = "placeholder"
             data = "placeholder"
 
     [local_server.config_stores]
+        [local_server.config_stores.edgezero_runtime_env]
+            format = "inline-toml"
+        [local_server.config_stores.edgezero_runtime_env.contents]
+            EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME = "ts_secrets"
+
         [local_server.config_stores.trusted_server_config]
             format = "inline-toml"
         [local_server.config_stores.trusted_server_config.contents]

--- a/fastly.toml
+++ b/fastly.toml
@@ -78,7 +78,7 @@ build = """
         [local_server.config_stores.edgezero_runtime_env]
             format = "inline-toml"
         [local_server.config_stores.edgezero_runtime_env.contents]
-            EDGEZERO__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME = "ts_secrets"
+            EDGEZERO__SERVICES__0000000000000000000000__STORES__SECRETS__TRUSTED_SERVER_SECRETS__NAME = "ts_secrets"
 
         [local_server.config_stores.trusted_server_config]
             format = "inline-toml"

--- a/fastly.toml
+++ b/fastly.toml
@@ -53,15 +53,26 @@ build = """
             key = "api_key"
             env = "FASTLY_KEY"
 
+        # Local-only values for the three secret references in
+        # trusted-server.example.toml. These are public development fixtures.
+        [[local_server.secret_stores.ts_secrets]]
+            key = "publisher_proxy_secret"
+            data = "local-only-publisher-proxy-secret"
+
+        [[local_server.secret_stores.ts_secrets]]
+            key = "ec_passphrase"
+            data = "local-only-ec-passphrase-32-bytes"
+
+        [[local_server.secret_stores.ts_secrets]]
+            key = "handler_password"
+            data = "local-only-handler-password"
+
         [[local_server.secret_stores.ts_secrets]]
             key = "tinybird_auction_append_token"
             data = "test-tinybird-auction-append-token"
 
         # App-config references use logical `trusted_server_secrets`; the
         # edgezero_runtime_env mapping below resolves it to physical `ts_secrets`.
-        [[local_server.secret_stores.ts_secrets]]
-            key = "placeholder"
-            data = "placeholder"
 
     [local_server.config_stores]
         [local_server.config_stores.edgezero_runtime_env]

--- a/scripts/template-cache-local-test.sh
+++ b/scripts/template-cache-local-test.sh
@@ -176,21 +176,14 @@ sleep 1
 
 info "Generating stub config (mode: $MODE)"
 python3 - "$REPO_ROOT/trusted-server.example.toml" "$WORK/app.toml" "$MODE" "$ORIGIN_PORT" <<'PYEOF'
-import sys, re
+import sys
 src, out, mode, port = sys.argv[1:5]
 s = open(src).read()
 
 s = s.replace('origin_url = "https://origin.example.com"', f'origin_url = "http://127.0.0.1:{port}"', 1)
-# The example config ships placeholders that validation rejects outright,
-# including the reserved publisher domain/cookie_domain.
+# The example publisher domains are reserved placeholders that validation rejects.
 s = s.replace('domain = "example.com"', 'domain = "local-harness.example"', 1)
 s = s.replace('cookie_domain = ".example.com"', 'cookie_domain = ".local-harness.example"', 1)
-s = s.replace('password = "replace-with-admin-password-32-bytes"',
-              'password = "local-harness-admin-password-not-a-real-one"', 1)
-s = s.replace('proxy_secret = "change-me-proxy-secret"',
-              'proxy_secret = "local-harness-proxy-secret-not-a-real-one"', 1)
-s = re.sub(r'passphrase = "[^"]*"',
-           'passphrase = "local-harness-ec-passphrase-not-a-real-one"', s, count=1)
 
 # A real auction, pointed at the stub's slow endpoint, so the timings mean something.
 s = s.replace('[integrations.prebid]\nenabled = false\nserver_url = "https://prebid.example.com/openrtb2/auction"',
@@ -233,6 +226,24 @@ info "Seeding an isolated config store (tracked fastly.toml remains untouched)"
 # pointed at this checkout without copying the workspace.
 cp "$REPO_ROOT/edgezero.toml" "$WORK/edgezero.toml"
 cp "$REPO_ROOT/fastly.toml" "$WORK/fastly.toml"
+python3 - "$WORK/fastly.toml" <<'PYEOF'
+import sys
+
+with open(sys.argv[1], "a") as manifest:
+    manifest.write('''
+[[local_server.secret_stores.ts_secrets]]
+key = "publisher_proxy_secret"
+data = "fictional-local-publisher-proxy-secret-value"
+
+[[local_server.secret_stores.ts_secrets]]
+key = "ec_passphrase"
+data = "fictional-local-ec-passphrase-secret-value"
+
+[[local_server.secret_stores.ts_secrets]]
+key = "handler_password"
+data = "fictional-local-handler-password-secret-value"
+''')
+PYEOF
 ln -s "$REPO_ROOT/crates" "$WORK/crates"
 (cd "$WORK" && "$TS" config push --adapter fastly --local \
   --manifest "$WORK/edgezero.toml" --app-config "$WORK/app.toml" \

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -95,8 +95,9 @@ pull_sync_concurrency = 3
 # openrtb_atype = 3
 # include this partner's UIDs in auction user.eids
 # bidstream_enabled = true
+# Only for inbound identify or batch-sync API access:
 # api_token = "partner_api_token"
-# Optional when pull sync is enabled:
+# Required when pull sync is enabled:
 # ts_pull_token = "partner_ts_pull_token"
 # batch_rate_limit = 60      # max batch-sync requests/min (default 60)
 # pull_sync_enabled = false  # default false

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -81,9 +81,6 @@ passphrase = "ec_passphrase"
 ec_store = "ec_identity_store"
 # Max concurrent partner pull-sync requests.
 pull_sync_concurrency = 3
-# Keep this empty when no partners are configured. Replace this line with
-# `[[ec.partners]]` entries when adding partners.
-partners = []
 # Optional cluster-heuristic tuning (defaults shown):
 # cluster_trust_threshold = 10    # entries with cluster_size <= this are individual users
 # cluster_recheck_secs = 3600     # re-evaluate cluster_size after this many seconds

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -38,7 +38,7 @@
 # Regex matched against the request path. This one guards the admin surface.
 path = "^/_ts/admin"
 username = "admin"
-password = "replace-with-admin-password-32-bytes"
+password = "handler_password"
 
 # You can add more handlers to basic-auth-protect other path prefixes. The
 # sample password below is a known placeholder that deploy validation rejects,
@@ -59,8 +59,8 @@ domain = "example.com"
 cookie_domain = ".example.com"
 # Upstream origin to proxy publisher content from. No trailing slash.
 origin_url = "https://origin.example.com"
-# HMAC secret for signing first-party proxy URLs. Replace before deploying.
-proxy_secret = "change-me-proxy-secret"
+# Secret Store key for the HMAC secret used to sign first-party proxy URLs.
+proxy_secret = "publisher_proxy_secret"
 # Optional: override the outbound Host header sent to origin_url.
 # origin_host_header_override = "www.example.com"
 # Optional: max bytes buffered when a response is post-processed in full (HTML
@@ -73,22 +73,23 @@ proxy_secret = "change-me-proxy-secret"
 # REQUIRED — Edge Cookie (EC) identity
 # -----------------------------------------------------------------------------
 [ec]
-# Secret used to derive EC identifiers. Must be >= 32 chars and non-placeholder
-# in production (deploy validation rejects known placeholders).
-passphrase = "trusted-server-placeholder-secret"
+# Secret Store key for the secret used to derive EC identifiers.
+passphrase = "ec_passphrase"
 # KV store that persists EC identity state. This is the physical store name
 # bound per adapter (e.g. `ec_identity_store` in fastly.toml); edgezero.toml's
 # logical KV id is `trusted_server_kv`.
 ec_store = "ec_identity_store"
 # Max concurrent partner pull-sync requests.
 pull_sync_concurrency = 3
+# Keep this empty when no partners are configured. Replace this line with
+# `[[ec.partners]]` entries when adding partners.
+partners = []
 # Optional cluster-heuristic tuning (defaults shown):
 # cluster_trust_threshold = 10    # entries with cluster_size <= this are individual users
 # cluster_recheck_secs = 3600     # re-evaluate cluster_size after this many seconds
 
-# Optional identity partners (SSP/DSP/identity vendors). Each needs a real,
-# non-placeholder api_token (>= 32 bytes) at deploy. Configure real partners via
-# private config, not this template.
+# Example partner configuration. Provision referenced keys in
+# trusted_server_secrets before validating/pushing.
 # [[ec.partners]]
 # name = "Example Partner"
 # source_domain = "partner.example.com"
@@ -97,7 +98,9 @@ pull_sync_concurrency = 3
 # openrtb_atype = 3
 # include this partner's UIDs in auction user.eids
 # bidstream_enabled = true
-# api_token = "replace-with-partner-api-token-32-bytes-minimum"
+# api_token = "partner_api_token"
+# Optional when pull sync is enabled:
+# ts_pull_token = "partner_ts_pull_token"
 # batch_rate_limit = 60      # max batch-sync requests/min (default 60)
 # pull_sync_enabled = false  # default false
 

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -131,11 +131,12 @@ pull_sync_concurrency = 3
 # Trust a fronting CDN's reader IP only when the same request also supplies
 # the matching shared secret. The front door must set both headers on requests
 # it sends here and remove client-supplied copies on its other routes.
+# `shared_secret` is a key in trusted_server_secrets, not the credential itself.
 # Fastly-only; see docs/guide/fastly.md for the required front-door setup.
 # [trusted_client_ip]
 # ip_header = "x-ts-client-ip"
 # auth_header = "x-ts-client-ip-auth"
-# shared_secret = "replace-with-a-random-shared-secret"
+# shared_secret = "trusted_client_ip_shared_secret"
 
 # Tester-cookie endpoints: GET /_ts/set-tester sets ts-tester=true and
 # GET /_ts/clear-tester clears it on publisher.cookie_domain.

--- a/trusted-server.example.toml
+++ b/trusted-server.example.toml
@@ -373,9 +373,8 @@ auction_timeout_ms = 500
 # [tinybird]
 # enabled = true
 # api_host = "api.us-east.tinybird.example"   # required when enabled; host only
-# secret_store = "ts_secrets"                 # Secret Store holding the append token
 # auction_dataset = "auction_events"          # Events API datasource name
-# auction_token_secret = "tinybird_auction_append_token"  # Secret Store key for the token
+# auction_token_secret = "tinybird_auction_append_token"  # Key in trusted_server_secrets
 
 # Debug endpoints (all default false — never enable in production).
 # [debug]
@@ -507,7 +506,8 @@ enabled = false
 # rewrite_sdk = true
 # Server-side Protection API validation (fails open on timeout/error):
 # enable_protection = false
-# server_side_key_secret_store = "ts_secrets"
+# Required when enable_protection = true. The value is a key in
+# trusted_server_secrets, not the DataDome credential itself.
 # server_side_key_secret_name = "datadome_server_side_key"
 # protection_api_origin = "https://api.example.com"
 # timeout_ms = 1500


### PR DESCRIPTION
## Summary

- Store references to static credentials in Trusted Server configuration, then resolve those references from the platform's secret store after the signed configuration blob passes integrity checks.
- Resolve publisher, Edge Cookie partner, handler, Tinybird, DataDome, and S3 credentials while loading typed application configuration. Runtime code receives redacted values and no longer reads these static credentials during requests.
- Keep `trusted_server_secrets` as the logical store name while allowing adapters to map it to a physical store such as Fastly's `ts_secrets`. Missing or invalid secrets fail configuration loading without exposing their values.
- Accept the old feature-specific `secret_store` selectors for one release, warn that they are ignored, and omit them when serializing configuration.
- Make Edge Cookie partner `api_token` references optional. Partners without one remain available for source-domain lookup, bidstream EIDs, and outbound pull sync, but cannot authenticate to the inbound identify or batch-sync APIs. `ts_pull_token` remains required only when pull sync is enabled.

This fixes the deployment failure where a valid secret existed in Fastly but Trusted Server opened the logical store name instead of the mapped physical store.

## Changes

| File | Change |
| ---- | ------ |
| `.env.dev` | Clarify that the file contains non-secret development overlays and point local users to the config blob and secret-store setup. |
| `.env.example` | Document logical-to-physical secret-store mapping and replace plaintext secret examples with platform secret-store guidance. |
| `Cargo.toml` | Pin the EdgeZero revision that supports optional secret paths and persisted Fastly store mappings. |
| `Cargo.lock` | Record the updated EdgeZero dependency graph. |
| `crates/trusted-server-adapter-axum/src/app.rs` | Pass the Axum secret-store adapter into typed settings loading. |
| `crates/trusted-server-adapter-cloudflare/src/app.rs` | Resolve configuration references through the Cloudflare Worker environment during startup. |
| `crates/trusted-server-adapter-cloudflare/src/lib.rs` | Make the Worker environment available to startup configuration loading. |
| `crates/trusted-server-adapter-cloudflare/src/platform.rs` | Expose the Cloudflare secret-store adapter within the crate for configuration resolution. |
| `crates/trusted-server-adapter-cloudflare/wrangler.ci.toml` | Add fictional local secret bindings used by Cloudflare integration tests. |
| `crates/trusted-server-adapter-cloudflare/wrangler.toml` | Document how operators provision Worker secrets referenced by application configuration. |
| `crates/trusted-server-adapter-fastly/src/app.rs` | Load Fastly runtime store mappings, resolve typed secrets at startup and reload, and cover mapped-store behavior with tests. |
| `crates/trusted-server-adapter-fastly/src/main.rs` | Build the Fastly application with the runtime environment mapping used by EdgeZero. |
| `crates/trusted-server-adapter-fastly/src/tinybird.rs` | Use the Tinybird token resolved during configuration loading instead of reading a secret store during each request. |
| `crates/trusted-server-adapter-spin/spin.toml` | Declare Spin secret variables for application-config references. |
| `crates/trusted-server-adapter-spin/src/app.rs` | Pass the Spin secret store into startup configuration loading. |
| `crates/trusted-server-adapter-spin/src/platform.rs` | Add the Spin adapter used to resolve typed application secrets. |
| `crates/trusted-server-core/src/config.rs` | Mark secret-bearing fields, make partner API-token references optional, add conditional requirements, support the deserialize-only selector bridge, and split deploy-time structure checks from post-resolution validation. |
| `crates/trusted-server-core/src/config_payload.rs` | Verify blob integrity before resolving references and add fail-closed tests for missing, malformed, inactive, and optional secrets, including partners without API tokens. |
| `crates/trusted-server-core/src/ec/auth.rs` | Keep inbound bearer authentication fail-closed when a configured partner has no API token. |
| `crates/trusted-server-core/src/ec/registry.rs` | Register every partner by source domain while hashing and indexing only configured API tokens; validate partner structure before deployment and defer token-value checks until references have been resolved. |
| `crates/trusted-server-core/src/integrations/datadome.rs` | Load DataDome credentials into redacted runtime settings and ignore the old store selector. |
| `crates/trusted-server-core/src/integrations/datadome/protection.rs` | Use the resolved DataDome key without a request-time secret-store lookup while retaining the configuration-gated test bypass. |
| `crates/trusted-server-core/src/lib.rs` | Export the secret-resolution module. |
| `crates/trusted-server-core/src/proxy.rs` | Use resolved publisher and S3 credentials and remove feature-specific runtime secret-store reads. |
| `crates/trusted-server-core/src/publisher.rs` | Update publisher tests for DataDome's typed secret reference. |
| `crates/trusted-server-core/src/secret_resolution.rs` | Add recursive typed resolution for nested objects, arrays, optional containers, and redacted errors. |
| `crates/trusted-server-core/src/settings.rs` | Separate reference-bearing application configuration from resolved runtime settings, make partner API tokens optional, and sanitize validation failures. |
| `crates/trusted-server-core/src/settings_data.rs` | Define the logical default secret store and thread it through config-store loading. |
| `crates/trusted-server-integration-tests/Cargo.toml` | Make TOML parsing available to the integration config generator. |
| `crates/trusted-server-integration-tests/fixtures/configs/trusted-server.integration.toml` | Replace integration fixture credentials with secret key names. |
| `crates/trusted-server-integration-tests/fixtures/configs/viceroy-template.toml` | Add the local runtime mapping and fictional secret-store entries used by Viceroy. |
| `crates/trusted-server-integration-tests/src/bin/generate-viceroy-config.rs` | Generate local secret-store data for references found in integration configuration. |
| `crates/trusted-server-integration-tests/tests/common/config.rs` | Build test envelopes from the typed application-config representation. |
| `crates/trusted-server-integration-tests/tests/environments/axum.rs` | Supply fictional referenced secrets to the Axum integration environment. |
| `docs/guide/asset-routes.md` | Update asset-route examples to use the resolved publisher secret model. |
| `docs/guide/configuration.md` | Explain reference syntax, conditional requirements, optional partner API access, compatibility behavior, redaction, and migration from feature-specific stores. |
| `docs/guide/ec-setup-guide.md` | Clarify that the demo requires a partner API token because it exercises inbound identify and batch-sync APIs, while other partners may omit it. |
| `docs/guide/fastly.md` | Document Fastly's logical `trusted_server_secrets` to physical `ts_secrets` mapping and provisioning requirements. |
| `docs/guide/getting-started.md` | Add local setup instructions for config blobs and referenced secret values. |
| `docs/guide/integrations/datadome.md` | Replace the old DataDome store selector with a typed key reference. |
| `fastly.toml` | Configure the local Fastly runtime mapping and a placeholder physical secret store. |
| `trusted-server.example.toml` | Replace plaintext credentials with key names, mark partner API tokens as optional for partners that do not use inbound APIs, and add Tinybird and DataDome reference examples. |

## Scope

This PR touches the core schema, each adapter startup path, integration fixtures, and operator documentation because secret references must behave the same on Fastly, Axum, Cloudflare, and Spin. The request-signing key collection, rotation stores, and Fastly management credentials remain outside this change because those stores are managed at runtime rather than loaded as static application configuration.

## EdgeZero dependency

This PR depends on [stackpop/edgezero#344](https://github.com/stackpop/edgezero/pull/344), "Support optional typed secret paths and Fastly store mappings." That PR adds optional intermediate path handling and persists validated logical-to-physical store mappings during Fastly provisioning and staged deployment. Trusted Server pins its tested commit, `0d6ebf9b0250efa5f7031a93ec7b7f09f2c9bf34`. All checks on the EdgeZero PR pass.

## Closes

Closes #684

## Test plan

- [x] `cargo test-fastly && cargo test-axum`
- [x] `cargo clippy-fastly && cargo clippy-axum`
- [x] `cargo fmt --all -- --check`
- [x] JS tests: `cd crates/trusted-server-js/lib && npx vitest run`, no JS source changed
- [x] JS format: `cd crates/trusted-server-js/lib && npm run format`, no JS source changed
- [x] Docs format: `cd docs && npm run format`
- [x] WASM build: the deployment workflow built and staged the Fastly artifact
- [ ] Manual testing via `fastly compute serve`
- [x] Other: `cargo test-cloudflare`, `cargo test-spin`, adapter parity tests, CLI tests, Cloudflare and Spin WASM checks, all adapter-specific Clippy targets, and `git diff --check`
- [x] Staged Fastly deployment: [run 32784895487](https://github.com/stackpop/trusted-server-deployer/actions/runs/32784895487) passed `/health`; a settings-load probe found no secret-resolution or application-state errors

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code, use `expect("should ...")`
- [x] Logging follows project conventions; no direct stdout or stderr logging was added
- [x] New code has tests
- [x] No secrets or credentials committed

