### PR TITLE
Fix dead links and gate the docs build in CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -118,3 +118,6 @@ jobs:
 
       - name: Run Prettier (check)
         run: npm run format
+
+      - name: Build with VitePress (fails on dead links)
+        run: npm run build

--- a/docs/superpowers/archive/2026-08-08-esi-cacheable-root-validation-design.md
+++ b/docs/superpowers/archive/2026-08-08-esi-cacheable-root-validation-design.md
@@ -10,7 +10,7 @@ cross-reference point at it. The subject moved, the path did not._
 > subrequest described below belongs to a rejected spike; do not use those sections to
 > infer current runtime behavior. The final branch retains `assembly_mode = "esi"` only as
 > the operator spelling for Fastly C2 plus exact byte-seam assembly. See
-> [the merge-hardening design](./2026-08-12-1009-esi-merge-hardening-design.md).
+> [the merge-hardening design](../specs/2026-08-12-1009-esi-merge-hardening-design.md).
 
 **Revised:** 2026-08-10
 **Baseline:** citations verified at `cfb98f4`; unchanged as of `b0ce56c3`.
@@ -251,7 +251,7 @@ Two regression signals, both checked before the win is:
 **Why it is safe in principle.** The conditional-header strip runs 34 lines earlier
 under the same gate (`publisher.rs:2832-2836`,
 which also strips `Range`/`If-Range`), so the request already reaches the cache
-unconditional and a HIT returns a full body. [The 304-prevention design](./2026-07-22-ssat-root-document-304-prevention-design.md)
+unconditional and a HIT returns a full body. [The 304-prevention design](../specs/2026-07-22-ssat-root-document-304-prevention-design.md)
 added the bypass as belt-and-braces and listed the TTFB cost under its own Risks. The
 strip alone satisfies its invariant.
 

--- a/docs/superpowers/archive/2026-08-10-1009-esi-validation-spike.md
+++ b/docs/superpowers/archive/2026-08-10-1009-esi-validation-spike.md
@@ -6,7 +6,7 @@
 > implementation keeps the public `esi` spelling but uses Fastly C2 plus exact byte-seam
 > assembly. See
 > [the merge-hardening design](../specs/2026-08-12-1009-esi-merge-hardening-design.md) and
