### PR TITLE
Stop logging creative-rewriting warnings on every request

### DIFF
--- a/crates/trusted-server-core/src/settings.rs
+++ b/crates/trusted-server-core/src/settings.rs
@@ -2920,12 +2920,6 @@ impl Settings {
         settings.validate_admin_coverage()?;
         settings.validate_admin_handler_passwords()?;
 
-        if settings.auction.enabled && !settings.auction.rewrite_creatives {
-            log::warn!(
-                "Auction creative rewriting disabled; creative assets and clicks may contact third-party hosts directly"
-            );
-        }
-
         Ok(settings)
     }
 


### PR DESCRIPTION
## Summary

- Stop request-time settings loading from logging a static creative-rewriting warning.
- Keep creative-rewriting defaults, validation, and runtime behavior unchanged.

## Changes

| File | Change |
| ---- | ------ |
| `crates/trusted-server-core/src/settings.rs` | Remove the warning emitted when auctions are enabled and creative rewriting is disabled. |

## Closes

Closes #1089

## Test plan

- [x] `cargo test-fastly && cargo test-axum`
- [x] `cargo test-cloudflare && cargo test-spin`
- [x] `cargo clippy-fastly && cargo clippy-axum`
- [x] `cargo clippy-cloudflare && cargo clippy-cloudflare-wasm`
- [x] `cargo clippy-spin-native && cargo clippy-spin-wasm`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --manifest-path crates/trusted-server-integration-tests/Cargo.toml --test parity`
- [x] JS tests: `cd crates/trusted-server-js/lib && npx vitest run`
- [x] JS format: `cd crates/trusted-server-js/lib && npm run format`
- [x] Docs format: `cd docs && npm run format`
- [ ] WASM release build
- [ ] Manual testing via `fastly compute serve`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No `unwrap()` or output macros added
- [x] No new code requiring test coverage
- [x] No secrets or credentials committed