-> [implementation plan](./2026-08-12-1009-esi-merge-hardening.md).
+> [implementation plan](../plans/2026-08-12-1009-esi-merge-hardening.md).
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
 > (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
@@ -36,7 +36,7 @@ read the 2026-08-10 correction at the top and
 [§6.6](./2026-08-08-esi-cacheable-root-validation-design.md#66-the-esi-pipeline-corrected)
 before writing any code.
 
-**Control:** [the Stage 0 plan](./2026-08-08-1009-measurement-and-stage-0.md). Its
+**Control:** [the Stage 0 plan](../plans/2026-08-08-1009-measurement-and-stage-0.md). Its
 instrumentation and its bypass flag are prerequisites — this plan compares against them
 and does not duplicate them.
 
@@ -163,14 +163,14 @@ version, since `regex`, `bytes`, and `log` are used across the workspace. Adding
 major that coexists is harmless; moving an existing one is not. If one moves, fix with a
 targeted `cargo update -p <crate> --precise <version>` — **never a full update**.
 
-**Already run and recorded** in [the findings](./2026-08-08-1009-measurement-findings.md):
+**Already run and recorded** in [the findings](../plans/2026-08-08-1009-measurement-findings.md):
 no existing shared dependency moved.
 
 - [ ] **Step 4: Record and commit, or stop**
 
 **Task 1 is complete — verdict PASS, recorded 2026-08-10.** `esi` 0.7.1 compiles clean on
 Rust 1.95.0 / `wasm32-wasip1`, all six clippy targets pass, and no existing shared
-dependency moved. See [the findings](./2026-08-08-1009-measurement-findings.md).
+dependency moved. See [the findings](../plans/2026-08-08-1009-measurement-findings.md).
 
 Had Step 2 failed, this plan would have stopped here with #1009 answered "not on this
 toolchain." It did not.
@@ -189,7 +189,7 @@ works locally.** A probe exercised `cache::core::insert`, `lookup`, `finish`, `t
 and — the shape Task 3 Step 4 actually specifies — `Transaction::lookup`,
 `must_insert_or_update`, `insert(...).surrogate_keys(...).execute_and_stream_back()`, and
 hit-after-insert semantics. All passed. Recorded in
-[the findings](./2026-08-08-1009-measurement-findings.md).
+[the findings](../plans/2026-08-08-1009-measurement-findings.md).
 
 That reorders this plan. An earlier revision made provisioning a Fastly service Task 2 and
 a blocker on everything after it. It is not a blocker: **almost all of the correctness and

--- a/docs/superpowers/specs/2026-07-20-ssat-debug-comment-config-design.md
+++ b/docs/superpowers/specs/2026-07-20-ssat-debug-comment-config-design.md
@@ -60,9 +60,9 @@ alongside the existing bool, with:
   config-driven," not "applied unconditionally in every mode."
 - Adding failure-reason instrumentation to provider adapters that don't
   capture any today. Notably, `AuctionResponse::no_bid()`
-  ([auction/types.rs:296](../../../crates/trusted-server-core/src/auction/types.rs#L296))
+  (`auction/types.rs:296`)
   always carries empty metadata, and `aps.rs`
-  ([integrations/aps.rs:546](../../../crates/trusted-server-core/src/integrations/aps.rs#L546))
+  (`integrations/aps.rs:546`)
   never attaches a no-fill reason. `verbosity=full` will show nothing more for
   an APS no-bid than redacted mode does today, because there is nothing more
   captured server-side. Fixing that is separate, larger, per-provider work —
@@ -76,23 +76,23 @@ alongside the existing bool, with:
 - Tightening `Bid`-level fields (`Bid.metadata`, `nurl`, `burl`) to a
   fail-closed allowlist. These already pass through `redact_bid_for_dump`
   unfiltered today in all verbosity modes
-  ([publisher.rs:966-972](../../../crates/trusted-server-core/src/publisher.rs#L966-L972)),
+  (`publisher.rs:966-972`),
   pre-existing and tracked separately as issue #925. Unaffected by, and
   orthogonal to, this design.
 
 ## Current Behavior (today, for reference)
 
 `prepend_auction_debug_comment`
-([publisher.rs:950](../../../crates/trusted-server-core/src/publisher.rs#L950))
+(`publisher.rs:950`)
 unconditionally:
 
 - Includes `provider_responses` and `mediator_response` (when present).
 - Includes every provider's `bids` array.
 - Filters each response's metadata to a fixed 7-key allowlist:
   `error_type, status, message, responsetimemillis, errors, warnings, bidstatus`
-  ([publisher.rs:878](../../../crates/trusted-server-core/src/publisher.rs#L878)).
+  (`publisher.rs:878`).
 - Previews each bid's `creative` to 512 bytes
-  ([publisher.rs:893](../../../crates/trusted-server-core/src/publisher.rs#L893)).
+  (`publisher.rs:893`).
 - Neutralizes `-->`/`--!>` comment terminators and caps the total serialized
   dump at 256KB, unconditionally.
 
@@ -100,10 +100,10 @@ Notably absent from the allowlist today despite already being captured
 server-side by the prebid integration:
 
 - `http_status` — numeric HTTP status from a non-2xx PBS response
-  ([prebid.rs:2025](../../../crates/trusted-server-core/src/integrations/prebid.rs#L2025)).
+  (`prebid.rs:2025`).
 - `upstream_message` / `upstream_message_truncated` — the actual PBS error
   body text, only populated when `[integrations.prebid] debug = true`
-  ([prebid.rs:2038-2046](../../../crates/trusted-server-core/src/integrations/prebid.rs#L2038-L2046)).
+  (`prebid.rs:2038-2046`).
   The text is bounded but provider-controlled, and may echo identifiers or
   other request values. It is therefore available only in `upstream` and
   `full` modes, never in the safe `redacted` default.
@@ -117,7 +117,7 @@ strings or nested identity data. This design therefore moves all four out of
 Also captured server-side, but deliberately excluded from the allowlist and
 staying that way in redacted mode: the raw `debug` subtree
 (`httpcalls`/`resolvedrequest`) that PBS returns when `integrations.prebid.debug`
-is on ([prebid.rs:1945-1948](../../../crates/trusted-server-core/src/integrations/prebid.rs#L1945-L1948)).
+is on (`prebid.rs:1945-1948`).
 This carries the resolved OpenRTB request: device IP, geo, `user.ext.eids`, TC
 consent string, per-bidder request/response bodies. This is the data `full`
 verbosity exists to expose, on explicit opt-in.
@@ -216,7 +216,7 @@ pub enum AuctionDebugCommentVerbosity {
 ```
 
 `DebugConfig` derives `#[derive(Default, ...)]`
-([settings.rs:1895](../../../crates/trusted-server-core/src/settings.rs#L1895)),
+(`settings.rs:1895`),
 which requires every field's type to implement `Default`. The hand-written
 `impl Default for AuctionDebugCommentOptions` above is required for this to
 compile — a naive `#[derive(Default)]` would produce
@@ -263,7 +263,7 @@ This makes `redacted` fail closed at the rendering boundary even if a future
 provider writes an unexpected value beneath a familiar metadata key.
 
 `Settings::finalize_deserialized`
-([settings.rs:2038-2059](../../../crates/trusted-server-core/src/settings.rs#L2038-L2059))
+(`settings.rs:2038-2059`)
 — the associated fn that already calls `settings.integrations.normalize();
 settings.proxy.normalize(); settings.image_optimizer.normalize();` on a
 locally-owned `settings: Self` — gains
@@ -336,7 +336,7 @@ Unconditional regardless of `options` (safety nets, not redaction controls):
 - `MAX_AUCTION_DEBUG_DUMP_BYTES` (256KB) final cap on the serialized dump
 
 **Wiring** — production call site
-[publisher.rs:1394](../../../crates/trusted-server-core/src/publisher.rs#L1394)
+`publisher.rs:1394`
 (the two existing test call sites for `prepend_auction_debug_comment`, around
 publisher.rs:2638 and 2699, also need the new parameter — same signature
 change ripples to both):


### PR DESCRIPTION
## Summary

- The VitePress build on `main` has been failing since #943 landed; #1013 added
  more breakage on top. Nineteen dead links across three files, now fixed, so
  the docs deploy goes green again.
- Dead links were only ever checked by `deploy-docs.yml`, which runs on push to
  `main` alone. Move the build into the existing `format-docs` job so the check
  runs on pull requests, before breakage reaches `main`.

## Changes

| File | Change |
| ---- | ------ |
| `.github/workflows/format.yml` | Run `npm run build` in the `format-docs` job. That job already runs on `pull_request`, already installs the `docs` dependencies, and is already a required status check, so dead links become a merge blocker with no ruleset change. |
| `docs/superpowers/specs/2026-07-20-ssat-debug-comment-config-design.md` | Twelve links pointed into the source tree via `../../../crates/...`. Those targets sit outside the VitePress root and can never resolve. Rewritten as inline code spans, e.g. `` (`publisher.rs:950`) ``, matching the 172 source references already written that way under `docs/superpowers/`. |
| `docs/superpowers/archive/2026-08-08-esi-cacheable-root-validation-design.md` | Two sibling links kept a `./` prefix after the document moved into `archive/`. Retargeted to `../specs/`. |
| `docs/superpowers/archive/2026-08-10-1009-esi-validation-spike.md` | Five sibling links likewise retargeted to `../plans/`. Every target already existed one directory over. |

## Closes

No linked issue — this repairs a build that is red on `main` right now.

## Test plan

- [x] Docs format: `cd docs && npm run format` — all matched files use Prettier code style
- [x] Docs lint: `cd docs && npm run lint` — clean
- [x] Docs build: `cd docs && npm run build` — `build complete in 10.91s` (was `[vitepress] 19 dead link(s) found`)
- [x] `cargo fmt --all -- --check`
- [x] Other: verified the new gate fails closed. A deliberate dead link exits 1 with `[vitepress] 1 dead link(s) found`; the build completes once removed.
- [ ] `cargo test-fastly && cargo test-axum` — not run, no Rust source changed
- [ ] `cargo clippy-fastly && cargo clippy-axum` — not run, no Rust source changed
- [ ] JS tests / JS format — not run, no JS source changed

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` in production code — no Rust changed
- [x] Uses `tracing` macros (not `println!`) — no Rust changed
- [x] New code has tests — the CI gate is itself the regression test, and it was verified to fail closed
- [x] No secrets or credentials committed

## Note on the two fix sets

The two halves have different origins, worth separating for anyone reading
`git log` later:

- The twelve source-tree links arrived with #943 and turned the docs deploy red
  at 04:34 on 2026-08-22.
- The seven archive links arrived with #1013, whose squash landed as
  `d97bda69f`. That commit carries the subject `probe` because of a tooling
  error during its merge; it is the "Add shared root caching with hybrid ESI and
  streaming assembly" merge, and its full message body is intact.
